### PR TITLE
test(web): cover approval fallback during socket reconnect

### DIFF
--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1051,7 +1051,11 @@ describe('useChatSession', () => {
     expect(result.current.sessionState).toBe('approved');
   });
 
-  it('falls back to HTTP approval when the websocket is not ready', async () => {
+  it.each([
+    ['connecting', 0],
+    ['closing', 2],
+    ['closed', 3],
+  ])('falls back to HTTP approval when the websocket is %s', async (_stateName, readyState) => {
     const { result } = renderHook(() => useChatSession(opts));
 
     await waitFor(() => {
@@ -1059,6 +1063,7 @@ describe('useChatSession', () => {
     });
 
     const socket = MockWebSocket.instances[0]!;
+    socket.readyState = readyState;
 
     act(() => {
       socket.message({


### PR DESCRIPTION
## Summary
- Expands the `useChatSession` approval fallback regression from a generic not-ready socket to explicit connecting, closing, and closed WebSocket states.
- Confirms reconnecting/disconnected approval clicks use the REST approval fallback and do not emit a socket frame.
- Notes: the current `main` implementation already contained the REST approval fallback; this PR locks the issue-specific reconnect cases down so the no-op regression cannot return.

## Test Plan
- [x] `npm run build --workspace @franken/types`
- [x] `npm test --workspace @franken/web -- --run tests/hooks/use-chat-session.test.ts`
- [x] `npm run lint --workspace @franken/web` (passes with existing warnings)
- [x] `npm run typecheck --workspace @franken/web`
- [x] `npm run build --workspace @franken/web`

Closes #2043
