### PR TITLE
fix(stability): classify worker crash outcomes

### DIFF
--- a/docs/guides/run-cli-beast.md
+++ b/docs/guides/run-cli-beast.md
@@ -166,6 +166,22 @@ frankenbeast beasts delete <agent-id>
 
 `resume` and `delete` operate on tracked agent IDs, not run IDs. Use `resume` to continue the agent's linked run and `delete` to soft-delete the tracked agent.
 
+### Worker crash classification
+
+Every Beast worker lifecycle event now carries a structured `crashClassification` object so operators and PM/liveness tooling do not need to infer failure type from prose. The taxonomy includes:
+
+| Kind | Meaning | Operator action |
+|------|---------|-----------------|
+| `clean_exit` | Process exited with code `0`. | No crash remediation. |
+| `spawn_failure` | Command/cwd/runtime could not spawn. | Check command path, permissions, cwd containment, and installed dependencies before retrying. |
+| `operator_stop` / `operator_kill` | Human or supervisor intentionally stopped the run. | Treat as intentional unless the operator action trail says otherwise. |
+| `oom_killed` | `SIGKILL`, exit `137`, or OOM-like stderr. | Reduce concurrency or memory footprint and inspect host OOM evidence before retrying. |
+| `signal_termination` | Process ended from another signal. | Correlate with host shutdown, container runtime, or supervisor actions. |
+| `runtime_error` | Non-zero exit with exception-like stderr. | Use the redacted stderr tail as the primary debugging handle. |
+| `nonzero_exit` / `unknown_exit` | Deterministic non-zero or ambiguous exit without a stronger signal. | Preserve exit evidence in handoffs and inspect logs/run config. |
+
+The classification includes `kind`, `severity`, `retryable`, `summary`, and `operatorGuidance`. Treat `retryable` as liveness guidance, not permission to ignore the underlying failure.
+
 Available catalog entries: `design-interview`, `chunk-plan`, `martin-loop`.
 
 ### Execution isolation

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -12,6 +12,7 @@ import {
 } from './git-worktree-isolation.js';
 import { wallClockNow } from '@franken/types';
 import type { ProcessSupervisorLike } from './process-supervisor.js';
+import { classifyWorkerCrash } from './worker-crash-classification.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
 
 const STDERR_BUFFER_SIZE = 50;
@@ -383,6 +384,11 @@ export class ProcessBeastExecutor implements BeastExecutor {
         stopReason: 'spawn_failed',
       });
 
+      const crashClassification = classifyWorkerCrash({
+        stopReason: 'spawn_failed',
+        spawnErrorCode: errorCode,
+        stderrTail: earlyStderrLines,
+      });
       const spawnFailedEvent = {
         type: 'run.spawn_failed' as const,
         payload: {
@@ -390,6 +396,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
           ...(errorCode ? { code: errorCode } : {}),
           command: processSpec.command,
           args: [...processSpec.args],
+          crashClassification,
         },
         createdAt: failedAt,
       };
@@ -701,6 +708,12 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const attemptRecord = this.repository.getAttempt(attemptId);
     const durationMs = attemptRecord?.startedAt ? finishedAtMs - new Date(attemptRecord.startedAt).getTime() : undefined;
     const redactedStderrTail = code !== 0 ? redactFailureStderrTail(stderrTail, configuredSecrets) : [];
+    const crashClassification = classifyWorkerCrash({
+      code,
+      signal,
+      stopReason,
+      stderrTail: redactedStderrTail,
+    });
     const exitEvent = {
       attemptId,
       type: eventType,
@@ -708,7 +721,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
         exitCode: code,
         signal,
         ...(durationMs !== undefined ? { durationMs } : {}),
-        ...(code !== 0 ? { lastStderrLines: redactedStderrTail, summary: `Process exited with code ${code}` } : {}),
+        ...(code !== 0 ? { lastStderrLines: redactedStderrTail, summary: crashClassification.summary } : {}),
+        crashClassification,
       },
       createdAt: finishedAt,
     };
@@ -793,7 +807,10 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const finishEvent = {
       attemptId: attempt.id,
       type: (status === 'stopped' ? 'attempt.stopped' : 'attempt.finished') as string,
-      payload: { stopReason },
+      payload: {
+        stopReason,
+        crashClassification: classifyWorkerCrash({ stopReason }),
+      },
       createdAt: finishedAt,
     };
     this.repository.appendEvent(runId, finishEvent);

