### PR TITLE
fix(security): bound safe archive extraction

### DIFF
--- a/docs/security/safe-archive-extraction.md
+++ b/docs/security/safe-archive-extraction.md
@@ -19,8 +19,9 @@ The default limits are intentionally conservative for operator-supplied artifact
 | `maxArchiveBytes` | 50 MiB | Bounds compressed input accepted into the extractor. |
 | `maxTotalUncompressedBytes` | 250 MiB | Bounds zip-bomb expansion across all extracted files. |
 | `maxFileBytes` | 25 MiB | Bounds any single extracted file. |
-| `maxFileCount` | 10,000 files | Bounds path-count and inode exhaustion. |
-| `maxNestingDepth` | 0 | Rejects archive-looking entries such as `.zip`, `.tar`, `.tgz`, `.gz`, `.bz2`, and `.xz`. |
+| `maxFileCount` | 10,000 files | Bounds regular file count. |
+| `maxDirectoryCount` | 10,000 directories | Bounds explicit and implicit directory/inode creation. |
+| `maxNestingDepth` | 0 | Rejects archive-looking entries such as `.zip`, `.jar`, `.war`, `.apk`, `.whl`, `.tar`, `.tgz`, `.gz`, `.bz2`, `.xz`, `.zst`, `.7z`, and `.rar`, including leading-dot names. |
 
 ## Override policy
 
