### PR TITLE
fix(security): protect local web controls

### DIFF
--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -70,6 +70,12 @@ If the daemon or chat server is launched by a wrapper from outside the intended 
 
 If you bind to a non-loopback host, the server refuses to start without an operator token. The same fail-closed rule applies when `chat-server` is launched by `frankenbeast network`: the supervisor sets the internal `FRANKENBEAST_NETWORK_MANAGED=1` child-process marker, and managed `chat-server` requires an operator token even on loopback. Do not export this marker for normal standalone debugging; unset it for local standalone `chat-server` runs, or provide `FRANKENBEAST_BEAST_OPERATOR_TOKEN` / the configured secret-store token when intentionally exercising managed semantics.
 
+### Local browser threat model
+
+The local dashboard assumes same-origin browser access through the Vite proxy or a production same-origin frontend. The backend rejects unsafe browser mutations to local control paths (`/v1/chat`, `/v1/beasts`, `/v1/network`, `/v1/comms`, `/api/security`, `/api/skills`, `/api/dashboard`, and `/api/analytics`) when `Origin` / `Sec-Fetch-Site` shows a cross-origin page is trying to drive the controls. Non-browser CLI/API callers should continue to use the operator bearer token or `x-frankenbeast-operator-token`; do not rely on browser cookies or embedded iframes for automation.
+
+Control responses also send `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` by default so the dashboard/control API cannot be clickjacked from another page. If you intentionally front this behind another origin, terminate/proxy it as same-origin instead of relaxing these headers.
+
 ## 2. Start the dashboard
 
 In a second terminal, either reuse the same repo-root `.env`/secret-store token or export the same local token before starting Vite so the Node-side dev proxy can inject it server-side:

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -35,7 +35,7 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   const services = options.services;
 
   app.onError(errorHandler);