--- a/packages/franken-orchestrator/src/beasts/execution/worker-crash-classification.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/worker-crash-classification.ts
@@ -1,0 +1,145 @@
+export type WorkerCrashKind =
+  | 'clean_exit'
+  | 'spawn_failure'
+  | 'operator_stop'
+  | 'operator_kill'
+  | 'oom_killed'
+  | 'signal_termination'
+  | 'nonzero_exit'
+  | 'runtime_error'
+  | 'unknown_exit';
+
+export type WorkerCrashSeverity = 'none' | 'info' | 'warning' | 'error' | 'critical';
+
+export interface WorkerCrashClassificationInput {
+  readonly code?: number | null | undefined;
+  readonly signal?: string | null | undefined;
+  readonly stopReason?: string | undefined;
+  readonly spawnErrorCode?: string | undefined;
+  readonly stderrTail?: readonly string[] | undefined;
+}
+
+export interface WorkerCrashClassification {
+  readonly kind: WorkerCrashKind;
+  readonly severity: WorkerCrashSeverity;
+  readonly retryable: boolean;
+  readonly summary: string;
+  readonly operatorGuidance: string;
+}
+
+const OOM_PATTERNS = [
+  /\bout of memory\b/i,
+  /\boom\b/i,
+  /\bheap out of memory\b/i,
+  /\ballocation failed\b/i,
+  /\bkilled process\b/i,
+];
+
+const RUNTIME_ERROR_PATTERNS = [
+  /\buncaught(?: exception)?\b/i,
+  /\bunhandled(?: promise)? rejection\b/i,
+  /\btraceback\b/i,
+  /\btypeerror\b/i,
+  /\breferenceerror\b/i,
+  /\bsyntaxerror\b/i,
+  /\berror:\s+.+/i,
+];
+
+function stderrContains(stderrTail: readonly string[] | undefined, patterns: readonly RegExp[]): boolean {
+  if (!stderrTail || stderrTail.length === 0) return false;
+  const text = stderrTail.join('\n');
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+export function classifyWorkerCrash(input: WorkerCrashClassificationInput): WorkerCrashClassification {
+  const stopReason = input.stopReason;
+
+  if (input.code === 0 && !input.signal && !stopReason) {
+    return {
+      kind: 'clean_exit',
+      severity: 'none',
+      retryable: false,
+      summary: 'Worker process exited successfully.',
+      operatorGuidance: 'No crash remediation is required.',
+    };
+  }
+
+  if (stopReason === 'operator_stop') {
+    return {
+      kind: 'operator_stop',
+      severity: 'info',
+      retryable: false,
+      summary: 'Worker process stopped after an operator-requested graceful stop.',
+      operatorGuidance: 'Treat this as intentional unless the stop request was unexpected; inspect the operator action trail before restarting.',
+    };
+  }
+
+  if (stopReason === 'operator_kill') {
+    return {
+      kind: 'operator_kill',
+      severity: 'warning',
+      retryable: false,
+      summary: 'Worker process was force-killed by an operator action.',
+      operatorGuidance: 'Do not auto-retry until the operator confirms the force-kill was not protecting shared state or credentials.',
+    };
+  }
+
+  if (input.spawnErrorCode || stopReason === 'spawn_failed') {
+    const detail = input.spawnErrorCode ? ` (${input.spawnErrorCode})` : '';
+    return {
+      kind: 'spawn_failure',
+      severity: 'error',
+      retryable: false,
+      summary: `Worker process could not be spawned${detail}.`,
+      operatorGuidance: 'Check command path, permissions, cwd containment, and runtime installation before retrying; repeated immediate retries will not repair missing dependencies.',
+    };
+  }
+
+  if (input.signal === 'SIGKILL' || input.code === 137 || stderrContains(input.stderrTail, OOM_PATTERNS)) {
+    return {
+      kind: 'oom_killed',
+      severity: 'critical',
+      retryable: true,
+      summary: 'Worker process appears to have been killed by the OS or runtime due to memory pressure.',
+      operatorGuidance: 'Retry only with reduced concurrency or memory footprint; inspect host OOM logs and the stderr tail before marking the worker as flaky.',
+    };
+  }
+
+  if (input.signal) {
+    return {
+      kind: 'signal_termination',
+      severity: input.signal === 'SIGTERM' ? 'warning' : 'error',
+      retryable: input.signal !== 'SIGTERM',
+      summary: `Worker process terminated by signal ${input.signal}.`,
+      operatorGuidance: 'Correlate the signal with supervisor stop/kill requests, host shutdowns, and container runtime events before retrying.',
+    };
+  }
+
+  if (stderrContains(input.stderrTail, RUNTIME_ERROR_PATTERNS)) {
+    return {
+      kind: 'runtime_error',
+      severity: 'error',
+      retryable: true,
+      summary: `Worker process exited with code ${input.code ?? 'unknown'} after emitting runtime error output.`,
+      operatorGuidance: 'Use the redacted stderr tail as the primary debugging handle; retry only after the exception path is understood or the input has been corrected.',
+    };
+  }
+
+  if (typeof input.code === 'number') {
+    return {
+      kind: 'nonzero_exit',
+      severity: 'error',
+      retryable: true,
+      summary: `Worker process exited with code ${input.code}.`,
+      operatorGuidance: 'Inspect logs and the run configuration; the exit code is deterministic evidence and should be preserved in handoffs.',
+    };
+  }
+
+  return {
+    kind: 'unknown_exit',
+    severity: 'error',
+    retryable: true,
+    summary: 'Worker process exited without an exit code or signal.',
+    operatorGuidance: 'Treat the run as ambiguous; inspect supervisor logs, host process state, and stream closure order before retrying.',
+  };
+}

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/worker-crash-classification.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/worker-crash-classification.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { classifyWorkerCrash } from '../../../../src/beasts/execution/worker-crash-classification.js';
+
+describe('worker crash classification taxonomy', () => {
+  it('classifies clean exits as non-crashes', () => {
+    expect(classifyWorkerCrash({ code: 0, signal: null })).toMatchObject({
+      kind: 'clean_exit',
+      severity: 'none',
+      retryable: false,
+    });
+  });
+
+  it('classifies spawn failures as non-retryable operator setup errors', () => {
+    expect(classifyWorkerCrash({ stopReason: 'spawn_failed', spawnErrorCode: 'ENOENT' })).toMatchObject({
+      kind: 'spawn_failure',
+      severity: 'error',
+      retryable: false,
+      summary: expect.stringContaining('ENOENT'),
+    });
+  });
+
+  it('classifies SIGKILL and exit code 137 as likely OOM kills', () => {
+    expect(classifyWorkerCrash({ signal: 'SIGKILL' })).toMatchObject({
+      kind: 'oom_killed',
+      severity: 'critical',
+      retryable: true,
+    });
+    expect(classifyWorkerCrash({ code: 137, stderrTail: ['Killed process after heap out of memory'] })).toMatchObject({
+      kind: 'oom_killed',
+      severity: 'critical',
+      retryable: true,
+    });
+  });
+
+  it('classifies runtime exception stderr separately from generic nonzero exits', () => {
+    expect(classifyWorkerCrash({ code: 1, signal: null, stderrTail: ['TypeError: bad input'] })).toMatchObject({
+      kind: 'runtime_error',
+      severity: 'error',
+      retryable: true,
+    });
+    expect(classifyWorkerCrash({ code: 2, signal: null, stderrTail: ['usage: missing --goal'] })).toMatchObject({
+      kind: 'nonzero_exit',
+      severity: 'error',
+      retryable: true,
+    });
+  });
+
+  it('classifies operator stop and force-kill as intentional lifecycle outcomes', () => {
+    expect(classifyWorkerCrash({ stopReason: 'operator_stop' })).toMatchObject({
+      kind: 'operator_stop',
+      severity: 'info',
+      retryable: false,
+    });
+    expect(classifyWorkerCrash({ stopReason: 'operator_kill' })).toMatchObject({
+      kind: 'operator_kill',
+      severity: 'warning',
+      retryable: false,
+    });
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -422,6 +422,17 @@ describe('ProcessBeastExecutor', () => {
 
     await expect(executor.start(run, createDefinitionWithCwd(workDir))).rejects.toThrow('spawn failed');
 
+    const spawnFailedEvent = repo.listEvents(run.id).find((event) => event.type === 'run.spawn_failed');
+    expect(spawnFailedEvent?.payload).toMatchObject({
+      error: 'spawn failed',
+      crashClassification: {
+        kind: 'spawn_failure',
+        severity: 'error',
+        retryable: false,
+        operatorGuidance: expect.stringContaining('command path'),
+      },
+    });
+
     const expectedWorktree = join(workDir, '.frankenbeast', '.worktrees', agent.id);
     expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', '--force', expectedWorktree], workDir);
     expect(runGit).toHaveBeenCalledWith(['branch', '-D', `beast/${agent.id}`], workDir);
@@ -712,6 +723,15 @@ describe('ProcessBeastExecutor', () => {
       id: attempt.id,
       status: 'stopped',
       stopReason: 'operator_stop',
+    });
+    const stoppedEvent = repo.listEvents(run.id).find((event) => event.type === 'attempt.stopped');
+    expect(stoppedEvent?.payload).toMatchObject({
+      stopReason: 'operator_stop',
+      crashClassification: {
+        kind: 'operator_stop',
+        severity: 'info',
+        retryable: false,
+      },
     });
   });
 
@@ -1329,7 +1349,13 @@ describe('ProcessBeastExecutor', () => {
       expect(failEvent!.payload).toMatchObject({
         exitCode: 1,
         lastStderrLines: ['Error: something broke'],
-        summary: 'Process exited with code 1',
+        summary: 'Worker process exited with code 1 after emitting runtime error output.',
+        crashClassification: {
+          kind: 'runtime_error',
+          severity: 'error',
+          retryable: true,
+          operatorGuidance: expect.stringContaining('stderr tail'),
+        },
       });
     });
 


### PR DESCRIPTION
## Summary
- Add a structured worker crash classification taxonomy for Beast process exits, spawn failures, operator stops/kills, signals, OOM-like terminations, and runtime/nonzero exits.
- Attach `crashClassification` metadata to spawn-failure, attempt exit, and stopped/finished lifecycle events.
- Document the taxonomy and add unit coverage for classifier behavior plus event payload integration.

## Test Plan
- [x] `npm ci`
- [x] `npm --prefix packages/franken-types run build`
- [x] `npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/execution/worker-crash-classification.test.ts tests/unit/beasts/process-beast-executor.test.ts`
- [x] `npm run build`
- [x] `npm --prefix packages/franken-orchestrator run typecheck`
- [x] `npm --prefix packages/franken-orchestrator run build`
- [x] `npm --prefix packages/franken-orchestrator run lint` (passes with existing warnings)

Closes #1805
