### PR TITLE
feat(security): add dependency vulnerability SLA dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,22 @@ jobs:
           status=$?
           set -e
           node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format human --no-fail-on-sla
-          mv "$state.next" "$state"
+          if [ "$status" -eq 0 ]; then
+            mv "$state.next" "$state"
+          else
+            rm -f "$state.next"
+          fi
           exit "$status"
 
       - name: Save dependency vulnerability SLA state
-        if: always()
+        if: success()
         uses: actions/cache/save@v4
         with:
           path: .cache/dependency-vulnerability-sla-state.json
           key: dependency-vulnerability-sla-${{ github.ref_name }}-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
 
       - name: Dependency vulnerability audit
-        run: npm run audit:dependencies -- --json > "${RUNNER_TEMP}/audit.json" || true
+        run: npm run audit:dependencies -- --json > "${RUNNER_TEMP}/audit.json"
 
       - name: Dependency major-version freshness check
         run: npm run deps:outdated:major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,41 @@ jobs:
           CI_BOOTSTRAP_DRY_RUN: "1"
         run: npm run bootstrap:dry-run
 
+      - name: Restore dependency vulnerability SLA state
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/dependency-vulnerability-sla-state.json
+          key: dependency-vulnerability-sla-${{ github.ref_name }}-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
+          restore-keys: |
+            dependency-vulnerability-sla-${{ github.ref_name }}-${{ hashFiles('package-lock.json') }}-
+            dependency-vulnerability-sla-${{ github.event.repository.default_branch }}-${{ hashFiles('package-lock.json') }}-
+            dependency-vulnerability-sla-${{ github.event.repository.default_branch }}-
+
       - name: Dependency vulnerability SLA dashboard
-        run: npm run deps:vulnerability-sla
+        run: |
+          set -euo pipefail
+          mkdir -p .cache
+          state=.cache/dependency-vulnerability-sla-state.json
+          state_args=()
+          if [ -s "$state" ]; then
+            state_args=(--state "$state")
+          fi
+
+          node scripts/check-package-manager.mjs
+          set +e
+          node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format json > "$state.next"
+          status=$?
+          set -e
+          node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format human --no-fail-on-sla
+          mv "$state.next" "$state"
+          exit "$status"
+
+      - name: Save dependency vulnerability SLA state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/dependency-vulnerability-sla-state.json
+          key: dependency-vulnerability-sla-${{ github.ref_name }}-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
 
       - name: Dependency vulnerability audit
         run: npm run audit:dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
           CI_BOOTSTRAP_DRY_RUN: "1"
         run: npm run bootstrap:dry-run
 
-      - name: Dependency vulnerability audit
-        run: npm run audit:dependencies
-
       - name: Dependency vulnerability SLA dashboard
         run: npm run deps:vulnerability-sla
+
+      - name: Dependency vulnerability audit
+        run: npm run audit:dependencies
 
       - name: Dependency major-version freshness check
         run: npm run deps:outdated:major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
           node scripts/check-package-manager.mjs
           set +e
-          node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format json > "$state.next"
+          node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format json --fail-on-new-critical-high > "$state.next"
           status=$?
           set -e
           node scripts/dependency-vulnerability-sla.mjs "${state_args[@]}" --format human --no-fail-on-sla

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           key: dependency-vulnerability-sla-${{ github.ref_name }}-${{ hashFiles('package-lock.json') }}-${{ github.run_id }}
 
       - name: Dependency vulnerability audit
-        run: npm run audit:dependencies
+        run: npm run audit:dependencies -- --json > "${RUNNER_TEMP}/audit.json" || true
 
       - name: Dependency major-version freshness check
         run: npm run deps:outdated:major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Dependency vulnerability audit
         run: npm run audit:dependencies
 
+      - name: Dependency vulnerability SLA dashboard
+        run: npm run deps:vulnerability-sla
+
       - name: Dependency major-version freshness check
         run: npm run deps:outdated:major
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-      - run: npm run audit:security
+      - name: Security audit snapshot
+        run: npm run audit:security -- --json > "${RUNNER_TEMP}/security-audit.json" || true
 
       - name: Run Docker sandbox build smoke test
         run: npm run test:docker:sandbox

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -129,10 +129,12 @@ jobs:
           node scripts/dependency-vulnerability-sla.mjs \
             --audit-input "$RUNNER_TEMP/audit.json" \
             --format human \
+            --allow-invalid-audit \
             --no-fail-on-sla > "$RUNNER_TEMP/dependency-vulnerability-sla.md"
           node scripts/dependency-vulnerability-sla.mjs \
             --audit-input "$RUNNER_TEMP/audit.json" \
             --format json \
+            --allow-invalid-audit \
             --no-fail-on-sla > "$RUNNER_TEMP/dependency-vulnerability-sla.json"
 
       # ── Persist all raw reports ──────────────────────────────────────────

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -124,6 +124,17 @@ jobs:
           # Reads package-lock.json directly; no install needed.
           npm audit --audit-level=high --json > "$RUNNER_TEMP/audit.json" || true
 
+      - name: Build dependency vulnerability SLA dashboard
+        run: |
+          node scripts/dependency-vulnerability-sla.mjs \
+            --audit-input "$RUNNER_TEMP/audit.json" \
+            --format human \
+            --no-fail-on-sla > "$RUNNER_TEMP/dependency-vulnerability-sla.md"
+          node scripts/dependency-vulnerability-sla.mjs \
+            --audit-input "$RUNNER_TEMP/audit.json" \
+            --format json \
+            --no-fail-on-sla > "$RUNNER_TEMP/dependency-vulnerability-sla.json"
+
       # ── Persist all raw reports ──────────────────────────────────────────
       - name: Upload scan reports
         if: always()
@@ -134,6 +145,8 @@ jobs:
             ${{ runner.temp }}/semgrep.sarif
             ${{ runner.temp }}/gitleaks.sarif
             ${{ runner.temp }}/audit.json
