### PR TITLE
feat(availability): reserve urgent agent capacity

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -77,12 +77,12 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     executors,
   });
 
-  runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus });
+  runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy });
 
   return {
     agents: new AgentService(repository, undefined, { capacityPolicy }),
     catalog,
-    dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, { eventBus }),
+    dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy }),
     runs: runService,
     interviews: new BeastInterviewService(repository, catalog),
     metrics,
@@ -99,6 +99,9 @@ function createCapacityReservationPolicyFromEnv(): CapacityReservationPolicy | u
   const totalSlots = parsePositiveInteger(process.env.FBEAST_AGENT_CAPACITY_TOTAL);
   const reservations = parseCapacityReservations(process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS);
   const releasedReservationIds = parseCsv(process.env.FBEAST_AGENT_CAPACITY_RELEASED_RESERVATIONS);
+  if (reservations.length > 0 && totalSlots === undefined) {
+    throw new RangeError('FBEAST_AGENT_CAPACITY_TOTAL is required when FBEAST_AGENT_CAPACITY_RESERVATIONS is set');
+  }
   if (totalSlots === undefined || reservations.length === 0) {
     return undefined;
   }

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -12,6 +12,7 @@ import { BeastDispatchService } from './services/beast-dispatch-service.js';
 import { assertDispatcherStartupIntegrity } from './services/dispatcher-startup-integrity.js';
 import { BeastInterviewService } from './services/beast-interview-service.js';
 import { AgentService } from './services/agent-service.js';
+import { CapacityReservationPolicy, type CapacityReservationRule } from './services/capacity-reservation-policy.js';
 import { BeastRunService } from './services/beast-run-service.js';
 import { PrometheusBeastMetrics } from './telemetry/prometheus-beast-metrics.js';
 
@@ -42,6 +43,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const metrics = new PrometheusBeastMetrics();
   const eventBus = new BeastEventBus();
   const ticketStore = new SseConnectionTicketStore();
+  const capacityPolicy = createCapacityReservationPolicyFromEnv();
 
   // Deferred reference to break circular dep: executor → runService → executors → executor
   // eslint-disable-next-line prefer-const
@@ -78,7 +80,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus });
 
   return {
-    agents: new AgentService(repository),
+    agents: new AgentService(repository, undefined, { capacityPolicy }),
     catalog,
     dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, { eventBus }),
     runs: runService,
@@ -91,4 +93,76 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       repository.close();
     },
   };
