### PR TITLE
feat(orchestrator): add provider circuit breakers

### DIFF
--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -193,6 +193,11 @@ function normalizeJitterRatio(value: number | undefined): number {
 function classifyProviderError(error: Error | string): string {
   const message = error instanceof Error ? error.message : error;
   const normalized = message.toLowerCase();
+  if (normalized.includes('rate limit') || normalized.includes('429')) return 'rate_limit';
+  if (normalized.includes('auth') || normalized.includes('permission') || normalized.includes('unauthorized')) return 'auth';
+  if (normalized.includes('timeout') || normalized.includes('timed out')) return 'timeout';
+  if (normalized.includes('unavailable') || normalized.includes('enoent')) return 'unavailable';
+  if (normalized.includes('stream ended without done')) return 'stream_incomplete';
   if (
     normalized.includes('bad request')
     || normalized.includes('invalid request')
@@ -200,13 +205,8 @@ function classifyProviderError(error: Error | string): string {
     || normalized.includes('context window')
     || normalized.includes('tool schema')
     || normalized.includes('schema validation')
-    || normalized.includes('400')
+    || /(?:^|\D)400(?:\D|$)/.test(normalized)
   ) return 'request_error';
-  if (normalized.includes('rate limit') || normalized.includes('429')) return 'rate_limit';
-  if (normalized.includes('auth') || normalized.includes('permission') || normalized.includes('unauthorized')) return 'auth';
-  if (normalized.includes('timeout') || normalized.includes('timed out')) return 'timeout';
-  if (normalized.includes('unavailable') || normalized.includes('enoent')) return 'unavailable';
-  if (normalized.includes('stream ended without done')) return 'stream_incomplete';
   return 'execution_error';
 }
 
@@ -417,11 +417,19 @@ export class ProviderRegistry {
   private recordProviderSuccess(provider: ILlmProvider): void {
     const record = this.getOrCreateProviderHealth(provider);
     const previousState = record.state;
-    record.successes += 1;
-    record.updatedAtMs = this.opts.now();
 
     if (previousState === 'open') {
       this.emitProviderHealthChange(provider, 'stale-success-ignored');
+      return;
+    }
+
+    record.updatedAtMs = this.opts.now();
+    record.successes += 1;
+
+    if (previousState === 'half-open' && record.halfOpenProbeCount > 1) {
+      record.halfOpenProbeCount -= 1;
+      record.consecutiveFailures = 0;
+      this.emitProviderHealthChange(provider, 'half-open-probe-succeeded');
       return;
     }
 
@@ -467,6 +475,14 @@ export class ProviderRegistry {
     const record = this.providerHealth.get(this.providerKey(provider));
     if (record?.state !== 'half-open' || record.halfOpenProbeCount <= 0) return;
     this.tripProvider(provider, reason, 'half-open-probe-released');
+  }
+
+  private releaseHalfOpenProbeWithoutHealthFailure(provider: ILlmProvider, reason: string): void {
+    const record = this.providerHealth.get(this.providerKey(provider));
+    if (record?.state !== 'half-open' || record.halfOpenProbeCount <= 0) return;
+    record.halfOpenProbeCount -= 1;
+    record.updatedAtMs = this.opts.now();
+    this.emitProviderHealthChange(provider, reason);
   }
 
   private getProviderIterationOrder(): number[] {
@@ -643,6 +659,8 @@ export class ProviderRegistry {
             terminalEventObserved = true;
             if (shouldRecordProviderHealthFailure(lastError)) {
               this.recordProviderFailure(provider, lastError, { tripHalfOpenProbe: halfOpenProbeReserved });
+            } else if (halfOpenProbeReserved) {
+              this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-request-error');
             }
           }
           terminalError = lastError;

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -492,8 +492,8 @@ export class ProviderRegistry {
       .map((provider, index) => ({ provider, index }))
       .filter(({ provider }) => {
         const record = this.providerHealth.get(this.providerKey(provider));
-        return record?.state === 'open'
-          && (record.cooldownUntilMs === null || now >= record.cooldownUntilMs);
+        return (record?.state === 'open' && (record.cooldownUntilMs === null || now >= record.cooldownUntilMs))
+          || (record?.state === 'half-open' && record.halfOpenProbeCount < this.opts.circuitBreakerHalfOpenMaxProbes);
       })
       .map(({ index }) => index);
 
@@ -545,7 +545,7 @@ export class ProviderRegistry {
       attemptedProviders++;
 
       let effectiveRequest = request;
-      if (providerIndex !== this.currentProviderIndex) {
+      if (providerIndex !== this.currentProviderIndex || (i > 0 && lastError)) {
         const snapshot = this.brain.serialize();
         const failedProviderName = lastFailedProviderName ?? this.providers[this.currentProviderIndex]!.name;
         const health = this.providerHealth.get(this.providerKey(provider));
@@ -621,6 +621,9 @@ export class ProviderRegistry {
                 this.recordProviderFailure(provider, lastError, { tripHalfOpenProbe: halfOpenProbeReserved });
                 failureAlreadyRecorded = true;
               } else {
+                if (halfOpenProbeReserved) {
+                  this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-request-error');
+                }
                 failureAlreadyRecorded = true;
               }
               terminalError = lastError;

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -193,12 +193,25 @@ function normalizeJitterRatio(value: number | undefined): number {
 function classifyProviderError(error: Error | string): string {
   const message = error instanceof Error ? error.message : error;
   const normalized = message.toLowerCase();
+  if (
+    normalized.includes('bad request')
+    || normalized.includes('invalid request')
+    || normalized.includes('context length')
+    || normalized.includes('context window')
+    || normalized.includes('tool schema')
+    || normalized.includes('schema validation')
+    || normalized.includes('400')
+  ) return 'request_error';
   if (normalized.includes('rate limit') || normalized.includes('429')) return 'rate_limit';
   if (normalized.includes('auth') || normalized.includes('permission') || normalized.includes('unauthorized')) return 'auth';
   if (normalized.includes('timeout') || normalized.includes('timed out')) return 'timeout';
   if (normalized.includes('unavailable') || normalized.includes('enoent')) return 'unavailable';
   if (normalized.includes('stream ended without done')) return 'stream_incomplete';
   return 'execution_error';
+}
+
+function shouldRecordProviderHealthFailure(error: Error | string): boolean {
+  return classifyProviderError(error) !== 'request_error';
 }
 
 export class ProviderRegistry {
@@ -284,13 +297,21 @@ export class ProviderRegistry {
     }
 
     const occurrences = new Map<string, number>();
+    const usedKeys = new Set<string>();
     for (const provider of providers) {
       if (this.providerKeys.has(provider)) continue;
       const occurrence = occurrences.get(provider.name) ?? 0;
       occurrences.set(provider.name, occurrence + 1);
-      const providerKey = (totals.get(provider.name) ?? 0) > 1
+      const candidateKey = (totals.get(provider.name) ?? 0) > 1
         ? `${provider.name}#${occurrence + 1}`
         : provider.name;
+      let providerKey = candidateKey;
+      let collisionSuffix = 2;
+      while (usedKeys.has(providerKey)) {
+        providerKey = `${candidateKey}#${collisionSuffix}`;
+        collisionSuffix += 1;
+      }
+      usedKeys.add(providerKey);
       this.providerKeys.set(provider, providerKey);
     }
   }
@@ -368,7 +389,11 @@ export class ProviderRegistry {
     return record;
   }
 
-  private recordProviderFailure(provider: ILlmProvider, error: Error | string): ProviderHealthRecord {
+  private recordProviderFailure(
+    provider: ILlmProvider,
+    error: Error | string,
+    options: { tripHalfOpenProbe?: boolean } = {},
+  ): ProviderHealthRecord {
     const record = this.getOrCreateProviderHealth(provider);
     const now = this.opts.now();
     record.failures += 1;
@@ -377,7 +402,11 @@ export class ProviderRegistry {
     record.lastFailureAtMs = now;
     record.updatedAtMs = now;
 
-    if (record.state === 'half-open' || record.consecutiveFailures >= this.opts.circuitBreakerFailureThreshold) {
+    if (
+      options.tripHalfOpenProbe
+      || record.state === 'half-open'
+      || record.consecutiveFailures >= this.opts.circuitBreakerFailureThreshold
+    ) {
       return this.tripProvider(provider, error, 'provider-failure-threshold');
     }
 
@@ -500,11 +529,14 @@ export class ProviderRegistry {
       attemptedProviders++;
 
       let effectiveRequest = request;
-      if (i > 0) {
+      if (providerIndex !== this.currentProviderIndex) {
         const snapshot = this.brain.serialize();
         const failedProviderName = lastFailedProviderName ?? this.providers[this.currentProviderIndex]!.name;
+        const health = this.providerHealth.get(this.providerKey(provider));
+        const switchReason = lastError?.message
+          ?? (health?.state === 'half-open' ? 'provider circuit breaker cooldown elapsed' : 'unknown');
         snapshot.metadata.lastProvider = failedProviderName;
-        snapshot.metadata.switchReason = lastError?.message ?? 'unknown';
+        snapshot.metadata.switchReason = switchReason;
 
         if (this.opts.onProviderSwitch) {
           const json = JSON.stringify(snapshot);
@@ -513,7 +545,7 @@ export class ProviderRegistry {
           this.opts.onProviderSwitch({
             from: failedProviderName,
             to: provider.name,
-            reason: lastError?.message ?? 'unknown',
+            reason: switchReason,
             brainSnapshotHash: hash,
           });
         }
@@ -569,8 +601,12 @@ export class ProviderRegistry {
             if (event.type === 'error') {
               lastError = new Error(event.error);
               terminalEventObserved = true;
-              this.recordProviderFailure(provider, lastError);
-              failureAlreadyRecorded = true;
+              if (shouldRecordProviderHealthFailure(lastError)) {
+                this.recordProviderFailure(provider, lastError, { tripHalfOpenProbe: halfOpenProbeReserved });
+                failureAlreadyRecorded = true;
+              } else {
+                failureAlreadyRecorded = true;
+              }
               terminalError = lastError;
               lastFailedProviderName = provider.name;
               throw lastError; // discard buffer, failover
@@ -605,7 +641,9 @@ export class ProviderRegistry {
             error instanceof Error ? error : new Error(String(error));
           if (!failureAlreadyRecorded) {
             terminalEventObserved = true;
-            this.recordProviderFailure(provider, lastError);
+            if (shouldRecordProviderHealthFailure(lastError)) {
+              this.recordProviderFailure(provider, lastError, { tripHalfOpenProbe: halfOpenProbeReserved });
+            }
           }
           terminalError = lastError;
           lastFailedProviderName = provider.name;

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -50,6 +50,8 @@ export interface ProviderSwitchEvent {
 export type ProviderCircuitState = 'closed' | 'open' | 'half-open';
 
 export interface ProviderHealthState {
+  /** Stable key for one provider instance; duplicate provider names receive #2/#3 suffixes. */
+  providerKey: string;
   providerName: string;
   /** Request-level model when known; typed LlmRequest currently leaves this unspecified. */
   model: string | null;
@@ -66,6 +68,8 @@ export interface ProviderHealthState {
 }
 
 export interface ProviderHealthEvent {
+  /** Stable key for the provider instance that changed state. */
+  providerKey: string;
   providerName: string;
   state: ProviderCircuitState;
   reason: string;
@@ -263,9 +267,10 @@ export class ProviderRegistry {
   }
 
   getProviderHealth(providerNameOrKey: string): ProviderHealthState | undefined {
-    const record = this.providerHealth.get(providerNameOrKey)
-      ?? [...this.providerHealth.values()].find((health) => health.providerName === providerNameOrKey);
-    return record ? this.toHealthState(record) : undefined;
+    const exact = this.providerHealth.get(providerNameOrKey);
+    if (exact) return this.toHealthState(exact);
+    const matches = [...this.providerHealth.values()].filter((health) => health.providerName === providerNameOrKey);
+    return matches.length === 1 ? this.toHealthState(matches[0]!) : undefined;
   }
 
   listProviderHealth(): ProviderHealthState[] {
@@ -320,6 +325,7 @@ export class ProviderRegistry {
   private toHealthState(record: ProviderHealthRecord): ProviderHealthState {
     const total = record.failures + record.successes;
     return {
+      providerKey: record.providerKey,
       providerName: record.providerName,
       model: record.model,
       state: record.state,
@@ -339,6 +345,7 @@ export class ProviderRegistry {
     const record = this.providerHealth.get(this.providerKey(provider));
     if (!record || !this.opts.onProviderHealthChange) return;
     this.opts.onProviderHealthChange({
+      providerKey: record.providerKey,
       providerName: record.providerName,
       state: record.state,
       reason,
@@ -422,6 +429,17 @@ export class ProviderRegistry {
     return undefined;
   }
 
+  private hasReservedHalfOpenProbe(provider: ILlmProvider): boolean {
+    const record = this.providerHealth.get(this.providerKey(provider));
+    return record?.state === 'half-open' && record.halfOpenProbeCount > 0;
+  }
+
+  private releaseHalfOpenProbe(provider: ILlmProvider, reason: string): void {
+    const record = this.providerHealth.get(this.providerKey(provider));
+    if (record?.state !== 'half-open' || record.halfOpenProbeCount <= 0) return;
+    this.tripProvider(provider, reason, 'half-open-probe-released');
+  }
+
   private getProviderIterationOrder(): number[] {
     const normalOrder = this.providers.map((_, offset) => (this.currentProviderIndex + offset) % this.providers.length);
     const now = this.opts.now();
@@ -443,6 +461,7 @@ export class ProviderRegistry {
     let lastFailedProviderName: string | undefined;
     const unavailableProviders: string[] = [];
     const circuitErrors: string[] = [];
+    const availabilityErrors: string[] = [];
     let attemptedProviders = 0;
 
     const providerOrder = this.getProviderIterationOrder();
@@ -454,6 +473,10 @@ export class ProviderRegistry {
       if (circuitError) {
         unavailableProviders.push(provider.name);
         circuitErrors.push(circuitError.message);
+        const health = this.providerHealth.get(this.providerKey(provider));
+        if (health?.lastErrorClass === 'unavailable' || health?.lastErrorClass === 'auth') {
+          availabilityErrors.push(`Provider ${provider.name} circuit opened after ${health.lastErrorClass} failure`);
+        }
         if (!lastError) {
           lastFailedProviderName = provider.name;
           lastError = circuitError;
@@ -465,6 +488,7 @@ export class ProviderRegistry {
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
         const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
+        availabilityErrors.push(availabilityError.message);
         this.recordProviderFailure(provider, availabilityError);
         if (!lastError) {
           lastFailedProviderName = provider.name;
@@ -511,6 +535,8 @@ export class ProviderRegistry {
         retry++
       ) {
         let failureAlreadyRecorded = false;
+        let terminalEventObserved = false;
+        const halfOpenProbeReserved = this.hasReservedHalfOpenProbe(provider);
         try {
           const stream = provider.execute(effectiveRequest);
           let retried = false;
@@ -523,6 +549,7 @@ export class ProviderRegistry {
               retry < this.opts.maxRetriesPerProvider
             ) {
               lastError = new Error(event.error);
+              terminalEventObserved = true;
               const health = this.recordProviderFailure(provider, lastError);
               failureAlreadyRecorded = true;
               if (health.state === 'open') {
@@ -541,6 +568,7 @@ export class ProviderRegistry {
             }
             if (event.type === 'error') {
               lastError = new Error(event.error);
+              terminalEventObserved = true;
               this.recordProviderFailure(provider, lastError);
               failureAlreadyRecorded = true;
               terminalError = lastError;
@@ -555,6 +583,7 @@ export class ProviderRegistry {
           // Attempt completed — flush buffered events
           for (const event of buffer) {
             if (event.type === 'done') {
+              terminalEventObserved = true;
               this.tokenAggregator.record(provider.name, event.usage);
               this.recordProviderSuccess(provider);
             }
@@ -566,6 +595,7 @@ export class ProviderRegistry {
           }
 
           lastError = new Error('stream ended without done');
+          terminalEventObserved = true;
           this.recordProviderFailure(provider, lastError);
           terminalError = lastError;
           lastFailedProviderName = provider.name;
@@ -574,11 +604,16 @@ export class ProviderRegistry {
           lastError =
             error instanceof Error ? error : new Error(String(error));
           if (!failureAlreadyRecorded) {
+            terminalEventObserved = true;
             this.recordProviderFailure(provider, lastError);
           }
           terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // failover to next provider
+        } finally {
+          if (halfOpenProbeReserved && !terminalEventObserved) {
+            this.releaseHalfOpenProbe(provider, 'half-open probe stream ended before a terminal event');
+          }
         }
       }
     }
@@ -593,10 +628,18 @@ export class ProviderRegistry {
     });
 
     const exhaustionReason = attemptedProviders === 0
-      ? circuitErrors.length > 0
-        ? `No providers available because provider circuit breakers are open: ${circuitErrors.join('; ')}. `
-        : `No providers available. Checked: ${unavailableProviders.join(', ')}. `
-          + 'Install or authenticate at least one configured provider CLI, or configure provider overrides.'
+      ? [
+        `No providers available. Checked: ${unavailableProviders.join(', ')}.`,
+        circuitErrors.length > 0
+          ? `Provider circuit breakers are open: ${circuitErrors.join('; ')}.`
+          : undefined,
+        availabilityErrors.length > 0
+          ? `Unavailable providers: ${availabilityErrors.join('; ')}.`
+          : undefined,
+        availabilityErrors.length > 0
+          ? 'Install or authenticate configured provider CLIs, or configure provider overrides.'
+          : undefined,
+      ].filter((part): part is string => part !== undefined).join(' ')
       : `All providers exhausted. Last error: ${(terminalError ?? lastError)?.message ?? 'unknown'}. `;
 
     throw new Error(

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -73,6 +73,7 @@ export interface ProviderHealthEvent {
 }
 
 interface ProviderHealthRecord {
+  providerKey: string;
   providerName: string;
   model: string | null;
   state: ProviderCircuitState;
@@ -203,6 +204,7 @@ export class ProviderRegistry {
   private currentProviderIndex = 0;
   private readonly tokenAggregator = new TokenAggregator();
   private readonly providerHealth = new Map<string, ProviderHealthRecord>();
+  private readonly providerKeys = new WeakMap<ILlmProvider, string>();
 
   constructor(
     providers: ILlmProvider[],
@@ -213,6 +215,7 @@ export class ProviderRegistry {
       throw new Error('ProviderRegistry requires at least one provider');
     }
     this.providers = providers;
+    this.assignProviderKeys(providers);
     this.brain = brain;
     const retryDelayMs = normalizeNonNegativeFinite('retryDelayMs', options.retryDelayMs, 1000);
     const maxRetryDelayMs = normalizeNonNegativeFinite('maxRetryDelayMs', options.maxRetryDelayMs, MAX_RETRY_DELAY_MS);
@@ -259,8 +262,9 @@ export class ProviderRegistry {
     );
   }
 
-  getProviderHealth(providerName: string): ProviderHealthState | undefined {
-    const record = this.providerHealth.get(providerName);
+  getProviderHealth(providerNameOrKey: string): ProviderHealthState | undefined {
+    const record = this.providerHealth.get(providerNameOrKey)
+      ?? [...this.providerHealth.values()].find((health) => health.providerName === providerNameOrKey);
     return record ? this.toHealthState(record) : undefined;
   }
 
@@ -268,12 +272,36 @@ export class ProviderRegistry {
     return [...this.providerHealth.values()].map((record) => this.toHealthState(record));
   }
 
-  private getOrCreateProviderHealth(providerName: string): ProviderHealthRecord {
-    const existing = this.providerHealth.get(providerName);
+  private assignProviderKeys(providers: ILlmProvider[]): void {
+    const totals = new Map<string, number>();
+    for (const provider of providers) {
+      totals.set(provider.name, (totals.get(provider.name) ?? 0) + 1);
+    }
+
+    const occurrences = new Map<string, number>();
+    for (const provider of providers) {
+      if (this.providerKeys.has(provider)) continue;
+      const occurrence = occurrences.get(provider.name) ?? 0;
+      occurrences.set(provider.name, occurrence + 1);
+      const providerKey = (totals.get(provider.name) ?? 0) > 1
+        ? `${provider.name}#${occurrence + 1}`
+        : provider.name;
+      this.providerKeys.set(provider, providerKey);
+    }
+  }
+
+  private providerKey(provider: ILlmProvider): string {
+    return this.providerKeys.get(provider) ?? provider.name;
+  }
+
+  private getOrCreateProviderHealth(provider: ILlmProvider): ProviderHealthRecord {
+    const providerKey = this.providerKey(provider);
+    const existing = this.providerHealth.get(providerKey);
     if (existing) return existing;
     const now = this.opts.now();
     const created: ProviderHealthRecord = {
-      providerName,
+      providerKey,
+      providerName: provider.name,
       model: null,
       state: 'closed',
       failures: 0,
@@ -285,7 +313,7 @@ export class ProviderRegistry {
       halfOpenProbeCount: 0,
       updatedAtMs: now,
     };
-    this.providerHealth.set(providerName, created);
+    this.providerHealth.set(providerKey, created);
     return created;
   }
 
@@ -307,19 +335,19 @@ export class ProviderRegistry {
     };
   }
 
-  private emitProviderHealthChange(providerName: string, reason: string): void {
-    const record = this.providerHealth.get(providerName);
+  private emitProviderHealthChange(provider: ILlmProvider, reason: string): void {
+    const record = this.providerHealth.get(this.providerKey(provider));
     if (!record || !this.opts.onProviderHealthChange) return;
     this.opts.onProviderHealthChange({
-      providerName,
+      providerName: record.providerName,
       state: record.state,
       reason,
       health: this.toHealthState(record),
     });
   }
 
-  private tripProvider(providerName: string, error: Error | string, reason: string): ProviderHealthRecord {
-    const record = this.getOrCreateProviderHealth(providerName);
+  private tripProvider(provider: ILlmProvider, error: Error | string, reason: string): ProviderHealthRecord {
+    const record = this.getOrCreateProviderHealth(provider);
     const now = this.opts.now();
     const jitterMs = this.opts.circuitBreakerCooldownMs
       * this.opts.circuitBreakerCooldownJitterRatio
@@ -329,12 +357,12 @@ export class ProviderRegistry {
     record.halfOpenProbeCount = 0;
     record.lastErrorClass = classifyProviderError(error);
     record.updatedAtMs = now;
-    this.emitProviderHealthChange(providerName, reason);
+    this.emitProviderHealthChange(provider, reason);
     return record;
   }
 
-  private recordProviderFailure(providerName: string, error: Error | string): ProviderHealthRecord {
-    const record = this.getOrCreateProviderHealth(providerName);
+  private recordProviderFailure(provider: ILlmProvider, error: Error | string): ProviderHealthRecord {
+    const record = this.getOrCreateProviderHealth(provider);
     const now = this.opts.now();
     record.failures += 1;
     record.consecutiveFailures += 1;
@@ -343,49 +371,70 @@ export class ProviderRegistry {
     record.updatedAtMs = now;
 
     if (record.state === 'half-open' || record.consecutiveFailures >= this.opts.circuitBreakerFailureThreshold) {
-      return this.tripProvider(providerName, error, 'provider-failure-threshold');
+      return this.tripProvider(provider, error, 'provider-failure-threshold');
     }
 
-    this.emitProviderHealthChange(providerName, 'provider-failure');
+    this.emitProviderHealthChange(provider, 'provider-failure');
     return record;
   }
 
-  private recordProviderSuccess(providerName: string): void {
-    const record = this.getOrCreateProviderHealth(providerName);
+  private recordProviderSuccess(provider: ILlmProvider): void {
+    const record = this.getOrCreateProviderHealth(provider);
     const previousState = record.state;
     record.successes += 1;
+    record.updatedAtMs = this.opts.now();
+
+    if (previousState === 'open') {
+      this.emitProviderHealthChange(provider, 'stale-success-ignored');
+      return;
+    }
+
     record.consecutiveFailures = 0;
     record.state = 'closed';
     record.cooldownUntilMs = null;
     record.halfOpenProbeCount = 0;
-    record.updatedAtMs = this.opts.now();
-    this.emitProviderHealthChange(providerName, previousState === 'half-open' ? 'half-open-probe-succeeded' : 'provider-success');
+    this.emitProviderHealthChange(provider, previousState === 'half-open' ? 'half-open-probe-succeeded' : 'provider-success');
   }
 
-  private reserveCircuitBreakerProbe(providerName: string): Error | undefined {
-    const record = this.getOrCreateProviderHealth(providerName);
+  private reserveCircuitBreakerProbe(provider: ILlmProvider): Error | undefined {
+    const record = this.getOrCreateProviderHealth(provider);
     const now = this.opts.now();
 
     if (record.state === 'open') {
       if (record.cooldownUntilMs !== null && now < record.cooldownUntilMs) {
-        return new Error(`Provider ${providerName} circuit breaker is open until ${new Date(record.cooldownUntilMs).toISOString()}`);
+        return new Error(`Provider ${record.providerName} circuit breaker is open until ${new Date(record.cooldownUntilMs).toISOString()}`);
       }
       record.state = 'half-open';
       record.halfOpenProbeCount = 0;
       record.updatedAtMs = now;
-      this.emitProviderHealthChange(providerName, 'cooldown-elapsed-half-open');
+      this.emitProviderHealthChange(provider, 'cooldown-elapsed-half-open');
     }
 
     if (record.state === 'half-open') {
       if (record.halfOpenProbeCount >= this.opts.circuitBreakerHalfOpenMaxProbes) {
-        return new Error(`Provider ${providerName} circuit breaker half-open probe limit reached`);
+        return new Error(`Provider ${record.providerName} circuit breaker half-open probe limit reached`);
       }
       record.halfOpenProbeCount += 1;
       record.updatedAtMs = now;
-      this.emitProviderHealthChange(providerName, 'half-open-probe-started');
+      this.emitProviderHealthChange(provider, 'half-open-probe-started');
     }
 
     return undefined;
+  }
+
+  private getProviderIterationOrder(): number[] {
+    const normalOrder = this.providers.map((_, offset) => (this.currentProviderIndex + offset) % this.providers.length);
+    const now = this.opts.now();
+    const readyProbeIndexes = this.providers
+      .map((provider, index) => ({ provider, index }))
+      .filter(({ provider }) => {
+        const record = this.providerHealth.get(this.providerKey(provider));
+        return record?.state === 'open'
+          && (record.cooldownUntilMs === null || now >= record.cooldownUntilMs);
+      })
+      .map(({ index }) => index);
+
+    return [...new Set([...readyProbeIndexes, ...normalOrder])];
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
@@ -393,16 +442,18 @@ export class ProviderRegistry {
     let terminalError: Error | undefined;
     let lastFailedProviderName: string | undefined;
     const unavailableProviders: string[] = [];
+    const circuitErrors: string[] = [];
     let attemptedProviders = 0;
 
-    for (let i = 0; i < this.providers.length; i++) {
-      const providerIndex =
-        (this.currentProviderIndex + i) % this.providers.length;
+    const providerOrder = this.getProviderIterationOrder();
+    for (let i = 0; i < providerOrder.length; i++) {
+      const providerIndex = providerOrder[i]!;
       const provider = this.providers[providerIndex]!;
 
-      const circuitError = this.reserveCircuitBreakerProbe(provider.name);
+      const circuitError = this.reserveCircuitBreakerProbe(provider);
       if (circuitError) {
         unavailableProviders.push(provider.name);
+        circuitErrors.push(circuitError.message);
         if (!lastError) {
           lastFailedProviderName = provider.name;
           lastError = circuitError;
@@ -414,7 +465,7 @@ export class ProviderRegistry {
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
         const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
-        this.recordProviderFailure(provider.name, availabilityError);
+        this.recordProviderFailure(provider, availabilityError);
         if (!lastError) {
           lastFailedProviderName = provider.name;
           lastError = availabilityError;
@@ -472,7 +523,7 @@ export class ProviderRegistry {
               retry < this.opts.maxRetriesPerProvider
             ) {
               lastError = new Error(event.error);
-              const health = this.recordProviderFailure(provider.name, lastError);
+              const health = this.recordProviderFailure(provider, lastError);
               failureAlreadyRecorded = true;
               if (health.state === 'open') {
                 terminalError = lastError;
@@ -490,7 +541,7 @@ export class ProviderRegistry {
             }
             if (event.type === 'error') {
               lastError = new Error(event.error);
-              this.recordProviderFailure(provider.name, lastError);
+              this.recordProviderFailure(provider, lastError);
               failureAlreadyRecorded = true;
               terminalError = lastError;
               lastFailedProviderName = provider.name;
@@ -505,7 +556,7 @@ export class ProviderRegistry {
           for (const event of buffer) {
             if (event.type === 'done') {
               this.tokenAggregator.record(provider.name, event.usage);
-              this.recordProviderSuccess(provider.name);
+              this.recordProviderSuccess(provider);
             }
             yield event;
             if (event.type === 'done') {
@@ -515,7 +566,7 @@ export class ProviderRegistry {
           }
 
           lastError = new Error('stream ended without done');
-          this.recordProviderFailure(provider.name, lastError);
+          this.recordProviderFailure(provider, lastError);
           terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // stream ended without done — failover
@@ -523,7 +574,7 @@ export class ProviderRegistry {
           lastError =
             error instanceof Error ? error : new Error(String(error));
           if (!failureAlreadyRecorded) {
-            this.recordProviderFailure(provider.name, lastError);
+            this.recordProviderFailure(provider, lastError);
           }
           terminalError = lastError;
           lastFailedProviderName = provider.name;
@@ -542,8 +593,10 @@ export class ProviderRegistry {
     });
 
     const exhaustionReason = attemptedProviders === 0
-      ? `No providers available. Checked: ${unavailableProviders.join(', ')}. `
-        + 'Install or authenticate at least one configured provider CLI, or configure provider overrides.'
+      ? circuitErrors.length > 0
+        ? `No providers available because provider circuit breakers are open: ${circuitErrors.join('; ')}. `
+        : `No providers available. Checked: ${unavailableProviders.join(', ')}. `
+          + 'Install or authenticate at least one configured provider CLI, or configure provider overrides.'
       : `All providers exhausted. Last error: ${(terminalError ?? lastError)?.message ?? 'unknown'}. `;
 
     throw new Error(

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -4,7 +4,7 @@ import type {
   LlmRequest,
   LlmStreamEvent,
 } from '@franken/types';
-import { isoNow } from '@franken/types';
+import { isoNow, seededRandom, wallClockNow } from '@franken/types';
 import type { IBrain } from '@franken/types';
 import { TokenAggregator, type AggregatedTokenUsage } from './token-aggregator.js';
 import { truncateSnapshot } from './format-handoff.js';
@@ -26,6 +26,18 @@ export interface ProviderRegistryOptions {
   sleep?: (ms: number) => Promise<void>;
   /** Callback fired when switching providers */
   onProviderSwitch?: (event: ProviderSwitchEvent) => void;
+  /** Consecutive failures before opening the provider circuit. Default: 5. */
+  circuitBreakerFailureThreshold?: number;
+  /** Base provider cool-down window in ms after a breaker opens. Default: 60s. */
+  circuitBreakerCooldownMs?: number;
+  /** Jitter ratio applied to cool-downs to avoid synchronized retry storms. Default: 0.1. */
+  circuitBreakerCooldownJitterRatio?: number;
+  /** Bounded half-open probes allowed per cool-down window. Default: 1. */
+  circuitBreakerHalfOpenMaxProbes?: number;
+  /** Injectable clock for deterministic tests. */
+  now?: () => number;
+  /** Callback fired when provider health/circuit state changes. */
+  onProviderHealthChange?: (event: ProviderHealthEvent) => void;
 }
 
 export interface ProviderSwitchEvent {
@@ -33,6 +45,45 @@ export interface ProviderSwitchEvent {
   to: string;
   reason: string;
   brainSnapshotHash: string;
+}
+
+export type ProviderCircuitState = 'closed' | 'open' | 'half-open';
+
+export interface ProviderHealthState {
+  providerName: string;
+  /** Request-level model when known; typed LlmRequest currently leaves this unspecified. */
+  model: string | null;
+  state: ProviderCircuitState;
+  failures: number;
+  successes: number;
+  consecutiveFailures: number;
+  failureRate: number;
+  lastErrorClass: string | null;
+  lastFailureAt: string | null;
+  cooldownUntil: string | null;
+  halfOpenProbeCount: number;
+  updatedAt: string;
+}
+
+export interface ProviderHealthEvent {
+  providerName: string;
+  state: ProviderCircuitState;
+  reason: string;
+  health: ProviderHealthState;
+}
+
+interface ProviderHealthRecord {
+  providerName: string;
+  model: string | null;
+  state: ProviderCircuitState;
+  failures: number;
+  successes: number;
+  consecutiveFailures: number;
+  lastErrorClass: string | null;
+  lastFailureAtMs: number | null;
+  cooldownUntilMs: number | null;
+  halfOpenProbeCount: number;
+  updatedAtMs: number;
 }
 
 export interface ModelProviderFailoverAuditPayload extends ProviderSwitchEvent {
@@ -63,10 +114,19 @@ interface ResolvedOptions {
   backoffMultiplier: number;
   sleep: (ms: number) => Promise<void>;
   onProviderSwitch?: ProviderRegistryOptions['onProviderSwitch'];
+  circuitBreakerFailureThreshold: number;
+  circuitBreakerCooldownMs: number;
+  circuitBreakerCooldownJitterRatio: number;
+  circuitBreakerHalfOpenMaxProbes: number;
+  now: () => number;
+  onProviderHealthChange?: ProviderRegistryOptions['onProviderHealthChange'];
 }
 
 const MAX_RETRIES_PER_PROVIDER = 5;
 const MAX_RETRY_DELAY_MS = 30_000;
+const MAX_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 20;
+const MAX_CIRCUIT_BREAKER_COOLDOWN_MS = 3_600_000;
+const MAX_CIRCUIT_BREAKER_HALF_OPEN_PROBES = 10;
 
 function normalizeMaxRetriesPerProvider(value: number | undefined): number {
   const normalized = value ?? 1;
@@ -96,12 +156,53 @@ function normalizeBackoffMultiplier(value: number | undefined): number {
   return normalized;
 }
 
+function normalizePositiveInteger(
+  name: 'circuitBreakerFailureThreshold' | 'circuitBreakerHalfOpenMaxProbes',
+  value: number | undefined,
+  defaultValue: number,
+  maxValue: number,
+): number {
+  const normalized = value ?? defaultValue;
+  if (!Number.isInteger(normalized) || normalized < 1 || normalized > maxValue) {
+    throw new Error(`${name} must be an integer between 1 and ${maxValue}`);
+  }
+  return normalized;
+}
+
+function normalizeCircuitBreakerCooldownMs(value: number | undefined): number {
+  const normalized = value ?? 60_000;
+  if (!Number.isFinite(normalized) || normalized < 0 || normalized > MAX_CIRCUIT_BREAKER_COOLDOWN_MS) {
+    throw new Error(`circuitBreakerCooldownMs must be a finite number between 0 and ${MAX_CIRCUIT_BREAKER_COOLDOWN_MS}`);
+  }
+  return normalized;
+}
+
+function normalizeJitterRatio(value: number | undefined): number {
+  const normalized = value ?? 0.1;
+  if (!Number.isFinite(normalized) || normalized < 0 || normalized > 1) {
+    throw new Error('circuitBreakerCooldownJitterRatio must be a finite number between 0 and 1');
+  }
+  return normalized;
+}
+
+function classifyProviderError(error: Error | string): string {
+  const message = error instanceof Error ? error.message : error;
+  const normalized = message.toLowerCase();
+  if (normalized.includes('rate limit') || normalized.includes('429')) return 'rate_limit';
+  if (normalized.includes('auth') || normalized.includes('permission') || normalized.includes('unauthorized')) return 'auth';
+  if (normalized.includes('timeout') || normalized.includes('timed out')) return 'timeout';
+  if (normalized.includes('unavailable') || normalized.includes('enoent')) return 'unavailable';
+  if (normalized.includes('stream ended without done')) return 'stream_incomplete';
+  return 'execution_error';
+}
+
 export class ProviderRegistry {
   private providers: ILlmProvider[];
   private brain: IBrain;
   private opts: ResolvedOptions;
   private currentProviderIndex = 0;
   private readonly tokenAggregator = new TokenAggregator();
+  private readonly providerHealth = new Map<string, ProviderHealthRecord>();
 
   constructor(
     providers: ILlmProvider[],
@@ -122,6 +223,22 @@ export class ProviderRegistry {
       backoffMultiplier: normalizeBackoffMultiplier(options.backoffMultiplier),
       sleep: options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))),
       onProviderSwitch: options.onProviderSwitch,
+      circuitBreakerFailureThreshold: normalizePositiveInteger(
+        'circuitBreakerFailureThreshold',
+        options.circuitBreakerFailureThreshold,
+        5,
+        MAX_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+      ),
+      circuitBreakerCooldownMs: normalizeCircuitBreakerCooldownMs(options.circuitBreakerCooldownMs),
+      circuitBreakerCooldownJitterRatio: normalizeJitterRatio(options.circuitBreakerCooldownJitterRatio),
+      circuitBreakerHalfOpenMaxProbes: normalizePositiveInteger(
+        'circuitBreakerHalfOpenMaxProbes',
+        options.circuitBreakerHalfOpenMaxProbes,
+        1,
+        MAX_CIRCUIT_BREAKER_HALF_OPEN_PROBES,
+      ),
+      now: options.now ?? wallClockNow,
+      onProviderHealthChange: options.onProviderHealthChange,
     };
   }
 
@@ -142,6 +259,135 @@ export class ProviderRegistry {
     );
   }
 
+  getProviderHealth(providerName: string): ProviderHealthState | undefined {
+    const record = this.providerHealth.get(providerName);
+    return record ? this.toHealthState(record) : undefined;
+  }
+
+  listProviderHealth(): ProviderHealthState[] {
+    return [...this.providerHealth.values()].map((record) => this.toHealthState(record));
+  }
+
+  private getOrCreateProviderHealth(providerName: string): ProviderHealthRecord {
+    const existing = this.providerHealth.get(providerName);
+    if (existing) return existing;
+    const now = this.opts.now();
+    const created: ProviderHealthRecord = {
+      providerName,
+      model: null,
+      state: 'closed',
+      failures: 0,
+      successes: 0,
+      consecutiveFailures: 0,
+      lastErrorClass: null,
+      lastFailureAtMs: null,
+      cooldownUntilMs: null,
+      halfOpenProbeCount: 0,
+      updatedAtMs: now,
+    };
+    this.providerHealth.set(providerName, created);
+    return created;
+  }
+
+  private toHealthState(record: ProviderHealthRecord): ProviderHealthState {
+    const total = record.failures + record.successes;
+    return {
+      providerName: record.providerName,
+      model: record.model,
+      state: record.state,
+      failures: record.failures,
+      successes: record.successes,
+      consecutiveFailures: record.consecutiveFailures,
+      failureRate: total === 0 ? 0 : record.failures / total,
+      lastErrorClass: record.lastErrorClass,
+      lastFailureAt: record.lastFailureAtMs === null ? null : new Date(record.lastFailureAtMs).toISOString(),
+      cooldownUntil: record.cooldownUntilMs === null ? null : new Date(record.cooldownUntilMs).toISOString(),
+      halfOpenProbeCount: record.halfOpenProbeCount,
+      updatedAt: new Date(record.updatedAtMs).toISOString(),
+    };
+  }
+
+  private emitProviderHealthChange(providerName: string, reason: string): void {
+    const record = this.providerHealth.get(providerName);
+    if (!record || !this.opts.onProviderHealthChange) return;
+    this.opts.onProviderHealthChange({
+      providerName,
+      state: record.state,
+      reason,
+      health: this.toHealthState(record),
+    });
+  }
+
+  private tripProvider(providerName: string, error: Error | string, reason: string): ProviderHealthRecord {
+    const record = this.getOrCreateProviderHealth(providerName);
+    const now = this.opts.now();
+    const jitterMs = this.opts.circuitBreakerCooldownMs
+      * this.opts.circuitBreakerCooldownJitterRatio
+      * seededRandom.random();
+    record.state = 'open';
+    record.cooldownUntilMs = now + this.opts.circuitBreakerCooldownMs + jitterMs;
+    record.halfOpenProbeCount = 0;
+    record.lastErrorClass = classifyProviderError(error);
+    record.updatedAtMs = now;
+    this.emitProviderHealthChange(providerName, reason);
+    return record;
+  }
+
+  private recordProviderFailure(providerName: string, error: Error | string): ProviderHealthRecord {
+    const record = this.getOrCreateProviderHealth(providerName);
+    const now = this.opts.now();
+    record.failures += 1;
+    record.consecutiveFailures += 1;
+    record.lastErrorClass = classifyProviderError(error);
+    record.lastFailureAtMs = now;
+    record.updatedAtMs = now;
+
+    if (record.state === 'half-open' || record.consecutiveFailures >= this.opts.circuitBreakerFailureThreshold) {
+      return this.tripProvider(providerName, error, 'provider-failure-threshold');
+    }
+
+    this.emitProviderHealthChange(providerName, 'provider-failure');
+    return record;
+  }
+
+  private recordProviderSuccess(providerName: string): void {
+    const record = this.getOrCreateProviderHealth(providerName);
+    const previousState = record.state;
+    record.successes += 1;
+    record.consecutiveFailures = 0;
+    record.state = 'closed';
+    record.cooldownUntilMs = null;
+    record.halfOpenProbeCount = 0;
+    record.updatedAtMs = this.opts.now();
+    this.emitProviderHealthChange(providerName, previousState === 'half-open' ? 'half-open-probe-succeeded' : 'provider-success');
+  }
+
+  private reserveCircuitBreakerProbe(providerName: string): Error | undefined {
+    const record = this.getOrCreateProviderHealth(providerName);
+    const now = this.opts.now();
+
+    if (record.state === 'open') {
+      if (record.cooldownUntilMs !== null && now < record.cooldownUntilMs) {
+        return new Error(`Provider ${providerName} circuit breaker is open until ${new Date(record.cooldownUntilMs).toISOString()}`);
+      }
+      record.state = 'half-open';
+      record.halfOpenProbeCount = 0;
+      record.updatedAtMs = now;
+      this.emitProviderHealthChange(providerName, 'cooldown-elapsed-half-open');
+    }
+
+    if (record.state === 'half-open') {
+      if (record.halfOpenProbeCount >= this.opts.circuitBreakerHalfOpenMaxProbes) {
+        return new Error(`Provider ${providerName} circuit breaker half-open probe limit reached`);
+      }
+      record.halfOpenProbeCount += 1;
+      record.updatedAtMs = now;
+      this.emitProviderHealthChange(providerName, 'half-open-probe-started');
+    }
+
+    return undefined;
+  }
+
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     let lastError: Error | undefined;
     let terminalError: Error | undefined;
@@ -154,9 +400,21 @@ export class ProviderRegistry {
         (this.currentProviderIndex + i) % this.providers.length;
       const provider = this.providers[providerIndex]!;
 
+      const circuitError = this.reserveCircuitBreakerProbe(provider.name);
+      if (circuitError) {
+        unavailableProviders.push(provider.name);
+        if (!lastError) {
+          lastFailedProviderName = provider.name;
+          lastError = circuitError;
+        }
+        terminalError ??= circuitError;
+        continue;
+      }
+
       if (!(await provider.isAvailable())) {
         unavailableProviders.push(provider.name);
         const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
+        this.recordProviderFailure(provider.name, availabilityError);
         if (!lastError) {
           lastFailedProviderName = provider.name;
           lastError = availabilityError;
@@ -201,6 +459,7 @@ export class ProviderRegistry {
         retry <= this.opts.maxRetriesPerProvider;
         retry++
       ) {
+        let failureAlreadyRecorded = false;
         try {
           const stream = provider.execute(effectiveRequest);
           let retried = false;
@@ -213,6 +472,13 @@ export class ProviderRegistry {
               retry < this.opts.maxRetriesPerProvider
             ) {
               lastError = new Error(event.error);
+              const health = this.recordProviderFailure(provider.name, lastError);
+              failureAlreadyRecorded = true;
+              if (health.state === 'open') {
+                terminalError = lastError;
+                lastFailedProviderName = provider.name;
+                throw lastError;
+              }
               const delay = Math.min(
                 this.opts.retryDelayMs *
                 Math.pow(this.opts.backoffMultiplier, retry),
@@ -224,6 +490,8 @@ export class ProviderRegistry {
             }
             if (event.type === 'error') {
               lastError = new Error(event.error);
+              this.recordProviderFailure(provider.name, lastError);
+              failureAlreadyRecorded = true;
               terminalError = lastError;
               lastFailedProviderName = provider.name;
               throw lastError; // discard buffer, failover
@@ -237,6 +505,7 @@ export class ProviderRegistry {
           for (const event of buffer) {
             if (event.type === 'done') {
               this.tokenAggregator.record(provider.name, event.usage);
+              this.recordProviderSuccess(provider.name);
             }
             yield event;
             if (event.type === 'done') {
@@ -246,12 +515,16 @@ export class ProviderRegistry {
           }
 
           lastError = new Error('stream ended without done');
+          this.recordProviderFailure(provider.name, lastError);
           terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // stream ended without done — failover
         } catch (error) {
           lastError =
             error instanceof Error ? error : new Error(String(error));
+          if (!failureAlreadyRecorded) {
+            this.recordProviderFailure(provider.name, lastError);
+          }
           terminalError = lastError;
           lastFailedProviderName = provider.name;
           break; // failover to next provider

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -635,18 +635,25 @@ export class ProviderRegistry {
 
           if (retried) continue;
 
-          // Attempt completed — flush buffered events
+          // Attempt completed — flush buffered events. The provider stream has
+          // already completed at this point, so mark a buffered `done` as terminal
+          // before yielding earlier buffered chunks. Otherwise a caller that stops
+          // after the first yielded text event can make a successful half-open
+          // probe look like an abandoned stream in `finally`.
+          const bufferedDone = buffer.find((event) => event.type === 'done');
+          if (bufferedDone?.type === 'done') {
+            terminalEventObserved = true;
+            this.tokenAggregator.record(provider.name, bufferedDone.usage);
+            this.recordProviderSuccess(provider);
+            this.currentProviderIndex = providerIndex;
+          }
+
           for (const event of buffer) {
             if (event.type === 'done') {
-              terminalEventObserved = true;
-              this.tokenAggregator.record(provider.name, event.usage);
-              this.recordProviderSuccess(provider);
-            }
-            yield event;
-            if (event.type === 'done') {
-              this.currentProviderIndex = providerIndex;
+              yield event;
               return;
             }
+            yield event;
           }
 
           lastError = new Error('stream ended without done');

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -597,6 +597,75 @@ describe('ProviderRegistry', () => {
       });
     });
 
+    it('probes recovered providers after cooldown even when fallback is current', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let primaryShouldFail = true;
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          if (primaryShouldFail) throw new Error('transient outage');
+          yield { type: 'text' as const, content: 'primary recovered' };
+          yield { type: 'done' as const, usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      expect(registry.currentProvider.name).toBe('fallback');
+
+      now += 10_001;
+      primaryShouldFail = false;
+      const events = await collectEvents(registry.execute(makeRequest()));
+
+      expect(events[0]).toEqual({ type: 'text', content: 'primary recovered' });
+      expect(p1.execute).toHaveBeenCalledTimes(2);
+      expect(registry.currentProvider.name).toBe('primary');
+      expect(registry.getProviderHealth('primary')?.state).toBe('closed');
+    });
+
+    it('keeps circuit breaker state isolated for duplicate provider names', async () => {
+      const p1 = mockProvider('openai-api', { failOnExecute: new Error('credential A exhausted') });
+      const p2 = mockProvider('openai-api');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      const events = await collectEvents(registry.execute(makeRequest()));
+      const states = registry.listProviderHealth().map((health) => health.state).sort();
+
+      expect(events[0]).toEqual({ type: 'text', content: 'Hello from openai-api' });
+      expect(p1.execute).toHaveBeenCalledTimes(1);
+      expect(p2.execute).toHaveBeenCalledTimes(1);
+      expect(states).toEqual(['closed', 'open']);
+    });
+
+    it('reports open breaker cooldowns instead of credential guidance when all providers are skipped', async () => {
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const registry = new ProviderRegistry([p1], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('All providers exhausted');
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('provider circuit breakers are open');
+    });
+
     it('reopens the breaker when a half-open probe fails without retry storms', async () => {
       let now = Date.UTC(2026, 0, 1);
       const p1: ILlmProvider = {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -640,12 +640,17 @@ describe('ProviderRegistry', () => {
       });
 
       const events = await collectEvents(registry.execute(makeRequest()));
-      const states = registry.listProviderHealth().map((health) => health.state).sort();
+      const health = registry.listProviderHealth();
+      const states = health.map((entry) => entry.state).sort();
 
       expect(events[0]).toEqual({ type: 'text', content: 'Hello from openai-api' });
       expect(p1.execute).toHaveBeenCalledTimes(1);
       expect(p2.execute).toHaveBeenCalledTimes(1);
       expect(states).toEqual(['closed', 'open']);
+      expect(health.map((entry) => entry.providerKey).sort()).toEqual(['openai-api#1', 'openai-api#2']);
+      expect(registry.getProviderHealth('openai-api')).toBeUndefined();
+      expect(registry.getProviderHealth('openai-api#1')?.state).toBe('open');
+      expect(registry.getProviderHealth('openai-api#2')?.state).toBe('closed');
     });
 
     it('reports open breaker cooldowns instead of credential guidance when all providers are skipped', async () => {
@@ -663,7 +668,52 @@ describe('ProviderRegistry', () => {
 
       await expect(async () => {
         await collectEvents(registry.execute(makeRequest()));
-      }).rejects.toThrow('provider circuit breakers are open');
+      }).rejects.toThrow('Provider circuit breakers are open');
+    });
+
+    it('keeps unavailable fallback guidance with mixed open breakers and unavailable providers', async () => {
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('backup', { available: false });
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow('outage');
+
+      await expect(async () => {
+        await collectEvents(registry.execute(makeRequest()));
+      }).rejects.toThrow(/Provider circuit breakers are open:.*Unavailable providers: Provider backup circuit opened after unavailable failure.*authenticate/s);
+    });
+
+    it('reopens half-open probes when consumers cancel before a terminal event', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+      const controls = registry as unknown as {
+        reserveCircuitBreakerProbe(provider: ILlmProvider): Error | undefined;
+        releaseHalfOpenProbe(provider: ILlmProvider, reason: string): void;
+      };
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      controls.releaseHalfOpenProbe(p1, 'cancelled stream');
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'open',
+        cooldownUntil: '2026-01-01T00:00:20.001Z',
+      });
     });
 
     it('reopens the breaker when a half-open probe fails without retry storms', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -645,6 +645,44 @@ describe('ProviderRegistry', () => {
       });
     });
 
+    it('closes a half-open probe when the buffered stream completed before the caller stops early', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let primaryShouldFail = true;
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          if (primaryShouldFail) throw new Error('transient outage');
+          yield { type: 'text' as const, content: 'primary recovered' };
+          yield { type: 'done' as const, usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      primaryShouldFail = false;
+      registry.setOrder(['primary', 'fallback']);
+      const iterator = registry.execute(makeRequest());
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'text', content: 'primary recovered' },
+      });
+      await iterator.return(undefined);
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'closed',
+        successes: 1,
+        halfOpenProbeCount: 0,
+        cooldownUntil: null,
+      });
+    });
+
     it('probes recovered providers after cooldown even when fallback is current', async () => {
       let now = Date.UTC(2026, 0, 1);
       let primaryShouldFail = true;

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -6,6 +6,7 @@ import type {
   ProviderCapabilities,
   BrainSnapshot,
 } from '@franken/types';
+import { seededRandom } from '@franken/types';
 import { ProviderRegistry } from '../../../src/providers/provider-registry.js';
 
 // --- Helpers ---
@@ -453,12 +454,25 @@ describe('ProviderRegistry', () => {
         { backoffMultiplier: 0 },
         { backoffMultiplier: Number.NaN },
         { backoffMultiplier: Number.POSITIVE_INFINITY },
+        { circuitBreakerFailureThreshold: 0 },
+        { circuitBreakerFailureThreshold: 21 },
+        { circuitBreakerFailureThreshold: 1.5 },
+        { circuitBreakerCooldownMs: -1 },
+        { circuitBreakerCooldownMs: Number.NaN },
+        { circuitBreakerCooldownMs: Number.POSITIVE_INFINITY },
+        { circuitBreakerCooldownMs: 3_600_001 },
+        { circuitBreakerCooldownJitterRatio: -0.1 },
+        { circuitBreakerCooldownJitterRatio: 1.1 },
+        { circuitBreakerCooldownJitterRatio: Number.NaN },
+        { circuitBreakerHalfOpenMaxProbes: 0 },
+        { circuitBreakerHalfOpenMaxProbes: 11 },
+        { circuitBreakerHalfOpenMaxProbes: 1.5 },
       ];
 
       for (const options of invalidOptions) {
         const provider = mockProvider('guarded');
         expect(() => new ProviderRegistry([provider], mockBrain(), options)).toThrow(
-          /maxRetriesPerProvider|retryDelayMs|maxRetryDelayMs|backoffMultiplier/,
+          /maxRetriesPerProvider|retryDelayMs|maxRetryDelayMs|backoffMultiplier|circuitBreaker/,
         );
         expect(provider.execute).not.toHaveBeenCalled();
       }
@@ -489,6 +503,151 @@ describe('ProviderRegistry', () => {
           reason: 'rate limit',
         }),
       );
+    });
+
+    it('opens provider circuit breakers and routes to fallback during cooldown', async () => {
+      const onHealthChange = vi.fn();
+      const p1 = mockProvider('primary', { failOnExecute: new Error('rate limit 429') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+        onProviderHealthChange: onHealthChange,
+      });
+
+      const events = await collectEvents(registry.execute(makeRequest()));
+
+      expect(events[0]).toEqual({ type: 'text', content: 'Hello from fallback' });
+      expect(p1.execute).toHaveBeenCalledTimes(1);
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        providerName: 'primary',
+        model: null,
+        state: 'open',
+        failures: 1,
+        successes: 0,
+        consecutiveFailures: 1,
+        failureRate: 1,
+        lastErrorClass: 'rate_limit',
+        cooldownUntil: '2026-01-01T00:00:10.000Z',
+      });
+      expect(onHealthChange).toHaveBeenCalledWith(expect.objectContaining({
+        providerName: 'primary',
+        state: 'open',
+        reason: 'provider-failure-threshold',
+      }));
+    });
+
+    it('keeps an open breaker from calling the provider before cooldown expires', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('provider down') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 5_000;
+      registry.setOrder(['primary', 'fallback']);
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(p1.execute).toHaveBeenCalledTimes(1);
+      expect(p2.execute).toHaveBeenCalledTimes(2);
+      expect(registry.getProviderHealth('primary')?.state).toBe('open');
+    });
+
+    it('allows a bounded half-open probe after cooldown and closes on success', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let primaryShouldFail = true;
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          if (primaryShouldFail) throw new Error('transient outage');
+          yield { type: 'text' as const, content: 'primary recovered' };
+          yield { type: 'done' as const, usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      primaryShouldFail = false;
+      registry.setOrder(['primary', 'fallback']);
+      const events = await collectEvents(registry.execute(makeRequest()));
+
+      expect(events[0]).toEqual({ type: 'text', content: 'primary recovered' });
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'closed',
+        failures: 1,
+        successes: 1,
+        consecutiveFailures: 0,
+        failureRate: 0.5,
+        cooldownUntil: null,
+        halfOpenProbeCount: 0,
+      });
+    });
+
+    it('reopens the breaker when a half-open probe fails without retry storms', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          yield { type: 'error' as const, error: 'rate limit', retryable: true };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        maxRetriesPerProvider: 2,
+        retryDelayMs: 1,
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        circuitBreakerHalfOpenMaxProbes: 1,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      registry.setOrder(['primary', 'fallback']);
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(p1.execute).toHaveBeenCalledTimes(2);
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'open',
+        failures: 2,
+        lastErrorClass: 'rate_limit',
+        cooldownUntil: '2026-01-01T00:00:20.001Z',
+      });
+    });
+
+    it('adds bounded cooldown jitter to prevent synchronized provider retries', async () => {
+      const randomSpy = vi.spyOn(seededRandom, 'random').mockReturnValue(0.5);
+      try {
+        const p1 = mockProvider('primary', { failOnExecute: new Error('timeout') });
+        const p2 = mockProvider('fallback');
+        const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+          circuitBreakerFailureThreshold: 1,
+          circuitBreakerCooldownMs: 10_000,
+          circuitBreakerCooldownJitterRatio: 0.2,
+          now: () => Date.UTC(2026, 0, 1),
+        });
+
+        await collectEvents(registry.execute(makeRequest()));
+
+        expect(registry.getProviderHealth('primary')?.cooldownUntil).toBe('2026-01-01T00:00:11.000Z');
+      } finally {
+        randomSpy.mockRestore();
+      }
     });
 
     it('preserves execution failure as terminal error when later providers are unavailable', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -895,6 +895,72 @@ describe('ProviderRegistry', () => {
       expect(registry.getProviderHealth('primary')).toMatchObject({ halfOpenProbeCount: 1 });
     });
 
+    it('releases request-error event probes and reschedules idle half-open providers', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let mode: 'outage' | 'request-error' | 'success' = 'outage';
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          if (mode === 'outage') throw new Error('provider outage');
+          if (mode === 'request-error') {
+            yield { type: 'error' as const, error: 'invalid request: context length exceeded', retryable: false };
+            return;
+          }
+          yield { type: 'text' as const, content: 'primary recovered' };
+          yield { type: 'done' as const, usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      expect(registry.currentProvider.name).toBe('fallback');
+      now += 10_001;
+      mode = 'request-error';
+      await collectEvents(registry.execute(makeRequest()));
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'half-open',
+        halfOpenProbeCount: 0,
+        failures: 1,
+      });
+
+      mode = 'success';
+      const events = await collectEvents(registry.execute(makeRequest()));
+      expect(events[0]).toEqual({ type: 'text', content: 'primary recovered' });
+      expect(registry.currentProvider.name).toBe('primary');
+    });
+
+    it('emits failover audit metadata after a failed recovery probe returns to fallback', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('provider outage') });
+      const p2 = mockProvider('fallback');
+      const onSwitch = vi.fn();
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+        onProviderSwitch: onSwitch,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      expect(registry.currentProvider.name).toBe('fallback');
+      now += 10_001;
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(p2.execute).toHaveBeenCalledTimes(2);
+      expect(onSwitch).toHaveBeenLastCalledWith(expect.objectContaining({
+        from: 'primary',
+        to: 'fallback',
+        reason: 'provider outage',
+      }));
+    });
+
     it('does not count stale successes after another execution has opened the breaker', async () => {
       const p1 = mockProvider('primary');
       const registry = new ProviderRegistry([p1], mockBrain(), {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -568,6 +568,25 @@ describe('ProviderRegistry', () => {
       });
     });
 
+    it('still records provider outages when messages contain non-status 400 values', async () => {
+      const p1 = mockProvider('primary', { failOnExecute: new Error('provider timed out after 40000ms') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'open',
+        failures: 1,
+        lastErrorClass: 'timeout',
+      });
+    });
+
     it('keeps an open breaker from calling the provider before cooldown expires', async () => {
       let now = Date.UTC(2026, 0, 1);
       const p1 = mockProvider('primary', { failOnExecute: new Error('provider down') });
@@ -844,6 +863,95 @@ describe('ProviderRegistry', () => {
         state: 'open',
         lastErrorClass: 'execution_error',
         cooldownUntil: '2026-01-01T00:00:20.001Z',
+      });
+    });
+
+    it('releases half-open probe slots for request errors without opening the breaker', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+      const controls = registry as unknown as {
+        reserveCircuitBreakerProbe(provider: ILlmProvider): Error | undefined;
+        releaseHalfOpenProbeWithoutHealthFailure(provider: ILlmProvider, reason: string): void;
+      };
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      controls.releaseHalfOpenProbeWithoutHealthFailure(p1, 'half-open-probe-request-error');
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'half-open',
+        halfOpenProbeCount: 0,
+        failures: 1,
+      });
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      expect(registry.getProviderHealth('primary')).toMatchObject({ halfOpenProbeCount: 1 });
+    });
+
+    it('does not count stale successes after another execution has opened the breaker', async () => {
+      const p1 = mockProvider('primary');
+      const registry = new ProviderRegistry([p1], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+      const controls = registry as unknown as {
+        recordProviderFailure(provider: ILlmProvider, error: Error): void;
+        recordProviderSuccess(provider: ILlmProvider): void;
+      };
+
+      controls.recordProviderFailure(p1, new Error('outage'));
+      const before = registry.getProviderHealth('primary')!;
+      controls.recordProviderSuccess(p1);
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'open',
+        successes: before.successes,
+        failureRate: before.failureRate,
+      });
+    });
+
+    it('keeps a breaker half-open until every reserved success probe finishes', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        circuitBreakerHalfOpenMaxProbes: 2,
+        now: () => now,
+      });
+      const controls = registry as unknown as {
+        reserveCircuitBreakerProbe(provider: ILlmProvider): Error | undefined;
+        recordProviderSuccess(provider: ILlmProvider): void;
+      };
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      controls.recordProviderSuccess(p1);
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'half-open',
+        halfOpenProbeCount: 1,
+        successes: 1,
+      });
+
+      controls.recordProviderSuccess(p1);
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'closed',
+        halfOpenProbeCount: 0,
+        successes: 2,
       });
     });
 

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -539,6 +539,35 @@ describe('ProviderRegistry', () => {
       }));
     });
 
+    it('does not open provider breakers for caller request errors', async () => {
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* () {
+          yield { type: 'error' as const, error: 'Bad request: invalid tool schema', retryable: false };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      registry.setOrder(['primary', 'fallback']);
+      await collectEvents(registry.execute(makeRequest()));
+
+      expect(p1.execute).toHaveBeenCalledTimes(2);
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'closed',
+        failures: 0,
+        consecutiveFailures: 0,
+        lastErrorClass: null,
+        cooldownUntil: null,
+      });
+    });
+
     it('keeps an open breaker from calling the provider before cooldown expires', async () => {
       let now = Date.UTC(2026, 0, 1);
       const p1 = mockProvider('primary', { failOnExecute: new Error('provider down') });
@@ -609,11 +638,13 @@ describe('ProviderRegistry', () => {
         }),
       };
       const p2 = mockProvider('fallback');
+      const onSwitch = vi.fn();
       const registry = new ProviderRegistry([p1, p2], mockBrain(), {
         circuitBreakerFailureThreshold: 1,
         circuitBreakerCooldownMs: 10_000,
         circuitBreakerCooldownJitterRatio: 0,
         now: () => now,
+        onProviderSwitch: onSwitch,
       });
 
       await collectEvents(registry.execute(makeRequest()));
@@ -627,6 +658,11 @@ describe('ProviderRegistry', () => {
       expect(p1.execute).toHaveBeenCalledTimes(2);
       expect(registry.currentProvider.name).toBe('primary');
       expect(registry.getProviderHealth('primary')?.state).toBe('closed');
+      expect(onSwitch).toHaveBeenLastCalledWith(expect.objectContaining({
+        from: 'fallback',
+        to: 'primary',
+        reason: 'provider circuit breaker cooldown elapsed',
+      }));
     });
 
     it('keeps circuit breaker state isolated for duplicate provider names', async () => {
@@ -651,6 +687,37 @@ describe('ProviderRegistry', () => {
       expect(registry.getProviderHealth('openai-api')).toBeUndefined();
       expect(registry.getProviderHealth('openai-api#1')?.state).toBe('open');
       expect(registry.getProviderHealth('openai-api#2')?.state).toBe('closed');
+    });
+
+    it('keeps generated provider health keys globally unique when names contain suffixes', async () => {
+      const p1 = mockProvider('openai-api', { failOnExecute: new Error('credential A exhausted') });
+      const p2 = mockProvider('openai-api', { failOnExecute: new Error('credential B exhausted') });
+      const p3 = mockProvider('openai-api#2');
+      const registry = new ProviderRegistry([p1, p2, p3], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => Date.UTC(2026, 0, 1),
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      const health = registry.listProviderHealth();
+
+      expect(health.map((entry) => entry.providerKey).sort()).toEqual([
+        'openai-api#1',
+        'openai-api#2',
+        'openai-api#2#2',
+      ]);
+      expect(registry.getProviderHealth('openai-api#2')).toMatchObject({
+        providerKey: 'openai-api#2',
+        providerName: 'openai-api',
+        state: 'open',
+      });
+      expect(registry.getProviderHealth('openai-api#2#2')).toMatchObject({
+        providerKey: 'openai-api#2#2',
+        providerName: 'openai-api#2',
+        state: 'closed',
+      });
     });
 
     it('reports open breaker cooldowns instead of credential guidance when all providers are skipped', async () => {
@@ -745,6 +812,37 @@ describe('ProviderRegistry', () => {
         state: 'open',
         failures: 2,
         lastErrorClass: 'rate_limit',
+        cooldownUntil: '2026-01-01T00:00:20.001Z',
+      });
+    });
+
+    it('reopens the breaker when any concurrent half-open probe fails', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        circuitBreakerHalfOpenMaxProbes: 2,
+        now: () => now,
+      });
+      const controls = registry as unknown as {
+        reserveCircuitBreakerProbe(provider: ILlmProvider): Error | undefined;
+        recordProviderSuccess(provider: ILlmProvider): void;
+        recordProviderFailure(provider: ILlmProvider, error: Error, options: { tripHalfOpenProbe: boolean }): void;
+      };
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      expect(controls.reserveCircuitBreakerProbe(p1)).toBeUndefined();
+      controls.recordProviderSuccess(p1);
+      controls.recordProviderFailure(p1, new Error('late probe failed'), { tripHalfOpenProbe: true });
+
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'open',
+        lastErrorClass: 'execution_error',
         cooldownUntil: '2026-01-01T00:00:20.001Z',
       });
     });


### PR DESCRIPTION
## Summary
- Adds provider circuit-breaker health state to the orchestrator provider registry.
- Opens failing providers for a bounded cool-down, skips open providers during fallback routing, and supports bounded half-open recovery probes.
- Exposes provider health snapshots/events and adds targeted provider-registry coverage for open, half-open, close, jitter, validation, and fallback behavior.

## Test Plan
- npm test -- tests/unit/providers/provider-registry.test.ts --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1717