@@ -44,6 +45,7 @@ await extractZipArchive(uploadBuffer, stagingDir, {
   maxTotalUncompressedBytes: 50 * 1024 * 1024,
   maxFileBytes: 5 * 1024 * 1024,
   maxFileCount: 1_000,
+  maxDirectoryCount: 1_000,
   maxNestingDepth: 0,
 });
 ```

--- a/docs/security/safe-archive-extraction.md
+++ b/docs/security/safe-archive-extraction.md
@@ -1,0 +1,49 @@
+# Safe archive extraction
+
+Frankenbeast archive and artifact consumers should use the orchestrator safe archive helper before writing user-supplied archive contents to disk.
+
+Current helper:
+
+- `extractZipArchive(archive, destination, overrides)` in `@franken/orchestrator`
+- Supports regular ZIP entries compressed with STORE or DEFLATE.
+- Rejects encrypted, symlink, unsupported-method, path-traversal, absolute-path, and nested-archive entries.
+- Performs a central-directory preflight before writing files so limit failures are rejected before extracted content is created where feasible.
+- Writes with exclusive creation (`wx`) to avoid silently overwriting an existing destination file.
+
+## Default limits
+
+The default limits are intentionally conservative for operator-supplied artifacts:
+
+| Limit | Default | Purpose |
+| --- | ---: | --- |
+| `maxArchiveBytes` | 50 MiB | Bounds compressed input accepted into the extractor. |
+| `maxTotalUncompressedBytes` | 250 MiB | Bounds zip-bomb expansion across all extracted files. |
+| `maxFileBytes` | 25 MiB | Bounds any single extracted file. |
+| `maxFileCount` | 10,000 files | Bounds path-count and inode exhaustion. |
+| `maxNestingDepth` | 0 | Rejects archive-looking entries such as `.zip`, `.tar`, `.tgz`, `.gz`, `.bz2`, and `.xz`. |
+
+## Override policy
+
+Consumers may pass explicit overrides when they have a trusted environment or a narrower product-specific budget. Do not raise limits globally for convenience. Prefer setting the smallest limits that match the caller's artifact contract, and surface those limits in the caller's operator documentation or config help.
+
+For untrusted uploads or remote artifacts:
+
+1. Keep `maxNestingDepth: 0` unless a later recursive extractor handles nested archives with the same preflight accounting.
+2. Set `maxArchiveBytes` below the maximum request body size for that endpoint.
+3. Set `maxTotalUncompressedBytes` below the available scratch-disk budget.
+4. Extract into a new empty destination directory and promote the result only after extraction succeeds.
+5. Treat `SafeArchiveExtractionError` as a client/input failure, not an internal retryable error.
+
+## Example
+
+```ts
+import { extractZipArchive } from '@franken/orchestrator';
+
+await extractZipArchive(uploadBuffer, stagingDir, {
+  maxArchiveBytes: 10 * 1024 * 1024,
+  maxTotalUncompressedBytes: 50 * 1024 * 1024,
+  maxFileBytes: 5 * 1024 * 1024,
+  maxFileCount: 1_000,
+  maxNestingDepth: 0,
+});
+```

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -110,6 +110,19 @@ export { PrCreator } from './closure/pr-creator.js';
 export { PATTERNS_ALL_TIERS, PATTERNS_STRICT_ONLY } from './middleware/index.js';
 export type { InjectionTier } from './middleware/index.js';
 
+// Archive extraction hardening
+export {
+  DEFAULT_SAFE_ARCHIVE_LIMITS,
+  SafeArchiveExtractionError,
+  extractZipArchive,
+} from './security/safe-archive-extractor.js';
+export type {
+  SafeArchiveEntryResult,
+  SafeArchiveExtractionResult,
+  SafeArchiveLimitOverrides,
+  SafeArchiveLimits,
+} from './security/safe-archive-extractor.js';
+
 // Circuit breakers
 export { checkInjection } from './breakers/injection-breaker.js';
 export { checkBudget, BudgetExceededError } from './breakers/budget-breaker.js';

--- a/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
+++ b/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
@@ -67,7 +67,8 @@ const SYMLINK_FILE_TYPE = 0o120000;
 const FILE_TYPE_MASK = 0o170000;
 const MAX_ARCHIVE_PATH_SEGMENTS = 256;
 
-const ARCHIVE_ENTRY_PATTERN = /(?:^|[/\\])[^/\\]+\.(?:zip|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz)$/iu;
+const ARCHIVE_ENTRY_PATTERN =
+  /(?:^|[/\\])[^/\\]+\.(?:zip|jar|war|ear|apk|whl|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz|zst|7z|rar)$/iu;
 const WINDOWS_RESERVED_NAMES = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/iu;
 const CRC32_TABLE = makeCrc32Table();
 
@@ -88,10 +89,10 @@ export async function extractZipArchive(
   await rejectSymlinkedExistingAncestors(destinationRoot);
   const entries = parseZipCentralDirectory(buffer, destinationRoot);
   const files = preflightEntries(entries, limits);
+  const decodedFiles = files.map((entry) => ({ entry, data: readZipEntry(buffer, entry, limits) }));
 
   await mkdir(destinationRoot, { recursive: true });
-  for (const entry of files) {
-    const data = readZipEntry(buffer, entry, limits);
+  for (const { entry, data } of decodedFiles) {
     await rejectSymlinkedPathComponents(destinationRoot, entry.targetPath);
     await mkdir(dirname(entry.targetPath), { recursive: true });
     await rejectSymlinkedPathComponents(destinationRoot, entry.targetPath);
@@ -369,7 +370,7 @@ function readZipEntry(buffer: Buffer, entry: ZipCentralDirectoryEntry, limits: S
     data =
       entry.method === 0
         ? Buffer.from(compressed)
-        : inflateRawSync(compressed, { maxOutputLength: Math.min(entry.uncompressedBytes, limits.maxFileBytes) });
+        : inflateRawSync(compressed, { maxOutputLength: Math.max(1, Math.min(entry.uncompressedBytes, limits.maxFileBytes)) });
   } catch (cause) {
     throw new SafeArchiveExtractionError(`Unable to inflate ZIP entry ${entry.path}: ${(cause as Error).message}`);
   }

--- a/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
+++ b/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
@@ -11,6 +11,8 @@ export interface SafeArchiveLimits {
   readonly maxFileBytes: number;
   /** Maximum number of regular file entries. */
   readonly maxFileCount: number;
+  /** Maximum number of explicit or implicit directory entries created while extracting. */
+  readonly maxDirectoryCount: number;
   /** Maximum nested archive depth. Zero rejects archive-looking entries. */
   readonly maxNestingDepth: number;
 }
@@ -34,6 +36,7 @@ export const DEFAULT_SAFE_ARCHIVE_LIMITS: SafeArchiveLimits = Object.freeze({
   maxTotalUncompressedBytes: 250 * 1024 * 1024,
   maxFileBytes: 25 * 1024 * 1024,
   maxFileCount: 10_000,
+  maxDirectoryCount: 10_000,
   maxNestingDepth: 0,
 });
 
@@ -68,7 +71,7 @@ const FILE_TYPE_MASK = 0o170000;
 const MAX_ARCHIVE_PATH_SEGMENTS = 256;
 
 const ARCHIVE_ENTRY_PATTERN =
-  /(?:^|[/\\])[^/\\]+\.(?:zip|jar|war|ear|apk|whl|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz|zst|7z|rar)$/iu;
+  /(?:^|[/\\])[^/\\]*\.(?:zip|jar|war|ear|apk|whl|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz|zst|7z|rar)$/iu;
 const WINDOWS_RESERVED_NAMES = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/iu;
 const CRC32_TABLE = makeCrc32Table();
 
@@ -244,6 +247,12 @@ function preflightEntries(entries: readonly ZipCentralDirectoryEntry[], limits: 
     files,
     entries.filter((entry) => entry.isDirectory).map((entry) => entry.path),
   );
+  const directoryCount = countDirectoryPaths(files, entries.filter((entry) => entry.isDirectory).map((entry) => entry.path));
+  if (directoryCount > limits.maxDirectoryCount) {
+    throw new SafeArchiveExtractionError(
+      `Archive directory count ${directoryCount} exceeds maxDirectoryCount ${limits.maxDirectoryCount}`,
+    );
+  }
   for (const entry of files) {
     if (entry.flags & 0x1) {
       throw new SafeArchiveExtractionError(`Encrypted ZIP entries are not supported: ${entry.path}`);
@@ -311,6 +320,19 @@ function rejectPathCollisions(files: readonly ZipCentralDirectoryEntry[], explic
 
 function collisionKey(path: string): string {
   return path.toLocaleLowerCase('en-US');
+}
+
+function countDirectoryPaths(files: readonly ZipCentralDirectoryEntry[], explicitDirectories: readonly string[]): number {
+  const directories = new Set(explicitDirectories.map((path) => collisionKey(path)));
+  for (const entry of files) {
+    const parts = entry.path.split('/');
+    let ancestor = '';
+    for (const part of parts.slice(0, -1)) {
+      ancestor = ancestor.length === 0 ? part : `${ancestor}/${part}`;
+      directories.add(collisionKey(ancestor));
+    }
+  }
+  return directories.size;
 }
 
 async function rejectSymlinkedPathComponents(destinationRoot: string, targetPath: string): Promise<void> {

--- a/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
+++ b/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
@@ -1,5 +1,5 @@
 import { lstat, mkdir, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, parse, resolve, sep } from 'node:path';
 import { inflateRawSync } from 'node:zlib';
 
 export interface SafeArchiveLimits {
@@ -52,6 +52,7 @@ interface ZipCentralDirectoryEntry {
   readonly uncompressedBytes: number;
   readonly localHeaderOffset: number;
   readonly externalAttributes: number;
+  readonly crc32: number;
   readonly isDirectory: boolean;
   readonly targetPath: string;
 }
@@ -64,9 +65,11 @@ const ZIP64_SENTINEL_32 = 0xffffffff;
 const MAX_EOCD_SEARCH = 22 + 65_535;
 const SYMLINK_FILE_TYPE = 0o120000;
 const FILE_TYPE_MASK = 0o170000;
+const MAX_ARCHIVE_PATH_SEGMENTS = 256;
 
 const ARCHIVE_ENTRY_PATTERN = /(?:^|[/\\])[^/\\]+\.(?:zip|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz)$/iu;
-const WINDOWS_RESERVED_NAMES = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/iu;
+const WINDOWS_RESERVED_NAMES = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/iu;
+const CRC32_TABLE = makeCrc32Table();
 
 export async function extractZipArchive(
   archive: Buffer | Uint8Array,
@@ -82,6 +85,7 @@ export async function extractZipArchive(
   }
 
   const destinationRoot = resolve(destination);
+  await rejectSymlinkedExistingAncestors(destinationRoot);
   const entries = parseZipCentralDirectory(buffer, destinationRoot);
   const files = preflightEntries(entries, limits);
 
@@ -150,6 +154,7 @@ function parseZipCentralDirectory(buffer: Buffer, destinationRoot: string): ZipC
 
     const flags = buffer.readUInt16LE(cursor + 8);
     const method = buffer.readUInt16LE(cursor + 10);
+    const crc32 = buffer.readUInt32LE(cursor + 16);
     const compressedBytes = buffer.readUInt32LE(cursor + 20);
     const uncompressedBytes = buffer.readUInt32LE(cursor + 24);
     const nameLength = buffer.readUInt16LE(cursor + 28);
@@ -174,6 +179,7 @@ function parseZipCentralDirectory(buffer: Buffer, destinationRoot: string): ZipC
       uncompressedBytes,
       localHeaderOffset,
       externalAttributes,
+      crc32,
       isDirectory,
       targetPath: normalizedPath.targetPath,
     });
@@ -205,6 +211,11 @@ function normalizeArchivePath(rawPath: string, destinationRoot: string): { relat
     throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
   }
   const parts = relativePath.split('/');
+  if (parts.length > MAX_ARCHIVE_PATH_SEGMENTS) {
+    throw new SafeArchiveExtractionError(
+      `Archive entry path has ${parts.length} segments, exceeding limit ${MAX_ARCHIVE_PATH_SEGMENTS}: ${rawPath}`,
+    );
+  }
   if (parts.some((part) => part === '' || part === '.' || part === '..')) {
     throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
   }
@@ -270,28 +281,35 @@ function isWindowsSpecialSegment(segment: string): boolean {
 function rejectPathCollisions(files: readonly ZipCentralDirectoryEntry[], explicitDirectories: readonly string[]): void {
   const filePaths = new Set<string>();
   const ancestorDirectories = new Set<string>();
-  const directoryPaths = new Set(explicitDirectories);
+  const directoryPaths = new Set(explicitDirectories.map((path) => collisionKey(path)));
 
   for (const entry of files) {
-    if (filePaths.has(entry.path) || directoryPaths.has(entry.path) || ancestorDirectories.has(entry.path)) {
+    const entryKey = collisionKey(entry.path);
+    if (filePaths.has(entryKey) || directoryPaths.has(entryKey) || ancestorDirectories.has(entryKey)) {
       throw new SafeArchiveExtractionError(`Archive path collision is not allowed: ${entry.path}`);
     }
 
     const parts = entry.path.split('/');
     const ancestors: string[] = [];
-    for (let index = 1; index < parts.length; index += 1) {
-      const ancestor = parts.slice(0, index).join('/');
-      if (filePaths.has(ancestor)) {
+    let ancestor = '';
+    for (const part of parts.slice(0, -1)) {
+      ancestor = ancestor.length === 0 ? part : `${ancestor}/${part}`;
+      const ancestorKey = collisionKey(ancestor);
+      if (filePaths.has(ancestorKey)) {
         throw new SafeArchiveExtractionError(`Archive path collision is not allowed: ${entry.path}`);
       }
-      ancestors.push(ancestor);
+      ancestors.push(ancestorKey);
     }
 
-    filePaths.add(entry.path);
-    for (const ancestor of ancestors) {
-      ancestorDirectories.add(ancestor);
+    filePaths.add(entryKey);
+    for (const ancestorKey of ancestors) {
+      ancestorDirectories.add(ancestorKey);
     }
   }
+}
+
+function collisionKey(path: string): string {
+  return path.toLocaleLowerCase('en-US');
 }
 
 async function rejectSymlinkedPathComponents(destinationRoot: string, targetPath: string): Promise<void> {
@@ -302,6 +320,16 @@ async function rejectSymlinkedPathComponents(destinationRoot: string, targetPath
   for (const part of parts.slice(0, -1)) {
     current = resolve(current, part);
     await rejectSymlink(current, destinationRoot);
+  }
+}
+
+async function rejectSymlinkedExistingAncestors(path: string): Promise<void> {
+  const root = parse(path).root;
+  const relativeParts = path.slice(root.length).split(sep).filter(Boolean);
+  let current = root;
+  for (const part of relativeParts) {
+    current = resolve(current, part);
+    await rejectSymlink(current, path);
   }
 }
 
@@ -353,5 +381,29 @@ function readZipEntry(buffer: Buffer, entry: ZipCentralDirectoryEntry, limits: S
   if (data.byteLength > limits.maxFileBytes) {
     throw new SafeArchiveExtractionError(`ZIP entry ${entry.path} exceeds per-file limit ${limits.maxFileBytes} bytes`);
   }
+  const actualCrc32 = crc32(data);
+  if (actualCrc32 !== entry.crc32) {
+    throw new SafeArchiveExtractionError(`ZIP entry ${entry.path} failed CRC validation`);
+  }
   return data;
+}
+
+function makeCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+function crc32(data: Buffer): number {
+  let value = 0xffffffff;
+  for (const byte of data) {
+    value = CRC32_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
 }

--- a/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
+++ b/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
@@ -1,0 +1,280 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve, sep } from 'node:path';
+import { inflateRawSync } from 'node:zlib';
+
+export interface SafeArchiveLimits {
+  /** Maximum compressed archive payload accepted by the helper. */
+  readonly maxArchiveBytes: number;
+  /** Maximum summed uncompressed bytes across all regular files. */
+  readonly maxTotalUncompressedBytes: number;
+  /** Maximum uncompressed bytes for any single file. */
+  readonly maxFileBytes: number;
+  /** Maximum number of regular file entries. */
+  readonly maxFileCount: number;
+  /** Maximum nested archive depth. Zero rejects archive-looking entries. */
+  readonly maxNestingDepth: number;
+}
+
+export type SafeArchiveLimitOverrides = Partial<SafeArchiveLimits>;
+
+export interface SafeArchiveEntryResult {
+  readonly path: string;
+  readonly compressedBytes: number;
+  readonly uncompressedBytes: number;
+}
+
+export interface SafeArchiveExtractionResult {
+  readonly files: SafeArchiveEntryResult[];
+  readonly compressedBytes: number;
+  readonly uncompressedBytes: number;
+}
+
+export const DEFAULT_SAFE_ARCHIVE_LIMITS: SafeArchiveLimits = Object.freeze({
+  maxArchiveBytes: 50 * 1024 * 1024,
+  maxTotalUncompressedBytes: 250 * 1024 * 1024,
+  maxFileBytes: 25 * 1024 * 1024,
+  maxFileCount: 10_000,
+  maxNestingDepth: 0,
+});
+
+export class SafeArchiveExtractionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SafeArchiveExtractionError';
+  }
+}
+
+interface ZipCentralDirectoryEntry {
+  readonly path: string;
+  readonly method: number;
+  readonly flags: number;
+  readonly compressedBytes: number;
+  readonly uncompressedBytes: number;
+  readonly localHeaderOffset: number;
+  readonly externalAttributes: number;
+  readonly isDirectory: boolean;
+  readonly targetPath: string;
+}
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_SIGNATURE = 0x04034b50;
+const ZIP64_SENTINEL_16 = 0xffff;
+const ZIP64_SENTINEL_32 = 0xffffffff;
+const MAX_EOCD_SEARCH = 22 + 65_535;
+const SYMLINK_FILE_TYPE = 0o120000;
+const FILE_TYPE_MASK = 0o170000;
+
+const ARCHIVE_ENTRY_PATTERN = /(?:^|[/\\])[^/\\]+\.(?:zip|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz)$/iu;
+
+export async function extractZipArchive(
+  archive: Buffer | Uint8Array,
+  destination: string,
+  overrides: SafeArchiveLimitOverrides = {},
+): Promise<SafeArchiveExtractionResult> {
+  const buffer = toBuffer(archive);
+  const limits = normalizeLimits(overrides);
+  if (buffer.byteLength > limits.maxArchiveBytes) {
+    throw new SafeArchiveExtractionError(
+      `Archive compressed size ${buffer.byteLength} exceeds maxArchiveBytes ${limits.maxArchiveBytes}`,
+    );
+  }
+
+  const destinationRoot = resolve(destination);
+  const entries = parseZipCentralDirectory(buffer, destinationRoot);
+  const files = preflightEntries(entries, limits);
+
+  await mkdir(destinationRoot, { recursive: true });
+  for (const entry of files) {
+    const data = readZipEntry(buffer, entry, limits);
+    await mkdir(dirname(entry.targetPath), { recursive: true });
+    await writeFile(entry.targetPath, data, { flag: 'wx', mode: 0o600 });
+  }
+
+  return {
+    compressedBytes: buffer.byteLength,
+    uncompressedBytes: files.reduce((sum, entry) => sum + entry.uncompressedBytes, 0),
+    files: files.map((entry) => ({
+      path: entry.path,
+      compressedBytes: entry.compressedBytes,
+      uncompressedBytes: entry.uncompressedBytes,
+    })),
+  };
+}
+
+function normalizeLimits(overrides: SafeArchiveLimitOverrides): SafeArchiveLimits {
+  const limits = { ...DEFAULT_SAFE_ARCHIVE_LIMITS, ...overrides };
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new SafeArchiveExtractionError(`${name} must be a non-negative safe integer`);
+    }
+  }
+  if (limits.maxArchiveBytes === 0) {
+    throw new SafeArchiveExtractionError('maxArchiveBytes must be greater than zero');
+  }
+  return limits;
+}
+
+function toBuffer(archive: Buffer | Uint8Array): Buffer {
+  if (Buffer.isBuffer(archive)) {
+    return archive;
+  }
+  return Buffer.from(archive.buffer, archive.byteOffset, archive.byteLength);
+}
+
+function parseZipCentralDirectory(buffer: Buffer, destinationRoot: string): ZipCentralDirectoryEntry[] {
+  const eocdOffset = findEndOfCentralDirectory(buffer);
+  const entryCount = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirectorySize = buffer.readUInt32LE(eocdOffset + 12);
+  const centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16);
+  if (
+    entryCount === ZIP64_SENTINEL_16 ||
+    centralDirectorySize === ZIP64_SENTINEL_32 ||
+    centralDirectoryOffset === ZIP64_SENTINEL_32
+  ) {
+    throw new SafeArchiveExtractionError('ZIP64 archives are not supported by the safe extractor');
+  }
+  if (centralDirectoryOffset + centralDirectorySize > buffer.byteLength) {
+    throw new SafeArchiveExtractionError('ZIP central directory points outside the archive');
+  }
+
+  const entries: ZipCentralDirectoryEntry[] = [];
+  let cursor = centralDirectoryOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (cursor + 46 > buffer.byteLength || buffer.readUInt32LE(cursor) !== CENTRAL_DIRECTORY_SIGNATURE) {
+      throw new SafeArchiveExtractionError('Invalid ZIP central directory entry');
+    }
+
+    const flags = buffer.readUInt16LE(cursor + 8);
+    const method = buffer.readUInt16LE(cursor + 10);
+    const compressedBytes = buffer.readUInt32LE(cursor + 20);
+    const uncompressedBytes = buffer.readUInt32LE(cursor + 24);
+    const nameLength = buffer.readUInt16LE(cursor + 28);
+    const extraLength = buffer.readUInt16LE(cursor + 30);
+    const commentLength = buffer.readUInt16LE(cursor + 32);
+    const externalAttributes = buffer.readUInt32LE(cursor + 38);
+    const localHeaderOffset = buffer.readUInt32LE(cursor + 42);
+    const nameStart = cursor + 46;
+    const nameEnd = nameStart + nameLength;
+    if (nameEnd + extraLength + commentLength > buffer.byteLength) {
+      throw new SafeArchiveExtractionError('ZIP entry metadata points outside the archive');
+    }
+
+    const rawPath = buffer.subarray(nameStart, nameEnd).toString('utf8');
+    const normalizedPath = normalizeArchivePath(rawPath, destinationRoot);
+    entries.push({
+      path: normalizedPath.relativePath,
+      method,
+      flags,
+      compressedBytes,
+      uncompressedBytes,
+      localHeaderOffset,
+      externalAttributes,
+      isDirectory: rawPath.endsWith('/') || rawPath.endsWith('\\'),
+      targetPath: normalizedPath.targetPath,
+    });
+    cursor = nameEnd + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const minOffset = Math.max(0, buffer.byteLength - MAX_EOCD_SEARCH);
+  for (let offset = buffer.byteLength - 22; offset >= minOffset; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === EOCD_SIGNATURE) {
+      const commentLength = buffer.readUInt16LE(offset + 20);
+      if (offset + 22 + commentLength === buffer.byteLength) {
+        return offset;
+      }
+    }
+  }
+  throw new SafeArchiveExtractionError('Archive is not a valid ZIP file');
+}
+
+function normalizeArchivePath(rawPath: string, destinationRoot: string): { relativePath: string; targetPath: string } {
+  if (rawPath.length === 0 || rawPath.includes('\0')) {
+    throw new SafeArchiveExtractionError('Archive entry path is empty or contains NUL');
+  }
+  const relativePath = rawPath.replace(/\\/gu, '/');
+  if (isAbsolute(relativePath) || /^[a-z]:/iu.test(relativePath)) {
+    throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
+  }
+  const parts = relativePath.split('/');
+  if (parts.some((part) => part === '' || part === '.' || part === '..')) {
+    throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
+  }
+  const targetPath = resolve(destinationRoot, ...parts);
+  const rootWithSeparator = destinationRoot.endsWith(sep) ? destinationRoot : `${destinationRoot}${sep}`;
+  if (targetPath !== destinationRoot && !targetPath.startsWith(rootWithSeparator)) {
+    throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
+  }
+  return { relativePath: parts.join('/'), targetPath };
+}
+
+function preflightEntries(entries: readonly ZipCentralDirectoryEntry[], limits: SafeArchiveLimits): ZipCentralDirectoryEntry[] {
+  const files = entries.filter((entry) => !entry.isDirectory);
+  if (files.length > limits.maxFileCount) {
+    throw new SafeArchiveExtractionError(`Archive file count ${files.length} exceeds maxFileCount ${limits.maxFileCount}`);
+  }
+
+  let totalUncompressedBytes = 0;
+  for (const entry of files) {
+    if (entry.flags & 0x1) {
+      throw new SafeArchiveExtractionError(`Encrypted ZIP entries are not supported: ${entry.path}`);
+    }
+    if (entry.method !== 0 && entry.method !== 8) {
+      throw new SafeArchiveExtractionError(`Unsupported ZIP compression method ${entry.method} for ${entry.path}`);
+    }
+    if (((entry.externalAttributes >>> 16) & FILE_TYPE_MASK) === SYMLINK_FILE_TYPE) {
+      throw new SafeArchiveExtractionError(`Archive symlink entries are not allowed: ${entry.path}`);
+    }
+    if (entry.compressedBytes > limits.maxArchiveBytes) {
+      throw new SafeArchiveExtractionError(`Entry compressed size exceeds maxArchiveBytes: ${entry.path}`);
+    }
+    if (entry.uncompressedBytes > limits.maxFileBytes) {
+      throw new SafeArchiveExtractionError(
+        `Archive entry ${entry.path} exceeds per-file limit ${limits.maxFileBytes} bytes`,
+      );
+    }
+    if (limits.maxNestingDepth === 0 && ARCHIVE_ENTRY_PATTERN.test(entry.path)) {
+      throw new SafeArchiveExtractionError(`Nested archive entries are not allowed: ${entry.path}`);
+    }
+    totalUncompressedBytes += entry.uncompressedBytes;
+    if (totalUncompressedBytes > limits.maxTotalUncompressedBytes) {
+      throw new SafeArchiveExtractionError(
+        `Archive uncompressed size ${totalUncompressedBytes} exceeds maxTotalUncompressedBytes ${limits.maxTotalUncompressedBytes}`,
+      );
+    }
+  }
+  return files;
+}
+
+function readZipEntry(buffer: Buffer, entry: ZipCentralDirectoryEntry, limits: SafeArchiveLimits): Buffer {
+  const cursor = entry.localHeaderOffset;
+  if (cursor + 30 > buffer.byteLength || buffer.readUInt32LE(cursor) !== LOCAL_FILE_SIGNATURE) {
+    throw new SafeArchiveExtractionError(`Invalid local ZIP header for ${entry.path}`);
+  }
+  const localNameLength = buffer.readUInt16LE(cursor + 26);
+  const localExtraLength = buffer.readUInt16LE(cursor + 28);
+  const dataStart = cursor + 30 + localNameLength + localExtraLength;
+  const dataEnd = dataStart + entry.compressedBytes;
+  if (dataEnd > buffer.byteLength) {
+    throw new SafeArchiveExtractionError(`ZIP entry data points outside the archive: ${entry.path}`);
+  }
+
+  const compressed = buffer.subarray(dataStart, dataEnd);
+  const data =
+    entry.method === 0
+      ? Buffer.from(compressed)
+      : inflateRawSync(compressed, { maxOutputLength: Math.min(entry.uncompressedBytes, limits.maxFileBytes) });
+  if (data.byteLength !== entry.uncompressedBytes) {
+    throw new SafeArchiveExtractionError(
+      `ZIP entry ${entry.path} inflated to ${data.byteLength} bytes, expected ${entry.uncompressedBytes}`,
+    );
+  }
+  if (data.byteLength > limits.maxFileBytes) {
+    throw new SafeArchiveExtractionError(`ZIP entry ${entry.path} exceeds per-file limit ${limits.maxFileBytes} bytes`);
+  }
+  return data;
+}

--- a/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
+++ b/packages/franken-orchestrator/src/security/safe-archive-extractor.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve, sep } from 'node:path';
 import { inflateRawSync } from 'node:zlib';
 
@@ -66,6 +66,7 @@ const SYMLINK_FILE_TYPE = 0o120000;
 const FILE_TYPE_MASK = 0o170000;
 
 const ARCHIVE_ENTRY_PATTERN = /(?:^|[/\\])[^/\\]+\.(?:zip|tar|tgz|tar\.gz|tar\.bz2|tbz2|tar\.xz|txz|gz|bz2|xz)$/iu;
+const WINDOWS_RESERVED_NAMES = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/iu;
 
 export async function extractZipArchive(
   archive: Buffer | Uint8Array,
@@ -87,7 +88,9 @@ export async function extractZipArchive(
   await mkdir(destinationRoot, { recursive: true });
   for (const entry of files) {
     const data = readZipEntry(buffer, entry, limits);
+    await rejectSymlinkedPathComponents(destinationRoot, entry.targetPath);
     await mkdir(dirname(entry.targetPath), { recursive: true });
+    await rejectSymlinkedPathComponents(destinationRoot, entry.targetPath);
     await writeFile(entry.targetPath, data, { flag: 'wx', mode: 0o600 });
   }
 
@@ -161,7 +164,8 @@ function parseZipCentralDirectory(buffer: Buffer, destinationRoot: string): ZipC
     }
 
     const rawPath = buffer.subarray(nameStart, nameEnd).toString('utf8');
-    const normalizedPath = normalizeArchivePath(rawPath, destinationRoot);
+    const isDirectory = rawPath.endsWith('/') || rawPath.endsWith('\\');
+    const normalizedPath = normalizeArchivePath(isDirectory ? rawPath.replace(/[\\/]+$/u, '') : rawPath, destinationRoot);
     entries.push({
       path: normalizedPath.relativePath,
       method,
@@ -170,7 +174,7 @@ function parseZipCentralDirectory(buffer: Buffer, destinationRoot: string): ZipC
       uncompressedBytes,
       localHeaderOffset,
       externalAttributes,
-      isDirectory: rawPath.endsWith('/') || rawPath.endsWith('\\'),
+      isDirectory,
       targetPath: normalizedPath.targetPath,
     });
     cursor = nameEnd + extraLength + commentLength;
@@ -204,6 +208,11 @@ function normalizeArchivePath(rawPath: string, destinationRoot: string): { relat
   if (parts.some((part) => part === '' || part === '.' || part === '..')) {
     throw new SafeArchiveExtractionError(`Archive entry path traversal is not allowed: ${rawPath}`);
   }
+  for (const part of parts) {
+    if (isWindowsSpecialSegment(part)) {
+      throw new SafeArchiveExtractionError(`Windows-special archive path segment is not allowed: ${rawPath}`);
+    }
+  }
   const targetPath = resolve(destinationRoot, ...parts);
   const rootWithSeparator = destinationRoot.endsWith(sep) ? destinationRoot : `${destinationRoot}${sep}`;
   if (targetPath !== destinationRoot && !targetPath.startsWith(rootWithSeparator)) {
@@ -219,6 +228,10 @@ function preflightEntries(entries: readonly ZipCentralDirectoryEntry[], limits: 
   }
 
   let totalUncompressedBytes = 0;
+  rejectPathCollisions(
+    files,
+    entries.filter((entry) => entry.isDirectory).map((entry) => entry.path),
+  );
   for (const entry of files) {
     if (entry.flags & 0x1) {
       throw new SafeArchiveExtractionError(`Encrypted ZIP entries are not supported: ${entry.path}`);
@@ -250,6 +263,65 @@ function preflightEntries(entries: readonly ZipCentralDirectoryEntry[], limits: 
   return files;
 }
 
+function isWindowsSpecialSegment(segment: string): boolean {
+  return segment.includes(':') || segment.endsWith('.') || segment.endsWith(' ') || WINDOWS_RESERVED_NAMES.test(segment);
+}
+
+function rejectPathCollisions(files: readonly ZipCentralDirectoryEntry[], explicitDirectories: readonly string[]): void {
+  const filePaths = new Set<string>();
+  const ancestorDirectories = new Set<string>();
+  const directoryPaths = new Set(explicitDirectories);
+
+  for (const entry of files) {
+    if (filePaths.has(entry.path) || directoryPaths.has(entry.path) || ancestorDirectories.has(entry.path)) {
+      throw new SafeArchiveExtractionError(`Archive path collision is not allowed: ${entry.path}`);
+    }
+
+    const parts = entry.path.split('/');
+    const ancestors: string[] = [];
+    for (let index = 1; index < parts.length; index += 1) {
+      const ancestor = parts.slice(0, index).join('/');
+      if (filePaths.has(ancestor)) {
+        throw new SafeArchiveExtractionError(`Archive path collision is not allowed: ${entry.path}`);
+      }
+      ancestors.push(ancestor);
+    }
+
+    filePaths.add(entry.path);
+    for (const ancestor of ancestors) {
+      ancestorDirectories.add(ancestor);
+    }
+  }
+}
+
+async function rejectSymlinkedPathComponents(destinationRoot: string, targetPath: string): Promise<void> {
+  const relative = targetPath.slice(destinationRoot.length).replace(new RegExp(`^\\${sep}`), '');
+  const parts = relative.length === 0 ? [] : relative.split(sep);
+  let current = destinationRoot;
+  await rejectSymlink(current, destinationRoot);
+  for (const part of parts.slice(0, -1)) {
+    current = resolve(current, part);
+    await rejectSymlink(current, destinationRoot);
+  }
+}
+
+async function rejectSymlink(path: string, destinationRoot: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink()) {
+      throw new SafeArchiveExtractionError(`Archive extraction destination contains a symlink: ${path}`);
+    }
+  } catch (error) {
+    if (error instanceof SafeArchiveExtractionError) {
+      throw error;
+    }
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw new SafeArchiveExtractionError(`Unable to validate extraction path under ${destinationRoot}: ${path}`);
+  }
+}
+
 function readZipEntry(buffer: Buffer, entry: ZipCentralDirectoryEntry, limits: SafeArchiveLimits): Buffer {
   const cursor = entry.localHeaderOffset;
   if (cursor + 30 > buffer.byteLength || buffer.readUInt32LE(cursor) !== LOCAL_FILE_SIGNATURE) {
@@ -264,10 +336,15 @@ function readZipEntry(buffer: Buffer, entry: ZipCentralDirectoryEntry, limits: S
   }
 
   const compressed = buffer.subarray(dataStart, dataEnd);
-  const data =
-    entry.method === 0
-      ? Buffer.from(compressed)
-      : inflateRawSync(compressed, { maxOutputLength: Math.min(entry.uncompressedBytes, limits.maxFileBytes) });
+  let data: Buffer;
+  try {
+    data =
+      entry.method === 0
+        ? Buffer.from(compressed)
+        : inflateRawSync(compressed, { maxOutputLength: Math.min(entry.uncompressedBytes, limits.maxFileBytes) });
+  } catch (cause) {
+    throw new SafeArchiveExtractionError(`Unable to inflate ZIP entry ${entry.path}: ${(cause as Error).message}`);
+  }
   if (data.byteLength !== entry.uncompressedBytes) {
     throw new SafeArchiveExtractionError(
       `ZIP entry ${entry.path} inflated to ${data.byteLength} bytes, expected ${entry.uncompressedBytes}`,

--- a/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { deflateRawSync } from 'node:zlib';
@@ -11,6 +11,7 @@ import {
 } from '../../../src/security/safe-archive-extractor.js';
 
 const tempDirs: string[] = [];
+const CRC32_TABLE = makeCrc32Table();
 
 async function tempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'franken-safe-archive-'));
@@ -37,6 +38,7 @@ function createZip(entries: readonly ZipEntryFixture[]): Buffer {
     const method = entry.method ?? 8;
     const name = Buffer.from(entry.name, 'utf8');
     const compressed = method === 8 ? deflateRawSync(entry.body) : entry.body;
+    const entryCrc32 = crc32(entry.body);
 
     const local = Buffer.alloc(30 + name.length);
     local.writeUInt32LE(0x04034b50, 0);
@@ -44,7 +46,7 @@ function createZip(entries: readonly ZipEntryFixture[]): Buffer {
     local.writeUInt16LE(0, 6);
     local.writeUInt16LE(method, 8);
     local.writeUInt32LE(0, 10);
-    local.writeUInt32LE(0, 14);
+    local.writeUInt32LE(entryCrc32, 14);
     local.writeUInt32LE(compressed.length, 18);
     local.writeUInt32LE(entry.body.length, 22);
     local.writeUInt16LE(name.length, 26);
@@ -58,7 +60,7 @@ function createZip(entries: readonly ZipEntryFixture[]): Buffer {
     central.writeUInt16LE(0, 8);
     central.writeUInt16LE(method, 10);
     central.writeUInt32LE(0, 12);
-    central.writeUInt32LE(0, 16);
+    central.writeUInt32LE(entryCrc32, 16);
     central.writeUInt32LE(compressed.length, 20);
     central.writeUInt32LE(entry.body.length, 24);
     central.writeUInt16LE(name.length, 28);
@@ -88,6 +90,26 @@ function createZip(entries: readonly ZipEntryFixture[]): Buffer {
   end.writeUInt16LE(0, 20);
 
   return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+function makeCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+function crc32(data: Buffer): number {
+  let value = 0xffffffff;
+  for (const byte of data) {
+    value = CRC32_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
 }
 
 describe('safe archive extraction', () => {
@@ -166,7 +188,7 @@ describe('safe archive extraction', () => {
   });
 
   it('rejects Windows-special path segments before writing', async () => {
-    for (const name of ['docs/victim.txt:payload', 'docs/NUL', 'docs/name. ', 'docs/trailing.']) {
+    for (const name of ['docs/victim.txt:payload', 'docs/NUL', 'docs/COM¹', 'docs/name. ', 'docs/trailing.']) {
       const destination = await tempDir();
       await expect(extractZipArchive(createZip([{ name, body: Buffer.from('x') }]), destination)).rejects.toThrow(
         /Windows-special/i,
@@ -199,6 +221,40 @@ describe('safe archive extraction', () => {
       ),
     ).rejects.toThrow(/collision/i);
     await expect(readdir(prefixDestination)).resolves.toEqual([]);
+
+    const caseInsensitiveDestination = await tempDir();
+    await expect(
+      extractZipArchive(
+        createZip([
+          { name: 'Readme.txt', body: Buffer.from('first') },
+          { name: 'README.txt', body: Buffer.from('second') },
+        ]),
+        caseInsensitiveDestination,
+      ),
+    ).rejects.toThrow(/collision/i);
+    await expect(readdir(caseInsensitiveDestination)).resolves.toEqual([]);
+  });
+
+  it('rejects symlinked destination ancestors before creating the extraction root', async () => {
+    const parent = await tempDir();
+    const outside = await tempDir();
+    await mkdir(join(parent, 'staging'));
+    await symlink(outside, join(parent, 'staging', 'link'));
+
+    await expect(
+      extractZipArchive(createZip([{ name: 'safe.txt', body: Buffer.from('owned') }]), join(parent, 'staging', 'link', 'run')),
+    ).rejects.toThrow(/symlink/i);
+    await expect(stat(join(outside, 'run', 'safe.txt'))).rejects.toThrow();
+  });
+
+  it('rejects excessive path component counts before collision checks', async () => {
+    const destination = await tempDir();
+    const longPath = `${Array.from({ length: 257 }, (_, index) => `p${index}`).join('/')}/file.txt`;
+
+    await expect(extractZipArchive(createZip([{ name: longPath, body: Buffer.from('x') }]), destination)).rejects.toThrow(
+      /segments/i,
+    );
+    await expect(readdir(destination)).resolves.toEqual([]);
   });
 
   it('wraps corrupt deflate payloads as safe archive errors', async () => {
@@ -210,6 +266,17 @@ describe('safe archive extraction', () => {
     archive[corruptIndex] = 0xff;
 
     await expect(extractZipArchive(archive, destination)).rejects.toThrow(SafeArchiveExtractionError);
+    await expect(readdir(destination)).resolves.toEqual([]);
+  });
+
+  it('rejects entries whose payload does not match the central directory CRC', async () => {
+    const destination = await tempDir();
+    const archive = Buffer.from(createZip([{ name: 'stored.txt', body: Buffer.from('abc'), method: 0 }]));
+    const payloadOffset = archive.indexOf(Buffer.from('abc'));
+    expect(payloadOffset).toBeGreaterThanOrEqual(0);
+    archive[payloadOffset] = 'z'.charCodeAt(0);
+
+    await expect(extractZipArchive(archive, destination)).rejects.toThrow(/CRC/i);
     await expect(readdir(destination)).resolves.toEqual([]);
   });
 

--- a/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
@@ -175,7 +175,7 @@ describe('safe archive extraction', () => {
   it('rejects nested archives and path traversal entries before writing', async () => {
     const traversalArchive = createZip([{ name: '../outside.txt', body: Buffer.from('owned') }]);
 
-    for (const archiveName of ['nested.zip', 'lib.jar', 'plugin.war', 'android.apk', 'package.whl', 'bundle.7z']) {
+    for (const archiveName of ['nested.zip', 'lib.jar', 'plugin.war', 'android.apk', 'package.whl', 'bundle.7z', '.tgz']) {
       const nestedDestination = await tempDir();
       await expect(
         extractZipArchive(createZip([{ name: archiveName, body: Buffer.from('x') }]), nestedDestination, {
@@ -271,6 +271,17 @@ describe('safe archive extraction', () => {
     await expect(readdir(destination)).resolves.toEqual([]);
   });
 
+  it('rejects excessive implicit directories before recursive mkdir', async () => {
+    const destination = await tempDir();
+    const archive = createZip([
+      { name: 'one/file.txt', body: Buffer.from('1') },
+      { name: 'two/file.txt', body: Buffer.from('2') },
+    ]);
+
+    await expect(extractZipArchive(archive, destination, { maxDirectoryCount: 1 })).rejects.toThrow(/directory count/i);
+    await expect(readdir(destination)).resolves.toEqual([]);
+  });
+
   it('wraps corrupt deflate payloads as safe archive errors', async () => {
     const destination = await tempDir();
     const originalPayload = Buffer.from('valid deflate data');
@@ -316,6 +327,7 @@ describe('safe archive extraction', () => {
       maxTotalUncompressedBytes: 250 * 1024 * 1024,
       maxFileBytes: 25 * 1024 * 1024,
       maxFileCount: 10_000,
+      maxDirectoryCount: 10_000,
       maxNestingDepth: 0,
     });
   });

--- a/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { deflateRawSync } from 'node:zlib';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SAFE_ARCHIVE_LIMITS,
+  SafeArchiveExtractionError,
+  extractZipArchive,
+} from '../../../src/security/safe-archive-extractor.js';
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'franken-safe-archive-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+interface ZipEntryFixture {
+  readonly name: string;
+  readonly body: Buffer;
+  readonly method?: 0 | 8;
+}
+
+function createZip(entries: readonly ZipEntryFixture[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const method = entry.method ?? 8;
+    const name = Buffer.from(entry.name, 'utf8');
+    const compressed = method === 8 ? deflateRawSync(entry.body) : entry.body;
+
+    const local = Buffer.alloc(30 + name.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 6);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(0, 10);
+    local.writeUInt32LE(0, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(entry.body.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(0, 28);
+    name.copy(local, 30);
+
+    const central = Buffer.alloc(46 + name.length);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0, 8);
+    central.writeUInt16LE(method, 10);
+    central.writeUInt32LE(0, 12);
+    central.writeUInt32LE(0, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(entry.body.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE(0, 38);
+    central.writeUInt32LE(offset, 42);
+    name.copy(central, 46);
+
+    localParts.push(local, compressed);
+    centralParts.push(central);
+    offset += local.length + compressed.length;
+  }
+
+  const centralOffset = offset;
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(centralOffset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+describe('safe archive extraction', () => {
+  it('extracts a small zip inside the destination', async () => {
+    const destination = await tempDir();
+    const archive = createZip([{ name: 'nested/readme.txt', body: Buffer.from('hello') }]);
+
+    const result = await extractZipArchive(archive, destination);
+
+    await expect(readFile(join(destination, 'nested/readme.txt'), 'utf8')).resolves.toBe('hello');
+    expect(result.files).toEqual([{ path: 'nested/readme.txt', compressedBytes: expect.any(Number), uncompressedBytes: 5 }]);
+  });
+
+  it('rejects archives that exceed the compressed byte limit before writing', async () => {
+    const destination = await tempDir();
+    const archive = createZip([{ name: 'safe.txt', body: Buffer.from('content'), method: 0 }]);
+
+    await expect(extractZipArchive(archive, destination, { maxArchiveBytes: 1 })).rejects.toThrow(
+      SafeArchiveExtractionError,
+    );
+    await expect(readdir(destination)).resolves.toEqual([]);
+  });
+
+  it('rejects zip bombs, per-file overflows, and path-count exhaustion before writing', async () => {
+    const zipBomb = createZip([{ name: 'bomb.txt', body: Buffer.alloc(1024, 'a') }]);
+    const tooManyFiles = createZip([
+      { name: 'one.txt', body: Buffer.from('1') },
+      { name: 'two.txt', body: Buffer.from('2') },
+    ]);
+    const perFileOverflow = createZip([{ name: 'large.txt', body: Buffer.from('large') }]);
+
+    const bombDestination = await tempDir();
+    await expect(extractZipArchive(zipBomb, bombDestination, { maxTotalUncompressedBytes: 32 })).rejects.toThrow(
+      /uncompressed/i,
+    );
+    await expect(readdir(bombDestination)).resolves.toEqual([]);
+
+    const countDestination = await tempDir();
+    await expect(extractZipArchive(tooManyFiles, countDestination, { maxFileCount: 1 })).rejects.toThrow(/file count/i);
+    await expect(readdir(countDestination)).resolves.toEqual([]);
+
+    const perFileDestination = await tempDir();
+    await expect(extractZipArchive(perFileOverflow, perFileDestination, { maxFileBytes: 4 })).rejects.toThrow(
+      /per-file/i,
+    );
+    await expect(readdir(perFileDestination)).resolves.toEqual([]);
+  });
+
+  it('rejects nested archives and path traversal entries before writing', async () => {
+    const nestedArchive = createZip([{ name: 'nested.zip', body: createZip([{ name: 'inside.txt', body: Buffer.from('x') }]) }]);
+    const traversalArchive = createZip([{ name: '../outside.txt', body: Buffer.from('owned') }]);
+
+    const nestedDestination = await tempDir();
+    await expect(extractZipArchive(nestedArchive, nestedDestination, { maxNestingDepth: 0 })).rejects.toThrow(
+      /nested archive/i,
+    );
+    await expect(readdir(nestedDestination)).resolves.toEqual([]);
+
+    const traversalDestination = await tempDir();
+    await expect(extractZipArchive(traversalArchive, traversalDestination)).rejects.toThrow(/path traversal/i);
+    await expect(stat(join(traversalDestination, '..', 'outside.txt'))).rejects.toThrow();
+  });
+
+  it('documents conservative default limits for consumers and operators', () => {
+    expect(DEFAULT_SAFE_ARCHIVE_LIMITS).toMatchObject({
+      maxArchiveBytes: 50 * 1024 * 1024,
+      maxTotalUncompressedBytes: 250 * 1024 * 1024,
+      maxFileBytes: 25 * 1024 * 1024,
+      maxFileCount: 10_000,
+      maxNestingDepth: 0,
+    });
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { deflateRawSync } from 'node:zlib';
@@ -93,7 +93,10 @@ function createZip(entries: readonly ZipEntryFixture[]): Buffer {
 describe('safe archive extraction', () => {
   it('extracts a small zip inside the destination', async () => {
     const destination = await tempDir();
-    const archive = createZip([{ name: 'nested/readme.txt', body: Buffer.from('hello') }]);
+    const archive = createZip([
+      { name: 'nested/', body: Buffer.alloc(0), method: 0 },
+      { name: 'nested/readme.txt', body: Buffer.from('hello') },
+    ]);
 
     const result = await extractZipArchive(archive, destination);
 
@@ -149,6 +152,65 @@ describe('safe archive extraction', () => {
     const traversalDestination = await tempDir();
     await expect(extractZipArchive(traversalArchive, traversalDestination)).rejects.toThrow(/path traversal/i);
     await expect(stat(join(traversalDestination, '..', 'outside.txt'))).rejects.toThrow();
+  });
+
+  it('rejects symlinked destination components before writing outside the extraction root', async () => {
+    const destination = await tempDir();
+    const outside = await tempDir();
+    await symlink(outside, join(destination, 'link'));
+
+    await expect(
+      extractZipArchive(createZip([{ name: 'link/file.txt', body: Buffer.from('owned') }]), destination),
+    ).rejects.toThrow(/symlink/i);
+    await expect(stat(join(outside, 'file.txt'))).rejects.toThrow();
+  });
+
+  it('rejects Windows-special path segments before writing', async () => {
+    for (const name of ['docs/victim.txt:payload', 'docs/NUL', 'docs/name. ', 'docs/trailing.']) {
+      const destination = await tempDir();
+      await expect(extractZipArchive(createZip([{ name, body: Buffer.from('x') }]), destination)).rejects.toThrow(
+        /Windows-special/i,
+      );
+      await expect(readdir(destination)).resolves.toEqual([]);
+    }
+  });
+
+  it('rejects colliding normalized paths before partial writes', async () => {
+    const duplicateDestination = await tempDir();
+    await expect(
+      extractZipArchive(
+        createZip([
+          { name: 'duplicate.txt', body: Buffer.from('first') },
+          { name: 'duplicate.txt', body: Buffer.from('second') },
+        ]),
+        duplicateDestination,
+      ),
+    ).rejects.toThrow(/collision/i);
+    await expect(readdir(duplicateDestination)).resolves.toEqual([]);
+
+    const prefixDestination = await tempDir();
+    await expect(
+      extractZipArchive(
+        createZip([
+          { name: 'a', body: Buffer.from('file') },
+          { name: 'a/b', body: Buffer.from('child') },
+        ]),
+        prefixDestination,
+      ),
+    ).rejects.toThrow(/collision/i);
+    await expect(readdir(prefixDestination)).resolves.toEqual([]);
+  });
+
+  it('wraps corrupt deflate payloads as safe archive errors', async () => {
+    const destination = await tempDir();
+    const originalPayload = Buffer.from('valid deflate data');
+    const archive = Buffer.from(createZip([{ name: 'bad.txt', body: originalPayload }]));
+    const corruptIndex = archive.indexOf(deflateRawSync(originalPayload));
+    expect(corruptIndex).toBeGreaterThanOrEqual(0);
+    archive[corruptIndex] = 0xff;
+
+    await expect(extractZipArchive(archive, destination)).rejects.toThrow(SafeArchiveExtractionError);
+    await expect(readdir(destination)).resolves.toEqual([]);
   });
 
   it('documents conservative default limits for consumers and operators', () => {

--- a/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/safe-archive-extractor.test.ts
@@ -126,6 +126,17 @@ describe('safe archive extraction', () => {
     expect(result.files).toEqual([{ path: 'nested/readme.txt', compressedBytes: expect.any(Number), uncompressedBytes: 5 }]);
   });
 
+  it('extracts empty deflated files without relaxing output bounds', async () => {
+    const destination = await tempDir();
+
+    const result = await extractZipArchive(createZip([{ name: 'empty.txt', body: Buffer.alloc(0), method: 8 }]), destination, {
+      maxFileBytes: 0,
+    });
+
+    await expect(readFile(join(destination, 'empty.txt'))).resolves.toHaveLength(0);
+    expect(result.files).toEqual([{ path: 'empty.txt', compressedBytes: expect.any(Number), uncompressedBytes: 0 }]);
+  });
+
   it('rejects archives that exceed the compressed byte limit before writing', async () => {
     const destination = await tempDir();
     const archive = createZip([{ name: 'safe.txt', body: Buffer.from('content'), method: 0 }]);
@@ -162,14 +173,17 @@ describe('safe archive extraction', () => {
   });
 
   it('rejects nested archives and path traversal entries before writing', async () => {
-    const nestedArchive = createZip([{ name: 'nested.zip', body: createZip([{ name: 'inside.txt', body: Buffer.from('x') }]) }]);
     const traversalArchive = createZip([{ name: '../outside.txt', body: Buffer.from('owned') }]);
 
-    const nestedDestination = await tempDir();
-    await expect(extractZipArchive(nestedArchive, nestedDestination, { maxNestingDepth: 0 })).rejects.toThrow(
-      /nested archive/i,
-    );
-    await expect(readdir(nestedDestination)).resolves.toEqual([]);
+    for (const archiveName of ['nested.zip', 'lib.jar', 'plugin.war', 'android.apk', 'package.whl', 'bundle.7z']) {
+      const nestedDestination = await tempDir();
+      await expect(
+        extractZipArchive(createZip([{ name: archiveName, body: Buffer.from('x') }]), nestedDestination, {
+          maxNestingDepth: 0,
+        }),
+      ).rejects.toThrow(/nested archive/i);
+      await expect(readdir(nestedDestination)).resolves.toEqual([]);
+    }
 
     const traversalDestination = await tempDir();
     await expect(extractZipArchive(traversalArchive, traversalDestination)).rejects.toThrow(/path traversal/i);
@@ -277,6 +291,22 @@ describe('safe archive extraction', () => {
     archive[payloadOffset] = 'z'.charCodeAt(0);
 
     await expect(extractZipArchive(archive, destination)).rejects.toThrow(/CRC/i);
+    await expect(readdir(destination)).resolves.toEqual([]);
+  });
+
+  it('validates all payloads before writing any files', async () => {
+    const destination = await tempDir();
+    const archive = Buffer.from(
+      createZip([
+        { name: 'valid-first.txt', body: Buffer.from('safe') },
+        { name: 'corrupt-second.txt', body: Buffer.from('bad') },
+      ]),
+    );
+    const corruptIndex = archive.indexOf(deflateRawSync(Buffer.from('bad')));
+    expect(corruptIndex).toBeGreaterThanOrEqual(0);
+    archive[corruptIndex] = 0xff;
+
+    await expect(extractZipArchive(archive, destination)).rejects.toThrow(SafeArchiveExtractionError);
     await expect(readdir(destination)).resolves.toEqual([]);
   });
 

--- a/tasks/resolve-issue-1710-progress.md
+++ b/tasks/resolve-issue-1710-progress.md
@@ -1,0 +1,9 @@
+# Resolve issue #1710 progress
+
+- [x] Read shared lessons and live issue state.
+- [x] Create isolated issue worktree on `resolve/issue-1710-security-bound-archive-and-artifact-extraction-s`.
+- [x] Add red tests for bounded archive extraction.
+- [x] Implement safe archive extraction utility.
+- [x] Document defaults and override policy.
+- [x] Run targeted tests and package gates.
+- [ ] Commit, push, open PR, run Codex/CI gate.


### PR DESCRIPTION
## Summary
- add a safe ZIP extraction helper with preflight limits for compressed size, total expansion, per-file size, file count, path traversal, symlinks, unsupported methods, and nested archive entries
- export the helper from `@franken/orchestrator` for artifact/archive consumers
- document default limits and the override policy for trusted environments

## Test Plan
- [x] npm test --workspace @franken/orchestrator -- tests/unit/security/safe-archive-extractor.test.ts
- [x] npm run build --workspace @franken/types
- [x] npm run build --workspace @franken/planner
- [x] npm run build --workspace @franken/brain
- [x] npm run build --workspace @franken/observer
- [x] npm run build --workspace @franken/critique
- [x] npm run build --workspace @franken/governor
- [x] npm run typecheck --workspace @franken/orchestrator
- [x] npm run build --workspace @franken/orchestrator
- [x] npm run lint --workspace @franken/orchestrator
- [x] npm run test:root

Closes #1710