+}
+
+function createCapacityReservationPolicyFromEnv(): CapacityReservationPolicy | undefined {
+  const totalSlots = parsePositiveInteger(process.env.FBEAST_AGENT_CAPACITY_TOTAL);
+  const reservations = parseCapacityReservations(process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS);
+  const releasedReservationIds = parseCsv(process.env.FBEAST_AGENT_CAPACITY_RELEASED_RESERVATIONS);
+  if (totalSlots === undefined || reservations.length === 0) {
+    return undefined;
+  }
+  return new CapacityReservationPolicy({
+    totalSlots,
+    reservations,
+    releasedReservationIds,
+  });
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new RangeError(`FBEAST_AGENT_CAPACITY_TOTAL must be a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+function parseCapacityReservations(value: string | undefined): CapacityReservationRule[] {
+  if (!value) return [];
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new RangeError('FBEAST_AGENT_CAPACITY_RESERVATIONS must be a JSON array');
+  }
+  return parsed.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new RangeError(`FBEAST_AGENT_CAPACITY_RESERVATIONS[${index}] must be an object`);
+    }
+    return {
+      id: requiredString(entry.id, `FBEAST_AGENT_CAPACITY_RESERVATIONS[${index}].id`),
+      slots: requiredPositiveInteger(entry.slots, `FBEAST_AGENT_CAPACITY_RESERVATIONS[${index}].slots`),
+      labels: optionalStringArray(entry.labels, `FBEAST_AGENT_CAPACITY_RESERVATIONS[${index}].labels`),
+      categories: optionalStringArray(entry.categories, `FBEAST_AGENT_CAPACITY_RESERVATIONS[${index}].categories`),
+    };
+  });
+}
+
+function parseCsv(value: string | undefined): string[] {
+  return value?.split(',').map((entry) => entry.trim()).filter(Boolean) ?? [];
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new RangeError(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError(`${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function optionalStringArray(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new RangeError(`${field} must be an array of strings`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -102,7 +102,7 @@ function createCapacityReservationPolicyFromEnv(): CapacityReservationPolicy | u
   if (reservations.length > 0 && totalSlots === undefined) {
     throw new RangeError('FBEAST_AGENT_CAPACITY_TOTAL is required when FBEAST_AGENT_CAPACITY_RESERVATIONS is set');
   }
-  if (totalSlots === undefined || reservations.length === 0) {
+  if (totalSlots === undefined) {
     return undefined;
   }
   return new CapacityReservationPolicy({

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -157,11 +157,13 @@ export class AgentService {
 
   private activeCapacityItems(): CapacityReservationWorkItem[] {
     return this.listAgents()
-      .filter((agent) => agent.status === 'initializing'
-        || agent.status === 'dispatching'
+      .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')
-      .map(capacityItemFromAgent);
+      .map((agent) => {
+        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
+        return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
+      });
   }
 }
 

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -14,6 +14,7 @@ import type {
   CapacityReservationState,
   CapacityReservationWorkItem,
 } from './capacity-reservation-policy.js';
+import { capacityItemFromConfig } from './capacity-reservation-policy.js';
 
 export interface CreateTrackedAgentRequest {
   readonly definitionId: string;
@@ -166,36 +167,4 @@ export class AgentService {
 
 function capacityItemFromAgent(agent: TrackedAgent): CapacityReservationWorkItem {
   return capacityItemFromConfig(agent.id, agent.initConfig);
-}
-
-function capacityItemFromConfig(id: string, initConfig: Readonly<Record<string, unknown>>): CapacityReservationWorkItem {
-  const issue = isRecord(initConfig.issue) ? initConfig.issue : undefined;
-  return {
-    id,
-    labels: [
-      ...stringsFromUnknown(initConfig.labels),
-      ...stringsFromUnknown(initConfig.label),
-      ...stringsFromUnknown(initConfig.issueLabels),
-      ...stringsFromUnknown(issue?.labels),
-    ],
-    categories: [
-      ...stringsFromUnknown(initConfig.categories),
-      ...stringsFromUnknown(initConfig.category),
-      ...stringsFromUnknown(issue?.category),
-    ],
-  };
-}
-
-function stringsFromUnknown(value: unknown): string[] {
-  if (typeof value === 'string') {
-    return [value];
-  }
-  if (Array.isArray(value)) {
-    return value.filter((entry): entry is string => typeof entry === 'string');
-  }
-  return [];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -8,6 +8,12 @@ import type {
 import { isoNow } from '@franken/types';
 import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../errors.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
+import type {
+  CapacityReservationDecision,
+  CapacityReservationPolicy,
+  CapacityReservationState,
+  CapacityReservationWorkItem,
+} from './capacity-reservation-policy.js';
 
 export interface CreateTrackedAgentRequest {
   readonly definitionId: string;
@@ -41,10 +47,15 @@ export interface TrackedAgentDetail {
   readonly events: TrackedAgentEvent[];
 }
 
+export interface AgentServiceOptions {
+  readonly capacityPolicy?: CapacityReservationPolicy | undefined;
+}
+
 export class AgentService {
   constructor(
     private readonly repository: SQLiteBeastRepository,
     private readonly now: () => string = () => isoNow(),
+    private readonly options: AgentServiceOptions = {},
   ) {}
 
   createAgent(request: CreateTrackedAgentRequest): TrackedAgent {
@@ -66,6 +77,21 @@ export class AgentService {
 
   listAgents(): TrackedAgent[] {
     return this.repository.listTrackedAgents();
+  }
+
+  getCapacityReservationState(): CapacityReservationState | undefined {
+    return this.options.capacityPolicy?.describe(this.activeCapacityItems());
+  }
+
+  canStartInitConfig(initConfig: Readonly<Record<string, unknown>>): CapacityReservationDecision {
+    return this.options.capacityPolicy?.canStart(capacityItemFromConfig('candidate', initConfig), this.activeCapacityItems())
+      ?? { allowed: true, reason: 'normal_capacity_available', reservationId: undefined };
+  }
+
+  canStartAgent(agent: TrackedAgent): CapacityReservationDecision {
+    const activeItems = this.activeCapacityItems().filter((item) => item.id !== agent.id);
+    return this.options.capacityPolicy?.canStart(capacityItemFromAgent(agent), activeItems)
+      ?? { allowed: true, reason: 'normal_capacity_available', reservationId: undefined };
   }
 
   getAgent(agentId: string): TrackedAgent {
@@ -127,4 +153,49 @@ export class AgentService {
       updatedAt: this.now(),
     });
   }
+
+  private activeCapacityItems(): CapacityReservationWorkItem[] {
+    return this.listAgents()
+      .filter((agent) => agent.status === 'initializing'
+        || agent.status === 'dispatching'
+        || agent.status === 'awaiting_approval'
+        || agent.status === 'running')
+      .map(capacityItemFromAgent);
+  }
+}
+
+function capacityItemFromAgent(agent: TrackedAgent): CapacityReservationWorkItem {
+  return capacityItemFromConfig(agent.id, agent.initConfig);
+}
+
+function capacityItemFromConfig(id: string, initConfig: Readonly<Record<string, unknown>>): CapacityReservationWorkItem {
+  const issue = isRecord(initConfig.issue) ? initConfig.issue : undefined;
+  return {
+    id,
+    labels: [
+      ...stringsFromUnknown(initConfig.labels),
+      ...stringsFromUnknown(initConfig.label),
+      ...stringsFromUnknown(initConfig.issueLabels),
+      ...stringsFromUnknown(issue?.labels),
+    ],
+    categories: [
+      ...stringsFromUnknown(initConfig.categories),
+      ...stringsFromUnknown(initConfig.category),
+      ...stringsFromUnknown(issue?.category),
+    ],
+  };
+}
+
+function stringsFromUnknown(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  }
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -181,6 +181,7 @@ export class BeastDispatchService {
       : config;
     const executionMode = request.executionMode ?? definition.executionModeDefault;
     if (request.trackedAgentId) {
+      this.repository.requireTrackedAgent(request.trackedAgentId);
       this.assertTrackedAgentCapacity(request.trackedAgentId, {
         ...request.config,
         ...configSnapshot,

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -335,7 +335,7 @@ export class BeastDispatchService {
     candidateConfig: Readonly<Record<string, unknown>>,
   ): void {
     if (!this.options.capacityPolicy) return;
-    const activeItems = this.activeCapacityItems(trackedAgentId);
+    const activeItems = this.activeCapacityItems();
     const decision = this.options.capacityPolicy.canStart(
       capacityItemFromConfig(trackedAgentId, candidateConfig),
       activeItems,
@@ -345,9 +345,8 @@ export class BeastDispatchService {
     }
   }
 
-  private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
+  private activeCapacityItems(): CapacityReservationWorkItem[] {
     return this.repository.listTrackedAgents()
-      .filter((agent) => agent.id !== excludeAgentId)
       .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -348,11 +348,13 @@ export class BeastDispatchService {
   private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
     return this.repository.listTrackedAgents()
       .filter((agent) => agent.id !== excludeAgentId)
-      .filter((agent) => agent.status === 'initializing'
-        || agent.status === 'dispatching'
+      .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')
-      .map((agent) => capacityItemFromConfig(agent.id, agent.initConfig));
+      .map((agent) => {
+        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
+        return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
+      });
   }
 
   private resolveAgentModuleConfig(trackedAgentId?: string): ModuleConfig | undefined {

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -35,6 +35,12 @@ const SHARED_RUNTIME_CONFIG_KEYS = [
   'maxDurationMs',
   'maxTotalTokens',
   'reflection',
+  'label',
+  'labels',
+  'issueLabels',
+  'category',
+  'categories',
+  'issue',
 ] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -96,6 +102,15 @@ function normalizeSharedRuntimeConfigValue(key: string, value: unknown): unknown
       return typeof value === 'number' ? value : undefined;
     case 'reflection':
       return typeof value === 'boolean' ? value : undefined;
+    case 'label':
+    case 'category':
+      return typeof value === 'string' ? value : undefined;
+    case 'labels':
+    case 'issueLabels':
+    case 'categories':
+      return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : undefined;
+    case 'issue':
+      return isRecord(value) ? value : undefined;
     default:
       return undefined;
   }
@@ -165,8 +180,11 @@ export class BeastDispatchService {
       ? { ...config, modules: moduleConfig }
       : config;
     const executionMode = request.executionMode ?? definition.executionModeDefault;
-    if (request.startNow && request.trackedAgentId) {
-      this.assertTrackedAgentCapacity(request.trackedAgentId);
+    if (request.trackedAgentId) {
+      this.assertTrackedAgentCapacity(request.trackedAgentId, {
+        ...request.config,
+        ...configSnapshot,
+      });
     }
     const createdAt = new Date(wallClockNow()).toISOString();
     const linkedAt = new Date(wallClockNow()).toISOString();
@@ -311,12 +329,14 @@ export class BeastDispatchService {
     return mode === 'container' ? this.executors.container : this.executors.process;
   }
 
-  private assertTrackedAgentCapacity(trackedAgentId: string): void {
+  private assertTrackedAgentCapacity(
+    trackedAgentId: string,
+    candidateConfig: Readonly<Record<string, unknown>>,
+  ): void {
     if (!this.options.capacityPolicy) return;
-    const trackedAgent = this.repository.requireTrackedAgent(trackedAgentId);
     const activeItems = this.activeCapacityItems(trackedAgentId);
     const decision = this.options.capacityPolicy.canStart(
-      capacityItemFromConfig(trackedAgent.id, trackedAgent.initConfig),
+      capacityItemFromConfig(trackedAgentId, candidateConfig),
       activeItems,
     );
     if (!decision.allowed) {

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -180,18 +180,15 @@ export class BeastDispatchService {
       ? { ...config, modules: moduleConfig }
       : config;
     const executionMode = request.executionMode ?? definition.executionModeDefault;
-    if (request.trackedAgentId) {
-      this.repository.requireTrackedAgent(request.trackedAgentId);
-      this.assertTrackedAgentCapacity(request.trackedAgentId, {
-        ...request.config,
-        ...configSnapshot,
-      });
-    }
     const createdAt = new Date(wallClockNow()).toISOString();
     const linkedAt = new Date(wallClockNow()).toISOString();
     const run = this.repository.transaction(() => {
       if (request.trackedAgentId) {
         this.repository.requireTrackedAgent(request.trackedAgentId);
+        this.assertTrackedAgentCapacity(request.trackedAgentId, {
+          ...request.config,
+          ...configSnapshot,
+        });
       }
 
       const createdRun = this.repository.createRun({

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -343,14 +343,13 @@ export class BeastDispatchService {
   }
 
   private activeCapacityItems(): CapacityReservationWorkItem[] {
-    return this.repository.listTrackedAgents()
-      .filter((agent) => agent.status === 'dispatching'
-        || agent.status === 'awaiting_approval'
-        || agent.status === 'running')
-      .map((agent) => {
-        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
-        return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
-      });
+    return this.repository.listRuns()
+      .filter(run => run.trackedAgentId)
+      .filter(run => run.status === 'queued'
+        || run.status === 'interviewing'
+        || run.status === 'pending_approval'
+        || run.status === 'running')
+      .map(run => capacityItemFromConfig(run.trackedAgentId!, run.configSnapshot));
   }
 
   private resolveAgentModuleConfig(trackedAgentId?: string): ModuleConfig | undefined {

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -8,9 +8,16 @@ import { BeastCatalogService } from './beast-catalog-service.js';
 import { wallClockNow } from '@franken/types';
 import { UnknownBeastDefinitionError } from '../errors.js';
 import { GitConfigSchema, LlmConfigSchema, PromptConfigSchema } from '../../cli/run-config-loader.js';
+import {
+  CapacityReservationError,
+  type CapacityReservationPolicy,
+  type CapacityReservationWorkItem,
+  capacityItemFromConfig,
+} from './capacity-reservation-policy.js';
 
 export interface BeastDispatchServiceOptions {
   eventBus?: BeastEventBus;
+  capacityPolicy?: CapacityReservationPolicy | undefined;
 }
 
 export interface BeastExecutors {
@@ -158,6 +165,9 @@ export class BeastDispatchService {
       ? { ...config, modules: moduleConfig }
       : config;
     const executionMode = request.executionMode ?? definition.executionModeDefault;
+    if (request.startNow && request.trackedAgentId) {
+      this.assertTrackedAgentCapacity(request.trackedAgentId);
+    }
     const createdAt = new Date(wallClockNow()).toISOString();
     const linkedAt = new Date(wallClockNow()).toISOString();
     const run = this.repository.transaction(() => {
@@ -299,6 +309,29 @@ export class BeastDispatchService {
 
   private executorFor(mode: BeastExecutionMode): BeastExecutor {
     return mode === 'container' ? this.executors.container : this.executors.process;
+  }
+
+  private assertTrackedAgentCapacity(trackedAgentId: string): void {
+    if (!this.options.capacityPolicy) return;
+    const trackedAgent = this.repository.requireTrackedAgent(trackedAgentId);
+    const activeItems = this.activeCapacityItems(trackedAgentId);
+    const decision = this.options.capacityPolicy.canStart(
+      capacityItemFromConfig(trackedAgent.id, trackedAgent.initConfig),
+      activeItems,
+    );
+    if (!decision.allowed) {
+      throw new CapacityReservationError(decision, this.options.capacityPolicy.describe(activeItems));
+    }
+  }
+
+  private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
+    return this.repository.listTrackedAgents()
+      .filter((agent) => agent.id !== excludeAgentId)
+      .filter((agent) => agent.status === 'initializing'
+        || agent.status === 'dispatching'
+        || agent.status === 'awaiting_approval'
+        || agent.status === 'running')
+      .map((agent) => capacityItemFromConfig(agent.id, agent.initConfig));
   }
 
   private resolveAgentModuleConfig(trackedAgentId?: string): ModuleConfig | undefined {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -276,6 +276,7 @@ export class BeastRunService {
   async restart(runId: string, actor: string): Promise<BeastRun> {
     const run = this.requireRun(runId);
     if (run.status === 'running') {
+      this.assertTrackedAgentCapacity(run);
       await this.stop(runId, actor);
     }
     return this.start(runId, actor);

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -331,7 +331,7 @@ export class BeastRunService {
 
     const activeItems = this.activeCapacityItems(run.trackedAgentId);
     const decision = this.serviceOptions.capacityPolicy.canStart(
-      capacityItemFromConfig(trackedAgent.id, trackedAgent.initConfig),
+      capacityItemFromConfig(trackedAgent.id, run.configSnapshot),
       activeItems,
     );
     if (!decision.allowed) {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -342,11 +342,13 @@ export class BeastRunService {
   private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
     return this.repository.listTrackedAgents()
       .filter((agent) => agent.id !== excludeAgentId)
-      .filter((agent) => agent.status === 'initializing'
-        || agent.status === 'dispatching'
+      .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')
-      .map((agent) => capacityItemFromConfig(agent.id, agent.initConfig));
+      .map((agent) => {
+        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
+        return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
+      });
   }
 
   private syncTrackedAgent(run: BeastRun): void {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -329,7 +329,7 @@ export class BeastRunService {
     const trackedAgent = this.repository.getTrackedAgent(run.trackedAgentId);
     if (!trackedAgent || trackedAgent.status === 'deleted') return;
 
-    const activeItems = this.activeCapacityItems(run.trackedAgentId);
+    const activeItems = this.activeCapacityItems(run.id);
     const decision = this.serviceOptions.capacityPolicy.canStart(
       capacityItemFromConfig(trackedAgent.id, run.configSnapshot),
       activeItems,
@@ -364,16 +364,15 @@ export class BeastRunService {
     });
   }
 
-  private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
-    return this.repository.listTrackedAgents()
-      .filter((agent) => agent.id !== excludeAgentId)
-      .filter((agent) => agent.status === 'dispatching'
-        || agent.status === 'awaiting_approval'
-        || agent.status === 'running')
-      .map((agent) => {
-        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
-        return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
-      });
+  private activeCapacityItems(excludeRunId: string): CapacityReservationWorkItem[] {
+    return this.repository.listRuns()
+      .filter(run => run.id !== excludeRunId)
+      .filter(run => run.trackedAgentId)
+      .filter(run => run.status === 'queued'
+        || run.status === 'interviewing'
+        || run.status === 'pending_approval'
+        || run.status === 'running')
+      .map(run => capacityItemFromConfig(run.trackedAgentId!, run.configSnapshot));
   }
 
   private syncTrackedAgent(run: BeastRun): void {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -67,8 +67,7 @@ export class BeastRunService {
   }
 
   async start(runId: string, _actor: string): Promise<BeastRun> {
-    const run = this.requireRun(runId);
-    this.assertTrackedAgentCapacity(run);
+    const run = this.reserveTrackedAgentCapacityForStart(this.requireRun(runId));
     const definition = this.getDefinitionOrThrow(run.definitionId);
     const priorAttemptId = run.currentAttemptId;
     const priorAttemptCount = run.attemptCount;
@@ -338,6 +337,31 @@ export class BeastRunService {
     if (!decision.allowed) {
       throw new CapacityReservationError(decision, this.serviceOptions.capacityPolicy.describe(activeItems));
     }
+  }
+
+  private reserveTrackedAgentCapacityForStart(run: BeastRun): BeastRun {
+    if (!run.trackedAgentId || !this.serviceOptions.capacityPolicy) return run;
+    const trackedAgent = this.repository.getTrackedAgent(run.trackedAgentId);
+    if (!trackedAgent || trackedAgent.status === 'deleted') return run;
+
+    const reservedAt = isoNow();
+    return this.repository.transaction(() => {
+      const currentRun = this.requireRun(run.id);
+      const currentTrackedAgent = this.repository.getTrackedAgent(run.trackedAgentId!);
+      if (!currentTrackedAgent || currentTrackedAgent.status === 'deleted') return currentRun;
+
+      this.assertTrackedAgentCapacity(currentRun);
+      if (currentTrackedAgent.status === 'dispatching' && currentTrackedAgent.dispatchRunId === currentRun.id) {
+        return currentRun;
+      }
+
+      this.repository.updateTrackedAgent(run.trackedAgentId!, {
+        status: 'dispatching',
+        dispatchRunId: currentRun.id,
+        updatedAt: reservedAt,
+      });
+      return currentRun;
+    });
   }
 
   private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -6,9 +6,16 @@ import type { BeastMetrics } from '../telemetry/beast-metrics.js';
 import type { BeastExecutors } from './beast-dispatch-service.js';
 import { BeastCatalogService } from './beast-catalog-service.js';
 import { isoNow } from '@franken/types';
+import {
+  CapacityReservationError,
+  type CapacityReservationPolicy,
+  type CapacityReservationWorkItem,
+  capacityItemFromConfig,
+} from './capacity-reservation-policy.js';
 
 export interface BeastRunServiceOptions {
   eventBus?: BeastEventBus;
+  capacityPolicy?: CapacityReservationPolicy | undefined;
 }
 
 export class UnknownBeastRunError extends Error {
@@ -61,6 +68,7 @@ export class BeastRunService {
 
   async start(runId: string, _actor: string): Promise<BeastRun> {
     const run = this.requireRun(runId);
+    this.assertTrackedAgentCapacity(run);
     const definition = this.getDefinitionOrThrow(run.definitionId);
     const priorAttemptId = run.currentAttemptId;
     const priorAttemptCount = run.attemptCount;
@@ -314,6 +322,31 @@ export class BeastRunService {
     if (run) {
       this.syncTrackedAgent(run);
     }
+  }
+
+  private assertTrackedAgentCapacity(run: BeastRun): void {
+    if (!run.trackedAgentId || !this.serviceOptions.capacityPolicy) return;
+    const trackedAgent = this.repository.getTrackedAgent(run.trackedAgentId);
+    if (!trackedAgent || trackedAgent.status === 'deleted') return;
+
+    const activeItems = this.activeCapacityItems(run.trackedAgentId);
+    const decision = this.serviceOptions.capacityPolicy.canStart(
+      capacityItemFromConfig(trackedAgent.id, trackedAgent.initConfig),
+      activeItems,
+    );
+    if (!decision.allowed) {
+      throw new CapacityReservationError(decision, this.serviceOptions.capacityPolicy.describe(activeItems));
+    }
+  }
+
+  private activeCapacityItems(excludeAgentId: string): CapacityReservationWorkItem[] {
+    return this.repository.listTrackedAgents()
+      .filter((agent) => agent.id !== excludeAgentId)
+      .filter((agent) => agent.status === 'initializing'
+        || agent.status === 'dispatching'
+        || agent.status === 'awaiting_approval'
+        || agent.status === 'running')
+      .map((agent) => capacityItemFromConfig(agent.id, agent.initConfig));
   }
 
   private syncTrackedAgent(run: BeastRun): void {

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -1,0 +1,166 @@
+export interface CapacityReservationRule {
+  readonly id: string;
+  readonly slots: number;
+  readonly labels?: readonly string[] | undefined;
+  readonly categories?: readonly string[] | undefined;
+}
+
+export interface CapacityReservationPolicyConfig {
+  readonly totalSlots: number;
+  readonly reservations: readonly CapacityReservationRule[];
+  readonly releasedReservationIds?: readonly string[] | undefined;
+}
+
+export interface CapacityReservationWorkItem {
+  readonly id: string;
+  readonly labels?: readonly string[] | undefined;
+  readonly category?: string | undefined;
+  readonly categories?: readonly string[] | undefined;
+}
+
+export interface CapacityReservationDecision {
+  readonly allowed: boolean;
+  readonly reason:
+    | 'normal_capacity_available'
+    | 'reserved_capacity_available'
+    | 'released_reserved_capacity_available'
+    | 'reserved_capacity_only'
+    | 'capacity_full';
+  readonly reservationId?: string | undefined;
+}
+
+export interface CapacityReservationState {
+  readonly totalSlots: number;
+  readonly usedSlots: number;
+  readonly freeSlots: number;
+  readonly normalSlots: {
+    readonly total: number;
+    readonly used: number;
+    readonly free: number;
+  };
+  readonly reservations: readonly CapacityReservationBucketState[];
+}
+
+export interface CapacityReservationBucketState {
+  readonly id: string;
+  readonly slots: number;
+  readonly used: number;
+  readonly free: number;
+  readonly released: boolean;
+  readonly labels: readonly string[];
+  readonly categories: readonly string[];
+}
+
+export class CapacityReservationPolicy {
+  private readonly releasedReservationIds: ReadonlySet<string>;
+  private readonly reservations: readonly CapacityReservationRule[];
+  readonly totalSlots: number;
+
+  constructor(config: CapacityReservationPolicyConfig) {
+    if (!Number.isSafeInteger(config.totalSlots) || config.totalSlots < 1) {
+      throw new RangeError(`capacity totalSlots must be a positive safe integer, received ${config.totalSlots}`);
+    }
+    const seen = new Set<string>();
+    let reservedSlots = 0;
+    this.reservations = config.reservations.map((reservation) => {
+      if (!reservation.id.trim()) {
+        throw new RangeError('capacity reservation id must be non-empty');
+      }
+      if (seen.has(reservation.id)) {
+        throw new RangeError(`duplicate capacity reservation id: ${reservation.id}`);
+      }
+      seen.add(reservation.id);
+      if (!Number.isSafeInteger(reservation.slots) || reservation.slots < 1) {
+        throw new RangeError(`capacity reservation '${reservation.id}' slots must be a positive safe integer`);
+      }
+      reservedSlots += reservation.slots;
+      const labels = normalizeMatchers(reservation.labels);
+      const categories = normalizeMatchers(reservation.categories);
+      if (labels.length === 0 && categories.length === 0) {
+        throw new RangeError(`capacity reservation '${reservation.id}' must match at least one label or category`);
+      }
+      return { ...reservation, labels, categories };
+    });
+    if (reservedSlots > config.totalSlots) {
+      throw new RangeError(`reserved capacity (${reservedSlots}) exceeds total capacity (${config.totalSlots})`);
+    }
+    this.totalSlots = config.totalSlots;
+    this.releasedReservationIds = new Set(config.releasedReservationIds ?? []);
+  }
+
+  canStart(candidate: CapacityReservationWorkItem, activeItems: readonly CapacityReservationWorkItem[]): CapacityReservationDecision {
+    const state = this.describe(activeItems);
+    if (state.freeSlots <= 0) {
+      return { allowed: false, reason: 'capacity_full', reservationId: undefined };
+    }
+
+    const matchingReservation = this.reservations.find((reservation) => this.matches(reservation, candidate));
+    if (matchingReservation) {
+      const bucket = state.reservations.find((entry) => entry.id === matchingReservation.id);
+      if (bucket && bucket.free > 0) {
+        return { allowed: true, reason: 'reserved_capacity_available', reservationId: matchingReservation.id };
+      }
+    }
+
+    if (state.normalSlots.free > 0) {
+      return { allowed: true, reason: 'normal_capacity_available', reservationId: undefined };
+    }
+
+    if (state.reservations.some((reservation) => reservation.released && reservation.free > 0)) {
+      return { allowed: true, reason: 'released_reserved_capacity_available', reservationId: undefined };
+    }
+
+    return { allowed: false, reason: 'reserved_capacity_only', reservationId: undefined };
+  }
+
+  describe(activeItems: readonly CapacityReservationWorkItem[]): CapacityReservationState {
+    const usedSlots = activeItems.length;
+    const buckets = this.reservations.map((reservation) => {
+      const used = activeItems.filter((item) => this.matches(reservation, item)).length;
+      return {
+        id: reservation.id,
+        slots: reservation.slots,
+        used: Math.min(used, reservation.slots),
+        free: Math.max(0, reservation.slots - used),
+        released: this.releasedReservationIds.has(reservation.id),
+        labels: [...(reservation.labels ?? [])],
+        categories: [...(reservation.categories ?? [])],
+      };
+    });
+    const totalReservedSlots = buckets.reduce((sum, bucket) => sum + bucket.slots, 0);
+    const reservedUsed = buckets.reduce((sum, bucket) => sum + bucket.used, 0);
+    const normalTotal = this.totalSlots - totalReservedSlots;
+    const normalUsed = Math.max(0, usedSlots - reservedUsed);
+
+    return {
+      totalSlots: this.totalSlots,
+      usedSlots,
+      freeSlots: Math.max(0, this.totalSlots - usedSlots),
+      normalSlots: {
+        total: normalTotal,
+        used: Math.min(normalUsed, normalTotal),
+        free: Math.max(0, normalTotal - normalUsed),
+      },
+      reservations: buckets,
+    };
+  }
+
+  private matches(reservation: CapacityReservationRule, item: CapacityReservationWorkItem): boolean {
+    const labels = new Set((item.labels ?? []).map(normalizeMatcher));
+    const categories = new Set([...(item.categories ?? []), item.category].filter(isString).map(normalizeMatcher));
+    return (reservation.labels ?? []).some((label) => labels.has(label))
+      || (reservation.categories ?? []).some((category) => categories.has(category));
+  }
+}
+
+function normalizeMatchers(values: readonly string[] | undefined): readonly string[] {
+  return [...new Set((values ?? []).map(normalizeMatcher).filter(Boolean))];
+}
+
+function normalizeMatcher(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -105,7 +105,7 @@ export class CapacityReservationPolicy {
     }
 
     const candidateIndex = activeItems.length;
-    const candidateAllocation = this.allocateReservations([...activeItems, candidate]);
+    const candidateAllocation = this.allocateReservations([...activeItems, candidate], candidateIndex);
     const matchingReservationIndex = candidateAllocation.assignedBucketByItemIndex.get(candidateIndex);
     if (matchingReservationIndex !== undefined) {
       const reservation = this.reservations[matchingReservationIndex];
@@ -163,7 +163,10 @@ export class CapacityReservationPolicy {
     return Math.max(0, releasedFree - normalOverflowUsed);
   }
 
-  private allocateReservations(activeItems: readonly CapacityReservationWorkItem[]): {
+  private allocateReservations(
+    activeItems: readonly CapacityReservationWorkItem[],
+    priorityItemIndex?: number,
+  ): {
     buckets: Array<{
       id: string;
       slots: number;
@@ -182,31 +185,64 @@ export class CapacityReservationPolicy {
       labels: [...(reservation.labels ?? [])],
       categories: [...(reservation.categories ?? [])],
     }));
-    const assignedBucketByItemIndex = new Map<number, number>();
+    const bucketSlots = buckets.flatMap((bucket, bucketIndex) => (
+      Array.from({ length: bucket.slots }, () => bucketIndex)
+    ));
+    const assignedSlotByItemIndex = new Map<number, number>();
+    const assignedItemBySlotIndex = new Map<number, number>();
     const indexedActiveItems = activeItems
       .map((item, activeIndex) => ({
         activeIndex,
-        matchingIndexes: this.matchingReservationIndexes(item),
+        matchingSlotIndexes: bucketSlots.flatMap((bucketIndex, slotIndex) => {
+          const reservation = this.reservations[bucketIndex];
+          if (!reservation) return [];
+          return this.matches(reservation, item) ? [slotIndex] : [];
+        }),
       }))
-      .filter(({ matchingIndexes }) => matchingIndexes.length > 0)
+      .filter(({ matchingSlotIndexes }) => matchingSlotIndexes.length > 0)
       .sort((left, right) => {
-        if (left.matchingIndexes.length !== right.matchingIndexes.length) {
-          return left.matchingIndexes.length - right.matchingIndexes.length;
+        if (priorityItemIndex !== undefined && left.activeIndex !== right.activeIndex) {
+          if (left.activeIndex === priorityItemIndex) return -1;
+          if (right.activeIndex === priorityItemIndex) return 1;
+        }
+        if (left.matchingSlotIndexes.length !== right.matchingSlotIndexes.length) {
+          return left.matchingSlotIndexes.length - right.matchingSlotIndexes.length;
         }
         return left.activeIndex - right.activeIndex;
       });
 
-    for (const { activeIndex, matchingIndexes } of indexedActiveItems) {
-      const bucketIndex = matchingIndexes.find((index) => {
-        const bucket = buckets[index];
-        return bucket !== undefined && bucket.used < bucket.slots;
-      });
-      if (bucketIndex !== undefined) {
-        const bucket = buckets[bucketIndex];
-        if (bucket) {
-          bucket.used += 1;
-          assignedBucketByItemIndex.set(activeIndex, bucketIndex);
+    const tryAssign = (activeIndex: number, matchingSlotIndexes: readonly number[], seenSlots: Set<number>): boolean => {
+      for (const slotIndex of matchingSlotIndexes) {
+        if (seenSlots.has(slotIndex)) continue;
+        seenSlots.add(slotIndex);
+        const displacedItemIndex = assignedItemBySlotIndex.get(slotIndex);
+        if (displacedItemIndex === undefined) {
+          assignedItemBySlotIndex.set(slotIndex, activeIndex);
+          assignedSlotByItemIndex.set(activeIndex, slotIndex);
+          return true;
         }
+        const displacedItem = indexedActiveItems.find((item) => item.activeIndex === displacedItemIndex);
+        if (displacedItem && tryAssign(displacedItemIndex, displacedItem.matchingSlotIndexes, seenSlots)) {
+          assignedItemBySlotIndex.set(slotIndex, activeIndex);
+          assignedSlotByItemIndex.set(activeIndex, slotIndex);
+          return true;
+        }
+      }
+      return false;
+    };
+
+    for (const { activeIndex, matchingSlotIndexes } of indexedActiveItems) {
+      tryAssign(activeIndex, matchingSlotIndexes, new Set<number>());
+    }
+
+    const assignedBucketByItemIndex = new Map<number, number>();
+    for (const [activeIndex, slotIndex] of assignedSlotByItemIndex.entries()) {
+      const bucketIndex = bucketSlots[slotIndex];
+      if (bucketIndex === undefined) continue;
+      const bucket = buckets[bucketIndex];
+      if (bucket) {
+        bucket.used += 1;
+        assignedBucketByItemIndex.set(activeIndex, bucketIndex);
       }
     }
     return { buckets, assignedBucketByItemIndex };

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -145,25 +145,22 @@ export class CapacityReservationPolicy {
     }>,
   ): CapacityReservationState {
 
-    const matchingBuckets = buckets.map((bucket) => ({
-      ...bucket,
-      free: Math.max(0, bucket.slots - bucket.used),
-    }));
-    const totalReservedSlots = matchingBuckets.reduce((sum, bucket) => sum + bucket.slots, 0);
-    const matchingReservedUsed = matchingBuckets.reduce((sum, bucket) => sum + bucket.used, 0);
+    const totalReservedSlots = buckets.reduce((sum, bucket) => sum + bucket.slots, 0);
+    const reservedUsed = buckets.reduce((sum, bucket) => sum + bucket.used, 0);
     const normalTotal = this.totalSlots - totalReservedSlots;
-    const normalUsed = Math.max(0, usedSlots - matchingReservedUsed);
-    let releasedOverflowUsed = Math.max(0, normalUsed - normalTotal);
-    const bucketsWithFree = matchingBuckets.map((bucket) => {
-      const overflowUsed = bucket.released ? Math.min(bucket.free, releasedOverflowUsed) : 0;
-      releasedOverflowUsed -= overflowUsed;
-      const used = bucket.used + overflowUsed;
+    let normalOverflowUsed = Math.max(0, usedSlots - reservedUsed - normalTotal);
+    const bucketsWithFree = buckets.map((bucket) => {
+      const releasedOverflowUsed = bucket.released ? Math.min(normalOverflowUsed, Math.max(0, bucket.slots - bucket.used)) : 0;
+      normalOverflowUsed -= releasedOverflowUsed;
+      const used = bucket.used + releasedOverflowUsed;
       return {
         ...bucket,
         used,
         free: Math.max(0, bucket.slots - used),
       };
     });
+    const adjustedReservedUsed = bucketsWithFree.reduce((sum, bucket) => sum + bucket.used, 0);
+    const normalUsed = Math.max(0, usedSlots - adjustedReservedUsed);
 
     return {
       totalSlots: this.totalSlots,

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -51,6 +51,16 @@ export interface CapacityReservationBucketState {
   readonly categories: readonly string[];
 }
 
+export class CapacityReservationError extends Error {
+  constructor(
+    public readonly decision: CapacityReservationDecision,
+    public readonly state: CapacityReservationState,
+  ) {
+    super('Agent capacity is reserved for urgent matching work');
+    this.name = 'CapacityReservationError';
+  }
+}
+
 export class CapacityReservationPolicy {
   private readonly releasedReservationIds: ReadonlySet<string>;
   private readonly reservations: readonly CapacityReservationRule[];
@@ -94,19 +104,18 @@ export class CapacityReservationPolicy {
       return { allowed: false, reason: 'capacity_full', reservationId: undefined };
     }
 
-    const matchingReservation = this.reservations.find((reservation) => this.matches(reservation, candidate));
+    const matchingReservation = this.reservations
+      .filter((reservation) => this.matches(reservation, candidate))
+      .find((reservation) => state.reservations.some((bucket) => bucket.id === reservation.id && bucket.free > 0));
     if (matchingReservation) {
-      const bucket = state.reservations.find((entry) => entry.id === matchingReservation.id);
-      if (bucket && bucket.free > 0) {
-        return { allowed: true, reason: 'reserved_capacity_available', reservationId: matchingReservation.id };
-      }
+      return { allowed: true, reason: 'reserved_capacity_available', reservationId: matchingReservation.id };
     }
 
     if (state.normalSlots.free > 0) {
       return { allowed: true, reason: 'normal_capacity_available', reservationId: undefined };
     }
 
-    if (state.reservations.some((reservation) => reservation.released && reservation.free > 0)) {
+    if (this.releasedReservationFreeForNormalWork(state, activeItems) > 0) {
       return { allowed: true, reason: 'released_reserved_capacity_available', reservationId: undefined };
     }
 
@@ -115,20 +124,33 @@ export class CapacityReservationPolicy {
 
   describe(activeItems: readonly CapacityReservationWorkItem[]): CapacityReservationState {
     const usedSlots = activeItems.length;
-    const buckets = this.reservations.map((reservation) => {
-      const used = activeItems.filter((item) => this.matches(reservation, item)).length;
-      return {
-        id: reservation.id,
-        slots: reservation.slots,
-        used: Math.min(used, reservation.slots),
-        free: Math.max(0, reservation.slots - used),
-        released: this.releasedReservationIds.has(reservation.id),
-        labels: [...(reservation.labels ?? [])],
-        categories: [...(reservation.categories ?? [])],
-      };
-    });
-    const totalReservedSlots = buckets.reduce((sum, bucket) => sum + bucket.slots, 0);
-    const reservedUsed = buckets.reduce((sum, bucket) => sum + bucket.used, 0);
+    const buckets = this.reservations.map((reservation) => ({
+      id: reservation.id,
+      slots: reservation.slots,
+      used: 0,
+      released: this.releasedReservationIds.has(reservation.id),
+      labels: [...(reservation.labels ?? [])],
+      categories: [...(reservation.categories ?? [])],
+    }));
+
+    for (const item of activeItems) {
+      const bucket = buckets.find((candidateBucket, index) => {
+        const reservation = this.reservations[index];
+        if (!reservation) return false;
+        return candidateBucket.used < candidateBucket.slots
+          && this.matches(reservation, item);
+      });
+      if (bucket) {
+        bucket.used += 1;
+      }
+    }
+
+    const bucketsWithFree = buckets.map((bucket) => ({
+      ...bucket,
+      free: Math.max(0, bucket.slots - bucket.used),
+    }));
+    const totalReservedSlots = bucketsWithFree.reduce((sum, bucket) => sum + bucket.slots, 0);
+    const reservedUsed = bucketsWithFree.reduce((sum, bucket) => sum + bucket.used, 0);
     const normalTotal = this.totalSlots - totalReservedSlots;
     const normalUsed = Math.max(0, usedSlots - reservedUsed);
 
@@ -141,8 +163,20 @@ export class CapacityReservationPolicy {
         used: Math.min(normalUsed, normalTotal),
         free: Math.max(0, normalTotal - normalUsed),
       },
-      reservations: buckets,
+      reservations: bucketsWithFree,
     };
+  }
+
+  private releasedReservationFreeForNormalWork(
+    state: CapacityReservationState,
+    activeItems: readonly CapacityReservationWorkItem[],
+  ): number {
+    const reservedUsed = state.reservations.reduce((sum, bucket) => sum + bucket.used, 0);
+    const normalOverflowUsed = Math.max(0, activeItems.length - reservedUsed - state.normalSlots.total);
+    const releasedFree = state.reservations
+      .filter((reservation) => reservation.released)
+      .reduce((sum, reservation) => sum + reservation.free, 0);
+    return Math.max(0, releasedFree - normalOverflowUsed);
   }
 
   private matches(reservation: CapacityReservationRule, item: CapacityReservationWorkItem): boolean {
@@ -153,6 +187,27 @@ export class CapacityReservationPolicy {
   }
 }
 
+export function capacityItemFromConfig(
+  id: string,
+  initConfig: Readonly<Record<string, unknown>>,
+): CapacityReservationWorkItem {
+  const issue = isRecord(initConfig.issue) ? initConfig.issue : undefined;
+  return {
+    id,
+    labels: [
+      ...stringsFromUnknown(initConfig.labels),
+      ...stringsFromUnknown(initConfig.label),
+      ...stringsFromUnknown(initConfig.issueLabels),
+      ...stringsFromUnknown(issue?.labels),
+    ],
+    categories: [
+      ...stringsFromUnknown(initConfig.categories),
+      ...stringsFromUnknown(initConfig.category),
+      ...stringsFromUnknown(issue?.category),
+    ],
+  };
+}
+
 function normalizeMatchers(values: readonly string[] | undefined): readonly string[] {
   return [...new Set((values ?? []).map(normalizeMatcher).filter(Boolean))];
 }
@@ -161,6 +216,20 @@ function normalizeMatcher(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function stringsFromUnknown(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  }
+  return [];
+}
+
 function isString(value: unknown): value is string {
   return typeof value === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -104,11 +104,14 @@ export class CapacityReservationPolicy {
       return { allowed: false, reason: 'capacity_full', reservationId: undefined };
     }
 
-    const matchingReservation = this.reservations
-      .filter((reservation) => this.matches(reservation, candidate))
-      .find((reservation) => state.reservations.some((bucket) => bucket.id === reservation.id && bucket.free > 0));
-    if (matchingReservation) {
-      return { allowed: true, reason: 'reserved_capacity_available', reservationId: matchingReservation.id };
+    const candidateIndex = activeItems.length;
+    const candidateAllocation = this.allocateReservations([...activeItems, candidate]);
+    const matchingReservationIndex = candidateAllocation.assignedBucketByItemIndex.get(candidateIndex);
+    if (matchingReservationIndex !== undefined) {
+      const reservation = this.reservations[matchingReservationIndex];
+      if (reservation) {
+        return { allowed: true, reason: 'reserved_capacity_available', reservationId: reservation.id };
+      }
     }
 
     if (state.normalSlots.free > 0) {
@@ -124,26 +127,7 @@ export class CapacityReservationPolicy {
 
   describe(activeItems: readonly CapacityReservationWorkItem[]): CapacityReservationState {
     const usedSlots = activeItems.length;
-    const buckets = this.reservations.map((reservation) => ({
-      id: reservation.id,
-      slots: reservation.slots,
-      used: 0,
-      released: this.releasedReservationIds.has(reservation.id),
-      labels: [...(reservation.labels ?? [])],
-      categories: [...(reservation.categories ?? [])],
-    }));
-
-    for (const item of activeItems) {
-      const bucket = buckets.find((candidateBucket, index) => {
-        const reservation = this.reservations[index];
-        if (!reservation) return false;
-        return candidateBucket.used < candidateBucket.slots
-          && this.matches(reservation, item);
-      });
-      if (bucket) {
-        bucket.used += 1;
-      }
-    }
+    const { buckets } = this.allocateReservations(activeItems);
 
     const bucketsWithFree = buckets.map((bucket) => ({
       ...bucket,
@@ -177,6 +161,61 @@ export class CapacityReservationPolicy {
       .filter((reservation) => reservation.released)
       .reduce((sum, reservation) => sum + reservation.free, 0);
     return Math.max(0, releasedFree - normalOverflowUsed);
+  }
+
+  private allocateReservations(activeItems: readonly CapacityReservationWorkItem[]): {
+    buckets: Array<{
+      id: string;
+      slots: number;
+      used: number;
+      released: boolean;
+      labels: string[];
+      categories: string[];
+    }>;
+    assignedBucketByItemIndex: Map<number, number>;
+  } {
+    const buckets = this.reservations.map((reservation) => ({
+      id: reservation.id,
+      slots: reservation.slots,
+      used: 0,
+      released: this.releasedReservationIds.has(reservation.id),
+      labels: [...(reservation.labels ?? [])],
+      categories: [...(reservation.categories ?? [])],
+    }));
+    const assignedBucketByItemIndex = new Map<number, number>();
+    const indexedActiveItems = activeItems
+      .map((item, activeIndex) => ({
+        activeIndex,
+        matchingIndexes: this.matchingReservationIndexes(item),
+      }))
+      .filter(({ matchingIndexes }) => matchingIndexes.length > 0)
+      .sort((left, right) => {
+        if (left.matchingIndexes.length !== right.matchingIndexes.length) {
+          return left.matchingIndexes.length - right.matchingIndexes.length;
+        }
+        return left.activeIndex - right.activeIndex;
+      });
+
+    for (const { activeIndex, matchingIndexes } of indexedActiveItems) {
+      const bucketIndex = matchingIndexes.find((index) => {
+        const bucket = buckets[index];
+        return bucket !== undefined && bucket.used < bucket.slots;
+      });
+      if (bucketIndex !== undefined) {
+        const bucket = buckets[bucketIndex];
+        if (bucket) {
+          bucket.used += 1;
+          assignedBucketByItemIndex.set(activeIndex, bucketIndex);
+        }
+      }
+    }
+    return { buckets, assignedBucketByItemIndex };
+  }
+
+  private matchingReservationIndexes(item: CapacityReservationWorkItem): number[] {
+    return this.reservations.flatMap((reservation, index) => (
+      this.matches(reservation, item) ? [index] : []
+    ));
   }
 
   private matches(reservation: CapacityReservationRule, item: CapacityReservationWorkItem): boolean {

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -145,14 +145,25 @@ export class CapacityReservationPolicy {
     }>,
   ): CapacityReservationState {
 
-    const bucketsWithFree = buckets.map((bucket) => ({
+    const matchingBuckets = buckets.map((bucket) => ({
       ...bucket,
       free: Math.max(0, bucket.slots - bucket.used),
     }));
-    const totalReservedSlots = bucketsWithFree.reduce((sum, bucket) => sum + bucket.slots, 0);
-    const reservedUsed = bucketsWithFree.reduce((sum, bucket) => sum + bucket.used, 0);
+    const totalReservedSlots = matchingBuckets.reduce((sum, bucket) => sum + bucket.slots, 0);
+    const matchingReservedUsed = matchingBuckets.reduce((sum, bucket) => sum + bucket.used, 0);
     const normalTotal = this.totalSlots - totalReservedSlots;
-    const normalUsed = Math.max(0, usedSlots - reservedUsed);
+    const normalUsed = Math.max(0, usedSlots - matchingReservedUsed);
+    let releasedOverflowUsed = Math.max(0, normalUsed - normalTotal);
+    const bucketsWithFree = matchingBuckets.map((bucket) => {
+      const overflowUsed = bucket.released ? Math.min(bucket.free, releasedOverflowUsed) : 0;
+      releasedOverflowUsed -= overflowUsed;
+      const used = bucket.used + overflowUsed;
+      return {
+        ...bucket,
+        used,
+        free: Math.max(0, bucket.slots - used),
+      };
+    });
 
     return {
       totalSlots: this.totalSlots,

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -105,9 +105,11 @@ export class CapacityReservationPolicy {
     }
 
     const candidateIndex = activeItems.length;
-    const candidateAllocation = this.allocateReservations([...activeItems, candidate], candidateIndex);
+    const candidateItems = [...activeItems, candidate];
+    const candidateAllocation = this.allocateReservations(candidateItems, candidateIndex);
+    const candidateState = this.stateFromAllocation(candidateItems.length, candidateAllocation.buckets);
     const matchingReservationIndex = candidateAllocation.assignedBucketByItemIndex.get(candidateIndex);
-    if (matchingReservationIndex !== undefined) {
+    if (matchingReservationIndex !== undefined && this.normalWorkFits(candidateState)) {
       const reservation = this.reservations[matchingReservationIndex];
       if (reservation) {
         return { allowed: true, reason: 'reserved_capacity_available', reservationId: reservation.id };
@@ -118,7 +120,7 @@ export class CapacityReservationPolicy {
       return { allowed: true, reason: 'normal_capacity_available', reservationId: undefined };
     }
 
-    if (this.releasedReservationFreeForNormalWork(state, activeItems) > 0) {
+    if (this.normalWorkFits(candidateState)) {
       return { allowed: true, reason: 'released_reserved_capacity_available', reservationId: undefined };
     }
 
@@ -126,8 +128,22 @@ export class CapacityReservationPolicy {
   }
 
   describe(activeItems: readonly CapacityReservationWorkItem[]): CapacityReservationState {
-    const usedSlots = activeItems.length;
     const { buckets } = this.allocateReservations(activeItems);
+
+    return this.stateFromAllocation(activeItems.length, buckets);
+  }
+
+  private stateFromAllocation(
+    usedSlots: number,
+    buckets: Array<{
+      id: string;
+      slots: number;
+      used: number;
+      released: boolean;
+      labels: string[];
+      categories: string[];
+    }>,
+  ): CapacityReservationState {
 
     const bucketsWithFree = buckets.map((bucket) => ({
       ...bucket,
@@ -151,16 +167,13 @@ export class CapacityReservationPolicy {
     };
   }
 
-  private releasedReservationFreeForNormalWork(
-    state: CapacityReservationState,
-    activeItems: readonly CapacityReservationWorkItem[],
-  ): number {
+  private normalWorkFits(state: CapacityReservationState): boolean {
     const reservedUsed = state.reservations.reduce((sum, bucket) => sum + bucket.used, 0);
-    const normalOverflowUsed = Math.max(0, activeItems.length - reservedUsed - state.normalSlots.total);
+    const normalOverflowUsed = Math.max(0, state.usedSlots - reservedUsed - state.normalSlots.total);
     const releasedFree = state.reservations
       .filter((reservation) => reservation.released)
       .reduce((sum, reservation) => sum + reservation.free, 0);
-    return Math.max(0, releasedFree - normalOverflowUsed);
+    return normalOverflowUsed <= releasedFree;
   }
 
   private allocateReservations(
@@ -197,6 +210,15 @@ export class CapacityReservationPolicy {
           const reservation = this.reservations[bucketIndex];
           if (!reservation) return [];
           return this.matches(reservation, item) ? [slotIndex] : [];
+        }).sort((leftSlotIndex, rightSlotIndex) => {
+          const leftBucketIndex = bucketSlots[leftSlotIndex];
+          const rightBucketIndex = bucketSlots[rightSlotIndex];
+          const leftReleased = leftBucketIndex !== undefined && buckets[leftBucketIndex]?.released === true;
+          const rightReleased = rightBucketIndex !== undefined && buckets[rightBucketIndex]?.released === true;
+          if (leftReleased !== rightReleased) {
+            return leftReleased ? 1 : -1;
+          }
+          return leftSlotIndex - rightSlotIndex;
         }),
       }))
       .filter(({ matchingSlotIndexes }) => matchingSlotIndexes.length > 0)

--- a/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
+++ b/packages/franken-orchestrator/src/beasts/services/capacity-reservation-policy.ts
@@ -236,13 +236,18 @@ export class CapacityReservationPolicy {
     const tryAssign = (activeIndex: number, matchingSlotIndexes: readonly number[], seenSlots: Set<number>): boolean => {
       for (const slotIndex of matchingSlotIndexes) {
         if (seenSlots.has(slotIndex)) continue;
-        seenSlots.add(slotIndex);
-        const displacedItemIndex = assignedItemBySlotIndex.get(slotIndex);
-        if (displacedItemIndex === undefined) {
+        if (!assignedItemBySlotIndex.has(slotIndex)) {
           assignedItemBySlotIndex.set(slotIndex, activeIndex);
           assignedSlotByItemIndex.set(activeIndex, slotIndex);
           return true;
         }
+      }
+
+      for (const slotIndex of matchingSlotIndexes) {
+        if (seenSlots.has(slotIndex)) continue;
+        seenSlots.add(slotIndex);
+        const displacedItemIndex = assignedItemBySlotIndex.get(slotIndex);
+        if (displacedItemIndex === undefined) continue;
         const displacedItem = indexedActiveItems.find((item) => item.activeIndex === displacedItemIndex);
         if (displacedItem && tryAssign(displacedItemIndex, displacedItem.matchingSlotIndexes, seenSlots)) {
           assignedItemBySlotIndex.set(slotIndex, activeIndex);

--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -35,9 +35,29 @@ interface TrackedAgentResponse {
   readonly dispatchRunId?: string | undefined;
 }
 
+interface BeastDaemonErrorEnvelope {
+  readonly error?: {
+    readonly code?: string | undefined;
+    readonly message?: string | undefined;
+    readonly details?: unknown;
+  } | undefined;
+}
+
 export interface BeastDaemonDispatchAdapterOptions {
   readonly baseUrl: string;
   readonly operatorToken: string;
+}
+
+export class BeastDaemonRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly code?: string | undefined,
+    public readonly details?: unknown,
+  ) {
+    super(code ? `Beast daemon request failed: ${status} ${statusText} (${code})` : `Beast daemon request failed: ${status} ${statusText}`);
+    this.name = 'BeastDaemonRequestError';
+  }
 }
 
 const BEAST_VERBS = /\b(spawn|dispatch|launch|start|run|create)\b/i;
@@ -202,7 +222,18 @@ export class BeastDaemonDispatchAdapter {
       headers,
     });
     if (!response.ok) {
-      throw new Error(`Beast daemon request failed: ${response.status} ${response.statusText}`);
+      let envelope: BeastDaemonErrorEnvelope | undefined;
+      try {
+        envelope = await response.clone().json() as BeastDaemonErrorEnvelope;
+      } catch {
+        envelope = undefined;
+      }
+      throw new BeastDaemonRequestError(
+        response.status,
+        response.statusText,
+        envelope?.error?.code,
+        envelope?.error?.details,
+      );
     }
     return response.json() as Promise<T>;
   }

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -14,6 +14,7 @@ import {
   validateBody,
 } from '../middleware.js';
 import { TransportSecurityService } from '../security/transport-security.js';
+import type { BeastRun, TrackedAgent } from '../../beasts/types.js';
 
 const ModuleConfigSchema = z.object({
   firewall: z.boolean().optional(),
@@ -265,7 +266,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         const existingRun = deps.runs.getRun(agent.dispatchRunId);
         const run = shouldDispatchFreshRunForModuleConfig(agent, existingRun)
           ? await dispatchDetachedAgent(deps, agentId)
-          : await deps.runs.start(agent.dispatchRunId, 'operator');
+          : await startLinkedAgentRun(deps, agent);
         deps.agents.appendEvent(agentId, {
           level: 'info',
           type: 'agent.start.requested',
@@ -344,7 +345,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         const existingRun = deps.runs.getRun(agent.dispatchRunId);
         const run = shouldDispatchFreshRunForModuleConfig(agent, existingRun)
           ? await dispatchReplacementAgentRun(deps, agentId, existingRun)
-          : await deps.runs.restart(agent.dispatchRunId, 'operator');
+          : await restartLinkedAgentRun(deps, agent);
         deps.agents.appendEvent(agentId, {
           level: 'info',
           type: 'agent.restart.requested',
@@ -563,6 +564,37 @@ async function dispatchReplacementAgentRun(
   return dispatchDetachedAgent(deps, agentId);
 }
 
+async function startLinkedAgentRun(deps: AgentRoutesDeps, agent: TrackedAgent): Promise<BeastRun> {
+  assertAgentCapacityAvailable(deps, agent);
+  if (!agent.dispatchRunId) {
+    throw new Error(`Tracked agent '${agent.id}' has no linked run`);
+  }
+  return deps.runs.start(agent.dispatchRunId, 'operator');
+}
+
+async function restartLinkedAgentRun(deps: AgentRoutesDeps, agent: TrackedAgent): Promise<BeastRun> {
+  assertAgentCapacityAvailable(deps, agent);
+  if (!agent.dispatchRunId) {
+    throw new Error(`Tracked agent '${agent.id}' has no linked run`);
+  }
+  return deps.runs.restart(agent.dispatchRunId, 'operator');
+}
+
+function assertAgentCapacityAvailable(deps: AgentRoutesDeps, agent: TrackedAgent): void {
+  const capacityDecision = deps.agents.canStartAgent(agent);
+  if (!capacityDecision.allowed) {
+    throw new HttpError(
+      409,
+      'AGENT_CAPACITY_RESERVED',
+      'Agent capacity is reserved for urgent matching work',
+      {
+        decision: capacityDecision,
+        capacity: deps.agents.getCapacityReservationState(),
+      },
+    );
+  }
+}
+
 async function dispatchDetachedAgent(
   deps: AgentRoutesDeps,
   agentId: string,
@@ -576,18 +608,7 @@ async function dispatchDetachedAgent(
     );
   }
 
-  const capacityDecision = deps.agents.canStartAgent(agent);
-  if (!capacityDecision.allowed) {
-    throw new HttpError(
-      409,
-      'AGENT_CAPACITY_RESERVED',
-      'Agent capacity is reserved for urgent matching work',
-      {
-        decision: capacityDecision,
-        capacity: deps.agents.getCapacityReservationState(),
-      },
-    );
-  }
+  assertAgentCapacityAvailable(deps, agent);
 
   return deps.dispatch.createRun({
     definitionId: agent.definitionId,

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../../beasts/errors.js';
+import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import type { BeastRunService } from '../../beasts/services/beast-run-service.js';
@@ -296,6 +297,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwCapacityReservationError(error);
       throw error;
     }
   });
@@ -344,7 +346,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
       if (agent.dispatchRunId) {
         const existingRun = deps.runs.getRun(agent.dispatchRunId);
         const run = shouldDispatchFreshRunForModuleConfig(agent, existingRun)
-          ? await dispatchReplacementAgentRun(deps, agentId, existingRun)
+          ? await dispatchReplacementAgentRun(deps, agent, existingRun)
           : await restartLinkedAgentRun(deps, agent);
         deps.agents.appendEvent(agentId, {
           level: 'info',
@@ -383,6 +385,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwCapacityReservationError(error);
       throw error;
     }
   });
@@ -466,6 +469,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwCapacityReservationError(error);
       throw error;
     }
   });
@@ -553,19 +557,33 @@ function shouldDispatchFreshRunForModuleConfig(
   return JSON.stringify(run.configSnapshot.modules ?? {}) !== JSON.stringify(agent.moduleConfig);
 }
 
+function throwCapacityReservationError(error: unknown): void {
+  if (error instanceof CapacityReservationError) {
+    throw new HttpError(
+      409,
+      'AGENT_CAPACITY_RESERVED',
+      'Agent capacity is reserved for urgent matching work',
+      {
+        decision: error.decision,
+        capacity: error.state,
+      },
+    );
+  }
+}
+
 async function dispatchReplacementAgentRun(
   deps: AgentRoutesDeps,
-  agentId: string,
+  agent: TrackedAgent,
   existingRun: ReturnType<BeastRunService['getRun']>,
 ) {
+  assertAgentCapacityAvailable(deps, agent);
   if (existingRun?.status === 'running') {
     await deps.runs.stop(existingRun.id, 'operator');
   }
-  return dispatchDetachedAgent(deps, agentId);
+  return dispatchDetachedAgent(deps, agent.id);
 }
 
 async function startLinkedAgentRun(deps: AgentRoutesDeps, agent: TrackedAgent): Promise<BeastRun> {
-  assertAgentCapacityAvailable(deps, agent);
   if (!agent.dispatchRunId) {
     throw new Error(`Tracked agent '${agent.id}' has no linked run`);
   }
@@ -573,7 +591,6 @@ async function startLinkedAgentRun(deps: AgentRoutesDeps, agent: TrackedAgent): 
 }
 
 async function restartLinkedAgentRun(deps: AgentRoutesDeps, agent: TrackedAgent): Promise<BeastRun> {
-  assertAgentCapacityAvailable(deps, agent);
   if (!agent.dispatchRunId) {
     throw new Error(`Tracked agent '${agent.id}' has no linked run`);
   }

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -77,6 +77,22 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
 
   app.post('/v1/beasts/agents', async (c) => {
     const body = validateBody(CreateAgentBody, await parseJsonBody(c));
+    const shouldAutoDispatch = body.autoDispatch !== false && deps.dispatch && shouldDispatchOnCreate(body.initAction.kind);
+    if (shouldAutoDispatch) {
+      const capacityDecision = deps.agents.canStartInitConfig(body.initConfig);
+      if (!capacityDecision.allowed) {
+        return c.json({
+          error: {
+            code: 'AGENT_CAPACITY_RESERVED',
+            message: 'Agent capacity is reserved for urgent matching work',
+            details: {
+              decision: capacityDecision,
+              capacity: deps.agents.getCapacityReservationState(),
+            },
+          },
+        }, 409);
+      }
+    }
     const agent = deps.agents.createAgent({
       definitionId: body.definitionId,
       source: body.chatSessionId ? 'chat' : 'dashboard',
@@ -167,6 +183,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
     return c.json({
       data: {
         agents: deps.agents.listAgents(),
+        capacityReservation: deps.agents.getCapacityReservationState(),
       },
     });
   });
@@ -556,6 +573,19 @@ async function dispatchDetachedAgent(
       409,
       'TRACKED_AGENT_NOT_STARTABLE',
       `Tracked agent '${agentId}' cannot be started without a linked run`,
+    );
+  }
+
+  const capacityDecision = deps.agents.canStartAgent(agent);
+  if (!capacityDecision.allowed) {
+    throw new HttpError(
+      409,
+      'AGENT_CAPACITY_RESERVED',
+      'Agent capacity is reserved for urgent matching work',
+      {
+        decision: capacityDecision,
+        capacity: deps.agents.getCapacityReservationState(),
+      },
     );
   }
 

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -152,6 +152,19 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         ...(body.moduleConfig ? { moduleConfig: body.moduleConfig } : {}),
       });
     } catch (error) {
+      if (error instanceof CapacityReservationError) {
+        return c.json({
+          error: {
+            code: 'AGENT_CAPACITY_RESERVED',
+            message: 'Agent capacity is reserved for urgent matching work',
+            details: {
+              decision: error.decision,
+              capacity: error.state,
+              agentId: agent.id,
+            },
+          },
+        }, 409);
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(`[agent-routes] Dispatch failed for ${agent.id}: ${errorMessage}`);
       if (error instanceof Error && error.stack) {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -12,6 +12,7 @@ import {
   UnknownBeastInterviewSessionError,
 } from '../../beasts/services/beast-interview-service.js';
 import { BeastRunService, UnknownBeastRunError } from '../../beasts/services/beast-run-service.js';
+import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -79,6 +80,20 @@ function beastRunNotFound(runId: string): HttpError {
   return new HttpError(404, 'BEAST_RUN_NOT_FOUND', `Beast run '${runId}' was not found`);
 }
 
+function throwCapacityReservationError(error: unknown): void {
+  if (error instanceof CapacityReservationError) {
+    throw new HttpError(
+      409,
+      'AGENT_CAPACITY_RESERVED',
+      'Agent capacity is reserved for urgent matching work',
+      {
+        decision: error.decision,
+        capacity: error.state,
+      },
+    );
+  }
+}
+
 class InterviewSessionNotFoundHttpError extends HttpError {
   constructor(sessionId: string) {
     super(404, 'INTERVIEW_SESSION_NOT_FOUND', `Beast interview session '${sessionId}' was not found`);
@@ -86,6 +101,7 @@ class InterviewSessionNotFoundHttpError extends HttpError {
 }
 
 function throwKnownRunError(runId: string, error: unknown): never {
+  throwCapacityReservationError(error);
   if (error instanceof UnknownBeastRunError) {
     throw beastRunNotFound(runId);
   }
@@ -211,6 +227,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
           `Tracked agent '${body.trackedAgentId}' was not found`,
         );
       }
+      throwCapacityReservationError(error);
       throw error;
     }
     return c.json({ data: runResponse(run, deps) }, 201);

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -20,6 +20,7 @@ import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import type { InMemoryRateLimiter } from '../../beasts/http/beast-rate-limit.js';
+import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
 import { ChatMutationAdmission, chatClientKey } from '../chat-rate-limit.js';
 
 const CreateSessionBody = z.object({
@@ -159,6 +160,21 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     }
   }
 
+  function throwKnownChatRuntimeError(error: unknown): never {
+    if (error instanceof CapacityReservationError) {
+      throw new HttpError(
+        409,
+        'AGENT_CAPACITY_RESERVED',
+        'Agent capacity is reserved for urgent matching work',
+        {
+          decision: error.decision,
+          capacity: error.state,
+        },
+      );
+    }
+    throw error;
+  }
+
   // Health check
   app.get('/health', (c) => {
     c.header('x-frankenbeast-service', 'chat-server');
@@ -249,7 +265,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
         transcript: session.transcript,
         ...(session.beastContext !== undefined ? { beastContext: session.beastContext } : {}),
         ...(executionMode ? { executionMode } : {}),
-      });
+      }).catch(throwKnownChatRuntimeError);
 
       session.transcript = result.transcript;
       session.state = result.state;

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { approvalRuntimeInput, UnsafeApprovalCommandError } from '../../chat/approval-input.js';
+import { BeastDaemonRequestError } from '../../chat/beast-daemon-dispatch-adapter.js';
 import { isValidChatSessionId, type CorruptChatSessionFile, type ISessionStore } from '../../chat/session-store.js';
 import type { ConversationEngine } from '../../chat/conversation-engine.js';
 import { ChatRuntime, pendingApprovalRuntimeState } from '../../chat/runtime.js';
@@ -170,6 +171,18 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
           decision: error.decision,
           capacity: error.state,
         },
+      );
+    }
+    if (
+      error instanceof BeastDaemonRequestError
+      && error.status === 409
+      && error.code === 'AGENT_CAPACITY_RESERVED'
+    ) {
+      throw new HttpError(
+        409,
+        'AGENT_CAPACITY_RESERVED',
+        'Agent capacity is reserved for urgent matching work',
+        error.details,
       );
     }
     throw error;
@@ -400,7 +413,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
           session.state = originalState;
           session.updatedAt = isoNow();
           sessionStore.save(session);
-          throw error;
+          throwKnownChatRuntimeError(error);
         }
 
         session.state = result.state === 'active' ? 'approved' : result.state;

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -11,6 +11,7 @@ import { BeastInterviewService } from '../../../src/beasts/services/beast-interv
 import { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import { BeastRunService } from '../../../src/beasts/services/beast-run-service.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
+import { CapacityReservationError, CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import { errorHandler } from '../../../src/http/middleware.js';
 import { agentRoutes } from '../../../src/http/routes/agent-routes.js';
@@ -34,7 +35,7 @@ function expectEventsToIncludeTypes(events: AgentEvent[], requiredTypes: string[
   }
 }
 
-function createIntegratedBeastApp(opts?: { rateLimitMax?: number }) {
+function createIntegratedBeastApp(opts?: { rateLimitMax?: number; capacityPolicy?: CapacityReservationPolicy }) {
   // Intentionally exercise the route with the real repository, dispatch service,
   // run service, and event log graph. This file lives under tests/integration so
   // circular service/linking behavior is covered here rather than hidden in unit tests.
@@ -107,10 +108,16 @@ function createIntegratedBeastApp(opts?: { rateLimitMax?: number }) {
       kill: vi.fn(),
     },
   };
-  const dispatch = new BeastDispatchService(repository, catalog, executors, metrics, logStore);
-  const runs = new BeastRunService(repository, catalog, executors, metrics, logStore);
+  const dispatch = new BeastDispatchService(repository, catalog, executors, metrics, logStore, {
+    capacityPolicy: opts?.capacityPolicy,
+  });
+  const runs = new BeastRunService(repository, catalog, executors, metrics, logStore, {
+    capacityPolicy: opts?.capacityPolicy,
+  });
   const interviews = new BeastInterviewService(repository, catalog);
-  const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
+  const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z', {
+    capacityPolicy: opts?.capacityPolicy,
+  });
   const security = new TransportSecurityService();
   const operatorToken = TEST_SUPER_SECRET_OPERATOR_TOKEN;
 
@@ -143,21 +150,23 @@ function createStandaloneAgentApp() {
   mkdirSync(TMP, { recursive: true });
   const repository = new SQLiteBeastRepository(join(TMP, 'standalone-beasts.db'));
   const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
+  const runs = {
+    getRun: vi.fn((runId: string) => repository.getRun(runId)),
+    start: vi.fn(),
+    stop: vi.fn(),
+    kill: vi.fn(),
+    restart: vi.fn(),
+  };
   const app = new Hono();
   app.onError(errorHandler);
   app.route('/', agentRoutes({
     agents,
-    runs: {
-      start: vi.fn(),
-      stop: vi.fn(),
-      kill: vi.fn(),
-      restart: vi.fn(),
-    } as never,
+    runs: runs as never,
     operatorToken: TEST_SUPER_SECRET_OPERATOR_TOKEN,
     security: new TransportSecurityService(),
   }));
 
-  return { app };
+  return { app, agents, runs, repository };
 }
 
 describe('agent routes integration', () => {
@@ -179,6 +188,63 @@ describe('agent routes integration', () => {
     const listResponse = await app.request('/v1/beasts/agents');
 
     expect(listResponse.status).toBe(401);
+  });
+
+  it('translates capacity reservation failures from linked agent resume into 409 responses', async () => {
+    const { app, agents, runs, repository } = createStandaloneAgentApp();
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: {
+        kind: 'martin-loop',
+        command: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'Resume with capacity guard',
+          chunkDirectory: 'docs/chunks',
+        },
+      },
+      initConfig: {
+        provider: 'claude',
+        objective: 'Resume with capacity guard',
+        chunkDirectory: 'docs/chunks',
+      },
+    });
+    const linkedRun = repository.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: agent.initConfig,
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-11T00:00:00.000Z',
+    });
+    agents.linkRun(agent.id, linkedRun.id);
+    agents.updateAgent(agent.id, { status: 'stopped' });
+    runs.start.mockRejectedValue(new CapacityReservationError(
+      { allowed: false, reason: 'reserved_capacity_only', reservationId: 'urgent' },
+      {
+        totalSlots: 1,
+        usedSlots: 0,
+        freeSlots: 1,
+        normalSlots: { total: 0, used: 0, free: 0 },
+        reservations: [{ id: 'urgent', slots: 1, used: 0, free: 1, released: false, labels: ['urgent'], categories: [] }],
+      },
+    ));
+
+    const response = await app.request(`/v1/beasts/agents/${agent.id}/resume`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${TEST_SUPER_SECRET_OPERATOR_TOKEN}` },
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'AGENT_CAPACITY_RESERVED',
+      },
+    });
   });
 
   it('returns validation errors for invalid tracked agent payloads', async () => {

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -247,6 +247,65 @@ describe('agent routes integration', () => {
     });
   });
 
+  it('preserves capacity conflict responses when auto-dispatch loses a capacity race', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const repository = new SQLiteBeastRepository(join(TMP, 'auto-dispatch-capacity.db'));
+    const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
+    const runs = { getRun: vi.fn(), start: vi.fn(), stop: vi.fn(), kill: vi.fn(), restart: vi.fn() };
+    const dispatch = {
+      createRun: vi.fn(async () => {
+        throw new CapacityReservationError(
+          { allowed: false, reason: 'reserved_capacity_only', reservationId: undefined },
+          {
+            totalSlots: 1,
+            usedSlots: 1,
+            freeSlots: 0,
+            normalSlots: { total: 1, used: 1, free: 0 },
+            reservations: [],
+          },
+        );
+      }),
+    };
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.route('/', agentRoutes({
+      agents,
+      dispatch: dispatch as never,
+      runs: runs as never,
+      operatorToken: TEST_SUPER_SECRET_OPERATOR_TOKEN,
+      security: new TransportSecurityService(),
+    }));
+
+    const response = await app.request('/v1/beasts/agents', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_SUPER_SECRET_OPERATOR_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        initAction: {
+          kind: 'martin-loop',
+          command: 'martin-loop',
+          config: { provider: 'claude', objective: 'Race auto-dispatch', chunkDirectory: 'docs/chunks' },
+        },
+        initConfig: { provider: 'claude', objective: 'Race auto-dispatch', chunkDirectory: 'docs/chunks' },
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'AGENT_CAPACITY_RESERVED',
+        details: {
+          decision: { reason: 'reserved_capacity_only' },
+        },
+      },
+    });
+    expect(repository.listTrackedAgents()).toHaveLength(1);
+    expect(repository.listTrackedAgents()[0]).toMatchObject({ status: 'initializing' });
+  });
+
   it('returns validation errors for invalid tracked agent payloads', async () => {
     const { app, operatorToken } = createIntegratedBeastApp();
 

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
+import { AgentService } from '../../../src/beasts/services/agent-service.js';
+import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
+
+let workDir: string | undefined;
+
+afterEach(async () => {
+  if (workDir) {
+    await rm(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  }
+});
+
+describe('AgentService capacity reservations', () => {
+  it('reports reservation liveness state from active tracked agents', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-agent-capacity-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const service = new AgentService(repo, () => '2026-07-15T00:00:00.000Z', {
+      capacityPolicy: new CapacityReservationPolicy({
+        totalSlots: 3,
+        reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'], categories: ['availability'] }],
+      }),
+    });
+
+    service.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['feature'] },
+    });
+    service.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['security'] },
+    });
+
+    expect(service.getCapacityReservationState()).toEqual({
+      totalSlots: 3,
+      usedSlots: 2,
+      freeSlots: 1,
+      normalSlots: { total: 2, used: 1, free: 1 },
+      reservations: [
+        {
+          id: 'security-urgent',
+          slots: 1,
+          used: 1,
+          free: 0,
+          released: false,
+          labels: ['security'],
+          categories: ['availability'],
+        },
+      ],
+    });
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
@@ -26,20 +26,22 @@ describe('AgentService capacity reservations', () => {
       }),
     });
 
-    service.createAgent({
+    const normalAgent = service.createAgent({
       definitionId: 'martin-loop',
       source: 'dashboard',
       createdByUser: 'operator',
       initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
       initConfig: { labels: ['feature'] },
     });
-    service.createAgent({
+    const securityAgent = service.createAgent({
       definitionId: 'martin-loop',
       source: 'dashboard',
       createdByUser: 'operator',
       initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
       initConfig: { labels: ['security'] },
     });
+    service.updateAgent(normalAgent.id, { status: 'running' });
+    service.updateAgent(securityAgent.id, { status: 'running' });
 
     expect(service.getCapacityReservationState()).toEqual({
       totalSlots: 3,

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -9,6 +9,7 @@ import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
+import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
 
 describe('BeastDispatchService', () => {
   let workDir: string | undefined;
@@ -207,6 +208,68 @@ describe('BeastDispatchService', () => {
       status: 'dispatching',
       dispatchRunId: run.id,
     });
+  });
+
+  it('counts an existing active run for the same tracked agent when dispatching another run', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => repo.createAttempt(run.id, { status: 'running' })),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs, {
+      capacityPolicy: new CapacityReservationPolicy({ totalSlots: 1, reservations: [] }),
+    });
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['availability'] },
+    });
+    const firstRun = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'First active run',
+        chunkDirectory: 'docs/chunks',
+        labels: ['availability'],
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: true,
+    });
+
+    await expect(dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Second concurrent run',
+        chunkDirectory: 'docs/chunks',
+        labels: ['availability'],
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: false,
+    })).rejects.toMatchObject({ name: 'CapacityReservationError' });
+
+    expect(repo.listRuns()).toHaveLength(1);
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'running', dispatchRunId: firstRun.id });
   });
 
   it('rejects unknown tracked agents before persisting a run', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -10,6 +10,7 @@ import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
+import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
 
 describe('BeastRunService', () => {
   let workDir: string | undefined;
@@ -324,6 +325,64 @@ describe('BeastRunService', () => {
       status: 'running',
       dispatchRunId: run.id,
     });
+  });
+
+  it('starts queued linked runs using reservation metadata from the run config snapshot', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => repo.createAttempt(run.id, { status: 'running' })),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const capacityPolicy = new CapacityReservationPolicy({
+      totalSlots: 2,
+      reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'] }],
+    });
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs, { capacityPolicy });
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs, { capacityPolicy });
+    agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['feature'] },
+    });
+    const urgentAgent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: {},
+    });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: urgentAgent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Resume urgent security work',
+        chunkDirectory: 'docs/chunks',
+        labels: ['security'],
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      startNow: false,
+    });
+
+    const started = await runs.start(run.id, 'operator');
+
+    expect(started.status).toBe('running');
+    expect(executors.process.start).toHaveBeenCalledOnce();
   });
 
   it('marks queued tracked runs failed when executor start throws', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -327,6 +327,69 @@ describe('BeastRunService', () => {
     });
   });
 
+  it('rejects running tracked-agent restarts before stopping the active attempt when capacity is reserved', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => repo.createAttempt(run.id, {
+          status: 'running',
+          pid: 2001,
+          startedAt: '2026-03-10T00:03:00.000Z',
+        })),
+        stop: vi.fn(async (runId: string, attemptId: string) => {
+          repo.updateAttempt(attemptId, { status: 'stopped' });
+          return repo.updateRun(runId, { status: 'stopped', stopReason: 'operator_stop' });
+        }),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs, {
+      capacityPolicy: new CapacityReservationPolicy({
+        totalSlots: 1,
+        reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'] }],
+      }),
+    });
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['feature'] },
+    });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      trackedAgentId: agent.id,
+      config: {
+        provider: 'claude',
+        objective: 'Restart safely',
+        chunkDirectory: 'docs/chunks',
+        labels: ['feature'],
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: true,
+    });
+
+    await expect(runs.restart(run.id, 'operator')).rejects.toMatchObject({
+      name: 'CapacityReservationError',
+    });
+
+    expect(executors.process.stop).not.toHaveBeenCalled();
+    expect(repo.getRun(run.id)).toMatchObject({ id: run.id, status: 'running' });
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'running', dispatchRunId: run.id });
+  });
+
   it('starts queued linked runs using reservation metadata from the run config snapshot', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -448,6 +448,63 @@ describe('BeastRunService', () => {
     expect(executors.process.start).toHaveBeenCalledOnce();
   });
 
+  it('reserves linked-agent capacity before awaiting executor start', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const agents = new AgentService(repo, () => '2026-03-11T00:00:00.000Z');
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => {
+          await startGate;
+          return repo.createAttempt(run.id, { status: 'running' });
+        }),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: { start: vi.fn(), stop: vi.fn(), kill: vi.fn() },
+    };
+    const capacityPolicy = new CapacityReservationPolicy({ totalSlots: 1, reservations: [] });
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs, { capacityPolicy });
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { labels: ['feature'] },
+    });
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        provider: 'claude',
+        objective: 'Reserve before await',
+        chunkDirectory: 'docs/chunks',
+        labels: ['feature'],
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-11T00:00:00.000Z',
+    });
+    agents.linkRun(agent.id, run.id);
+    agents.updateAgent(agent.id, { status: 'stopped' });
+
+    const started = runs.start(run.id, 'operator');
+    await vi.waitFor(() => expect(executors.process.start).toHaveBeenCalledOnce());
+
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'dispatching', dispatchRunId: run.id });
+
+    releaseStart();
+    await expect(started).resolves.toMatchObject({ id: run.id, status: 'running' });
+  });
+
   it('marks queued tracked runs failed when executor start throws', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -45,6 +45,50 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('checks all matching reservation buckets before rejecting overlapping urgent work', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'] },
+        { id: 'availability-urgent', slots: 1, categories: ['availability'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'security-1', labels: ['security'] },
+    ];
+
+    expect(policy.canStart({ id: 'security-availability', labels: ['security'], categories: ['availability'] }, runningItems)).toEqual({
+      allowed: true,
+      reason: 'reserved_capacity_available',
+      reservationId: 'availability-urgent',
+    });
+  });
+
+  it('counts normal work already admitted through released reservations before allowing another normal start', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 4,
+      releasedReservationIds: ['security-urgent'],
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'] },
+        { id: 'availability-urgent', slots: 1, categories: ['availability'] },
+      ],
+    });
+
+    const normalCapacityPlusReleasedSlot = [
+      { id: 'backlog-1', labels: ['feature'] },
+      { id: 'backlog-2', labels: ['feature'] },
+      { id: 'backlog-3', labels: ['feature'] },
+    ];
+
+    expect(policy.canStart({ id: 'backlog-4', labels: ['feature'] }, normalCapacityPlusReleasedSlot)).toEqual({
+      allowed: false,
+      reason: 'reserved_capacity_only',
+      reservationId: undefined,
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -89,6 +89,27 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('allocates flexible active work away from narrower urgent reservations', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'] },
+        { id: 'availability-urgent', slots: 1, categories: ['availability'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'flexible-urgent', labels: ['security'], categories: ['availability'] },
+    ];
+
+    expect(policy.canStart({ id: 'security-only', labels: ['security'] }, runningItems)).toEqual({
+      allowed: true,
+      reason: 'reserved_capacity_available',
+      reservationId: 'security-urgent',
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -175,6 +175,34 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('tries alternate unreleased slots before displacing work into released capacity', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      releasedReservationIds: ['a-released'],
+      reservations: [
+        { id: 'a-released', slots: 1, labels: ['a'] },
+        { id: 'a-reserved', slots: 1, labels: ['a'] },
+        { id: 'b-reserved', slots: 1, labels: ['b'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'active-a', labels: ['a'] },
+      { id: 'active-a-or-b', labels: ['a', 'b'] },
+    ];
+
+    expect(policy.describe(runningItems).reservations).toMatchObject([
+      { id: 'a-released', used: 0, free: 1, released: true },
+      { id: 'a-reserved', used: 1, free: 0, released: false },
+      { id: 'b-reserved', used: 1, free: 0, released: false },
+    ]);
+    expect(policy.canStart({ id: 'normal-1', labels: ['feature'] }, runningItems)).toEqual({
+      allowed: true,
+      reason: 'released_reserved_capacity_available',
+      reservationId: undefined,
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
+
+describe('CapacityReservationPolicy', () => {
+  it('keeps the reserved security slot unavailable to normal backlog work', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 4,
+      reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'], categories: ['availability'] }],
+    });
+
+    const runningBacklog = [
+      { id: 'backlog-1', labels: ['feature'] },
+      { id: 'backlog-2', labels: ['feature'] },
+      { id: 'backlog-3', labels: ['reliability'] },
+    ];
+
+    expect(policy.canStart({ id: 'backlog-4', labels: ['feature'] }, runningBacklog)).toEqual({
+      allowed: false,
+      reason: 'reserved_capacity_only',
+      reservationId: undefined,
+    });
+    expect(policy.canStart({ id: 'security-fix', labels: ['security'] }, runningBacklog)).toEqual({
+      allowed: true,
+      reason: 'reserved_capacity_available',
+      reservationId: 'security-urgent',
+    });
+  });
+
+  it('allows normal work to use a reserved slot only when the reservation is explicitly released', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 4,
+      releasedReservationIds: ['security-urgent'],
+      reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'] }],
+    });
+
+    const runningBacklog = [
+      { id: 'backlog-1', labels: ['feature'] },
+      { id: 'backlog-2', labels: ['feature'] },
+      { id: 'backlog-3', labels: ['feature'] },
+    ];
+
+    expect(policy.canStart({ id: 'backlog-4', labels: ['feature'] }, runningBacklog)).toMatchObject({
+      allowed: true,
+      reason: 'released_reserved_capacity_available',
+    });
+  });
+
+  it('renders operator-visible reservation state with used and free reserved capacity', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 5,
+      reservations: [
+        { id: 'security-urgent', slots: 2, labels: ['security'], categories: ['availability'] },
+      ],
+    });
+
+    const state = policy.describe([
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'security-1', labels: ['security'] },
+    ]);
+
+    expect(state).toEqual({
+      totalSlots: 5,
+      usedSlots: 2,
+      freeSlots: 3,
+      normalSlots: { total: 3, used: 1, free: 2 },
+      reservations: [
+        {
+          id: 'security-urgent',
+          slots: 2,
+          used: 1,
+          free: 1,
+          released: false,
+          labels: ['security'],
+          categories: ['availability'],
+        },
+      ],
+    });
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -132,6 +132,49 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('does not over-admit matching candidates by displacing active urgent work into unavailable capacity', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'] },
+        { id: 'availability-urgent', slots: 1, categories: ['availability'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'security-1', labels: ['security'] },
+      { id: 'normal-1', labels: ['feature'] },
+    ];
+
+    expect(policy.canStart({ id: 'security-2', labels: ['security'] }, runningItems)).toEqual({
+      allowed: false,
+      reason: 'reserved_capacity_only',
+      reservationId: undefined,
+    });
+  });
+
+  it('reallocates flexible urgent work away from released reservations before admitting normal work', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      releasedReservationIds: ['security-urgent'],
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'] },
+        { id: 'availability-urgent', slots: 1, categories: ['availability'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'flexible-urgent', labels: ['security'], categories: ['availability'] },
+    ];
+
+    expect(policy.canStart({ id: 'normal-2', labels: ['feature'] }, runningItems)).toEqual({
+      allowed: true,
+      reason: 'released_reserved_capacity_available',
+      reservationId: undefined,
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -203,6 +203,42 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('renders released reservation state consumed by normal overflow as used capacity', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 4,
+      releasedReservationIds: ['security-urgent'],
+      reservations: [
+        { id: 'security-urgent', slots: 1, labels: ['security'], categories: ['availability'] },
+      ],
+    });
+
+    const state = policy.describe([
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'normal-2', labels: ['feature'] },
+      { id: 'normal-3', labels: ['feature'] },
+      { id: 'normal-4', labels: ['feature'] },
+    ]);
+
+    expect(state).toMatchObject({
+      usedSlots: 4,
+      freeSlots: 0,
+      normalSlots: { total: 3, used: 3, free: 0 },
+      reservations: [
+        { id: 'security-urgent', used: 1, free: 0, released: true },
+      ],
+    });
+    expect(policy.canStart({ id: 'security-fix', labels: ['security'] }, [
+      { id: 'normal-1', labels: ['feature'] },
+      { id: 'normal-2', labels: ['feature'] },
+      { id: 'normal-3', labels: ['feature'] },
+      { id: 'normal-4', labels: ['feature'] },
+    ])).toEqual({
+      allowed: false,
+      reason: 'capacity_full',
+      reservationId: undefined,
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/capacity-reservation-policy.test.ts
@@ -110,6 +110,28 @@ describe('CapacityReservationPolicy', () => {
     });
   });
 
+  it('uses matching allocation for overlapping reservation buckets', () => {
+    const policy = new CapacityReservationPolicy({
+      totalSlots: 3,
+      reservations: [
+        { id: 'a', slots: 1, labels: ['a'] },
+        { id: 'b', slots: 1, labels: ['b'] },
+        { id: 'c', slots: 1, labels: ['c'] },
+      ],
+    });
+
+    const runningItems = [
+      { id: 'active-a', labels: ['a'] },
+      { id: 'active-b-or-c', labels: ['b', 'c'] },
+    ];
+
+    expect(policy.canStart({ id: 'candidate-a-or-b', labels: ['a', 'b'] }, runningItems)).toEqual({
+      allowed: true,
+      reason: 'reserved_capacity_available',
+      reservationId: 'b',
+    });
+  });
+
   it('renders operator-visible reservation state with used and free reserved capacity', () => {
     const policy = new CapacityReservationPolicy({
       totalSlots: 5,

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -21,6 +21,9 @@ describe('createBeastServices', () => {
   let tempDir: string | undefined;
 
   afterEach(async () => {
+    delete process.env.FBEAST_AGENT_CAPACITY_TOTAL;
+    delete process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS;
+    delete process.env.FBEAST_AGENT_CAPACITY_RELEASED_RESERVATIONS;
     processExecutorConstructor.mockClear();
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
@@ -59,5 +62,19 @@ describe('createBeastServices', () => {
     } finally {
       process.chdir(originalCwd);
     }
+  });
+
+  it('fails fast when reservation rules are configured without total capacity', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
+    process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS = JSON.stringify([
+      { id: 'security-urgent', slots: 1, labels: ['security'] },
+    ]);
+    const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
+
+    expect(() => createBeastServices({
+      beastsDb: join(tempDir!, 'beast.db'),
+      beastLogsDir: join(tempDir!, 'logs'),
+      root: tempDir!,
+    })).toThrow(/FBEAST_AGENT_CAPACITY_TOTAL is required/);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -77,4 +77,34 @@ describe('createBeastServices', () => {
       root: tempDir!,
     })).toThrow(/FBEAST_AGENT_CAPACITY_TOTAL is required/);
   });
+
+  it('honors total capacity even when no reservation rules are configured', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
+    process.env.FBEAST_AGENT_CAPACITY_TOTAL = '1';
+    const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
+    const services = createBeastServices({
+      beastsDb: join(tempDir!, 'beast.db'),
+      beastLogsDir: join(tempDir!, 'logs'),
+      root: tempDir!,
+    });
+
+    try {
+      const agent = services.agents.createAgent({
+        definitionId: 'martin-loop',
+        source: 'dashboard',
+        createdByUser: 'operator',
+        initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+        initConfig: { labels: ['feature'] },
+      });
+      services.agents.updateAgent(agent.id, { status: 'running' });
+
+      expect(services.agents.canStartInitConfig({ labels: ['feature'] })).toEqual({
+        allowed: false,
+        reason: 'capacity_full',
+        reservationId: undefined,
+      });
+    } finally {
+      services.dispose();
+    }
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/module-config-plumbing.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/module-config-plumbing.test.ts
@@ -9,6 +9,7 @@ import { BeastCatalogService } from '../../../src/beasts/services/beast-catalog-
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import type { ModuleConfig } from '../../../src/beasts/types.js';
+import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
 
 function stubExecutors(repo: SQLiteBeastRepository) {
   return {
@@ -230,6 +231,79 @@ describe('ModuleConfig plumbing', () => {
       expect(run.configSnapshot).toMatchObject({
         modules: { governor: false, heartbeat: false },
       });
+    });
+
+    it('preserves capacity classification metadata from strict run configs', async () => {
+      workDir = await mkdtemp(join(tmpdir(), 'franken-modcfg-dispatch-'));
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const metrics = new PrometheusBeastMetrics();
+      const executors = stubExecutors(repo);
+      const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+
+      const run = await dispatch.createRun({
+        definitionId: 'martin-loop',
+        config: {
+          provider: 'claude',
+          objective: 'security fix',
+          chunkDirectory: 'docs/chunks',
+          labels: ['security'],
+          categories: ['availability'],
+        },
+        dispatchedBy: 'dashboard',
+        dispatchedByUser: 'operator',
+      });
+
+      expect(run.configSnapshot).toMatchObject({
+        labels: ['security'],
+        categories: ['availability'],
+      });
+    });
+
+    it('classifies direct tracked dispatch capacity from the requested run config', async () => {
+      workDir = await mkdtemp(join(tmpdir(), 'franken-modcfg-dispatch-'));
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const metrics = new PrometheusBeastMetrics();
+      const executors = stubExecutors(repo);
+      const agents = new AgentService(repo, () => '2026-03-13T00:00:00.000Z');
+      const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs, {
+        capacityPolicy: new CapacityReservationPolicy({
+          totalSlots: 2,
+          reservations: [{ id: 'security-urgent', slots: 1, labels: ['security'] }],
+        }),
+      });
+      agents.createAgent({
+        definitionId: 'martin-loop',
+        source: 'dashboard',
+        createdByUser: 'operator',
+        initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+        initConfig: { labels: ['feature'] },
+      });
+      const urgentAgent = agents.createAgent({
+        definitionId: 'martin-loop',
+        source: 'dashboard',
+        createdByUser: 'operator',
+        initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+        initConfig: {},
+      });
+
+      const run = await dispatch.createRun({
+        definitionId: 'martin-loop',
+        trackedAgentId: urgentAgent.id,
+        config: {
+          provider: 'claude',
+          objective: 'security fix',
+          chunkDirectory: 'docs/chunks',
+          labels: ['security'],
+        },
+        dispatchedBy: 'dashboard',
+        dispatchedByUser: 'operator',
+        startNow: false,
+      });
+
+      expect(run.trackedAgentId).toBe(urgentAgent.id);
+      expect(run.configSnapshot).toMatchObject({ labels: ['security'] });
     });
 
     it('omits modules from configSnapshot when no moduleConfig provided', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createChatApp } from '../../../src/http/chat-app.js';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
+import { CapacityReservationError } from '../../../src/beasts/services/capacity-reservation-policy.js';
 import type { ChatSession } from '../../../src/chat/types.js';
 
 function pendingApprovalSession(session: ChatSession): ChatSession {
@@ -348,6 +349,50 @@ describe('chat approval route persistence', () => {
       pendingApproval: false,
       reason: expect.stringContaining('no approval metadata'),
     });
+  });
+
+  it('translates chat beast capacity reservation failures to conflict responses', async () => {
+    const runtime = {
+      run: vi.fn().mockRejectedValue(new CapacityReservationError(
+        { allowed: false, reason: 'reserved_capacity_only', reservationId: undefined },
+        {
+          totalSlots: 1,
+          usedSlots: 0,
+          freeSlots: 1,
+          normalSlots: { total: 0, used: 0, free: 0 },
+          reservations: [
+            {
+              id: 'security-urgent',
+              slots: 1,
+              used: 0,
+              free: 1,
+              released: false,
+              labels: ['security'],
+              categories: [],
+            },
+          ],
+        },
+      )),
+    };
+    const app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+    });
+    const session = sessionStore.create('project-1');
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Ship Beast monitoring' }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string; details: { decision: { reason: string } } } };
+    expect(body.error.code).toBe('AGENT_CAPACITY_RESERVED');
+    expect(body.error.details.decision.reason).toBe('reserved_capacity_only');
+    expect(sessionStore.get(session.id)?.transcript).toHaveLength(0);
   });
 
   it('reports unsafe approval-cop health without leaking unsafe command details in the reason', async () => {

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createChatApp } from '../../../src/http/chat-app.js';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
+import { BeastDaemonRequestError } from '../../../src/chat/beast-daemon-dispatch-adapter.js';
 import { CapacityReservationError } from '../../../src/beasts/services/capacity-reservation-policy.js';
 import type { ChatSession } from '../../../src/chat/types.js';
 
@@ -393,6 +394,83 @@ describe('chat approval route persistence', () => {
     expect(body.error.code).toBe('AGENT_CAPACITY_RESERVED');
     expect(body.error.details.decision.reason).toBe('reserved_capacity_only');
     expect(sessionStore.get(session.id)?.transcript).toHaveLength(0);
+  });
+
+  it('translates daemon chat beast capacity reservation failures to conflict responses', async () => {
+    const runtime = {
+      run: vi.fn().mockRejectedValue(new BeastDaemonRequestError(
+        409,
+        'Conflict',
+        'AGENT_CAPACITY_RESERVED',
+        { decision: { reason: 'reserved_capacity_only' } },
+      )),
+    };
+    const app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+    });
+    const session = sessionStore.create('project-1');
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Launch Beast monitoring' }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string; details: { decision: { reason: string } } } };
+    expect(body.error.code).toBe('AGENT_CAPACITY_RESERVED');
+    expect(body.error.details.decision.reason).toBe('reserved_capacity_only');
+    expect(sessionStore.get(session.id)?.transcript).toHaveLength(0);
+  });
+
+  it('translates approval-time capacity reservation failures to conflict responses', async () => {
+    const runtime = {
+      run: vi.fn().mockRejectedValue(new CapacityReservationError(
+        { allowed: false, reason: 'reserved_capacity_only', reservationId: undefined },
+        {
+          totalSlots: 1,
+          usedSlots: 0,
+          freeSlots: 1,
+          normalSlots: { total: 0, used: 0, free: 0 },
+          reservations: [
+            {
+              id: 'security-urgent',
+              slots: 1,
+              used: 0,
+              free: 1,
+              released: false,
+              labels: ['security'],
+              categories: [],
+            },
+          ],
+        },
+      )),
+    };
+    const app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+    });
+    const session = pendingApprovalSession(sessionStore.create('project-1'));
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ approved: true }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string; details: { decision: { reason: string } } } };
+    expect(body.error.code).toBe('AGENT_CAPACITY_RESERVED');
+    expect(body.error.details.decision.reason).toBe('reserved_capacity_only');
+    const stored = sessionStore.get(session.id);
+    expect(stored?.state).toBe('pending_approval');
+    expect(stored?.pendingApproval).not.toBeNull();
   });
 
   it('reports unsafe approval-cop health without leaking unsafe command details in the reason', async () => {

--- a/tasks/issue-1749-capacity-reservation-progress.md
+++ b/tasks/issue-1749-capacity-reservation-progress.md
@@ -1,0 +1,15 @@
+# Issue 1749 Capacity Reservation Progress
+
+- [x] Read issue #1749 and shared lessons.
+- [x] Confirm branch/worktree and Git identity.
+- [x] Add failing tests for capacity reservation behavior.
+- [x] Implement capacity reservation policy and operator-visible state.
+- [x] Run targeted tests and broader package checks.
+- [ ] Commit, push, open PR for issue #1749 only.
+- [ ] Complete Codex review/CI/merge gates or record blocker.
+
+## Verification
+- `npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/capacity-reservation-policy.test.ts tests/unit/beasts/agent-service-capacity.test.ts` — passed.
+- `npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner && npm --prefix packages/franken-orchestrator run typecheck` — passed.
+- `npm --prefix packages/franken-orchestrator run lint` — passed with pre-existing warnings only.
+- `npm --prefix packages/franken-orchestrator test` — passed, 263 files / 3380 tests.


### PR DESCRIPTION
## Summary
- Add a capacity reservation policy for tracked agents, with reserved slots matched by label/category and explicit release support.
- Wire reservation checks into auto-dispatch/start paths so normal backlog work cannot consume reserved urgent capacity.
- Surface reservation state in the tracked-agent liveness/list response.

## Configuration
- `FBEAST_AGENT_CAPACITY_TOTAL`: total tracked-agent capacity slots.
- `FBEAST_AGENT_CAPACITY_RESERVATIONS`: JSON array, e.g. `[{"id":"security-urgent","slots":1,"labels":["security"],"categories":["availability"]}]`.
- `FBEAST_AGENT_CAPACITY_RELEASED_RESERVATIONS`: optional comma-separated reservation ids that normal backlog work may use.

## Test Plan
- [x] `npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/capacity-reservation-policy.test.ts tests/unit/beasts/agent-service-capacity.test.ts`
- [x] `npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner && npm --prefix packages/franken-orchestrator run typecheck`
- [x] `npm --prefix packages/franken-orchestrator run lint` (passes with pre-existing warnings)
- [x] `npm --prefix packages/franken-orchestrator test`

Closes #1749