+            ${{ runner.temp }}/dependency-vulnerability-sla.md
+            ${{ runner.temp }}/dependency-vulnerability-sla.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ Frankenbeast is pre-1.0 and evolves quickly. Security fixes are applied to `main
 - Dependabot is configured for npm workspace dependencies and GitHub Actions updates.
 - Keep npm dependencies on the repository-pinned package manager (`packageManager` in `package.json`).
 - Run `npm run audit:dependencies` and `npm run audit:security` before shipping security-sensitive changes.
+- Run `npm run deps:vulnerability-sla` to produce the dependency vulnerability SLA dashboard. The dashboard summarizes npm audit findings by severity, package, ecosystem, vulnerable/fixed version, age, transitive path, and linked issue/PR metadata when provided. Critical findings older than 7 days and high findings older than 30 days are blocking by default; moderate and low findings are retained as triage signals.
 - The CI workflow runs dependency vulnerability checks, major-version freshness checks, and SBOM generation on pull requests.
 - Dependabot must ignore first-party `@franken/*` workspace packages, including security updates, and exclude that scope from every npm update group; release automation owns internal package version changes so registry-driven dependency PRs cannot confuse workspace packages with public packages.
 - The daily deterministic security scan runs Semgrep, Gitleaks, and dependency audit jobs; treat its filed issues as active security work until closed.
@@ -67,6 +68,7 @@ Useful local checks before opening or merging security-sensitive changes:
 ```bash
 npm run audit:dependencies
 npm run audit:security
+npm run deps:vulnerability-sla
 npm run check:dependabot-supply-chain
 npm run lint:security
 ```

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -29,7 +29,16 @@ binary still matches the root `packageManager` pin before `npm audit` runs:
 
 ```bash
 npm run audit:security
+npm run deps:vulnerability-sla
 ```
+
+`deps:vulnerability-sla` turns the current `npm audit` data into a compact
+human-readable dashboard. For automation, run the underlying script with
+`--format json`; both modes include severity, package, ecosystem, vulnerable
+range/fixed version, age, transitive path, and any supplied issue/PR links. CI
+fails only when critical/high findings exceed the default SLA window, while the
+daily deterministic security scan publishes both Markdown and JSON report
+artifacts without failing the scheduled issue reconciliation.
 
 Dependency-update automation is fail-closed for first-party packages: Dependabot
 may update external npm and GitHub Actions dependencies, but it must ignore the

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -35,10 +35,11 @@ npm run deps:vulnerability-sla
 `deps:vulnerability-sla` turns the current `npm audit` data into a compact
 human-readable dashboard. For automation, run the underlying script with
 `--format json`; both modes include severity, package, ecosystem, vulnerable
-range/fixed version, age, transitive path, and any supplied issue/PR links. CI
-fails only when critical/high findings exceed the default SLA window, while the
-daily deterministic security scan publishes both Markdown and JSON report
-artifacts without failing the scheduled issue reconciliation.
+range/fixed version, age, transitive path, and any supplied issue/PR links. The
+SLA dashboard gate fails only when critical/high findings exceed the default SLA
+window; other CI security gates may still fail independently. The daily
+deterministic security scan publishes both Markdown and JSON report artifacts
+without failing the scheduled issue reconciliation.
 
 Dependency-update automation is fail-closed for first-party packages: Dependabot
 may update external npm and GitHub Actions dependencies, but it must ignore the

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "turbo run typecheck",
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",
+    "deps:vulnerability-sla": "node scripts/check-package-manager.mjs && node scripts/dependency-vulnerability-sla.mjs",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
     "dr:worker-push-rollback:dry-run": "node scripts/worker-push-rollback-plan.mjs --dry-run",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "turbo run typecheck",
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",
-    "deps:vulnerability-sla": "node scripts/check-package-manager.mjs && node scripts/dependency-vulnerability-sla.mjs",
+    "deps:vulnerability-sla": "node scripts/check-package-manager.mjs --quiet && node scripts/dependency-vulnerability-sla.mjs",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
     "dr:worker-push-rollback:dry-run": "node scripts/worker-push-rollback-plan.mjs --dry-run",

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 
 const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const packageManager = manifest.packageManager;
+const quiet = process.argv.slice(2).includes('--quiet');
 
 if (typeof packageManager !== 'string') {
   console.error('package.json must declare packageManager, for example "npm@11.5.1".');
@@ -35,4 +36,6 @@ if (actual !== expected) {
   process.exit(1);
 }
 
-console.log(`npm ${actual} matches packageManager ${packageManager}.`);
+if (!quiet) {
+  console.log(`npm ${actual} matches packageManager ${packageManager}.`);
+}

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -28,7 +28,7 @@ const defaultSlaDays = { critical: 7, high: 30, moderate: 90, medium: 90, low: 1
 
 function usage() {
   console.error(
-    `Usage: node scripts/dependency-vulnerability-sla.mjs [--audit-input audit.json] [--state previous-report.json] [--links dependency-links.json] [--format human|json] [--now YYYY-MM-DD] [--fail-on-sla] [--no-fail-on-sla] [--allow-invalid-audit]`,
+    `Usage: node scripts/dependency-vulnerability-sla.mjs [--audit-input audit.json] [--state previous-report.json] [--links dependency-links.json] [--format human|json] [--now YYYY-MM-DD] [--fail-on-sla] [--no-fail-on-sla] [--fail-on-new-critical-high] [--allow-invalid-audit]`,
   );
 }
 
@@ -40,6 +40,7 @@ function parseArgs(argv) {
     format: 'human',
     now: new Date(),
     failOnSla: true,
+    failOnNewCriticalHigh: false,
     allowInvalidAudit: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -74,6 +75,10 @@ function parseArgs(argv) {
     }
     if (arg === '--no-fail-on-sla') {
       args.failOnSla = false;
+      continue;
+    }
+    if (arg === '--fail-on-new-critical-high') {
+      args.failOnNewCriticalHigh = true;
       continue;
     }
     if (arg === '--allow-invalid-audit') {
@@ -220,6 +225,7 @@ function buildStateIndex(statePath) {
     if (typeof finding.key === 'string') index.set(`exact:${finding.key}`, firstSeen);
     if (Array.isArray(finding.advisoryKeys)) {
       for (const advisory of finding.advisoryKeys) {
+        if (typeof advisory === 'string') index.set(`advisory:${finding.package}|${advisory}`, firstSeen);
         if (typeof advisory === 'string') index.set(`advisory:${finding.package}|${finding.severity}|${advisory}`, firstSeen);
       }
     }
@@ -238,12 +244,13 @@ function buildFindingKeys(name, vulnerability, viaObjects, severity) {
 
 function firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now) {
   const exact = stateIndex.get(`exact:${key}`);
-  if (exact) return exact;
+  if (exact) return { firstSeen: exact, isNew: false };
   const priorAdvisoryDates = advisoryKeys
-    .map((advisory) => stateIndex.get(`advisory:${name}|${severity}|${advisory}`))
+    .map((advisory) => stateIndex.get(`advisory:${name}|${advisory}`) ?? stateIndex.get(`advisory:${name}|${severity}|${advisory}`))
     .filter(Boolean)
     .sort();
-  return priorAdvisoryDates[0] ?? now.toISOString().slice(0, 10);
+  if (priorAdvisoryDates[0]) return { firstSeen: priorAdvisoryDates[0], isNew: false };
+  return { firstSeen: now.toISOString().slice(0, 10), isNew: true };
 }
 
 function daysBetween(start, end) {
@@ -285,7 +292,7 @@ export function buildSlaReport(audit, options = {}) {
       : [];
     const severity = normalizeSeverity(vulnerability?.severity);
     const { key, advisoryKeys } = buildFindingKeys(name, vulnerability, viaObjects, severity);
-    const firstSeen = firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now);
+    const { firstSeen, isNew } = firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now);
     const ageDays = daysBetween(firstSeen, now);
     const slaDays = defaultSlaDays[severity] ?? null;
     const overSla = Number.isInteger(slaDays) && Number.isInteger(ageDays) && ageDays > slaDays;
@@ -301,6 +308,7 @@ export function buildSlaReport(audit, options = {}) {
       fixedVersion: advisoryFixedVersion(name, vulnerability),
       ageDays,
       firstSeen,
+      isNew,
       slaDays,
       overSla,
       fixAvailable,
@@ -397,5 +405,10 @@ if (args.format === 'json') {
 const blocking = report.findings.filter((finding) => finding.overSla && ['critical', 'high'].includes(finding.severity));
 if (args.failOnSla && blocking.length > 0) {
   console.error(`Dependency vulnerability SLA exceeded for ${blocking.length} critical/high finding(s): ${blocking.map((finding) => finding.package).join(', ')}`);
+  process.exit(1);
+}
+const newBlocking = report.findings.filter((finding) => finding.isNew && ['critical', 'high'].includes(finding.severity));
+if (args.failOnNewCriticalHigh && newBlocking.length > 0) {
+  console.error(`New critical/high dependency vulnerability finding(s): ${newBlocking.map((finding) => finding.package).join(', ')}`);
   process.exit(1);
 }

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -198,6 +198,12 @@ function buildLinkIndex(linksPath) {
   return index;
 }
 
+function advisoryKey(via) {
+  if (!via || typeof via !== 'object') return null;
+  const value = via.url ?? via.source ?? via.name ?? via.title ?? via.range ?? null;
+  return value == null ? null : String(value);
+}
+
 function buildStateIndex(statePath) {
   if (!statePath) return new Map();
   if (!existsSync(resolve(repoRoot, statePath))) {
@@ -209,23 +215,35 @@ function buildStateIndex(statePath) {
   const index = new Map();
   if (!Array.isArray(findings)) return index;
   for (const finding of findings) {
-    if (!finding || typeof finding !== 'object') continue;
-    const key = finding.key;
-    if (typeof key === 'string' && typeof finding.firstSeen === 'string') {
-      index.set(key, finding.firstSeen.slice(0, 10));
+    if (!finding || typeof finding !== 'object' || typeof finding.firstSeen !== 'string') continue;
+    const firstSeen = finding.firstSeen.slice(0, 10);
+    if (typeof finding.key === 'string') index.set(`exact:${finding.key}`, firstSeen);
+    if (Array.isArray(finding.advisoryKeys)) {
+      for (const advisory of finding.advisoryKeys) {
+        if (typeof advisory === 'string') index.set(`advisory:${finding.package}|${finding.severity}|${advisory}`, firstSeen);
+      }
     }
   }
   return index;
 }
 
+function buildFindingKeys(name, vulnerability, viaObjects, severity) {
+  const advisoryKeys = viaObjects.map(advisoryKey).filter(Boolean).sort();
+  const advisoryPart = advisoryKeys.join(',') || 'no-advisory';
+  return {
+    key: [name, severity, vulnerability?.range ?? 'unknown-range', advisoryPart].join('|'),
+    advisoryKeys,
+  };
+}
 
-function buildFindingKey(name, vulnerability, viaObjects, severity) {
-  const advisoryKeys = viaObjects
-    .map((via) => via.url ?? via.source ?? via.name ?? via.title ?? via.range ?? '')
+function firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now) {
+  const exact = stateIndex.get(`exact:${key}`);
+  if (exact) return exact;
+  const priorAdvisoryDates = advisoryKeys
+    .map((advisory) => stateIndex.get(`advisory:${name}|${severity}|${advisory}`))
     .filter(Boolean)
-    .sort()
-    .join(',');
-  return [name, severity, vulnerability?.range ?? 'unknown-range', advisoryKeys || 'no-advisory'].join('|');
+    .sort();
+  return priorAdvisoryDates[0] ?? now.toISOString().slice(0, 10);
 }
 
 function daysBetween(start, end) {
@@ -238,10 +256,13 @@ function advisoryTitle(via) {
   return via.title ?? via.name ?? via.source ?? null;
 }
 
-function advisoryFixedVersion(vulnerability) {
+function advisoryFixedVersion(name, vulnerability) {
   const directFix = vulnerability.fixAvailable;
-  if (directFix && typeof directFix === 'object' && typeof directFix.version === 'string') return directFix.version;
-  return null;
+  if (!directFix || typeof directFix !== 'object' || typeof directFix.version !== 'string') return null;
+  if (typeof directFix.name === 'string' && directFix.name && directFix.name !== name) {
+    return `${directFix.name}@${directFix.version}`;
+  }
+  return directFix.version;
 }
 
 function normalizePath(path) {
@@ -263,8 +284,8 @@ export function buildSlaReport(audit, options = {}) {
       ? vulnerability.via.map((entry) => (typeof entry === 'string' ? entry : advisoryTitle(entry))).filter(Boolean)
       : [];
     const severity = normalizeSeverity(vulnerability?.severity);
-    const key = buildFindingKey(name, vulnerability, viaObjects, severity);
-    const firstSeen = stateIndex.get(key) ?? now.toISOString().slice(0, 10);
+    const { key, advisoryKeys } = buildFindingKeys(name, vulnerability, viaObjects, severity);
+    const firstSeen = firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now);
     const ageDays = daysBetween(firstSeen, now);
     const slaDays = defaultSlaDays[severity] ?? null;
     const overSla = Number.isInteger(slaDays) && Number.isInteger(ageDays) && ageDays > slaDays;
@@ -272,11 +293,12 @@ export function buildSlaReport(audit, options = {}) {
     const linked = linkIndex.get(name) ?? {};
     return {
       key,
+      advisoryKeys,
       package: name,
       ecosystem: 'npm',
       severity,
       currentVersion: vulnerability?.range ?? null,
-      fixedVersion: advisoryFixedVersion(vulnerability),
+      fixedVersion: advisoryFixedVersion(name, vulnerability),
       ageDays,
       firstSeen,
       slaDays,

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -6,6 +6,7 @@
  *   node scripts/dependency-vulnerability-sla.mjs [--format human|json]
  *   node scripts/dependency-vulnerability-sla.mjs --audit-input audit.json --format json
  *   node scripts/dependency-vulnerability-sla.mjs --links dependency-links.json --state previous-report.json
+ *   node scripts/dependency-vulnerability-sla.mjs --allow-invalid-audit --audit-input audit.json
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
@@ -26,7 +27,9 @@ const severityRank = new Map([
 const defaultSlaDays = { critical: 7, high: 30, moderate: 90, medium: 90, low: 180 };
 
 function usage() {
-  console.error(`Usage: node scripts/dependency-vulnerability-sla.mjs [--audit-input audit.json] [--state previous-report.json] [--links dependency-links.json] [--format human|json] [--now YYYY-MM-DD] [--fail-on-sla] [--no-fail-on-sla]`);
+  console.error(
+    `Usage: node scripts/dependency-vulnerability-sla.mjs [--audit-input audit.json] [--state previous-report.json] [--links dependency-links.json] [--format human|json] [--now YYYY-MM-DD] [--fail-on-sla] [--no-fail-on-sla] [--allow-invalid-audit]`,
+  );
 }
 
 function parseArgs(argv) {
@@ -37,6 +40,7 @@ function parseArgs(argv) {
     format: 'human',
     now: new Date(),
     failOnSla: true,
+    allowInvalidAudit: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -70,6 +74,10 @@ function parseArgs(argv) {
     }
     if (arg === '--no-fail-on-sla') {
       args.failOnSla = false;
+      continue;
+    }
+    if (arg === '--allow-invalid-audit') {
+      args.allowInvalidAudit = true;
       continue;
     }
     usage();
@@ -118,14 +126,39 @@ function runNpmAudit() {
   }
 }
 
-function readAuditReport(input) {
+function unknownAuditReport(reason) {
+  return {
+    auditStatus: 'unknown',
+    auditError: reason,
+    metadata: null,
+    vulnerabilities: {},
+  };
+}
+
+function readAuditReport(input, options = {}) {
   const raw = input ? readFileSync(resolve(repoRoot, input), 'utf8') : runNpmAudit();
+  let parsed;
   try {
-    return JSON.parse(raw || '{}');
+    parsed = JSON.parse(raw || '{}');
   } catch (error) {
-    console.error(`npm audit report is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    const message = `npm audit report is not valid JSON: ${error instanceof Error ? error.message : String(error)}`;
+    if (options.allowInvalidAudit) return unknownAuditReport(message);
+    console.error(message);
     process.exit(2);
   }
+  const hasAuditShape =
+    parsed &&
+    typeof parsed === 'object' &&
+    Object.hasOwn(parsed, 'metadata') &&
+    Object.hasOwn(parsed, 'vulnerabilities') &&
+    (parsed.vulnerabilities === null || typeof parsed.vulnerabilities === 'object');
+  if (!hasAuditShape) {
+    const message = 'npm audit report does not include metadata and vulnerabilities; treating scan state as unknown.';
+    if (options.allowInvalidAudit) return unknownAuditReport(message);
+    console.error(message);
+    process.exit(2);
+  }
+  return { auditStatus: 'ok', ...parsed };
 }
 
 function normalizeSeverity(severity) {
@@ -191,12 +224,9 @@ function advisoryTitle(via) {
   return via.title ?? via.name ?? via.source ?? null;
 }
 
-function advisoryFixedVersion(vulnerability, viaObjects) {
+function advisoryFixedVersion(vulnerability) {
   const directFix = vulnerability.fixAvailable;
   if (directFix && typeof directFix === 'object' && typeof directFix.version === 'string') return directFix.version;
-  for (const via of viaObjects) {
-    if (via && typeof via === 'object' && typeof via.range === 'string') return `outside ${via.range}`;
-  }
   return null;
 }
 
@@ -210,6 +240,7 @@ export function buildSlaReport(audit, options = {}) {
   const linkIndex = options.linkIndex ?? new Map();
   const stateIndex = options.stateIndex ?? new Map();
   const vulnerabilities = audit?.vulnerabilities && typeof audit.vulnerabilities === 'object' ? audit.vulnerabilities : {};
+  const hasPriorState = stateIndex.size > 0;
   const findings = Object.entries(vulnerabilities).map(([name, vulnerability]) => {
     const viaObjects = Array.isArray(vulnerability?.via)
       ? vulnerability.via.filter((entry) => entry && typeof entry === 'object')
@@ -218,10 +249,10 @@ export function buildSlaReport(audit, options = {}) {
       ? vulnerability.via.map((entry) => (typeof entry === 'string' ? entry : advisoryTitle(entry))).filter(Boolean)
       : [];
     const severity = normalizeSeverity(vulnerability?.severity);
-    const firstSeen = stateIndex.get(name) ?? now.toISOString().slice(0, 10);
-    const ageDays = daysBetween(firstSeen, now);
+    const firstSeen = stateIndex.get(name) ?? null;
+    const ageDays = firstSeen ? daysBetween(firstSeen, now) : null;
     const slaDays = defaultSlaDays[severity] ?? null;
-    const overSla = Number.isInteger(slaDays) && ageDays > slaDays;
+    const overSla = Number.isInteger(slaDays) && Number.isInteger(ageDays) && ageDays > slaDays;
     const fixAvailable = Boolean(vulnerability?.fixAvailable);
     const linked = linkIndex.get(name) ?? {};
     return {
@@ -230,7 +261,7 @@ export function buildSlaReport(audit, options = {}) {
       ecosystem: 'npm',
       severity,
       currentVersion: vulnerability?.range ?? null,
-      fixedVersion: advisoryFixedVersion(vulnerability, viaObjects),
+      fixedVersion: advisoryFixedVersion(vulnerability),
       ageDays,
       firstSeen,
       slaDays,
@@ -266,6 +297,9 @@ export function buildSlaReport(audit, options = {}) {
   return {
     generatedAt: now.toISOString(),
     source: 'npm audit',
+    auditStatus: audit?.auditStatus ?? 'ok',
+    auditError: audit?.auditError ?? null,
+    ageSource: hasPriorState ? 'state' : 'unknown',
     slaDays: defaultSlaDays,
     summary,
     findings,
@@ -282,6 +316,10 @@ function formatHuman(report) {
   lines.push('');
   lines.push(`Generated: ${report.generatedAt}`);
   lines.push(`Total findings: ${report.summary.total}; over SLA: ${report.summary.overSla}; fix available: ${report.summary.fixAvailable}`);
+  if (report.auditStatus !== 'ok') lines.push(`Audit status: unknown (${report.auditError})`);
+  if (report.ageSource === 'unknown' && report.summary.total > 0) {
+    lines.push('Age source: unknown (pass --state with a prior report to calculate SLA age).');
+  }
   lines.push(`Severity counts: ${Object.entries(report.summary.bySeverity).map(([severity, count]) => `${severity}=${count}`).join(', ') || 'none'}`);
   lines.push('');
   if (report.findings.length === 0) {
@@ -293,7 +331,7 @@ function formatHuman(report) {
     finding.severity.toUpperCase(),
     finding.package,
     `${finding.currentVersion ?? '?'} -> ${finding.fixedVersion ?? (finding.fixAvailable ? 'available' : 'not available')}`,
-    `${finding.ageDays}d/${finding.slaDays ?? 'n/a'}${finding.overSla ? ' OVER' : ''}`,
+    `${Number.isInteger(finding.ageDays) ? `${finding.ageDays}d` : 'unknown'}/${finding.slaDays ?? 'n/a'}${finding.overSla ? ' OVER' : ''}`,
     finding.transitivePath,
     [finding.linkedIssue, finding.linkedPr].filter(Boolean).join(' ') || '-',
   ]);
@@ -307,7 +345,7 @@ function formatHuman(report) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const report = buildSlaReport(readAuditReport(args.auditInput), {
+const report = buildSlaReport(readAuditReport(args.auditInput, { allowInvalidAudit: args.allowInvalidAudit }), {
   now: args.now,
   linkIndex: buildLinkIndex(args.links),
   stateIndex: buildStateIndex(args.state),

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -210,12 +210,22 @@ function buildStateIndex(statePath) {
   if (!Array.isArray(findings)) return index;
   for (const finding of findings) {
     if (!finding || typeof finding !== 'object') continue;
-    const key = finding.key ?? finding.package;
+    const key = finding.key;
     if (typeof key === 'string' && typeof finding.firstSeen === 'string') {
       index.set(key, finding.firstSeen.slice(0, 10));
     }
   }
   return index;
+}
+
+
+function buildFindingKey(name, vulnerability, viaObjects, severity) {
+  const advisoryKeys = viaObjects
+    .map((via) => via.url ?? via.source ?? via.name ?? via.title ?? via.range ?? '')
+    .filter(Boolean)
+    .sort()
+    .join(',');
+  return [name, severity, vulnerability?.range ?? 'unknown-range', advisoryKeys || 'no-advisory'].join('|');
 }
 
 function daysBetween(start, end) {
@@ -253,14 +263,15 @@ export function buildSlaReport(audit, options = {}) {
       ? vulnerability.via.map((entry) => (typeof entry === 'string' ? entry : advisoryTitle(entry))).filter(Boolean)
       : [];
     const severity = normalizeSeverity(vulnerability?.severity);
-    const firstSeen = stateIndex.get(name) ?? now.toISOString().slice(0, 10);
+    const key = buildFindingKey(name, vulnerability, viaObjects, severity);
+    const firstSeen = stateIndex.get(key) ?? now.toISOString().slice(0, 10);
     const ageDays = daysBetween(firstSeen, now);
     const slaDays = defaultSlaDays[severity] ?? null;
     const overSla = Number.isInteger(slaDays) && Number.isInteger(ageDays) && ageDays > slaDays;
     const fixAvailable = Boolean(vulnerability?.fixAvailable);
     const linked = linkIndex.get(name) ?? {};
     return {
-      key: name,
+      key,
       package: name,
       ecosystem: 'npm',
       severity,

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -199,7 +199,11 @@ function buildLinkIndex(linksPath) {
 }
 
 function buildStateIndex(statePath) {
-  if (!statePath || !existsSync(resolve(repoRoot, statePath))) return new Map();
+  if (!statePath) return new Map();
+  if (!existsSync(resolve(repoRoot, statePath))) {
+    console.error(`Requested dependency SLA state file does not exist: ${statePath}`);
+    process.exit(2);
+  }
   const parsed = readJsonFile(statePath, 'prior SLA state');
   const findings = Array.isArray(parsed) ? parsed : parsed.findings;
   const index = new Map();
@@ -249,8 +253,8 @@ export function buildSlaReport(audit, options = {}) {
       ? vulnerability.via.map((entry) => (typeof entry === 'string' ? entry : advisoryTitle(entry))).filter(Boolean)
       : [];
     const severity = normalizeSeverity(vulnerability?.severity);
-    const firstSeen = stateIndex.get(name) ?? null;
-    const ageDays = firstSeen ? daysBetween(firstSeen, now) : null;
+    const firstSeen = stateIndex.get(name) ?? now.toISOString().slice(0, 10);
+    const ageDays = daysBetween(firstSeen, now);
     const slaDays = defaultSlaDays[severity] ?? null;
     const overSla = Number.isInteger(slaDays) && Number.isInteger(ageDays) && ageDays > slaDays;
     const fixAvailable = Boolean(vulnerability?.fixAvailable);
@@ -299,7 +303,7 @@ export function buildSlaReport(audit, options = {}) {
     source: 'npm audit',
     auditStatus: audit?.auditStatus ?? 'ok',
     auditError: audit?.auditError ?? null,
-    ageSource: hasPriorState ? 'state' : 'unknown',
+    ageSource: hasPriorState ? 'state' : 'current-run',
     slaDays: defaultSlaDays,
     summary,
     findings,
@@ -317,13 +321,13 @@ function formatHuman(report) {
   lines.push(`Generated: ${report.generatedAt}`);
   lines.push(`Total findings: ${report.summary.total}; over SLA: ${report.summary.overSla}; fix available: ${report.summary.fixAvailable}`);
   if (report.auditStatus !== 'ok') lines.push(`Audit status: unknown (${report.auditError})`);
-  if (report.ageSource === 'unknown' && report.summary.total > 0) {
-    lines.push('Age source: unknown (pass --state with a prior report to calculate SLA age).');
+  if (report.ageSource === 'current-run' && report.summary.total > 0) {
+    lines.push('Age source: current run (persist this JSON report and pass it as --state on future runs to enforce SLA age).');
   }
   lines.push(`Severity counts: ${Object.entries(report.summary.bySeverity).map(([severity, count]) => `${severity}=${count}`).join(', ') || 'none'}`);
   lines.push('');
   if (report.findings.length === 0) {
-    lines.push('No npm audit vulnerabilities found.');
+    lines.push(report.auditStatus === 'ok' ? 'No npm audit vulnerabilities found.' : 'npm audit status is unknown; no vulnerability findings were evaluated.');
     return `${lines.join('\n')}\n`;
   }
   const headers = ['Severity', 'Package', 'Current/fixed', 'Age/SLA', 'Path', 'Issue/PR'];
@@ -331,7 +335,7 @@ function formatHuman(report) {
     finding.severity.toUpperCase(),
     finding.package,
     `${finding.currentVersion ?? '?'} -> ${finding.fixedVersion ?? (finding.fixAvailable ? 'available' : 'not available')}`,
-    `${Number.isInteger(finding.ageDays) ? `${finding.ageDays}d` : 'unknown'}/${finding.slaDays ?? 'n/a'}${finding.overSla ? ' OVER' : ''}`,
+    `${finding.ageDays}d/${finding.slaDays ?? 'n/a'}${finding.overSla ? ' OVER' : ''}`,
     finding.transitivePath,
     [finding.linkedIssue, finding.linkedPr].filter(Boolean).join(' ') || '-',
   ]);

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Build a compact dependency vulnerability SLA report from npm audit JSON.
+ *
+ * Usage:
+ *   node scripts/dependency-vulnerability-sla.mjs [--format human|json]
+ *   node scripts/dependency-vulnerability-sla.mjs --audit-input audit.json --format json
+ *   node scripts/dependency-vulnerability-sla.mjs --links dependency-links.json --state previous-report.json
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const severityRank = new Map([
+  ['critical', 0],
+  ['high', 1],
+  ['moderate', 2],
+  ['medium', 2],
+  ['low', 3],
+  ['info', 4],
+  ['none', 5],
+  ['unknown', 6],
+]);
+const defaultSlaDays = { critical: 7, high: 30, moderate: 90, medium: 90, low: 180 };
+
+function usage() {
+  console.error(`Usage: node scripts/dependency-vulnerability-sla.mjs [--audit-input audit.json] [--state previous-report.json] [--links dependency-links.json] [--format human|json] [--now YYYY-MM-DD] [--fail-on-sla] [--no-fail-on-sla]`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    auditInput: null,
+    state: null,
+    links: null,
+    format: 'human',
+    now: new Date(),
+    failOnSla: true,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--audit-input' && argv[i + 1]) {
+      args.auditInput = argv[++i];
+      continue;
+    }
+    if (arg === '--state' && argv[i + 1]) {
+      args.state = argv[++i];
+      continue;
+    }
+    if (arg === '--links' && argv[i + 1]) {
+      args.links = argv[++i];
+      continue;
+    }
+    if (arg === '--format' && argv[i + 1]) {
+      args.format = argv[++i];
+      if (!['human', 'json'].includes(args.format)) {
+        console.error(`Unsupported format: ${args.format}`);
+        process.exit(2);
+      }
+      continue;
+    }
+    if (arg === '--now' && argv[i + 1]) {
+      args.now = parseDate(argv[++i], '--now');
+      continue;
+    }
+    if (arg === '--fail-on-sla') {
+      args.failOnSla = true;
+      continue;
+    }
+    if (arg === '--no-fail-on-sla') {
+      args.failOnSla = false;
+      continue;
+    }
+    usage();
+    process.exit(2);
+  }
+  return args;
+}
+
+function parseDate(value, label) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}/.test(value)) {
+    console.error(`${label} must start with YYYY-MM-DD`);
+    process.exit(2);
+  }
+  const date = new Date(`${value.slice(0, 10)}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) {
+    console.error(`${label} is not a valid date: ${value}`);
+    process.exit(2);
+  }
+  return date;
+}
+
+function readJsonFile(path, label) {
+  try {
+    return JSON.parse(readFileSync(resolve(repoRoot, path), 'utf8'));
+  } catch (error) {
+    console.error(`Unable to read ${label} JSON at ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
+}
+
+function runNpmAudit() {
+  try {
+    return execFileSync('npm', ['audit', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+  } catch (error) {
+    // npm audit exits non-zero when vulnerabilities exist. Keep stdout if it is valid JSON.
+    if (typeof error === 'object' && error !== null && 'stdout' in error && typeof error.stdout === 'string') {
+      return error.stdout;
+    }
+    console.error(`Unable to run npm audit: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
+}
+
+function readAuditReport(input) {
+  const raw = input ? readFileSync(resolve(repoRoot, input), 'utf8') : runNpmAudit();
+  try {
+    return JSON.parse(raw || '{}');
+  } catch (error) {
+    console.error(`npm audit report is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  }
+}
+
+function normalizeSeverity(severity) {
+  const normalized = String(severity || 'unknown').toLowerCase();
+  return normalized === 'medium' ? 'moderate' : normalized;
+}
+
+function compareSeverity(a, b) {
+  return (severityRank.get(normalizeSeverity(a)) ?? 99) - (severityRank.get(normalizeSeverity(b)) ?? 99);
+}
+
+function normalizeLink(value) {
+  if (!value) return null;
+  if (Number.isInteger(value)) return `#${value}`;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && typeof value.url === 'string') return value.url;
+  if (typeof value === 'object' && Number.isInteger(value.number)) return `#${value.number}`;
+  return null;
+}
+
+function buildLinkIndex(linksPath) {
+  if (!linksPath || !existsSync(resolve(repoRoot, linksPath))) return new Map();
+  const parsed = readJsonFile(linksPath, 'dependency links');
+  const entries = Array.isArray(parsed) ? parsed : parsed.links;
+  const index = new Map();
+  if (!Array.isArray(entries)) {
+    console.error('Dependency links JSON must be an array or { "links": [...] }.');
+    process.exit(2);
+  }
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object' || typeof entry.package !== 'string') continue;
+    index.set(entry.package, {
+      issue: normalizeLink(entry.issue ?? entry.githubIssue),
+      pr: normalizeLink(entry.pr ?? entry.pullRequest),
+    });
+  }
+  return index;
+}
+
+function buildStateIndex(statePath) {
+  if (!statePath || !existsSync(resolve(repoRoot, statePath))) return new Map();
+  const parsed = readJsonFile(statePath, 'prior SLA state');
+  const findings = Array.isArray(parsed) ? parsed : parsed.findings;
+  const index = new Map();
+  if (!Array.isArray(findings)) return index;
+  for (const finding of findings) {
+    if (!finding || typeof finding !== 'object') continue;
+    const key = finding.key ?? finding.package;
+    if (typeof key === 'string' && typeof finding.firstSeen === 'string') {
+      index.set(key, finding.firstSeen.slice(0, 10));
+    }
+  }
+  return index;
+}
+
+function daysBetween(start, end) {
+  const startDate = parseDate(start.slice(0, 10), 'firstSeen');
+  return Math.max(0, Math.floor((end.getTime() - startDate.getTime()) / 86_400_000));
+}
+
+function advisoryTitle(via) {
+  if (!via || typeof via !== 'object') return null;
+  return via.title ?? via.name ?? via.source ?? null;
+}
+
+function advisoryFixedVersion(vulnerability, viaObjects) {
+  const directFix = vulnerability.fixAvailable;
+  if (directFix && typeof directFix === 'object' && typeof directFix.version === 'string') return directFix.version;
+  for (const via of viaObjects) {
+    if (via && typeof via === 'object' && typeof via.range === 'string') return `outside ${via.range}`;
+  }
+  return null;
+}
+
+function normalizePath(path) {
+  if (!Array.isArray(path) || path.length === 0) return '<direct or unknown>';
+  return path.join(' > ');
+}
+
+export function buildSlaReport(audit, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  const linkIndex = options.linkIndex ?? new Map();
+  const stateIndex = options.stateIndex ?? new Map();
+  const vulnerabilities = audit?.vulnerabilities && typeof audit.vulnerabilities === 'object' ? audit.vulnerabilities : {};
+  const findings = Object.entries(vulnerabilities).map(([name, vulnerability]) => {
+    const viaObjects = Array.isArray(vulnerability?.via)
+      ? vulnerability.via.filter((entry) => entry && typeof entry === 'object')
+      : [];
+    const viaNames = Array.isArray(vulnerability?.via)
+      ? vulnerability.via.map((entry) => (typeof entry === 'string' ? entry : advisoryTitle(entry))).filter(Boolean)
+      : [];
+    const severity = normalizeSeverity(vulnerability?.severity);
+    const firstSeen = stateIndex.get(name) ?? now.toISOString().slice(0, 10);
+    const ageDays = daysBetween(firstSeen, now);
+    const slaDays = defaultSlaDays[severity] ?? null;
+    const overSla = Number.isInteger(slaDays) && ageDays > slaDays;
+    const fixAvailable = Boolean(vulnerability?.fixAvailable);
+    const linked = linkIndex.get(name) ?? {};
+    return {
+      key: name,
+      package: name,
+      ecosystem: 'npm',
+      severity,
+      currentVersion: vulnerability?.range ?? null,
+      fixedVersion: advisoryFixedVersion(vulnerability, viaObjects),
+      ageDays,
+      firstSeen,
+      slaDays,
+      overSla,
+      fixAvailable,
+      transitivePath: normalizePath(vulnerability?.nodes),
+      dependencyPath: normalizePath(vulnerability?.effects),
+      linkedIssue: linked.issue ?? null,
+      linkedPr: linked.pr ?? null,
+      advisories: viaObjects.map((via) => ({
+        source: via.source ?? null,
+        name: via.name ?? null,
+        title: via.title ?? null,
+        url: via.url ?? null,
+        range: via.range ?? null,
+        severity: normalizeSeverity(via.severity ?? severity),
+      })),
+      via: viaNames,
+    };
+  }).sort((a, b) => compareSeverity(a.severity, b.severity) || b.ageDays - a.ageDays || a.package.localeCompare(b.package));
+
+  const summary = findings.reduce(
+    (acc, finding) => {
+      acc.total += 1;
+      acc.bySeverity[finding.severity] = (acc.bySeverity[finding.severity] ?? 0) + 1;
+      if (finding.overSla) acc.overSla += 1;
+      if (finding.fixAvailable) acc.fixAvailable += 1;
+      return acc;
+    },
+    { total: 0, overSla: 0, fixAvailable: 0, bySeverity: {} },
+  );
+
+  return {
+    generatedAt: now.toISOString(),
+    source: 'npm audit',
+    slaDays: defaultSlaDays,
+    summary,
+    findings,
+  };
+}
+
+function formatTableRow(cells, widths) {
+  return cells.map((cell, index) => String(cell ?? '').padEnd(widths[index])).join('  ').trimEnd();
+}
+
+function formatHuman(report) {
+  const lines = [];
+  lines.push('# Dependency vulnerability SLA dashboard');
+  lines.push('');
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push(`Total findings: ${report.summary.total}; over SLA: ${report.summary.overSla}; fix available: ${report.summary.fixAvailable}`);
+  lines.push(`Severity counts: ${Object.entries(report.summary.bySeverity).map(([severity, count]) => `${severity}=${count}`).join(', ') || 'none'}`);
+  lines.push('');
+  if (report.findings.length === 0) {
+    lines.push('No npm audit vulnerabilities found.');
+    return `${lines.join('\n')}\n`;
+  }
+  const headers = ['Severity', 'Package', 'Current/fixed', 'Age/SLA', 'Path', 'Issue/PR'];
+  const rows = report.findings.map((finding) => [
+    finding.severity.toUpperCase(),
+    finding.package,
+    `${finding.currentVersion ?? '?'} -> ${finding.fixedVersion ?? (finding.fixAvailable ? 'available' : 'not available')}`,
+    `${finding.ageDays}d/${finding.slaDays ?? 'n/a'}${finding.overSla ? ' OVER' : ''}`,
+    finding.transitivePath,
+    [finding.linkedIssue, finding.linkedPr].filter(Boolean).join(' ') || '-',
+  ]);
+  const widths = headers.map((header, index) => Math.max(header.length, ...rows.map((row) => String(row[index]).length)));
+  lines.push(formatTableRow(headers, widths));
+  lines.push(formatTableRow(headers.map((header) => '-'.repeat(header.length)), widths));
+  for (const row of rows) lines.push(formatTableRow(row, widths));
+  lines.push('');
+  lines.push('SLA policy: critical >7 days and high >30 days are release-blocking by default; moderate >90 and low >180 are warnings/triage signals.');
+  return `${lines.join('\n')}\n`;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const report = buildSlaReport(readAuditReport(args.auditInput), {
+  now: args.now,
+  linkIndex: buildLinkIndex(args.links),
+  stateIndex: buildStateIndex(args.state),
+});
+
+if (args.format === 'json') {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  process.stdout.write(formatHuman(report));
+}
+
+const blocking = report.findings.filter((finding) => finding.overSla && ['critical', 'high'].includes(finding.severity));
+if (args.failOnSla && blocking.length > 0) {
+  console.error(`Dependency vulnerability SLA exceeded for ${blocking.length} critical/high finding(s): ${blocking.map((finding) => finding.package).join(', ')}`);
+  process.exit(1);
+}

--- a/scripts/dependency-vulnerability-sla.mjs
+++ b/scripts/dependency-vulnerability-sla.mjs
@@ -249,7 +249,9 @@ function firstSeenForFinding(stateIndex, name, severity, key, advisoryKeys, now)
     .map((advisory) => stateIndex.get(`advisory:${name}|${advisory}`) ?? stateIndex.get(`advisory:${name}|${severity}|${advisory}`))
     .filter(Boolean)
     .sort();
-  if (priorAdvisoryDates[0]) return { firstSeen: priorAdvisoryDates[0], isNew: false };
+  if (priorAdvisoryDates.length > 0) {
+    return { firstSeen: priorAdvisoryDates[0], isNew: priorAdvisoryDates.length < advisoryKeys.length };
+  }
   return { firstSeen: now.toISOString().slice(0, 10), isNew: true };
 }
 

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -681,6 +681,59 @@ updates:
     expect(result.stderr).toContain("New critical/high dependency vulnerability");
   });
 
+  it("treats added advisories on an existing package finding as new", () => {
+    const state = writeSlaJson(
+      {
+        findings: [
+          {
+            key: "leftpad|high|<2.0.0|https://github.com/advisories/GHSA-leftpad-a",
+            package: "leftpad",
+            severity: "high",
+            advisoryKeys: ["https://github.com/advisories/GHSA-leftpad-a"],
+            firstSeen: "2026-06-01",
+          },
+        ],
+      },
+      "state.json",
+    );
+    const result = runVulnerabilitySlaReport(
+      {
+        metadata: { vulnerabilities: { high: 1, total: 1 } },
+        vulnerabilities: {
+          leftpad: {
+            severity: "high",
+            range: "<2.0.0",
+            nodes: ["node_modules/leftpad"],
+            fixAvailable: false,
+            via: [
+              { url: "https://github.com/advisories/GHSA-leftpad-a" },
+              { url: "https://github.com/advisories/GHSA-leftpad-b" },
+            ],
+          },
+        },
+      },
+      [
+        "--state",
+        state,
+        "--now",
+        "2026-07-15",
+        "--format",
+        "json",
+        "--fail-on-new-critical-high",
+      ],
+    );
+
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout) as {
+      findings: Array<{ ageDays: number; firstSeen: string; isNew: boolean }>;
+    };
+    expect(report.findings[0]).toMatchObject({
+      ageDays: 44,
+      firstSeen: "2026-06-01",
+      isNew: true,
+    });
+  });
+
   it("fails closed when a requested SLA state file is missing", () => {
     const audit = writeSlaJson({
       metadata: { vulnerabilities: { high: 1, total: 1 } },
@@ -743,10 +796,13 @@ updates:
     expect(workflow).toContain("dependency-vulnerability-sla-state.json");
     expect(workflow).toContain("scripts/dependency-vulnerability-sla.mjs");
     expect(workflow).toContain("--fail-on-new-critical-high");
+    expect(workflow).toContain('if [ "$status" -eq 0 ]; then');
+    expect(workflow).toContain("if: success()");
     expect(
       workflow.indexOf("Dependency vulnerability SLA dashboard"),
     ).toBeLessThan(workflow.indexOf("npm run audit:dependencies"));
-    expect(workflow).toContain("npm run audit:dependencies -- --json");
+    expect(workflow).toContain('run: npm run audit:dependencies -- --json > "${RUNNER_TEMP}/audit.json"');
+    expect(workflow).not.toContain('npm run audit:dependencies -- --json > "${RUNNER_TEMP}/audit.json" || true');
     expect(workflow).toContain("npm run audit:security -- --json");
     expect(workflow).toContain("|| true");
     expect(workflow).toContain("npm run deps:outdated:major");

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -404,6 +404,7 @@ updates:
     );
     const result = runVulnerabilitySlaReport(
       {
+        metadata: { vulnerabilities: { high: 1, total: 1 } },
         vulnerabilities: {
           vite: {
             name: "vite",
@@ -460,6 +461,7 @@ updates:
     );
     const result = runVulnerabilitySlaReport(
       {
+        metadata: { vulnerabilities: { critical: 1, total: 1 } },
         vulnerabilities: {
           protobufjs: {
             severity: "critical",
@@ -483,6 +485,66 @@ updates:
       overSla: true,
     });
     expect(result.stderr).toContain("Dependency vulnerability SLA exceeded");
+  });
+
+  it("rejects invalid npm audit error objects unless explicitly marked unknown", () => {
+    const invalid = {
+      error: { code: "EAUDIT", summary: "registry unavailable" },
+    };
+    const rejected = runVulnerabilitySlaReport(invalid, ["--format", "json"]);
+
+    expect(rejected.status).toBe(2);
+    expect(rejected.stderr).toContain("metadata and vulnerabilities");
+
+    const tolerated = runVulnerabilitySlaReport(invalid, [
+      "--format",
+      "json",
+      "--allow-invalid-audit",
+      "--no-fail-on-sla",
+    ]);
+    expect(tolerated.status).toBe(0);
+    const report = JSON.parse(tolerated.stdout) as {
+      auditStatus: string;
+      auditError: string;
+      findings: unknown[];
+    };
+    expect(report.auditStatus).toBe("unknown");
+    expect(report.auditError).toContain("metadata and vulnerabilities");
+    expect(report.findings).toHaveLength(0);
+  });
+
+  it("marks SLA age unknown without prior state and does not invent fixed versions", () => {
+    const result = runVulnerabilitySlaReport(
+      {
+        metadata: { vulnerabilities: { high: 1, total: 1 } },
+        vulnerabilities: {
+          leftpad: {
+            severity: "high",
+            range: "<2.0.0",
+            nodes: ["node_modules/leftpad"],
+            fixAvailable: false,
+            via: [{ title: "unpatched", range: "<2.0.0", severity: "high" }],
+          },
+        },
+      },
+      ["--now", "2026-07-15", "--format", "json"],
+    );
+
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      ageSource: string;
+      findings: Array<{
+        ageDays: number | null;
+        fixedVersion: string | null;
+        overSla: boolean;
+      }>;
+    };
+    expect(report.ageSource).toBe("unknown");
+    expect(report.findings[0]).toMatchObject({
+      ageDays: null,
+      fixedVersion: null,
+      overSla: false,
+    });
   });
 
   it("wires dependency audit, major outdated check, dependabot guard, and SBOM artifact generation into CI", () => {

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -387,7 +387,15 @@ updates:
 
   it("emits a human dependency vulnerability SLA dashboard with age, fixed version, path, and links", () => {
     const state = writeSlaJson(
-      { findings: [{ package: "vite", firstSeen: "2026-06-01" }] },
+      {
+        findings: [
+          {
+            key: "vite|high|<8.1.3|https://github.com/advisories/GHSA-test",
+            package: "vite",
+            firstSeen: "2026-06-01",
+          },
+        ],
+      },
       "state.json",
     );
     const links = writeSlaJson(
@@ -456,7 +464,15 @@ updates:
 
   it("fails critical and high dependency vulnerabilities that exceed the SLA in JSON mode", () => {
     const state = writeSlaJson(
-      { findings: [{ package: "protobufjs", firstSeen: "2026-07-01" }] },
+      {
+        findings: [
+          {
+            key: "protobufjs|critical|<7.6.5|no-advisory",
+            package: "protobufjs",
+            firstSeen: "2026-07-01",
+          },
+        ],
+      },
       "state.json",
     );
     const result = runVulnerabilitySlaReport(

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -613,7 +613,8 @@ updates:
     expect(
       workflow.indexOf("Dependency vulnerability SLA dashboard"),
     ).toBeLessThan(workflow.indexOf("npm run audit:dependencies"));
-    expect(workflow).toContain("npm run audit:dependencies");
+    expect(workflow).toContain("npm run audit:dependencies -- --json");
+    expect(workflow).toContain("|| true");
     expect(workflow).toContain("npm run deps:outdated:major");
     expect(workflow).toContain("npm run check:dependabot-supply-chain");
     expect(workflow).toContain("npm sbom --sbom-format cyclonedx");

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -112,6 +112,26 @@ function runVulnerabilitySlaReport(audit: unknown, extraArgs: string[] = []) {
   );
 }
 
+function runVulnerabilitySlaNpmScript(audit: unknown, extraArgs: string[] = []) {
+  return spawnSync(
+    "npm",
+    [
+      "--silent",
+      "run",
+      "deps:vulnerability-sla",
+      "--",
+      "--audit-input",
+      writeSlaJson(audit),
+      ...extraArgs,
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    },
+  );
+}
+
 describe("dependency CI guards for issue #1414", () => {
   it("removes tracked temp fixture roots even when assertions fail before guard execution", () => {
     const outdatedFixture = writeFixtureFile(
@@ -560,6 +580,7 @@ updates:
         firstSeen: string;
         fixedVersion: string | null;
         overSla: boolean;
+        isNew: boolean;
       }>;
     };
     expect(report.ageSource).toBe("current-run");
@@ -568,7 +589,96 @@ updates:
       firstSeen: "2026-07-15",
       fixedVersion: null,
       overSla: false,
+      isNew: true,
     });
+  });
+
+  it("keeps npm-script JSON SLA output parseable", () => {
+    const result = runVulnerabilitySlaNpmScript(
+      {
+        metadata: { vulnerabilities: { total: 0 } },
+        vulnerabilities: {},
+      },
+      ["--format", "json"],
+    );
+
+    expect(result.status).toBe(0);
+    expect(() => JSON.parse(result.stdout)).not.toThrow();
+    expect(result.stdout).not.toContain("matches packageManager");
+  });
+
+  it("preserves SLA age across advisory severity changes", () => {
+    const state = writeSlaJson(
+      {
+        findings: [
+          {
+            key: "leftpad|high|<2.0.0|https://github.com/advisories/GHSA-leftpad",
+            package: "leftpad",
+            severity: "high",
+            advisoryKeys: ["https://github.com/advisories/GHSA-leftpad"],
+            firstSeen: "2026-06-01",
+          },
+        ],
+      },
+      "state.json",
+    );
+    const result = runVulnerabilitySlaReport(
+      {
+        metadata: { vulnerabilities: { critical: 1, total: 1 } },
+        vulnerabilities: {
+          leftpad: {
+            severity: "critical",
+            range: "<2.0.0",
+            nodes: ["node_modules/leftpad"],
+            fixAvailable: false,
+            via: [
+              {
+                url: "https://github.com/advisories/GHSA-leftpad",
+                severity: "critical",
+              },
+            ],
+          },
+        },
+      },
+      ["--state", state, "--now", "2026-07-15", "--format", "json"],
+    );
+
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout) as {
+      findings: Array<{ ageDays: number; firstSeen: string; isNew: boolean }>;
+    };
+    expect(report.findings[0]).toMatchObject({
+      ageDays: 44,
+      firstSeen: "2026-06-01",
+      isNew: false,
+    });
+  });
+
+  it("can fail fresh critical/high dependency findings before SLA aging", () => {
+    const result = runVulnerabilitySlaReport(
+      {
+        metadata: { vulnerabilities: { high: 1, total: 1 } },
+        vulnerabilities: {
+          leftpad: {
+            severity: "high",
+            range: "<2.0.0",
+            nodes: ["node_modules/leftpad"],
+            fixAvailable: false,
+            via: [{ url: "https://github.com/advisories/GHSA-leftpad" }],
+          },
+        },
+      },
+      [
+        "--now",
+        "2026-07-15",
+        "--format",
+        "json",
+        "--fail-on-new-critical-high",
+      ],
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("New critical/high dependency vulnerability");
   });
 
   it("fails closed when a requested SLA state file is missing", () => {
@@ -621,7 +731,7 @@ updates:
       "node scripts/check-package-manager.mjs && npm audit",
     );
     expect(packageJson.scripts?.["deps:vulnerability-sla"]).toBe(
-      "node scripts/check-package-manager.mjs && node scripts/dependency-vulnerability-sla.mjs",
+      "node scripts/check-package-manager.mjs --quiet && node scripts/dependency-vulnerability-sla.mjs",
     );
     expect(packageJson.scripts?.["deps:outdated:major"]).toBe(
       "node scripts/check-major-outdated.mjs",
@@ -632,6 +742,7 @@ updates:
     expect(workflow).toContain("actions/cache/restore@v4");
     expect(workflow).toContain("dependency-vulnerability-sla-state.json");
     expect(workflow).toContain("scripts/dependency-vulnerability-sla.mjs");
+    expect(workflow).toContain("--fail-on-new-critical-high");
     expect(
       workflow.indexOf("Dependency vulnerability SLA dashboard"),
     ).toBeLessThan(workflow.indexOf("npm run audit:dependencies"));

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -513,7 +513,7 @@ updates:
     expect(report.findings).toHaveLength(0);
   });
 
-  it("marks SLA age unknown without prior state and does not invent fixed versions", () => {
+  it("starts new SLA findings at the current run and does not invent fixed versions", () => {
     const result = runVulnerabilitySlaReport(
       {
         metadata: { vulnerabilities: { high: 1, total: 1 } },
@@ -534,17 +534,54 @@ updates:
     const report = JSON.parse(result.stdout) as {
       ageSource: string;
       findings: Array<{
-        ageDays: number | null;
+        ageDays: number;
+        firstSeen: string;
         fixedVersion: string | null;
         overSla: boolean;
       }>;
     };
-    expect(report.ageSource).toBe("unknown");
+    expect(report.ageSource).toBe("current-run");
     expect(report.findings[0]).toMatchObject({
-      ageDays: null,
+      ageDays: 0,
+      firstSeen: "2026-07-15",
       fixedVersion: null,
       overSla: false,
     });
+  });
+
+  it("fails closed when a requested SLA state file is missing", () => {
+    const audit = writeSlaJson({
+      metadata: { vulnerabilities: { high: 1, total: 1 } },
+      vulnerabilities: {
+        vite: {
+          severity: "high",
+          range: "<8.1.3",
+          nodes: ["node_modules/vite"],
+          fixAvailable: true,
+          via: [],
+        },
+      },
+    });
+    const missingState = join(
+      tmpdir(),
+      `franken-missing-state-${process.pid}-${Date.now()}.json`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        DEPENDENCY_VULNERABILITY_SLA_SCRIPT,
+        "--audit-input",
+        audit,
+        "--state",
+        missingState,
+      ],
+      { cwd: ROOT, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      "Requested dependency SLA state file does not exist",
+    );
   });
 
   it("wires dependency audit, major outdated check, dependabot guard, and SBOM artifact generation into CI", () => {
@@ -570,8 +607,13 @@ updates:
     expect(packageJson.scripts?.["check:dependabot-supply-chain"]).toBe(
       "node scripts/check-dependabot-supply-chain.mjs",
     );
+    expect(workflow).toContain("actions/cache/restore@v4");
+    expect(workflow).toContain("dependency-vulnerability-sla-state.json");
+    expect(workflow).toContain("scripts/dependency-vulnerability-sla.mjs");
+    expect(
+      workflow.indexOf("Dependency vulnerability SLA dashboard"),
+    ).toBeLessThan(workflow.indexOf("npm run audit:dependencies"));
     expect(workflow).toContain("npm run audit:dependencies");
-    expect(workflow).toContain("npm run deps:vulnerability-sla");
     expect(workflow).toContain("npm run deps:outdated:major");
     expect(workflow).toContain("npm run check:dependabot-supply-chain");
     expect(workflow).toContain("npm sbom --sbom-format cyclonedx");

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -1,12 +1,25 @@
-import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
-const ROOT = resolve(import.meta.dirname, '..', '..');
-const OUTDATED_SCRIPT = resolve(ROOT, 'scripts/check-major-outdated.mjs');
-const DEPENDABOT_SUPPLY_CHAIN_SCRIPT = resolve(ROOT, 'scripts/check-dependabot-supply-chain.mjs');
+const ROOT = resolve(import.meta.dirname, "..", "..");
+const OUTDATED_SCRIPT = resolve(ROOT, "scripts/check-major-outdated.mjs");
+const DEPENDABOT_SUPPLY_CHAIN_SCRIPT = resolve(
+  ROOT,
+  "scripts/check-dependabot-supply-chain.mjs",
+);
+const DEPENDENCY_VULNERABILITY_SLA_SCRIPT = resolve(
+  ROOT,
+  "scripts/dependency-vulnerability-sla.mjs",
+);
 const fixtureRoots = new Set<string>();
 
 function cleanupFixtureRoots() {
@@ -16,42 +29,101 @@ function cleanupFixtureRoots() {
   fixtureRoots.clear();
 }
 
-function writeFixtureFile(prefix: 'franken-outdated-' | 'franken-dependabot-', filename: string, content: string) {
+function writeFixtureFile(
+  prefix:
+    "franken-outdated-" | "franken-dependabot-" | "franken-vulnerability-sla-",
+  filename: string,
+  content: string,
+) {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   fixtureRoots.add(dir);
   const file = join(dir, filename);
-  writeFileSync(file, content, 'utf8');
+  writeFileSync(file, content, "utf8");
   return { dir, file };
 }
 
-function writeJson(value: unknown, filename = 'outdated.json') {
-  return writeFixtureFile('franken-outdated-', filename, `${JSON.stringify(value, null, 2)}\n`).file;
+function writeJson(value: unknown, filename = "outdated.json") {
+  return writeFixtureFile(
+    "franken-outdated-",
+    filename,
+    `${JSON.stringify(value, null, 2)}\n`,
+  ).file;
+}
+
+function writeSlaJson(value: unknown, filename = "audit.json") {
+  return writeFixtureFile(
+    "franken-vulnerability-sla-",
+    filename,
+    `${JSON.stringify(value, null, 2)}\n`,
+  ).file;
 }
 
 function writeText(content: string, filename: string) {
-  return writeFixtureFile('franken-dependabot-', filename, content).file;
+  return writeFixtureFile("franken-dependabot-", filename, content).file;
 }
 
 afterEach(cleanupFixtureRoots);
 
 function runOutdatedGuard(report: unknown, baseline: unknown = []) {
-  return spawnSync(process.execPath, [OUTDATED_SCRIPT, '--input', writeJson(report), '--baseline', writeJson(baseline, 'baseline.json')], {
-    cwd: ROOT,
-    encoding: 'utf8',
-  });
+  return spawnSync(
+    process.execPath,
+    [
+      OUTDATED_SCRIPT,
+      "--input",
+      writeJson(report),
+      "--baseline",
+      writeJson(baseline, "baseline.json"),
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
 }
 
 function runDependabotSupplyChainGuard(config: string) {
-  return spawnSync(process.execPath, [DEPENDABOT_SUPPLY_CHAIN_SCRIPT, '--config', writeText(config, 'dependabot.yml')], {
-    cwd: ROOT,
-    encoding: 'utf8',
-  });
+  return spawnSync(
+    process.execPath,
+    [
+      DEPENDABOT_SUPPLY_CHAIN_SCRIPT,
+      "--config",
+      writeText(config, "dependabot.yml"),
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
 }
 
-describe('dependency CI guards for issue #1414', () => {
-  it('removes tracked temp fixture roots even when assertions fail before guard execution', () => {
-    const outdatedFixture = writeFixtureFile('franken-outdated-', 'outdated.json', '{}\n');
-    const dependabotFixture = writeFixtureFile('franken-dependabot-', 'dependabot.yml', 'version: 2\n');
+function runVulnerabilitySlaReport(audit: unknown, extraArgs: string[] = []) {
+  return spawnSync(
+    process.execPath,
+    [
+      DEPENDENCY_VULNERABILITY_SLA_SCRIPT,
+      "--audit-input",
+      writeSlaJson(audit),
+      ...extraArgs,
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+}
+
+describe("dependency CI guards for issue #1414", () => {
+  it("removes tracked temp fixture roots even when assertions fail before guard execution", () => {
+    const outdatedFixture = writeFixtureFile(
+      "franken-outdated-",
+      "outdated.json",
+      "{}\n",
+    );
+    const dependabotFixture = writeFixtureFile(
+      "franken-dependabot-",
+      "dependabot.yml",
+      "version: 2\n",
+    );
 
     expect(existsSync(outdatedFixture.dir)).toBe(true);
     expect(existsSync(dependabotFixture.dir)).toBe(true);
@@ -62,119 +134,139 @@ describe('dependency CI guards for issue #1414', () => {
     expect(existsSync(dependabotFixture.dir)).toBe(false);
   });
 
-  it('fails only for dependencies with latest versions on a newer major', () => {
+  it("fails only for dependencies with latest versions on a newer major", () => {
     const result = runOutdatedGuard({
       acorn: {
-        current: '8.17.0',
-        wanted: '8.17.1',
-        latest: '8.17.1',
-        location: 'node_modules/acorn',
+        current: "8.17.0",
+        wanted: "8.17.1",
+        latest: "8.17.1",
+        location: "node_modules/acorn",
       },
       vite: {
-        current: '8.1.3',
-        wanted: '9.0.0',
-        latest: '9.0.0',
-        location: 'node_modules/vite',
+        current: "8.1.3",
+        wanted: "9.0.0",
+        latest: "9.0.0",
+        location: "node_modules/vite",
       },
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('vite');
-    expect(result.stderr).toContain('current 8.1.3');
-    expect(result.stderr).not.toContain('acorn');
+    expect(result.stderr).toContain("vite");
+    expect(result.stderr).toContain("current 8.1.3");
+    expect(result.stderr).not.toContain("acorn");
   });
 
-  it('flattens npm workspace arrays before checking major gaps', () => {
+  it("flattens npm workspace arrays before checking major gaps", () => {
     const result = runOutdatedGuard({
       zod: [
         {
-          current: '3.25.0',
-          wanted: '4.0.0',
-          latest: '4.2.0',
-          location: 'packages/franken-web/node_modules/zod',
+          current: "3.25.0",
+          wanted: "4.0.0",
+          latest: "4.2.0",
+          location: "packages/franken-web/node_modules/zod",
         },
         {
-          current: '3.25.0',
-          wanted: '3.25.1',
-          latest: '4.2.0',
-          location: 'packages/franken-orchestrator/node_modules/zod',
+          current: "3.25.0",
+          wanted: "3.25.1",
+          latest: "4.2.0",
+          location: "packages/franken-orchestrator/node_modules/zod",
         },
       ],
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('zod');
-    expect(result.stderr).toContain('packages/franken-web');
+    expect(result.stderr).toContain("zod");
+    expect(result.stderr).toContain("packages/franken-web");
   });
 
-  it('fails closed when npm outdated returns an error JSON object', () => {
-    const result = runOutdatedGuard({ error: { code: 'E403', summary: 'forbidden' } });
+  it("fails closed when npm outdated returns an error JSON object", () => {
+    const result = runOutdatedGuard({
+      error: { code: "E403", summary: "forbidden" },
+    });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain('npm outdated reported an error');
-    expect(result.stderr).toContain('E403');
+    expect(result.stderr).toContain("npm outdated reported an error");
+    expect(result.stderr).toContain("E403");
   });
 
-  it('passes when existing direct major gaps match the approved baseline', () => {
+  it("passes when existing direct major gaps match the approved baseline", () => {
     const report = {
       react: {
-        current: '18.3.1',
-        wanted: '18.3.1',
-        latest: '19.2.7',
-        location: 'packages/franken-web/node_modules/react',
-        dependent: 'franken-web',
+        current: "18.3.1",
+        wanted: "18.3.1",
+        latest: "19.2.7",
+        location: "packages/franken-web/node_modules/react",
+        dependent: "franken-web",
       },
     };
 
-    const result = runOutdatedGuard(report, [{ name: 'react', dependent: 'franken-web', location: 'packages/franken-web/node_modules/react', currentMajor: 18, latestMajor: 19 }]);
+    const result = runOutdatedGuard(report, [
+      {
+        name: "react",
+        dependent: "franken-web",
+        location: "packages/franken-web/node_modules/react",
+        currentMajor: 18,
+        latestMajor: 19,
+      },
+    ]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('baseline-approved major gap');
+    expect(result.stdout).toContain("baseline-approved major gap");
   });
 
-  it('does not let one baseline entry approve another workspace location', () => {
+  it("does not let one baseline entry approve another workspace location", () => {
     const result = runOutdatedGuard(
       {
         react: [
           {
-            current: '18.3.1',
-            wanted: '18.3.1',
-            latest: '19.2.7',
-            location: 'node_modules/react',
-            dependent: 'franken-web',
+            current: "18.3.1",
+            wanted: "18.3.1",
+            latest: "19.2.7",
+            location: "node_modules/react",
+            dependent: "franken-web",
           },
           {
-            current: '18.3.1',
-            wanted: '18.3.1',
-            latest: '19.2.7',
-            location: 'node_modules/react',
-            dependent: 'franken-new',
+            current: "18.3.1",
+            wanted: "18.3.1",
+            latest: "19.2.7",
+            location: "node_modules/react",
+            dependent: "franken-new",
           },
         ],
       },
-      [{ name: 'react', dependent: 'franken-web', location: 'node_modules/react', currentMajor: 18, latestMajor: 19 }],
+      [
+        {
+          name: "react",
+          dependent: "franken-web",
+          location: "node_modules/react",
+          currentMajor: 18,
+          latestMajor: 19,
+        },
+      ],
     );
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('franken-new');
-    expect(result.stderr).toContain('node_modules/react');
+    expect(result.stderr).toContain("franken-new");
+    expect(result.stderr).toContain("node_modules/react");
   });
 
-  it('passes when dependencies are only behind within their current major', () => {
+  it("passes when dependencies are only behind within their current major", () => {
     const result = runOutdatedGuard({
       typescript: {
-        current: '5.9.3',
-        wanted: '5.9.4',
-        latest: '5.9.4',
-        location: 'node_modules/typescript',
+        current: "5.9.3",
+        wanted: "5.9.4",
+        latest: "5.9.4",
+        location: "node_modules/typescript",
       },
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('no unapproved direct dependencies are behind the latest major release');
+    expect(result.stdout).toContain(
+      "no unapproved direct dependencies are behind the latest major release",
+    );
   });
 
-  it('fails dependabot configs that allow registry-driven internal workspace updates', () => {
+  it("fails dependabot configs that allow registry-driven internal workspace updates", () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -187,12 +279,12 @@ updates:
 `);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('@franken/*');
-    expect(result.stderr).toContain('exclude-patterns');
-    expect(result.stderr).toContain('must ignore');
+    expect(result.stderr).toContain("@franken/*");
+    expect(result.stderr).toContain("exclude-patterns");
+    expect(result.stderr).toContain("must ignore");
   });
 
-  it('fails internal-scope ignores that only cover filtered update PRs', () => {
+  it("fails internal-scope ignores that only cover filtered update PRs", () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -211,7 +303,7 @@ updates:
 `);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('without update-types filters');
+    expect(result.stderr).toContain("without update-types filters");
 
     const versionFiltered = runDependabotSupplyChainGuard(`
 version: 2
@@ -228,10 +320,10 @@ updates:
 `);
 
     expect(versionFiltered.status).toBe(1);
-    expect(versionFiltered.stderr).toContain('without update-types filters');
+    expect(versionFiltered.stderr).toContain("without update-types filters");
   });
 
-  it('fails npm entries that target release branches instead of default-branch security coverage', () => {
+  it("fails npm entries that target release branches instead of default-branch security coverage", () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -247,11 +339,11 @@ updates:
 `);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('target-branch');
-    expect(result.stderr).toContain('default branch');
+    expect(result.stderr).toContain("target-branch");
+    expect(result.stderr).toContain("default branch");
   });
 
-  it('fails every npm group that lacks an internal-scope exclusion', () => {
+  it("fails every npm group that lacks an internal-scope exclusion", () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -268,11 +360,11 @@ updates:
 `);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('unsafe-production');
-    expect(result.stderr).toContain('exclude-patterns');
+    expect(result.stderr).toContain("unsafe-production");
+    expect(result.stderr).toContain("exclude-patterns");
   });
 
-  it('accepts dependabot configs that exclude internal packages from all npm updates', () => {
+  it("accepts dependabot configs that exclude internal packages from all npm updates", () => {
     const result = runDependabotSupplyChainGuard(`
 version: 2
 updates:
@@ -290,23 +382,138 @@ updates:
 `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Dependabot supply-chain guard OK');
+    expect(result.stdout).toContain("Dependabot supply-chain guard OK");
   });
 
-  it('wires dependency audit, major outdated check, dependabot guard, and SBOM artifact generation into CI', () => {
-    const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+  it("emits a human dependency vulnerability SLA dashboard with age, fixed version, path, and links", () => {
+    const state = writeSlaJson(
+      { findings: [{ package: "vite", firstSeen: "2026-06-01" }] },
+      "state.json",
+    );
+    const links = writeSlaJson(
+      {
+        links: [
+          {
+            package: "vite",
+            issue: 1673,
+            pr: "https://github.com/djm204/frankenbeast/pull/1",
+          },
+        ],
+      },
+      "links.json",
+    );
+    const result = runVulnerabilitySlaReport(
+      {
+        vulnerabilities: {
+          vite: {
+            name: "vite",
+            severity: "high",
+            range: "<8.1.3",
+            nodes: ["node_modules/vite"],
+            effects: ["@vitejs/plugin-react"],
+            fixAvailable: {
+              name: "vite",
+              version: "8.1.3",
+              isSemVerMajor: false,
+            },
+            via: [
+              {
+                source: 123,
+                name: "vite",
+                title: "dev server bypass",
+                url: "https://github.com/advisories/GHSA-test",
+                range: "<8.1.3",
+                severity: "high",
+              },
+            ],
+          },
+        },
+      },
+      [
+        "--state",
+        state,
+        "--links",
+        links,
+        "--now",
+        "2026-07-15",
+        "--no-fail-on-sla",
+      ],
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Dependency vulnerability SLA dashboard");
+    expect(result.stdout).toContain("HIGH");
+    expect(result.stdout).toContain("vite");
+    expect(result.stdout).toContain("<8.1.3 -> 8.1.3");
+    expect(result.stdout).toContain("44d/30 OVER");
+    expect(result.stdout).toContain("node_modules/vite");
+    expect(result.stdout).toContain("#1673");
+    expect(result.stdout).toContain(
+      "https://github.com/djm204/frankenbeast/pull/1",
+    );
+  });
+
+  it("fails critical and high dependency vulnerabilities that exceed the SLA in JSON mode", () => {
+    const state = writeSlaJson(
+      { findings: [{ package: "protobufjs", firstSeen: "2026-07-01" }] },
+      "state.json",
+    );
+    const result = runVulnerabilitySlaReport(
+      {
+        vulnerabilities: {
+          protobufjs: {
+            severity: "critical",
+            range: "<7.6.5",
+            nodes: ["node_modules/protobufjs"],
+            fixAvailable: true,
+            via: ["@anthropic-ai/sdk"],
+          },
+        },
+      },
+      ["--state", state, "--now", "2026-07-15", "--format", "json"],
+    );
+
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout) as {
+      findings: Array<{ package: string; ageDays: number; overSla: boolean }>;
+    };
+    expect(report.findings[0]).toMatchObject({
+      package: "protobufjs",
+      ageDays: 14,
+      overSla: true,
+    });
+    expect(result.stderr).toContain("Dependency vulnerability SLA exceeded");
+  });
+
+  it("wires dependency audit, major outdated check, dependabot guard, and SBOM artifact generation into CI", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(ROOT, "package.json"), "utf8"),
+    ) as {
       scripts?: Record<string, string>;
     };
-    const workflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf8');
+    const workflow = readFileSync(
+      resolve(ROOT, ".github/workflows/ci.yml"),
+      "utf8",
+    );
 
-    expect(packageJson.scripts?.['audit:dependencies']).toBe('node scripts/check-package-manager.mjs && npm audit');
-    expect(packageJson.scripts?.['deps:outdated:major']).toBe('node scripts/check-major-outdated.mjs');
-    expect(packageJson.scripts?.['check:dependabot-supply-chain']).toBe('node scripts/check-dependabot-supply-chain.mjs');
-    expect(workflow).toContain('npm run audit:dependencies');
-    expect(workflow).toContain('npm run deps:outdated:major');
-    expect(workflow).toContain('npm run check:dependabot-supply-chain');
-    expect(workflow).toContain('npm sbom --sbom-format cyclonedx');
-    expect(workflow).toContain('actions/upload-artifact@v7');
-    expect(workflow).toContain('dependency-sbom-cyclonedx');
+    expect(packageJson.scripts?.["audit:dependencies"]).toBe(
+      "node scripts/check-package-manager.mjs && npm audit",
+    );
+    expect(packageJson.scripts?.["deps:vulnerability-sla"]).toBe(
+      "node scripts/check-package-manager.mjs && node scripts/dependency-vulnerability-sla.mjs",
+    );
+    expect(packageJson.scripts?.["deps:outdated:major"]).toBe(
+      "node scripts/check-major-outdated.mjs",
+    );
+    expect(packageJson.scripts?.["check:dependabot-supply-chain"]).toBe(
+      "node scripts/check-dependabot-supply-chain.mjs",
+    );
+    expect(workflow).toContain("npm run audit:dependencies");
+    expect(workflow).toContain("npm run deps:vulnerability-sla");
+    expect(workflow).toContain("npm run deps:outdated:major");
+    expect(workflow).toContain("npm run check:dependabot-supply-chain");
+    expect(workflow).toContain("npm sbom --sbom-format cyclonedx");
+    expect(workflow).toContain("actions/upload-artifact@v7");
+    expect(workflow).toContain("dependency-sbom-cyclonedx");
   });
 });

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -483,7 +483,7 @@ updates:
             severity: "critical",
             range: "<7.6.5",
             nodes: ["node_modules/protobufjs"],
-            fixAvailable: true,
+            fixAvailable: { name: "@anthropic-ai/sdk", version: "0.110.0" },
             via: ["@anthropic-ai/sdk"],
           },
         },
@@ -493,11 +493,17 @@ updates:
 
     expect(result.status).toBe(1);
     const report = JSON.parse(result.stdout) as {
-      findings: Array<{ package: string; ageDays: number; overSla: boolean }>;
+      findings: Array<{
+        package: string;
+        ageDays: number;
+        overSla: boolean;
+        fixedVersion: string;
+      }>;
     };
     expect(report.findings[0]).toMatchObject({
       package: "protobufjs",
       ageDays: 14,
+      fixedVersion: "@anthropic-ai/sdk@0.110.0",
       overSla: true,
     });
     expect(result.stderr).toContain("Dependency vulnerability SLA exceeded");
@@ -630,6 +636,7 @@ updates:
       workflow.indexOf("Dependency vulnerability SLA dashboard"),
     ).toBeLessThan(workflow.indexOf("npm run audit:dependencies"));
     expect(workflow).toContain("npm run audit:dependencies -- --json");
+    expect(workflow).toContain("npm run audit:security -- --json");
     expect(workflow).toContain("|| true");
     expect(workflow).toContain("npm run deps:outdated:major");
     expect(workflow).toContain("npm run check:dependabot-supply-chain");


### PR DESCRIPTION
## Summary
- add `scripts/dependency-vulnerability-sla.mjs` for human/JSON npm audit SLA reporting with severity windows, age, paths, fix versions, and issue/PR links
- wire the SLA dashboard into CI and daily security scan artifacts
- document the dependency vulnerability SLA workflow in the security docs and quickstart

## Test Plan
- npm run test:root -- tests/unit/dependency-ci-guards.test.ts
- npm run deps:vulnerability-sla -- --format json
- npm run build
- npm run typecheck
- npm run lint

Closes #1673
