### PR TITLE
feat(learning): weight human feedback for lessons

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -39,6 +39,9 @@ export type {
   LessonUnquarantineMetadata,
   LessonCooldownMetadata,
   LessonCooldownSuppression,
+  LessonFeedbackSignalSource,
+  LessonFeedbackWeight,
+  LessonFeedbackWeighting,
   CrossTaskBlockerPattern,
   LearningBacklogPriority,
   LearningBacklogPrioritizationItem,
@@ -90,6 +93,7 @@ export { CritiquePipeline } from './pipeline/critique-pipeline.js';
 export { CritiqueLoop } from './loop/critique-loop.js';
 export {
   LessonRecorder,
+  applyHumanFeedbackToLesson,
   detectLessonContradictions,
   isLessonApplicable,
   quarantineLesson,
@@ -104,6 +108,7 @@ export type {
   LessonFailureSignal,
   RepeatedFailureQuarantineRequest,
   LessonUnquarantineRequest,
+  LessonHumanFeedbackRequest,
 } from './memory/lesson-recorder.js';
 
 // Evaluators

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -261,18 +261,21 @@ export function applyHumanFeedbackToLesson(
 
   if (request.source === 'explicit-user-correction') {
     const revisedLesson = request.revisedCorrectionApplied
-      ? removeStaleLessonValidation({
+      ? {
           ...lesson,
           correctionApplied: request.revisedCorrectionApplied,
-        })
+        }
       : lesson;
+    const quarantinedLesson = quarantineLesson(revisedLesson, {
+      trigger: 'explicit-user-correction',
+      reason: request.reason,
+      evidence: request.evidence,
+      quarantinedAt: request.observedAt,
+    });
     return {
-      ...quarantineLesson(revisedLesson, {
-        trigger: 'explicit-user-correction',
-        reason: request.reason,
-        evidence: request.evidence,
-        quarantinedAt: request.observedAt,
-      }),
+      ...(request.revisedCorrectionApplied
+        ? removeStaleLessonValidation(quarantinedLesson)
+        : quarantinedLesson),
       feedbackWeighting,
     };
   }
@@ -288,18 +291,27 @@ export function applyHumanFeedbackToLesson(
       'Explicit lesson approval requires at least one evidence item.',
     );
   }
-  const { quarantine, ...lessonWithoutQuarantine } = lesson;
-  const restoredLifecycleStatus =
-    quarantine?.previousLifecycleStatus ??
-    (lesson.lifecycleStatus === 'quarantined'
-      ? 'candidate'
-      : lesson.lifecycleStatus);
-  const lifecycleStatus = lesson.experimentSandbox?.promotionBlocked
-    ? (restoredLifecycleStatus ?? 'candidate')
-    : 'active';
+  const primaryApprovalEvidence = approvalEvidence[0];
+  if (primaryApprovalEvidence === undefined) {
+    throw new RangeError(
+      'Explicit lesson approval requires at least one evidence item.',
+    );
+  }
+  if (lesson.lifecycleStatus === 'quarantined' && lesson.quarantine !== undefined) {
+    return {
+      ...unquarantineLesson(lesson, {
+        reviewedAt: request.observedAt,
+        reviewer: request.source,
+        evidenceUrl: primaryApprovalEvidence.reference,
+        reason: request.reason,
+      }),
+      feedbackWeighting,
+    };
+  }
   return {
-    ...lessonWithoutQuarantine,
-    lifecycleStatus,
+    ...lesson,
+    lifecycleStatus:
+      lesson.lifecycleStatus === undefined ? 'active' : lesson.lifecycleStatus,
     feedbackWeighting,
   };
 }

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -325,7 +325,7 @@ export function applyHumanFeedbackToLesson(
   const { experimentSandbox, ...lessonWithoutSandbox } = lesson;
   void experimentSandbox;
   return {
-    ...(lesson.lifecycleStatus === 'candidate' ? lessonWithoutSandbox : lesson),
+    ...(shouldActivateApprovedLesson ? lessonWithoutSandbox : lesson),
     lifecycleStatus: shouldActivateApprovedLesson
       ? 'active'
       : lesson.lifecycleStatus,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -251,6 +251,10 @@ export function applyHumanFeedbackToLesson(
   request: LessonHumanFeedbackRequest,
 ): CritiqueLesson {
   const observedAt = normalizeTimestamp(request.observedAt);
+  const feedbackReason = requireNonEmptyString(
+    request.reason,
+    'feedback reason',
+  );
   const feedbackEvidence = request.evidence.map(normalizeQuarantineEvidence);
   const revisedCorrectionApplied =
     request.revisedCorrectionApplied !== undefined
@@ -264,7 +268,7 @@ export function applyHumanFeedbackToLesson(
     createLessonFeedbackWeight(
       request.source,
       observedAt,
-      request.reason,
+      feedbackReason,
       feedbackEvidence,
     ),
   ]);
@@ -279,7 +283,7 @@ export function applyHumanFeedbackToLesson(
       : lesson;
     const quarantinedLesson = quarantineLesson(revisedLesson, {
       trigger: 'explicit-user-correction',
-      reason: request.reason,
+      reason: feedbackReason,
       evidence: feedbackEvidence,
       quarantinedAt: observedAt,
     });
@@ -291,6 +295,11 @@ export function applyHumanFeedbackToLesson(
     };
   }
 
+  if (request.source !== 'explicit-user-approval') {
+    throw new RangeError(
+      'Lesson human feedback approval requires explicit-user-approval source.',
+    );
+  }
   if (request.evidence.length === 0) {
     throw new RangeError(
       'Explicit lesson approval requires at least one evidence item.',
@@ -308,13 +317,22 @@ export function applyHumanFeedbackToLesson(
     );
   }
   if (lesson.lifecycleStatus === 'quarantined' && lesson.quarantine !== undefined) {
+    const unquarantinedLesson = unquarantineLesson(lesson, {
+      reviewedAt: observedAt,
+      reviewer: request.source,
+      evidenceUrl: primaryApprovalEvidence.reference,
+      reason: feedbackReason,
+    });
+    const shouldClearApprovedSandbox =
+      unquarantinedLesson.lifecycleStatus === undefined ||
+      unquarantinedLesson.lifecycleStatus === 'active';
+    const { experimentSandbox, ...unquarantinedLessonWithoutSandbox } =
+      unquarantinedLesson;
+    void experimentSandbox;
     return {
-      ...unquarantineLesson(lesson, {
-        reviewedAt: observedAt,
-        reviewer: request.source,
-        evidenceUrl: primaryApprovalEvidence.reference,
-        reason: request.reason,
-      }),
+      ...(shouldClearApprovedSandbox
+        ? unquarantinedLessonWithoutSandbox
+        : unquarantinedLesson),
       feedbackWeighting,
     };
   }

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -261,7 +261,10 @@ export function applyHumanFeedbackToLesson(
 
   if (request.source === 'explicit-user-correction') {
     const revisedLesson = request.revisedCorrectionApplied
-      ? { ...lesson, correctionApplied: request.revisedCorrectionApplied }
+      ? removeStaleLessonValidation({
+          ...lesson,
+          correctionApplied: request.revisedCorrectionApplied,
+        })
       : lesson;
     return {
       ...quarantineLesson(revisedLesson, {
@@ -274,13 +277,27 @@ export function applyHumanFeedbackToLesson(
     };
   }
 
-  const { experimentSandbox, ...lessonWithoutSandbox } = lesson;
+  if (request.evidence.length === 0) {
+    throw new RangeError(
+      'Explicit lesson approval requires at least one evidence item.',
+    );
+  }
+  const { experimentSandbox, quarantine, ...lessonWithoutBlocks } = lesson;
   void experimentSandbox;
+  void quarantine;
   return {
-    ...lessonWithoutSandbox,
+    ...lessonWithoutBlocks,
     lifecycleStatus: 'active',
     feedbackWeighting,
   };
+}
+
+function removeStaleLessonValidation(lesson: CritiqueLesson): CritiqueLesson {
+  const { contradictionReport, testTraceability, ...lessonWithoutValidation } =
+    lesson;
+  void contradictionReport;
+  void testTraceability;
+  return lessonWithoutValidation;
 }
 
 export function isLessonApplicable(lesson: CritiqueLesson): boolean {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -14,6 +14,9 @@ import type {
   LessonQuarantineEvidence,
   LessonQuarantineMetadata,
   LessonUnquarantineMetadata,
+  LessonFeedbackSignalSource,
+  LessonFeedbackWeight,
+  LessonFeedbackWeighting,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -46,6 +49,17 @@ const AGENT_IMPROVEMENT_SCORECARD_GUIDANCE =
   'Use this per-agent scorecard in worker retrospectives and PM handoff summaries to compare improvement over time without parsing free-form lesson prose.';
 const LEARNING_BACKLOG_PRIORITIZATION_GUIDANCE =
   'Use this report to sort newly observed learning backlog items before promotion, retirement, or PM routing; higher priority items should receive durable mitigation before low-risk documentation follow-up.';
+const LESSON_FEEDBACK_WEIGHTING_GUIDANCE =
+  'Explicit user corrections and approvals are primary learning signals; inferred success or failure may inform routing but must not override direct human feedback.';
+const LESSON_FEEDBACK_WEIGHTS: Record<
+  LessonFeedbackSignalSource,
+  { readonly weight: number; readonly scoreImpact: number }
+> = {
+  'explicit-user-correction': { weight: 100, scoreImpact: -100 },
+  'explicit-user-approval': { weight: 80, scoreImpact: 80 },
+  'inferred-success': { weight: 25, scoreImpact: 25 },
+  'inferred-failure': { weight: 35, scoreImpact: -35 },
+};
 
 export interface BlockerPatternObservation {
   readonly taskId: TaskId;
@@ -222,6 +236,52 @@ export interface RepeatedFailureQuarantineRequest {
 }
 
 export type LessonUnquarantineRequest = LessonUnquarantineMetadata;
+
+export interface LessonHumanFeedbackRequest {
+  readonly source: 'explicit-user-correction' | 'explicit-user-approval';
+  readonly reason: string;
+  readonly observedAt: string;
+  readonly evidence: readonly LessonQuarantineEvidence[];
+  /** Optional replacement wording when a correction should immediately revise the learned guidance. */
+  readonly revisedCorrectionApplied?: string;
+}
+
+export function applyHumanFeedbackToLesson(
+  lesson: CritiqueLesson,
+  request: LessonHumanFeedbackRequest,
+): CritiqueLesson {
+  const feedbackWeighting = createLessonFeedbackWeighting([
+    ...(lesson.feedbackWeighting?.weights ?? []),
+    createLessonFeedbackWeight(
+      request.source,
+      normalizeTimestamp(request.observedAt),
+      request.reason,
+    ),
+  ]);
+
+  if (request.source === 'explicit-user-correction') {
+    const revisedLesson = request.revisedCorrectionApplied
+      ? { ...lesson, correctionApplied: request.revisedCorrectionApplied }
+      : lesson;
+    return {
+      ...quarantineLesson(revisedLesson, {
+        trigger: 'explicit-user-correction',
+        reason: request.reason,
+        evidence: request.evidence,
+        quarantinedAt: request.observedAt,
+      }),
+      feedbackWeighting,
+    };
+  }
+
+  const { experimentSandbox, ...lessonWithoutSandbox } = lesson;
+  void experimentSandbox;
+  return {
+    ...lessonWithoutSandbox,
+    lifecycleStatus: 'active',
+    feedbackWeighting,
+  };
+}
 
 export function isLessonApplicable(lesson: CritiqueLesson): boolean {
   if (lesson.quarantine !== undefined) {
@@ -644,6 +704,18 @@ export class LessonRecorder {
                 ),
               }
             : {}),
+          feedbackWeighting: createLessonFeedbackWeighting([
+            createLessonFeedbackWeight(
+              'inferred-failure',
+              recordedAt,
+              'A critique evaluator failed before the lesson was extracted.',
+            ),
+            createLessonFeedbackWeight(
+              'inferred-success',
+              recordedAt,
+              'A later critique iteration passed or warned after applying the correction.',
+            ),
+          ]),
           cooldown: {
             key: cooldownKey,
             windowMs: this.cooldownMs,
@@ -1087,6 +1159,57 @@ function addLessonBacklogItems(
   sortLearningBacklogItems(target);
 }
 
+function createLessonFeedbackWeight(
+  source: LessonFeedbackSignalSource,
+  observedAt: string,
+  rationale: string,
+): LessonFeedbackWeight {
+  const configured = LESSON_FEEDBACK_WEIGHTS[source];
+  return {
+    source,
+    weight: configured.weight,
+    scoreImpact: configured.scoreImpact,
+    observedAt,
+    rationale,
+  };
+}
+
+function createLessonFeedbackWeighting(
+  weights: readonly LessonFeedbackWeight[],
+): LessonFeedbackWeighting {
+  const deduped = new Map<LessonFeedbackSignalSource, LessonFeedbackWeight>();
+  for (const weight of weights) {
+    deduped.set(weight.source, weight);
+  }
+  const sortedWeights = [...deduped.values()].sort(
+    (left, right) => right.weight - left.weight || left.source.localeCompare(right.source),
+  );
+  const primarySource = sortedWeights[0]?.source ?? 'inferred-success';
+  return {
+    schemaVersion: 'lesson-feedback-weighting-v1',
+    primarySource,
+    totalScore: sortedWeights.reduce(
+      (total, weight) => total + weight.scoreImpact,
+      0,
+    ),
+    weights: sortedWeights,
+    guidance: LESSON_FEEDBACK_WEIGHTING_GUIDANCE,
+  };
+}
+
+function summarizeFeedbackSources(
+  feedbackWeighting: LessonFeedbackWeighting,
+): readonly Pick<
+  LessonFeedbackWeight,
+  'source' | 'weight' | 'scoreImpact'
+>[] {
+  return feedbackWeighting.weights.map(({ source, weight, scoreImpact }) => ({
+    source,
+    weight,
+    scoreImpact,
+  }));
+}
+
 function createRecordedLessonBacklogItem(
   lesson: CritiqueLesson,
 ): LearningBacklogPrioritizationItem {
@@ -1098,16 +1221,27 @@ function createRecordedLessonBacklogItem(
     ) === true;
   const suggestionsIncomplete =
     lesson.reviewerFeedback?.suggestionsComplete === false;
-  const priority = hasCriticalFindings
+  const primaryFeedbackSource = lesson.feedbackWeighting?.primarySource;
+  const hasExplicitCorrection = primaryFeedbackSource === 'explicit-user-correction';
+  const hasExplicitApproval = primaryFeedbackSource === 'explicit-user-approval';
+  const priority = hasExplicitCorrection || hasExplicitApproval || hasCriticalFindings
     ? 'high'
     : suggestionsIncomplete
       ? 'medium'
       : 'low';
-  const score = priority === 'high' ? 80 : priority === 'medium' ? 50 : 30;
+  const score = hasExplicitCorrection
+    ? 120
+    : hasExplicitApproval
+      ? 90
+      : priority === 'high'
+        ? 80
+        : priority === 'medium'
+          ? 50
+          : 30;
   const title = lesson.reviewerFeedback?.summary ?? lesson.failureDescription;
   const traceabilityId = lesson.testTraceability?.[0]?.lessonId;
 
-  return {
+  const item: LearningBacklogPrioritizationItem = {
     id: `lesson:${traceabilityId ?? stableHash(`${lesson.taskId}:${lesson.evaluatorName}:${lesson.failureDescription}`)}`,
     source: 'recorded-lesson',
     priority,
@@ -1115,14 +1249,25 @@ function createRecordedLessonBacklogItem(
     taskId: lesson.taskId,
     evaluatorName: lesson.evaluatorName,
     title,
-    rationale: hasCriticalFindings
-      ? 'Recorded lesson contains critical findings and should be reviewed before routine learning cleanup.'
-      : suggestionsIncomplete
-        ? 'Recorded lesson is missing reviewer suggestions and needs PM follow-up before promotion.'
-        : 'Recorded lesson is ready for routine learning backlog review once verification evidence is attached.',
+    rationale: hasExplicitCorrection
+      ? 'Explicit user correction overrides inferred success and requires immediate quarantine or revision review.'
+      : hasExplicitApproval
+        ? 'Explicit user approval carries primary weight and boosts this lesson ahead of inferred learning signals.'
+        : hasCriticalFindings
+          ? 'Recorded lesson contains critical findings and should be reviewed before routine learning cleanup.'
+          : suggestionsIncomplete
+            ? 'Recorded lesson is missing reviewer suggestions and needs PM follow-up before promotion.'
+            : 'Recorded lesson is ready for routine learning backlog review once verification evidence is attached.',
     recommendedAction:
       'Route this lesson through promotion review with its traceability verifier before adding it to durable guidance.',
   };
+  if (lesson.feedbackWeighting) {
+    return {
+      ...item,
+      feedbackSources: summarizeFeedbackSources(lesson.feedbackWeighting),
+    };
+  }
+  return item;
 }
 
 function createCooldownSuppressionBacklogItem(

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -250,30 +250,41 @@ export function applyHumanFeedbackToLesson(
   lesson: CritiqueLesson,
   request: LessonHumanFeedbackRequest,
 ): CritiqueLesson {
+  const observedAt = normalizeTimestamp(request.observedAt);
+  const feedbackEvidence = request.evidence.map(normalizeQuarantineEvidence);
+  const revisedCorrectionApplied =
+    request.revisedCorrectionApplied !== undefined
+      ? requireNonEmptyString(
+          request.revisedCorrectionApplied,
+          'revised correctionApplied',
+        )
+      : undefined;
   const feedbackWeighting = createLessonFeedbackWeighting([
     ...(lesson.feedbackWeighting?.weights ?? []),
     createLessonFeedbackWeight(
       request.source,
-      normalizeTimestamp(request.observedAt),
+      observedAt,
       request.reason,
+      feedbackEvidence,
     ),
   ]);
 
   if (request.source === 'explicit-user-correction') {
-    const revisedLesson = request.revisedCorrectionApplied
+    const revisedLesson = revisedCorrectionApplied
       ? {
           ...lesson,
-          correctionApplied: request.revisedCorrectionApplied,
+          correctionApplied: revisedCorrectionApplied,
+          lifecycleStatus: 'candidate' as const,
         }
       : lesson;
     const quarantinedLesson = quarantineLesson(revisedLesson, {
       trigger: 'explicit-user-correction',
       reason: request.reason,
-      evidence: request.evidence,
-      quarantinedAt: request.observedAt,
+      evidence: feedbackEvidence,
+      quarantinedAt: observedAt,
     });
     return {
-      ...(request.revisedCorrectionApplied
+      ...(revisedCorrectionApplied
         ? removeStaleLessonValidation(quarantinedLesson)
         : quarantinedLesson),
       feedbackWeighting,
@@ -285,13 +296,12 @@ export function applyHumanFeedbackToLesson(
       'Explicit lesson approval requires at least one evidence item.',
     );
   }
-  const approvalEvidence = request.evidence.map(normalizeQuarantineEvidence);
-  if (approvalEvidence.length === 0) {
+  if (feedbackEvidence.length === 0) {
     throw new RangeError(
       'Explicit lesson approval requires at least one evidence item.',
     );
   }
-  const primaryApprovalEvidence = approvalEvidence[0];
+  const primaryApprovalEvidence = feedbackEvidence[0];
   if (primaryApprovalEvidence === undefined) {
     throw new RangeError(
       'Explicit lesson approval requires at least one evidence item.',
@@ -300,7 +310,7 @@ export function applyHumanFeedbackToLesson(
   if (lesson.lifecycleStatus === 'quarantined' && lesson.quarantine !== undefined) {
     return {
       ...unquarantineLesson(lesson, {
-        reviewedAt: request.observedAt,
+        reviewedAt: observedAt,
         reviewer: request.source,
         evidenceUrl: primaryApprovalEvidence.reference,
         reason: request.reason,
@@ -308,10 +318,17 @@ export function applyHumanFeedbackToLesson(
       feedbackWeighting,
     };
   }
+  const shouldActivateApprovedLesson =
+    lesson.lifecycleStatus === undefined ||
+    lesson.lifecycleStatus === 'active' ||
+    lesson.lifecycleStatus === 'candidate';
+  const { experimentSandbox, ...lessonWithoutSandbox } = lesson;
+  void experimentSandbox;
   return {
-    ...lesson,
-    lifecycleStatus:
-      lesson.lifecycleStatus === undefined ? 'active' : lesson.lifecycleStatus,
+    ...(lesson.lifecycleStatus === 'candidate' ? lessonWithoutSandbox : lesson),
+    lifecycleStatus: shouldActivateApprovedLesson
+      ? 'active'
+      : lesson.lifecycleStatus,
     feedbackWeighting,
   };
 }
@@ -1204,6 +1221,7 @@ function createLessonFeedbackWeight(
   source: LessonFeedbackSignalSource,
   observedAt: string,
   rationale: string,
+  evidence: readonly LessonQuarantineEvidence[] = [],
 ): LessonFeedbackWeight {
   const configured = LESSON_FEEDBACK_WEIGHTS[source];
   return {
@@ -1212,6 +1230,7 @@ function createLessonFeedbackWeight(
     scoreImpact: configured.scoreImpact,
     observedAt,
     rationale,
+    ...(evidence.length > 0 ? { evidence } : {}),
   };
 }
 

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -282,12 +282,24 @@ export function applyHumanFeedbackToLesson(
       'Explicit lesson approval requires at least one evidence item.',
     );
   }
-  const { experimentSandbox, quarantine, ...lessonWithoutBlocks } = lesson;
-  void experimentSandbox;
-  void quarantine;
+  const approvalEvidence = request.evidence.map(normalizeQuarantineEvidence);
+  if (approvalEvidence.length === 0) {
+    throw new RangeError(
+      'Explicit lesson approval requires at least one evidence item.',
+    );
+  }
+  const { quarantine, ...lessonWithoutQuarantine } = lesson;
+  const restoredLifecycleStatus =
+    quarantine?.previousLifecycleStatus ??
+    (lesson.lifecycleStatus === 'quarantined'
+      ? 'candidate'
+      : lesson.lifecycleStatus);
+  const lifecycleStatus = lesson.experimentSandbox?.promotionBlocked
+    ? (restoredLifecycleStatus ?? 'candidate')
+    : 'active';
   return {
-    ...lessonWithoutBlocks,
-    lifecycleStatus: 'active',
+    ...lessonWithoutQuarantine,
+    lifecycleStatus,
     feedbackWeighting,
   };
 }
@@ -1201,7 +1213,7 @@ function createLessonFeedbackWeighting(
   const sortedWeights = [...deduped.values()].sort(
     (left, right) => right.weight - left.weight || left.source.localeCompare(right.source),
   );
-  const primarySource = sortedWeights[0]?.source ?? 'inferred-success';
+  const primarySource = selectPrimaryFeedbackSource(sortedWeights);
   return {
     schemaVersion: 'lesson-feedback-weighting-v1',
     primarySource,
@@ -1212,6 +1224,22 @@ function createLessonFeedbackWeighting(
     weights: sortedWeights,
     guidance: LESSON_FEEDBACK_WEIGHTING_GUIDANCE,
   };
+}
+
+function selectPrimaryFeedbackSource(
+  weights: readonly LessonFeedbackWeight[],
+): LessonFeedbackSignalSource {
+  const explicitSignals = weights.filter(
+    (weight) =>
+      weight.source === 'explicit-user-correction' ||
+      weight.source === 'explicit-user-approval',
+  );
+  const latestExplicitSignal = explicitSignals.sort(
+    (left, right) =>
+      Date.parse(right.observedAt) - Date.parse(left.observedAt) ||
+      right.weight - left.weight,
+  )[0];
+  return latestExplicitSignal?.source ?? weights[0]?.source ?? 'inferred-success';
 }
 
 function summarizeFeedbackSources(

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -180,6 +180,8 @@ export interface LessonFeedbackWeight {
   readonly scoreImpact: number;
   readonly observedAt: string;
   readonly rationale: string;
+  /** Optional audit evidence for explicit human feedback signals. */
+  readonly evidence?: readonly LessonQuarantineEvidence[];
 }
 
 /** Score model that explains which feedback sources influenced a lesson decision. */

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -164,6 +164,33 @@ export interface LessonUnquarantineMetadata {
   readonly reason: string;
 }
 
+/** Source classes used to weight lesson promotion, demotion, and quarantine decisions. */
+export type LessonFeedbackSignalSource =
+  | 'explicit-user-correction'
+  | 'explicit-user-approval'
+  | 'inferred-success'
+  | 'inferred-failure';
+
+/** One normalized feedback signal and its decision weight. */
+export interface LessonFeedbackWeight {
+  readonly source: LessonFeedbackSignalSource;
+  /** Relative importance of this source; explicit human signals are intentionally higher than inferred ones. */
+  readonly weight: number;
+  /** Signed contribution to the lesson score. Corrections/failures demote; approvals/successes promote. */
+  readonly scoreImpact: number;
+  readonly observedAt: string;
+  readonly rationale: string;
+}
+
+/** Score model that explains which feedback sources influenced a lesson decision. */
+export interface LessonFeedbackWeighting {
+  readonly schemaVersion: 'lesson-feedback-weighting-v1';
+  readonly primarySource: LessonFeedbackSignalSource;
+  readonly totalScore: number;
+  readonly weights: readonly LessonFeedbackWeight[];
+  readonly guidance: string;
+}
+
 /** A normalized reviewer finding captured alongside a learned critique lesson. */
 export interface ReviewerFeedbackLessonEntry {
   /** Iteration where the reviewer feedback was emitted. */
@@ -308,6 +335,11 @@ export interface LearningBacklogPrioritizationItem {
   readonly title: string;
   /** Why this item received its priority. */
   readonly rationale: string;
+  /** Feedback sources and weights that influenced this routing decision. */
+  readonly feedbackSources?: readonly Pick<
+    LessonFeedbackWeight,
+    'source' | 'weight' | 'scoreImpact'
+  >[];
   /** Next action PM/liveness tooling should present. */
   readonly recommendedAction: string;
 }
@@ -395,6 +427,8 @@ export interface CritiqueLesson {
   readonly blockerPatterns?: readonly CrossTaskBlockerPattern[];
   /** Optional per-agent learning scorecard for worker retrospectives and PM handoffs. */
   readonly agentImprovementScorecard?: AgentImprovementScorecard;
+  /** Human/inferred feedback weighting used for promotion, demotion, retirement, and quarantine decisions. */
+  readonly feedbackWeighting?: LessonFeedbackWeighting;
 }
 
 /** Escalation request sent to MOD-07 (Governor). */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -838,6 +838,34 @@ describe('LessonRecorder', () => {
     ).toThrow('Lesson quarantine evidence reference must be a non-empty string.');
     expect(() =>
       applyHumanFeedbackToLesson(lesson, {
+        source: 'explicit-user-approval',
+        reason: '   ',
+        observedAt: '2026-07-12T01:36:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#blank-reason',
+          },
+        ],
+      }),
+    ).toThrow('Lesson feedback reason must be a non-empty string.');
+    expect(() =>
+      applyHumanFeedbackToLesson(lesson, {
+        source: 'inferred-success' as never,
+        reason: 'Runtime input must not promote inferred signals.',
+        observedAt: '2026-07-12T01:37:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#inferred-runtime',
+          },
+        ],
+      }),
+    ).toThrow(
+      'Lesson human feedback approval requires explicit-user-approval source.',
+    );
+    expect(() =>
+      applyHumanFeedbackToLesson(lesson, {
         source: 'explicit-user-correction',
         reason: 'Blank revised guidance must not replace a lesson.',
         observedAt: '2026-07-12T01:40:00.000Z',
@@ -981,6 +1009,49 @@ describe('LessonRecorder', () => {
       'https://github.com/djm204/frankenbeast/issues/1763#legacy',
     );
     expect(isLessonApplicable(approvedLegacy)).toBe(true);
+
+    const legacySandboxedActiveQuarantine = quarantineLesson(
+      {
+        ...lesson,
+        lifecycleStatus: 'active',
+        experimentSandbox: {
+          state: 'experimental',
+          promotionBlocked: true,
+          requiredChecks: [],
+          promotionCriteria:
+            'Require independent verification before allowing lesson reuse.',
+        },
+      },
+      {
+        trigger: 'explicit-user-correction',
+        reason: 'Legacy active sandboxed lesson was quarantined for review.',
+        quarantinedAt: '2026-07-12T02:45:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-quarantine',
+          },
+        ],
+      },
+    );
+    const approvedLegacySandboxedQuarantine = applyHumanFeedbackToLesson(
+      legacySandboxedActiveQuarantine,
+      {
+        source: 'explicit-user-approval',
+        reason: 'User approved restoring this legacy active sandboxed lesson.',
+        observedAt: '2026-07-12T03:10:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-approval',
+          },
+        ],
+      },
+    );
+    expect(approvedLegacySandboxedQuarantine.lifecycleStatus).toBe('active');
+    expect(approvedLegacySandboxedQuarantine.quarantine).toBeUndefined();
+    expect(approvedLegacySandboxedQuarantine.experimentSandbox).toBeUndefined();
+    expect(isLessonApplicable(approvedLegacySandboxedQuarantine)).toBe(true);
 
     const approvedRetired = applyHumanFeedbackToLesson(
       { ...lesson, lifecycleStatus: 'retired', experimentSandbox: undefined },

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -875,6 +875,24 @@ describe('LessonRecorder', () => {
     });
     expect(isLessonApplicable(directlyApproved)).toBe(true);
 
+    const approvedLegacySandboxed = applyHumanFeedbackToLesson(
+      { ...lesson, lifecycleStatus: 'active' },
+      {
+        source: 'explicit-user-approval',
+        reason: 'User approved legacy active sandboxed guidance.',
+        observedAt: '2026-07-12T01:43:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandbox',
+          },
+        ],
+      },
+    );
+    expect(approvedLegacySandboxed.lifecycleStatus).toBe('active');
+    expect(approvedLegacySandboxed.experimentSandbox).toBeUndefined();
+    expect(isLessonApplicable(approvedLegacySandboxed)).toBe(true);
+
     const approvedAfterCorrection = applyHumanFeedbackToLesson(corrected, {
       source: 'explicit-user-approval',
       reason: 'User approved the revised lesson after reviewing correction evidence.',

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -800,6 +800,8 @@ describe('LessonRecorder', () => {
     expect(corrected.correctionApplied).toBe(
       'Require explicit human validation before promoting inferred learning signals.',
     );
+    expect(corrected.contradictionReport).toBeUndefined();
+    expect(corrected.testTraceability).toBeUndefined();
     expect(corrected.feedbackWeighting).toMatchObject({
       primarySource: 'explicit-user-correction',
       totalScore: -110,
@@ -815,7 +817,27 @@ describe('LessonRecorder', () => {
     });
     expect(isLessonApplicable(corrected)).toBe(false);
 
-    const approved = applyHumanFeedbackToLesson(lesson, {
+    expect(() =>
+      applyHumanFeedbackToLesson(lesson, {
+        source: 'explicit-user-approval',
+        reason: 'Missing audit evidence must not promote a lesson.',
+        observedAt: '2026-07-12T01:30:00.000Z',
+        evidence: [],
+      }),
+    ).toThrow('Explicit lesson approval requires at least one evidence item.');
+
+    const quarantinedCandidate = quarantineLesson(lesson, {
+      trigger: 'repeated-failure-threshold',
+      reason: 'Repeated failures paused this candidate before explicit approval.',
+      quarantinedAt: '2026-07-12T01:45:00.000Z',
+      evidence: [
+        {
+          kind: 'failed-regression',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763',
+        },
+      ],
+    });
+    const approved = applyHumanFeedbackToLesson(quarantinedCandidate, {
       source: 'explicit-user-approval',
       reason: 'User approved this lesson for reuse after reviewing the evidence.',
       observedAt: '2026-07-12T02:00:00.000Z',

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -802,6 +802,9 @@ describe('LessonRecorder', () => {
     );
     expect(corrected.contradictionReport).toBeUndefined();
     expect(corrected.testTraceability).toBeUndefined();
+    expect(corrected.quarantine?.reviewItem.lessonId).toBe(
+      lesson.testTraceability?.[0]?.lessonId,
+    );
     expect(corrected.feedbackWeighting).toMatchObject({
       primarySource: 'explicit-user-correction',
       totalScore: -110,
@@ -850,6 +853,10 @@ describe('LessonRecorder', () => {
       totalScore: -30,
     });
     expect(approvedAfterCorrection.quarantine).toBeUndefined();
+    expect(approvedAfterCorrection.unquarantine).toMatchObject({
+      reviewer: 'explicit-user-approval',
+      evidenceUrl: 'https://github.com/djm204/frankenbeast/issues/1763',
+    });
     expect(approvedAfterCorrection.lifecycleStatus).toBe('candidate');
     expect(isLessonApplicable(approvedAfterCorrection)).toBe(false);
 
@@ -883,6 +890,58 @@ describe('LessonRecorder', () => {
       totalScore: 70,
     });
     expect(isLessonApplicable(approved)).toBe(false);
+
+    const legacyActiveQuarantine = quarantineLesson(
+      {
+        ...lesson,
+        lifecycleStatus: undefined,
+        experimentSandbox: undefined,
+      },
+      {
+        trigger: 'explicit-user-correction',
+        reason: 'Legacy quarantine before lifecycle metadata existed.',
+        quarantinedAt: '2026-07-12T02:30:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763',
+          },
+        ],
+      },
+    );
+    const approvedLegacy = applyHumanFeedbackToLesson(legacyActiveQuarantine, {
+      source: 'explicit-user-approval',
+      reason: 'User approved this legacy active lesson after evidence review.',
+      observedAt: '2026-07-12T03:00:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy',
+        },
+      ],
+    });
+    expect(approvedLegacy.lifecycleStatus).toBe('active');
+    expect(approvedLegacy.unquarantine?.evidenceUrl).toBe(
+      'https://github.com/djm204/frankenbeast/issues/1763#legacy',
+    );
+    expect(isLessonApplicable(approvedLegacy)).toBe(true);
+
+    const approvedRetired = applyHumanFeedbackToLesson(
+      { ...lesson, lifecycleStatus: 'retired', experimentSandbox: undefined },
+      {
+        source: 'explicit-user-approval',
+        reason: 'User acknowledged retired guidance for audit history only.',
+        observedAt: '2026-07-12T03:30:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#retired',
+          },
+        ],
+      },
+    );
+    expect(approvedRetired.lifecycleStatus).toBe('retired');
+    expect(isLessonApplicable(approvedRetired)).toBe(false);
   });
 
   it('prioritizes suppressed duplicate learning items as low-risk reuse follow-up', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -825,6 +825,33 @@ describe('LessonRecorder', () => {
         evidence: [],
       }),
     ).toThrow('Explicit lesson approval requires at least one evidence item.');
+    expect(() =>
+      applyHumanFeedbackToLesson(lesson, {
+        source: 'explicit-user-approval',
+        reason: 'Blank audit evidence must not promote a lesson.',
+        observedAt: '2026-07-12T01:35:00.000Z',
+        evidence: [{ kind: 'operator-report', reference: '   ' }],
+      }),
+    ).toThrow('Lesson quarantine evidence reference must be a non-empty string.');
+
+    const approvedAfterCorrection = applyHumanFeedbackToLesson(corrected, {
+      source: 'explicit-user-approval',
+      reason: 'User approved the revised lesson after reviewing correction evidence.',
+      observedAt: '2026-07-12T01:45:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763',
+        },
+      ],
+    });
+    expect(approvedAfterCorrection.feedbackWeighting).toMatchObject({
+      primarySource: 'explicit-user-approval',
+      totalScore: -30,
+    });
+    expect(approvedAfterCorrection.quarantine).toBeUndefined();
+    expect(approvedAfterCorrection.lifecycleStatus).toBe('candidate');
+    expect(isLessonApplicable(approvedAfterCorrection)).toBe(false);
 
     const quarantinedCandidate = quarantineLesson(lesson, {
       trigger: 'repeated-failure-threshold',
@@ -849,13 +876,13 @@ describe('LessonRecorder', () => {
       ],
     });
 
-    expect(approved.lifecycleStatus).toBe('active');
-    expect(approved.experimentSandbox).toBeUndefined();
+    expect(approved.lifecycleStatus).toBe('candidate');
+    expect(approved.experimentSandbox).toBeDefined();
     expect(approved.feedbackWeighting).toMatchObject({
       primarySource: 'explicit-user-approval',
       totalScore: 70,
     });
-    expect(isLessonApplicable(approved)).toBe(true);
+    expect(isLessonApplicable(approved)).toBe(false);
   });
 
   it('prioritizes suppressed duplicate learning items as low-risk reuse follow-up', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -836,6 +836,44 @@ describe('LessonRecorder', () => {
         evidence: [{ kind: 'operator-report', reference: '   ' }],
       }),
     ).toThrow('Lesson quarantine evidence reference must be a non-empty string.');
+    expect(() =>
+      applyHumanFeedbackToLesson(lesson, {
+        source: 'explicit-user-correction',
+        reason: 'Blank revised guidance must not replace a lesson.',
+        observedAt: '2026-07-12T01:40:00.000Z',
+        evidence: [
+          {
+            kind: 'operator-report',
+            reference: 'https://github.com/djm204/frankenbeast/issues/1763#blank',
+          },
+        ],
+        revisedCorrectionApplied: '   ',
+      }),
+    ).toThrow('Lesson revised correctionApplied must be a non-empty string.');
+
+    const directlyApproved = applyHumanFeedbackToLesson(lesson, {
+      source: 'explicit-user-approval',
+      reason: 'User approved this candidate lesson after reviewing evidence.',
+      observedAt: '2026-07-12T01:42:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763#direct',
+        },
+      ],
+    });
+    expect(directlyApproved.lifecycleStatus).toBe('active');
+    expect(directlyApproved.experimentSandbox).toBeUndefined();
+    expect(directlyApproved.feedbackWeighting?.weights[0]).toMatchObject({
+      source: 'explicit-user-approval',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763#direct',
+        },
+      ],
+    });
+    expect(isLessonApplicable(directlyApproved)).toBe(true);
 
     const approvedAfterCorrection = applyHumanFeedbackToLesson(corrected, {
       source: 'explicit-user-approval',

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   LessonRecorder,
+  applyHumanFeedbackToLesson,
   detectLessonContradictions,
   isLessonApplicable,
   quarantineLesson,
@@ -712,6 +713,10 @@ describe('LessonRecorder', () => {
           title: 'Codex blocker was left unresolved',
           rationale:
             'Recorded lesson contains critical findings and should be reviewed before routine learning cleanup.',
+          feedbackSources: [
+            { source: 'inferred-failure', weight: 35, scoreImpact: -35 },
+            { source: 'inferred-success', weight: 25, scoreImpact: 25 },
+          ],
           recommendedAction:
             'Route this lesson through promotion review with its traceability verifier before adding it to durable guidance.',
         },
@@ -728,6 +733,107 @@ describe('LessonRecorder', () => {
         ],
       },
     });
+  });
+
+  it('weights explicit human feedback higher than inferred lesson signals', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      now: (): Date => new Date('2026-07-12T00:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message: 'Lesson inferred too much from a green local test',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const summary = await recorder.record(result, 'feedback-weight-task');
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as CritiqueLesson;
+
+    expect(lesson.feedbackWeighting).toMatchObject({
+      schemaVersion: 'lesson-feedback-weighting-v1',
+      primarySource: 'inferred-failure',
+      totalScore: -10,
+      weights: [
+        expect.objectContaining({
+          source: 'inferred-failure',
+          weight: 35,
+          scoreImpact: -35,
+        }),
+        expect.objectContaining({
+          source: 'inferred-success',
+          weight: 25,
+          scoreImpact: 25,
+        }),
+      ],
+    });
+    expect(summary.learningBacklogPrioritizationReport.items[0]).toMatchObject({
+      score: 50,
+      feedbackSources: [
+        { source: 'inferred-failure', weight: 35, scoreImpact: -35 },
+        { source: 'inferred-success', weight: 25, scoreImpact: 25 },
+      ],
+    });
+
+    const corrected = applyHumanFeedbackToLesson(lesson, {
+      source: 'explicit-user-correction',
+      reason: 'User corrected the lesson after it caused a bad handoff.',
+      observedAt: '2026-07-12T01:00:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763',
+        },
+      ],
+      revisedCorrectionApplied:
+        'Require explicit human validation before promoting inferred learning signals.',
+    });
+
+    expect(corrected.lifecycleStatus).toBe('quarantined');
+    expect(corrected.correctionApplied).toBe(
+      'Require explicit human validation before promoting inferred learning signals.',
+    );
+    expect(corrected.feedbackWeighting).toMatchObject({
+      primarySource: 'explicit-user-correction',
+      totalScore: -110,
+      weights: [
+        expect.objectContaining({
+          source: 'explicit-user-correction',
+          weight: 100,
+          scoreImpact: -100,
+        }),
+        expect.objectContaining({ source: 'inferred-failure' }),
+        expect.objectContaining({ source: 'inferred-success' }),
+      ],
+    });
+    expect(isLessonApplicable(corrected)).toBe(false);
+
+    const approved = applyHumanFeedbackToLesson(lesson, {
+      source: 'explicit-user-approval',
+      reason: 'User approved this lesson for reuse after reviewing the evidence.',
+      observedAt: '2026-07-12T02:00:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference: 'https://github.com/djm204/frankenbeast/issues/1763',
+        },
+      ],
+    });
+
+    expect(approved.lifecycleStatus).toBe('active');
+    expect(approved.experimentSandbox).toBeUndefined();
+    expect(approved.feedbackWeighting).toMatchObject({
+      primarySource: 'explicit-user-approval',
+      totalScore: 70,
+    });
+    expect(isLessonApplicable(approved)).toBe(true);
   });
 
   it('prioritizes suppressed duplicate learning items as low-risk reuse follow-up', async () => {

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -6,6 +6,7 @@ import type {
   CritiqueResult as DeprecatedCritiqueResult,
   LessonRollbackWorkflow,
   AgentImprovementScorecard,
+  LessonFeedbackWeighting,
   SessionId,
 } from '@franken/critique';
 
@@ -68,7 +69,7 @@ describe('public critique type contracts', () => {
     expect(workflow.workflowId).toBe('lesson-rollback-v1');
   });
 
-  it('exports per-agent improvement scorecards from the public barrel', () => {
+  it('exports per-agent improvement scorecards and feedback weighting from the public barrel', () => {
     const scorecard: AgentImprovementScorecard = {
       schemaVersion: 'agent-improvement-scorecard-v1',
       agentId: 'worker-alpha',
@@ -91,5 +92,30 @@ describe('public critique type contracts', () => {
     };
 
     expect(scorecard.schemaVersion).toBe('agent-improvement-scorecard-v1');
+
+    const feedbackWeighting: LessonFeedbackWeighting = {
+      schemaVersion: 'lesson-feedback-weighting-v1',
+      primarySource: 'explicit-user-correction',
+      totalScore: -75,
+      weights: [
+        {
+          source: 'explicit-user-correction',
+          weight: 100,
+          scoreImpact: -100,
+          observedAt: '2026-07-12T01:00:00.000Z',
+          rationale: 'User corrected stale learned guidance.',
+        },
+        {
+          source: 'inferred-success',
+          weight: 25,
+          scoreImpact: 25,
+          observedAt: '2026-07-12T00:00:00.000Z',
+          rationale: 'Lesson was inferred from a passing retry.',
+        },
+      ],
+      guidance: 'human feedback wins over inferred signals',
+    };
+
+    expect(feedbackWeighting.primarySource).toBe('explicit-user-correction');
   });
 });


### PR DESCRIPTION
## Summary
- add explicit lesson feedback weighting for user corrections, user approvals, inferred success, and inferred failure
- add helper to apply human feedback so corrections quarantine/revise lessons and approvals promote candidates
- surface feedback sources and weights in learning backlog prioritization reports and public contracts

## Test Plan
- npm ci
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/critique
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts tests/unit/types/public-contracts.test.ts
- npm run test --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique

Closes #1763