-  app.use('*', localBrowserControlProtection);
+  app.use('*', localBrowserControlProtection());
 
   app.get('/health', (c) => {
     c.header('x-frankenbeast-service', 'beasts-daemon');

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -3,7 +3,7 @@ import type { BeastServiceBundle } from '../beasts/create-beast-services.js';
 import { agentRoutes } from './routes/agent-routes.js';
 import { beastRoutes } from './routes/beast-routes.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
-import { HttpError, errorHandler } from './middleware.js';
+import { HttpError, errorHandler, localBrowserControlProtection } from './middleware.js';
 import { TransportSecurityService } from './security/transport-security.js';
 import { isoNow } from '@franken/types';
 
@@ -35,6 +35,7 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   const services = options.services;
 
   app.onError(errorHandler);
+  app.use('*', localBrowserControlProtection);
 
   app.get('/health', (c) => {
     c.header('x-frankenbeast-service', 'beasts-daemon');

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -351,11 +351,12 @@ async function proxyToBeastDaemon(
   const targetUrl = new URL(`${sourceUrl.pathname}${sourceUrl.search}`, daemon.baseUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  const browserOrigin = parseBrowserOrigin(headers.get('origin'));
   if (!headers.has('x-forwarded-host')) {
-    headers.set('x-forwarded-host', sourceUrl.host);
+    headers.set('x-forwarded-host', browserOrigin?.host ?? sourceUrl.host);
   }
   if (!headers.has('x-forwarded-proto')) {
-    headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
+    headers.set('x-forwarded-proto', browserOrigin?.protocol.replace(/:$/, '') ?? sourceUrl.protocol.replace(/:$/, ''));
   }
   if (!headers.has('authorization')) {
     const headerToken = headers.get('x-frankenbeast-operator-token')?.trim();
@@ -372,6 +373,17 @@ async function proxyToBeastDaemon(
     Object.assign(init, { duplex: 'half' });
   }
   return fetch(targetUrl, init);
+}
+
+function parseBrowserOrigin(origin: string | null): URL | undefined {
+  if (!origin) {
+    return undefined;
+  }
+  try {
+    return new URL(origin);
+  } catch {
+    return undefined;
+  }
 }
 
 function removeHopByHopHeaders(headers: Headers): void {

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -158,7 +158,9 @@ export function createChatApp(opts: ChatAppOptions): Hono {
 
   const app = new Hono();
   app.use('*', requestId);
-  app.use('*', localBrowserControlProtection);
+  app.use('*', localBrowserControlProtection(
+    opts.allowedOrigins ? { allowedOrigins: opts.allowedOrigins } : {},
+  ));
   if (opts.allowedOrigins && opts.allowedOrigins.length > 0) {
     const allowedOrigins = new Set(opts.allowedOrigins.filter((origin) => origin !== '*'));
     if (allowedOrigins.size > 0) {
@@ -349,6 +351,8 @@ async function proxyToBeastDaemon(
   const targetUrl = new URL(`${sourceUrl.pathname}${sourceUrl.search}`, daemon.baseUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  headers.set('x-forwarded-host', sourceUrl.host);
+  headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
   if (!headers.has('authorization')) {
     const headerToken = headers.get('x-frankenbeast-operator-token')?.trim();
     const forwardedToken = operatorToken ?? (headerToken ? headerToken : undefined);

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -351,8 +351,12 @@ async function proxyToBeastDaemon(
   const targetUrl = new URL(`${sourceUrl.pathname}${sourceUrl.search}`, daemon.baseUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
-  headers.set('x-forwarded-host', sourceUrl.host);
-  headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
+  if (!headers.has('x-forwarded-host')) {
+    headers.set('x-forwarded-host', sourceUrl.host);
+  }
+  if (!headers.has('x-forwarded-proto')) {
+    headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
+  }
   if (!headers.has('authorization')) {
     const headerToken = headers.get('x-frankenbeast-operator-token')?.trim();
     const forwardedToken = operatorToken ?? (headerToken ? headerToken : undefined);

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_MAX_BODY_SIZE,
   SKILL_CONTEXT_MAX_BODY_SIZE,
   errorHandler,
+  localBrowserControlProtection,
   requestId,
   requestSizeLimit,
 } from './middleware.js';
@@ -157,6 +158,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
 
   const app = new Hono();
   app.use('*', requestId);
+  app.use('*', localBrowserControlProtection);
   if (opts.allowedOrigins && opts.allowedOrigins.length > 0) {
     const allowedOrigins = new Set(opts.allowedOrigins.filter((origin) => origin !== '*'));
     if (allowedOrigins.size > 0) {

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -128,6 +128,8 @@ async function createProxyResponse(
   const targetUrl = resolveProxyTargetUrl(apiTarget, sourceUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  headers.set('x-forwarded-host', sourceUrl.host);
+  headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
   if (options.operatorToken) {
     headers.set('authorization', `Bearer ${options.operatorToken}`);
   }
@@ -367,7 +369,12 @@ function attachBackendUpgradeProxy(server: HttpServer, options: DashboardStaticS
     }
 
     const targetUrl = resolveProxyTargetUrl(apiTarget, requestUrl);
-    const headers = { ...req.headers, host: targetUrl.host };
+    const headers = {
+      ...req.headers,
+      host: targetUrl.host,
+      'x-forwarded-host': requestUrl.host,
+      'x-forwarded-proto': requestUrl.protocol.replace(/:$/, ''),
+    };
     if (options.operatorToken) {
       headers.authorization = `Bearer ${options.operatorToken}`;
     }

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -61,6 +61,10 @@ export interface DashboardStaticServerOptions extends DashboardStaticResponseOpt
 function response(body: BodyInit | null, init: ResponseInit = {}): Response {
   const headers = new Headers(init.headers);
   headers.set('x-frankenbeast-service', SERVICE_IDENTITY);
+  headers.set('Content-Security-Policy', "frame-ancestors 'none'");
+  headers.set('X-Frame-Options', 'DENY');
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('Referrer-Policy', 'same-origin');
   return new Response(body, { ...init, headers });
 }
 

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -30,6 +30,78 @@ export const requestId = createMiddleware(async (c, next) => {
   await next();
 });
 
+const UNSAFE_BROWSER_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const LOCAL_CONTROL_PATH_PREFIXES = [
+  '/api/analytics',
+  '/api/dashboard',
+  '/api/security',
+  '/api/skills',
+  '/v1/beasts',
+  '/v1/chat',
+  '/v1/comms',
+  '/v1/network',
+] as const;
+
+function firstHeaderValue(value: string | undefined): string | undefined {
+  return value?.split(',')[0]?.trim() || undefined;
+}
+
+function requestOrigin(c: Context): string {
+  const url = new URL(c.req.url);
+  const forwardedProto = firstHeaderValue(c.req.header('x-forwarded-proto'))?.toLowerCase();
+  const forwardedHost = firstHeaderValue(c.req.header('x-forwarded-host'));
+  if (forwardedProto === 'http' || forwardedProto === 'https') {
+    url.protocol = `${forwardedProto}:`;
+  }
+  if (forwardedHost) {
+    url.host = forwardedHost;
+  }
+  return url.origin;
+}
+
+function isLocalControlPath(pathname: string): boolean {
+  return LOCAL_CONTROL_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+function isSameOriginMutation(c: Context): boolean {
+  const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
+  if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
+    return false;
+  }
+
+  const origin = c.req.header('origin');
+  if (!origin) {
+    return true;
+  }
+
+  try {
+    return new URL(origin).origin === requestOrigin(c);
+  } catch {
+    return false;
+  }
+}
+
+function setLocalBrowserSecurityHeaders(c: Context): void {
+  c.header('Content-Security-Policy', "frame-ancestors 'none'");
+  c.header('X-Frame-Options', 'DENY');
+  c.header('X-Content-Type-Options', 'nosniff');
+  c.header('Referrer-Policy', 'same-origin');
+}
+
+export const localBrowserControlProtection = createMiddleware(async (c, next) => {
+  setLocalBrowserSecurityHeaders(c);
+
+  const pathname = new URL(c.req.url).pathname;
+  if (UNSAFE_BROWSER_METHODS.has(c.req.method.toUpperCase())
+    && isLocalControlPath(pathname)
+    && !isSameOriginMutation(c)) {
+    throw new HttpError(403, 'FORBIDDEN', 'Local web control mutations require a same-origin browser request');
+  }
+
+  await next();
+  setLocalBrowserSecurityHeaders(c);
+});
+
 export const DEFAULT_MAX_BODY_SIZE = 16 * 1024;
 export const BEAST_CONTROL_MAX_BODY_SIZE = 1024 * 1024;
 export const SKILL_CONTEXT_MAX_BODY_SIZE = 1024 * 1024;

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -59,6 +59,15 @@ function requestOrigin(c: Context): string {
   return url.origin;
 }
 
+function forwardedOrigin(c: Context): string | undefined {
+  const forwardedProto = firstHeaderValue(c.req.header('x-forwarded-proto'))?.toLowerCase();
+  const forwardedHost = firstHeaderValue(c.req.header('x-forwarded-host'));
+  if ((forwardedProto === 'http' || forwardedProto === 'https') && forwardedHost) {
+    return `${forwardedProto}://${forwardedHost}`;
+  }
+  return undefined;
+}
+
 function isLocalControlPath(pathname: string): boolean {
   return LOCAL_CONTROL_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
@@ -74,7 +83,11 @@ function isTrustedOriginHost(origin: string): boolean {
 
 function isSameOriginMutation(c: Context, allowedOrigins: ReadonlySet<string>): boolean {
   const origin = c.req.header('origin');
+  const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
   if (!origin) {
+    if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
+      return false;
+    }
     return true;
   }
 
@@ -89,12 +102,14 @@ function isSameOriginMutation(c: Context, allowedOrigins: ReadonlySet<string>): 
     return true;
   }
 
-  const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
   if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
     return false;
   }
 
-  return normalizedOrigin === requestOrigin(c) && isTrustedOriginHost(normalizedOrigin);
+  const normalizedRequestOrigin = requestOrigin(c);
+  const normalizedForwardedOrigin = forwardedOrigin(c);
+  return (normalizedOrigin === normalizedRequestOrigin && isTrustedOriginHost(normalizedOrigin))
+    || normalizedOrigin === normalizedForwardedOrigin;
 }
 
 function setLocalBrowserSecurityHeaders(c: Context): void {

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -66,30 +66,35 @@ function isLocalControlPath(pathname: string): boolean {
 function isTrustedOriginHost(origin: string): boolean {
   try {
     const hostname = new URL(origin).hostname;
-    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
   } catch {
     return false;
   }
 }
 
 function isSameOriginMutation(c: Context, allowedOrigins: ReadonlySet<string>): boolean {
-  const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
-  if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
-    return false;
-  }
-
   const origin = c.req.header('origin');
   if (!origin) {
     return true;
   }
 
+  let normalizedOrigin: string;
   try {
-    const normalizedOrigin = new URL(origin).origin;
-    return allowedOrigins.has(normalizedOrigin)
-      || (normalizedOrigin === requestOrigin(c) && isTrustedOriginHost(normalizedOrigin));
+    normalizedOrigin = new URL(origin).origin;
   } catch {
     return false;
   }
+
+  if (allowedOrigins.has(normalizedOrigin)) {
+    return true;
+  }
+
+  const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
+  if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
+    return false;
+  }
+
+  return normalizedOrigin === requestOrigin(c) && isTrustedOriginHost(normalizedOrigin);
 }
 
 function setLocalBrowserSecurityHeaders(c: Context): void {

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -63,7 +63,16 @@ function isLocalControlPath(pathname: string): boolean {
   return LOCAL_CONTROL_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
-function isSameOriginMutation(c: Context): boolean {
+function isTrustedOriginHost(origin: string): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+function isSameOriginMutation(c: Context, allowedOrigins: ReadonlySet<string>): boolean {
   const secFetchSite = c.req.header('sec-fetch-site')?.trim().toLowerCase();
   if (secFetchSite && secFetchSite !== 'same-origin' && secFetchSite !== 'none') {
     return false;
@@ -75,7 +84,9 @@ function isSameOriginMutation(c: Context): boolean {
   }
 
   try {
-    return new URL(origin).origin === requestOrigin(c);
+    const normalizedOrigin = new URL(origin).origin;
+    return allowedOrigins.has(normalizedOrigin)
+      || (normalizedOrigin === requestOrigin(c) && isTrustedOriginHost(normalizedOrigin));
   } catch {
     return false;
   }
@@ -88,19 +99,27 @@ function setLocalBrowserSecurityHeaders(c: Context): void {
   c.header('Referrer-Policy', 'same-origin');
 }
 
-export const localBrowserControlProtection = createMiddleware(async (c, next) => {
-  setLocalBrowserSecurityHeaders(c);
+export function localBrowserControlProtection(options: { allowedOrigins?: Iterable<string> } = {}) {
+  const allowedOrigins = new Set(
+    [...(options.allowedOrigins ?? [])]
+      .filter((origin) => origin !== '*')
+      .map((origin) => new URL(origin).origin),
+  );
 
-  const pathname = new URL(c.req.url).pathname;
-  if (UNSAFE_BROWSER_METHODS.has(c.req.method.toUpperCase())
-    && isLocalControlPath(pathname)
-    && !isSameOriginMutation(c)) {
-    throw new HttpError(403, 'FORBIDDEN', 'Local web control mutations require a same-origin browser request');
-  }
+  return createMiddleware(async (c, next) => {
+    setLocalBrowserSecurityHeaders(c);
 
-  await next();
-  setLocalBrowserSecurityHeaders(c);
-});
+    const pathname = new URL(c.req.url).pathname;
+    if (UNSAFE_BROWSER_METHODS.has(c.req.method.toUpperCase())
+      && isLocalControlPath(pathname)
+      && !isSameOriginMutation(c, allowedOrigins)) {
+      throw new HttpError(403, 'FORBIDDEN', 'Local web control mutations require a same-origin browser request');
+    }
+
+    await next();
+    setLocalBrowserSecurityHeaders(c);
+  });
+}
 
 export const DEFAULT_MAX_BODY_SIZE = 16 * 1024;
 export const BEAST_CONTROL_MAX_BODY_SIZE = 1024 * 1024;

--- a/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
@@ -146,4 +146,28 @@ describe('chat app beast daemon proxy', () => {
     expect(forwardedHeaders.get('x-forwarded-host')).toBe('dashboard.example.com');
     expect(forwardedHeaders.get('x-forwarded-proto')).toBe('https');
   });
+
+  it('derives forwarded origin headers from allowed browser origins when proxying to the beast daemon', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ data: 'ok' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const app = createProxyApp({ allowedOrigins: ['https://dashboard.example.com'] });
+
+    const response = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_DAEMON_TOKEN}`,
+        origin: 'https://dashboard.example.com',
+        'sec-fetch-site': 'cross-site',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    expect(response.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+    const forwardedHeaders = init.headers as Headers;
+    expect(forwardedHeaders.get('x-forwarded-host')).toBe('dashboard.example.com');
+    expect(forwardedHeaders.get('x-forwarded-proto')).toBe('https');
+  });
+
 });

--- a/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
@@ -5,11 +5,12 @@ import { testCredential } from '../../support/test-credentials.js';
 
 const TEST_DAEMON_TOKEN = testCredential('TEST_DAEMON_TOKEN');
 const TEST_GATEWAY_TOKEN = testCredential('TEST_GATEWAY_TOKEN');
-function createProxyApp() {
+function createProxyApp(options: { allowedOrigins?: string[] } = {}) {
   return createChatApp({
     sessionStoreDir: '/tmp/chat-app-beast-daemon-proxy-test',
     llm: { complete: vi.fn().mockResolvedValue('hello') },
     projectName: 'proxy-test',
+    ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
     beastDaemon: {
       baseUrl: 'http://127.0.0.1:4050',
       operatorToken: TEST_DAEMON_TOKEN,
@@ -120,5 +121,29 @@ describe('chat app beast daemon proxy', () => {
     expect(forwardedHeaders.has('transfer-encoding')).toBe(false);
     expect(forwardedHeaders.has('x-remove-me')).toBe(false);
     expect(forwardedHeaders.has('host')).toBe(false);
+  });
+
+  it('preserves dashboard forwarded origin headers when proxying to the beast daemon', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ data: 'ok' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const app = createProxyApp({ allowedOrigins: ['https://dashboard.example.com'] });
+
+    const response = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_DAEMON_TOKEN}`,
+        origin: 'https://dashboard.example.com',
+        'x-forwarded-host': 'dashboard.example.com',
+        'x-forwarded-proto': 'https',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    expect(response.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+    const forwardedHeaders = init.headers as Headers;
+    expect(forwardedHeaders.get('x-forwarded-host')).toBe('dashboard.example.com');
+    expect(forwardedHeaders.get('x-forwarded-proto')).toBe('https');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -144,7 +144,36 @@ describe('dashboard static server', () => {
     expect(proxied.status).toBe(200);
     const [targetUrl, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
     expect(targetUrl.toString()).toBe('http://127.0.0.1:4242/base/api/dashboard?fresh=1');
-    expect(new Headers(init.headers).get('authorization')).toBe(`Bearer ${TEST_OPERATOR_TOKEN}`);
+    const headers = new Headers(init.headers);
+    expect(headers.get('authorization')).toBe(`Bearer ${TEST_OPERATOR_TOKEN}`);
+    expect(headers.get('x-forwarded-host')).toBe('dashboard.local');
+    expect(headers.get('x-forwarded-proto')).toBe('http');
+  });
+
+  it('forwards the static dashboard origin headers without requiring an operator token', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    globalThis.fetch = fetchMock;
+
+    const proxied = await createDashboardStaticResponse(
+      new Request('https://dashboard.example.com/v1/chat/sessions', {
+        method: 'POST',
+        headers: { origin: 'https://dashboard.example.com' },
+      }),
+      staticDir,
+      { apiTarget: 'http://127.0.0.1:4242' },
+    );
+
+    expect(proxied.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get('x-forwarded-host')).toBe('dashboard.example.com');
+    expect(headers.get('x-forwarded-proto')).toBe('https');
+    expect(headers.get('authorization')).toBeNull();
   });
 
   it('loads dashboard operator token from network config even when provider trust metadata is unapproved', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -49,6 +49,8 @@ describe('dashboard static server', () => {
 
     await expect(index.text()).resolves.toContain('<div id="root"></div>');
     expect(index.headers.get('content-type')).toContain('text/html');
+    expect(index.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
+    expect(index.headers.get('x-frame-options')).toBe('DENY');
     await expect(asset.text()).resolves.toContain('console.log("dashboard")');
     expect(asset.headers.get('content-type')).toContain('text/javascript');
   });

--- a/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
@@ -59,6 +59,19 @@ describe('local browser control protection', () => {
     });
   });
 
+  it('denies cross-site fetch-metadata mutations even when Origin is absent', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://localhost:3737/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   it('does not apply the local control CSRF gate to provider webhook ingress paths', async () => {
     const app = createProtectedApp();
 
@@ -98,6 +111,22 @@ describe('local browser control protection', () => {
       headers: {
         origin: 'http://[::1]:3737',
         'sec-fetch-site': 'same-origin',
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('allows same-origin reverse-proxy browser mutations with forwarded public origin headers', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://127.0.0.1:3737/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        origin: 'https://dashboard.example.com',
+        'sec-fetch-site': 'same-origin',
+        'x-forwarded-host': 'dashboard.example.com',
+        'x-forwarded-proto': 'https',
       },
     });
 

--- a/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
@@ -83,6 +83,20 @@ describe('local browser control protection', () => {
       method: 'POST',
       headers: {
         origin: 'https://dashboard.example.com',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('allows IPv6 loopback same-origin browser mutations', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://[::1]:3737/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        origin: 'http://[::1]:3737',
         'sec-fetch-site': 'same-origin',
       },
     });

--- a/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
@@ -5,7 +5,7 @@ import { errorHandler, localBrowserControlProtection } from '../../../src/http/m
 function createProtectedApp() {
   const app = new Hono();
   app.onError(errorHandler);
-  app.use('*', localBrowserControlProtection);
+  app.use('*', localBrowserControlProtection());
   app.get('/api/dashboard', (c) => c.json({ ok: true }));
   app.post('/api/dashboard/events/ticket', (c) => c.json({ ok: true }));
   app.post('/v1/beasts/runs', (c) => c.json({ ok: true }));
@@ -17,7 +17,7 @@ describe('local browser control protection', () => {
   it('sets frame and browser hardening headers on local UI responses', async () => {
     const app = createProtectedApp();
 
-    const res = await app.request('http://dashboard.local/api/dashboard');
+    const res = await app.request('http://localhost:3737/api/dashboard');
 
     expect(res.status).toBe(200);
     expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
@@ -29,10 +29,10 @@ describe('local browser control protection', () => {
   it('allows same-origin browser mutations for local controls', async () => {
     const app = createProtectedApp();
 
-    const res = await app.request('http://dashboard.local/api/dashboard/events/ticket', {
+    const res = await app.request('http://localhost:3737/api/dashboard/events/ticket', {
       method: 'POST',
       headers: {
-        origin: 'http://dashboard.local',
+        origin: 'http://localhost:3737',
         'sec-fetch-site': 'same-origin',
       },
     });
@@ -43,7 +43,7 @@ describe('local browser control protection', () => {
   it('denies cross-origin browser mutations before local controls run', async () => {
     const app = createProtectedApp();
 
-    const res = await app.request('http://dashboard.local/v1/beasts/runs', {
+    const res = await app.request('http://localhost:3737/v1/beasts/runs', {
       method: 'POST',
       headers: {
         origin: 'http://evil.local',
@@ -62,7 +62,7 @@ describe('local browser control protection', () => {
   it('does not apply the local control CSRF gate to provider webhook ingress paths', async () => {
     const app = createProtectedApp();
 
-    const res = await app.request('http://dashboard.local/webhooks/provider', {
+    const res = await app.request('http://localhost:3737/webhooks/provider', {
       method: 'POST',
       headers: {
         origin: 'https://provider.example',
@@ -71,5 +71,36 @@ describe('local browser control protection', () => {
     });
 
     expect(res.status).toBe(200);
+  });
+
+  it('allows explicitly configured dashboard origins for direct backend deployments', async () => {
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.use('*', localBrowserControlProtection({ allowedOrigins: ['https://dashboard.example.com'] }));
+    app.post('/v1/chat/sessions', (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://127.0.0.1:3737/v1/chat/sessions', {
+      method: 'POST',
+      headers: {
+        origin: 'https://dashboard.example.com',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects same-origin mutations from unconfigured non-local hosts', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://attacker.example/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        origin: 'http://attacker.example',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/local-browser-control-protection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { errorHandler, localBrowserControlProtection } from '../../../src/http/middleware.js';
+
+function createProtectedApp() {
+  const app = new Hono();
+  app.onError(errorHandler);
+  app.use('*', localBrowserControlProtection);
+  app.get('/api/dashboard', (c) => c.json({ ok: true }));
+  app.post('/api/dashboard/events/ticket', (c) => c.json({ ok: true }));
+  app.post('/v1/beasts/runs', (c) => c.json({ ok: true }));
+  app.post('/webhooks/provider', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('local browser control protection', () => {
+  it('sets frame and browser hardening headers on local UI responses', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://dashboard.local/api/dashboard');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('referrer-policy')).toBe('same-origin');
+  });
+
+  it('allows same-origin browser mutations for local controls', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://dashboard.local/api/dashboard/events/ticket', {
+      method: 'POST',
+      headers: {
+        origin: 'http://dashboard.local',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('denies cross-origin browser mutations before local controls run', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://dashboard.local/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        origin: 'http://evil.local',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error).toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Local web control mutations require a same-origin browser request',
+    });
+  });
+
+  it('does not apply the local control CSRF gate to provider webhook ingress paths', async () => {
+    const app = createProtectedApp();
+
+    const res = await app.request('http://dashboard.local/webhooks/provider', {
+      method: 'POST',
+      headers: {
+        origin: 'https://provider.example',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -24,6 +24,8 @@ describe('vite dev proxy configuration', () => {
     expect(CONFIG_SOURCE).toContain('isSameOriginProxyRequest');
     expect(CONFIG_SOURCE).toContain("req.headers['sec-fetch-site']");
     expect(CONFIG_SOURCE).toContain('proxyReq.setHeader');
+    expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-host', req.headers.host)");
+    expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-proto', requestProtocol(req))");
     expect(CONFIG_SOURCE).not.toContain('headers: { authorization');
     expect(CONFIG_SOURCE).not.toContain('operatorProxy(');
   });

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -24,6 +24,7 @@ describe('vite dev proxy configuration', () => {
     expect(CONFIG_SOURCE).toContain('isSameOriginProxyRequest');
     expect(CONFIG_SOURCE).toContain("req.headers['sec-fetch-site']");
     expect(CONFIG_SOURCE).toContain('proxyReq.setHeader');
+    expect(CONFIG_SOURCE).toContain('if (operatorToken)');
     expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-host', req.headers.host)");
     expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-proto', requestProtocol(req))");
     expect(CONFIG_SOURCE).not.toContain('headers: { authorization');

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -44,6 +44,13 @@ describe('vite dev proxy configuration', () => {
     expect(CONFIG_SOURCE).toContain('preview:');
   });
 
+  it('applies dashboard hardening headers to both dev server and preview responses', () => {
+    expect(CONFIG_SOURCE).toContain('const dashboardSecurityHeaders');
+    expect(CONFIG_SOURCE).toContain('headers: dashboardSecurityHeaders');
+    expect(CONFIG_SOURCE).toContain("'X-Frame-Options': 'DENY'");
+    expect(CONFIG_SOURCE).toContain("'Content-Security-Policy': \"frame-ancestors 'none'\"");
+  });
+
   it('does not define VITE_BEAST_OPERATOR_TOKEN into the browser bundle', () => {
     expect(CONFIG_SOURCE).not.toContain("'import.meta.env.VITE_BEAST_OPERATOR_TOKEN'");
     expect(CONFIG_SOURCE).not.toContain('import.meta.env.VITE_BEAST_OPERATOR_TOKEN');

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -55,6 +55,10 @@ function isSameOriginProxyRequest(req: IncomingMessage): boolean {
   }
 }
 
+function requestProtocol(req: IncomingMessage): 'http' | 'https' {
+  return (req.socket as { encrypted?: boolean }).encrypted ? 'https' : 'http';
+}
+
 function withServerSideOperatorAuth(target: string, operatorToken: string, extra: ProxyOptions = {}): ProxyOptions {
   return {
     target,
@@ -71,8 +75,12 @@ function withServerSideOperatorAuth(target: string, operatorToken: string, extra
       if (!operatorToken) {
         return;
       }
-      proxy.on('proxyReq', (proxyReq) => {
+      proxy.on('proxyReq', (proxyReq, req) => {
         proxyReq.setHeader('authorization', `Bearer ${operatorToken}`);
+        if (req.headers.host) {
+          proxyReq.setHeader('x-forwarded-host', req.headers.host);
+          proxyReq.setHeader('x-forwarded-proto', requestProtocol(req));
+        }
       });
     },
     ...extra,

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -108,6 +108,12 @@ export default defineConfig(async ({ command, mode }) => {
       __FRANKENBEAST_VERSION__: JSON.stringify(rootPackageJson.version),
     },
     server: {
+      headers: {
+        'Content-Security-Policy': "frame-ancestors 'none'",
+        'X-Frame-Options': 'DENY',
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'same-origin',
+      },
       proxy: serverSideProxy,
     },
     preview: {

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -9,6 +9,12 @@ import { assertNoBrowserOperatorToken, assertSecureProxyTarget, loadProxyEnv, lo
 type ServerSideProxyConfig = Record<string, string | ProxyOptions>;
 
 const repoRootDir = fileURLToPath(new URL('../../', import.meta.url));
+const dashboardSecurityHeaders = {
+  'Content-Security-Policy': "frame-ancestors 'none'",
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'same-origin',
+} as const;
 const rootPackageJson = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
 ) as { version: string };
@@ -108,15 +114,11 @@ export default defineConfig(async ({ command, mode }) => {
       __FRANKENBEAST_VERSION__: JSON.stringify(rootPackageJson.version),
     },
     server: {
-      headers: {
-        'Content-Security-Policy': "frame-ancestors 'none'",
-        'X-Frame-Options': 'DENY',
-        'X-Content-Type-Options': 'nosniff',
-        'Referrer-Policy': 'same-origin',
-      },
+      headers: dashboardSecurityHeaders,
       proxy: serverSideProxy,
     },
     preview: {
+      headers: dashboardSecurityHeaders,
       proxy: serverSideProxy,
     },
     build: {

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -72,11 +72,10 @@ function withServerSideOperatorAuth(target: string, operatorToken: string, extra
       return undefined;
     },
     configure(proxy) {
-      if (!operatorToken) {
-        return;
-      }
       proxy.on('proxyReq', (proxyReq, req) => {
-        proxyReq.setHeader('authorization', `Bearer ${operatorToken}`);
+        if (operatorToken) {
+          proxyReq.setHeader('authorization', `Bearer ${operatorToken}`);
+        }
         if (req.headers.host) {
           proxyReq.setHeader('x-forwarded-host', req.headers.host);
           proxyReq.setHeader('x-forwarded-proto', requestProtocol(req));

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -17,6 +17,11 @@
 - After a dispatch `onRunCreated` callback, re-read persisted run state before startNow execution; signal cleanup can mark a just-created run stopped before any attempt exists.
 - Keep post-spawn metadata providers inside the same cleanup try/catch as attempt persistence so provider failures cannot leave a spawned process without an attempt record.
 
+## 2026-07-15 — Local dashboard CSRF/clickjacking hardening
+- Local UI CSRF gates must account for every dashboard serving path: Hono API, built static dashboard, Vite dev server, static proxy, and chat-server-to-daemon compatibility proxy. Pair frame denial headers with both API and HTML/static responses.
+- When comparing Origin for browser mutations, check explicit `allowedOrigins` before rejecting on `Sec-Fetch-Site`, and trust implicit same-origin only for loopback hosts (`localhost`, `127.0.0.1`, `[::1]`) to avoid DNS-rebinding Host equality bypasses.
+- Multi-hop dashboard proxies should preserve existing `x-forwarded-host`/`x-forwarded-proto` rather than overwriting them at inner hops; otherwise daemon-side same-origin checks see the wrong origin and break valid dashboard Beast mutations.
+
 ## 2026-07-15 — Graceful shutdown drain gates
 - For daemon drain modes, make one outer mutation-admission middleware own both the draining check and in-flight counter; nested route-specific re-checks can reject already-admitted requests after shutdown begins.
 - If shutdown times out waiting for in-flight mutations, do not release ownership markers such as pid files until mutations are quiesced or definitively aborted; otherwise a replacement daemon can start while the old handler still mutates shared state.


### PR DESCRIPTION
## Summary
- add same-origin browser mutation protection for local control routes using Origin / Sec-Fetch-Site checks
- add frame and browser hardening headers on chat and beast daemon apps
- document the local browser threat model for dashboard deployments

## Test Plan
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator test -- tests/unit/http/local-browser-control-protection.test.ts tests/unit/http/dashboard-routes.test.ts
- npm --workspace @franken/orchestrator run lint
- npm run build

Closes #1741