### PR TITLE
docs(critique): refresh ramp-up wiring status

### DIFF
--- a/packages/franken-critique/docs/RAMP_UP.md
+++ b/packages/franken-critique/docs/RAMP_UP.md
@@ -19,7 +19,7 @@
 - `packages/franken-orchestrator/src/cli/dep-factory.ts` imports `@franken/critique` lazily when `modules.critique` is enabled.
 - `createCritiqueDeps()` builds a package reviewer with guardrail, memory, observability, and known-package ports, then wraps it in `CritiquePortAdapter` for the Beast loop.
 - `packages/franken-orchestrator/src/cli/create-beast-deps.ts` also wires `ReflectionEvaluator` into heartbeat reflection when reflection is enabled.
-- Missing enabled critique packages fail closed by default. Unsafe all-pass fallback requires the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out documented in the root ramp-up guide.
+- Missing enabled critique packages fail closed by default. Unsafe all-pass fallback to `stubCritique` requires the explicit `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1` opt-out documented in the root ramp-up guide.
 
 ## Narrow Integration Notes
 - The critique module depends on caller-provided ports for guardrails, memory, observability, known package metadata, and LLM-backed reflection.

--- a/tests/docs-issue-2098.test.ts
+++ b/tests/docs-issue-2098.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+describe('issue #2098 critique ramp-up wiring status docs', () => {
+  it('documents the current orchestrator critique wiring and fallback conditions', () => {
+    const rampUp = readText('packages/franken-critique/docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('**Status**: **Integrated safety module**');
+    expect(rampUp).toContain('loads `@franken/critique` when the critique module is enabled');
+    expect(rampUp).toContain('`createCritiqueDeps()`');
+    expect(rampUp).toContain('`CritiquePortAdapter`');
+    expect(rampUp).toContain('`stubCritique`');
+    expect(rampUp).toContain('`FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1`');
+
+    expect(rampUp).not.toMatch(/\bGHOST\b/u);
+    expect(rampUp).not.toContain('currently **unwired**');
+    expect(rampUp).not.toContain('skips the reflection phase by using a stub that returns a perfect score');
+    expect(rampUp).not.toContain('real critique-loop wiring as future work');
+  });
+});


### PR DESCRIPTION
## Summary
- Clarifies the franken-critique ramp-up fallback path by naming `stubCritique` explicitly.
- Adds a root docs regression for issue #2098 so the guide keeps pointing contributors to `createCritiqueDeps()` / `CritiquePortAdapter` and no longer drifts back to stale GHOST/unwired language.

## Test Plan
- npm run test:root -- tests/docs-issue-2098.test.ts tests/docs-issue-949.test.ts tests/docs-issue-2099.test.ts
- git diff --check
- npm run typecheck -- --filter=@franken/critique
- npm run build -- --filter=@franken/critique
- npm run lint -- --filter=@franken/critique

Closes #2098