### PR TITLE
fix(security): constrain skill installer file writes

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -151,7 +151,15 @@ export function createSkillRoutes(deps: {
   // Context read/write routes (Chunk 5.11)
   app.get('/:name/context', (c) => {
     const name = c.req.param('name');
-    const content = deps.skillManager.readContext(name);
+    let content: string | null;
+    try {
+      content = deps.skillManager.readContext(name);
+    } catch (err) {
+      return c.json(
+        { error: isUnsafeSkillPathError(err) ? 'Unsafe skill path' : err instanceof Error ? err.message : 'Failed' },
+        400,
+      );
+    }
     if (content === null) {
       return c.json({ content: null, exists: false });
     }

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -174,7 +174,7 @@ export function createSkillRoutes(deps: {
       return c.json({ updated: true });
     } catch (err) {
       return c.json(
-        { error: err instanceof Error ? err.message : 'Failed' },
+        { error: isUnsafeSkillPathError(err) ? 'Unsafe skill path' : err instanceof Error ? err.message : 'Failed' },
         400,
       );
     }

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -17,6 +17,9 @@ function skillInstallErrorMessage(err: unknown): string {
       .map((issue) => `${issue.path.join('.') || 'config'}: ${issue.message}`)
       .join('; ');
   }
+  if (isUnsafeSkillPathError(err)) {
+    return 'Unsafe skill install path';
+  }
   return err instanceof Error ? err.message : 'Failed to install skill';
 }
 

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono';
 import { ZodError } from 'zod';
-import type { SkillManager } from '../../skills/skill-manager.js';
+import { isUnsafeSkillPathError, type SkillManager } from '../../skills/skill-manager.js';
 import { SkillHealthChecker } from '../../skills/skill-health-checker.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
 import { HttpError, parseJsonBody } from '../middleware.js';
 
 function isSkillInstallValidationError(err: unknown): boolean {
   return err instanceof ZodError
+    || isUnsafeSkillPathError(err)
     || (err instanceof Error && err.message.startsWith('Invalid skill name '));
 }
 

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -1,13 +1,18 @@
 import {
+  closeSync,
+  constants,
   existsSync,
+  lstatSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type {
   McpConfig,
   SkillInfo,
@@ -23,6 +28,42 @@ import { ProviderSkillTranslator } from './provider-skill-translator.js';
 
 const SAFE_NAME = /^[a-zA-Z0-9_-]+$/;
 
+function isContainedPath(candidate: string, root: string): boolean {
+  const relation = relative(root, candidate);
+  return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation));
+}
+
+function unsafePathError(path: string, reason: string): Error {
+  return new Error(`Unsafe skill path '${path}': ${reason}`);
+}
+
+function assertContainedPath(candidate: string, root: string, label: string): void {
+  if (!isContainedPath(candidate, root)) {
+    throw unsafePathError(candidate, `${label} escapes ${root}`);
+  }
+}
+
+function assertNoSymlink(path: string, label: string): void {
+  try {
+    if (lstatSync(path).isSymbolicLink()) {
+      throw unsafePathError(path, `${label} must not be a symlink`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+}
+
+function writeFileNoFollow(path: string, content: string): void {
+  const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow, 0o600);
+  try {
+    writeFileSync(fd, content);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function requireSecurityReviewByDefault(
   tools: ToolDefinition[],
 ): ToolDefinition[] {
@@ -34,13 +75,18 @@ function requireSecurityReviewByDefault(
 
 export class SkillManager {
   private readonly enabledSkills: Set<string>;
+  private readonly skillsDirRoot: string;
+  private readonly skillsDirReal: string;
 
   constructor(
     private readonly skillsDir: string,
     enabledSkills: Set<string>,
     private readonly configStore?: SkillConfigStore,
   ) {
+    this.skillsDirRoot = resolve(skillsDir);
     mkdirSync(skillsDir, { recursive: true });
+    assertNoSymlink(skillsDir, 'skills root');
+    this.skillsDirReal = realpathSync(skillsDir);
     // Merge: constructor-provided set takes precedence, then persisted defaults
     if (configStore && enabledSkills.size === 0) {
       this.enabledSkills = configStore.getEnabledSkills();
@@ -59,11 +105,71 @@ export class SkillManager {
         `Invalid skill name '${name}': must match ${SAFE_NAME.source}`,
       );
     }
-    // Belt-and-suspenders: verify resolved path is under skillsDir
-    const resolved = resolve(this.skillsDir, name);
-    if (!resolved.startsWith(resolve(this.skillsDir) + '/') && resolved !== resolve(this.skillsDir)) {
-      throw new Error(`Invalid skill name '${name}': path traversal detected`);
+  }
+
+  private skillDirectoryPath(name: string): string {
+    this.validateName(name);
+    const skillDir = resolve(this.skillsDir, name);
+    assertContainedPath(skillDir, this.skillsDirRoot, 'skill directory');
+    return skillDir;
+  }
+
+  private validateExistingSkillDirectory(skillDir: string): void {
+    if (!existsSync(skillDir)) return;
+    assertNoSymlink(skillDir, 'skill directory');
+    if (!lstatSync(skillDir).isDirectory()) {
+      throw unsafePathError(skillDir, 'skill path is not a directory');
     }
+    assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
+  }
+
+  private resolveSkillFilePath(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md'): string {
+    const skillDir = this.skillDirectoryPath(name);
+    this.validateExistingSkillDirectory(skillDir);
+    const filePath = resolve(skillDir, fileName);
+    assertContainedPath(filePath, skillDir, 'skill file');
+    return filePath;
+  }
+
+  private ensureSkillDirectory(name: string): string {
+    const skillDir = this.skillDirectoryPath(name);
+    if (existsSync(skillDir)) {
+      assertNoSymlink(skillDir, 'skill directory');
+      if (!lstatSync(skillDir).isDirectory()) {
+        throw unsafePathError(skillDir, 'skill path is not a directory');
+      }
+    } else {
+      mkdirSync(skillDir, { recursive: true });
+    }
+
+    const realSkillDir = realpathSync(skillDir);
+    assertContainedPath(realSkillDir, this.skillsDirReal, 'skill directory');
+    return skillDir;
+  }
+
+  private skillFilePath(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md'): string {
+    const skillDir = this.ensureSkillDirectory(name);
+    const filePath = resolve(skillDir, fileName);
+    assertContainedPath(filePath, skillDir, 'skill file');
+    return filePath;
+  }
+
+  private writeSkillFile(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md', content: string): void {
+    const filePath = this.skillFilePath(name, fileName);
+    assertNoSymlink(filePath, 'skill file');
+    if (existsSync(filePath) && !lstatSync(filePath).isFile()) {
+      throw unsafePathError(filePath, 'skill file target is not a regular file');
+    }
+    writeFileNoFollow(filePath, content);
+    const realFilePath = realpathSync(filePath);
+    assertContainedPath(realFilePath, this.skillsDirReal, 'skill file');
+  }
+
+  private removeSkillFile(name: string, fileName: 'tools.json'): void {
+    const filePath = this.skillFilePath(name, fileName);
+    if (!existsSync(filePath)) return;
+    assertNoSymlink(filePath, 'skill file');
+    rmSync(filePath);
   }
 
   listInstalled(): SkillInfo[] {
@@ -86,22 +192,21 @@ export class SkillManager {
         SkillToolManifestSchema.parse(catalogEntry.toolDefinitions),
       )
       : undefined;
-    const skillDir = join(this.skillsDir, catalogEntry.name);
-    mkdirSync(skillDir, { recursive: true });
-
-    writeFileSync(
-      join(skillDir, 'mcp.json'),
+    this.writeSkillFile(
+      catalogEntry.name,
+      'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
 
-    const toolsPath = join(skillDir, 'tools.json');
+    const toolsPath = this.skillFilePath(catalogEntry.name, 'tools.json');
     if (tools) {
-      writeFileSync(
-        toolsPath,
+      this.writeSkillFile(
+        catalogEntry.name,
+        'tools.json',
         JSON.stringify(tools, null, 2),
       );
     } else if (existsSync(toolsPath)) {
-      rmSync(toolsPath);
+      this.removeSkillFile(catalogEntry.name, 'tools.json');
     }
   }
 
@@ -110,17 +215,15 @@ export class SkillManager {
     const mcpConfig = McpConfigSchema.parse({
       mcpServers: { [name]: serverConfig },
     });
-    const skillDir = join(this.skillsDir, name);
-    mkdirSync(skillDir, { recursive: true });
-
-    writeFileSync(
-      join(skillDir, 'mcp.json'),
+    this.writeSkillFile(
+      name,
+      'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
 
-    const toolsPath = join(skillDir, 'tools.json');
+    const toolsPath = this.skillFilePath(name, 'tools.json');
     if (existsSync(toolsPath)) {
-      rmSync(toolsPath);
+      this.removeSkillFile(name, 'tools.json');
     }
   }
 
@@ -139,8 +242,9 @@ export class SkillManager {
 
   remove(name: string): void {
     this.validateName(name);
-    const skillDir = join(this.skillsDir, name);
+    const skillDir = this.skillDirectoryPath(name);
     if (existsSync(skillDir)) {
+      assertNoSymlink(skillDir, 'skill directory');
       rmSync(skillDir, { recursive: true });
     }
     this.enabledSkills.delete(name);
@@ -149,7 +253,20 @@ export class SkillManager {
 
   exists(name: string): boolean {
     if (!SAFE_NAME.test(name)) return false;
-    return existsSync(join(this.skillsDir, name, 'mcp.json'));
+    try {
+      const skillDir = this.skillDirectoryPath(name);
+      if (existsSync(skillDir)) {
+        assertNoSymlink(skillDir, 'skill directory');
+      }
+      const mcpPath = resolve(skillDir, 'mcp.json');
+      assertContainedPath(mcpPath, skillDir, 'skill file');
+      if (existsSync(mcpPath)) {
+        assertNoSymlink(mcpPath, 'skill file');
+      }
+      return existsSync(mcpPath);
+    } catch {
+      return false;
+    }
   }
 
   getEnabledSkills(): string[] {
@@ -157,24 +274,24 @@ export class SkillManager {
   }
 
   readMcpConfig(name: string): McpConfig | null {
-    this.validateName(name);
-    const configPath = join(this.skillsDir, name, 'mcp.json');
+    const configPath = this.resolveSkillFilePath(name, 'mcp.json');
     if (!existsSync(configPath)) return null;
+    assertNoSymlink(configPath, 'skill file');
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
     return McpConfigSchema.parse(raw);
   }
 
   readContext(name: string): string | null {
-    this.validateName(name);
-    const contextPath = join(this.skillsDir, name, 'context.md');
+    const contextPath = this.resolveSkillFilePath(name, 'context.md');
     if (!existsSync(contextPath)) return null;
+    assertNoSymlink(contextPath, 'skill file');
     return readFileSync(contextPath, 'utf-8');
   }
 
   readTools(name: string): ToolDefinition[] {
-    this.validateName(name);
-    const toolsPath = join(this.skillsDir, name, 'tools.json');
+    const toolsPath = this.resolveSkillFilePath(name, 'tools.json');
     if (!existsSync(toolsPath)) return [];
+    assertNoSymlink(toolsPath, 'skill file');
     const raw = JSON.parse(readFileSync(toolsPath, 'utf-8'));
     return requireSecurityReviewByDefault(SkillToolManifestSchema.parse(raw));
   }
@@ -183,7 +300,7 @@ export class SkillManager {
     this.validateName(name);
     if (!this.exists(name))
       throw new Error(`Skill '${name}' is not installed`);
-    writeFileSync(join(this.skillsDir, name, 'context.md'), content);
+    this.writeSkillFile(name, 'context.md', content);
   }
 
   loadForProvider(provider: ILlmProvider): ProviderSkillConfig {
@@ -204,11 +321,13 @@ export class SkillManager {
   private readSkillInfo(name: string): SkillInfo | null {
     const mcpConfig = this.readMcpConfig(name);
     if (!mcpConfig) return null;
-    const stat = statSync(join(this.skillsDir, name));
+    const skillDir = this.skillDirectoryPath(name);
+    this.validateExistingSkillDirectory(skillDir);
+    const stat = statSync(skillDir);
     return {
       name,
       enabled: this.enabledSkills.has(name),
-      hasContext: existsSync(join(this.skillsDir, name, 'context.md')),
+      hasContext: existsSync(this.resolveSkillFilePath(name, 'context.md')),
       mcpServerCount: Object.keys(mcpConfig.mcpServers).length,
       installedAt: stat.birthtime.toISOString(),
     };

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -301,6 +301,7 @@ export class SkillManager {
   exists(name: string): boolean {
     if (!SAFE_NAME.test(name)) return false;
     try {
+      this.assertSkillsRootStable();
       const skillDir = this.skillDirectoryPath(name);
       if (existsSync(skillDir)) {
         assertNoSymlink(skillDir, 'skill directory');

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -135,7 +135,15 @@ export class SkillManager {
     return skillDir;
   }
 
+  private assertSkillsRootStable(): void {
+    assertNoSymlink(this.skillsDirRoot, 'skills root');
+    if (realpathSync(this.skillsDirRoot) !== this.skillsDirReal) {
+      throw unsafePathError(this.skillsDirRoot, 'skills root changed after initialization');
+    }
+  }
+
   private validateExistingSkillDirectory(skillDir: string): void {
+    this.assertSkillsRootStable();
     if (!existsSync(skillDir)) return;
     assertNoSymlink(skillDir, 'skill directory');
     if (!lstatSync(skillDir).isDirectory()) {
@@ -154,6 +162,7 @@ export class SkillManager {
 
   private ensureSkillDirectory(name: string): string {
     const skillDir = this.skillDirectoryPath(name);
+    this.assertSkillsRootStable();
     if (existsSync(skillDir)) {
       assertNoSymlink(skillDir, 'skill directory');
       if (!lstatSync(skillDir).isDirectory()) {
@@ -274,6 +283,7 @@ export class SkillManager {
   remove(name: string): void {
     this.validateName(name);
     const skillDir = this.skillDirectoryPath(name);
+    this.assertSkillsRootStable();
     if (existsSync(skillDir)) {
       if (lstatSync(skillDir).isSymbolicLink()) {
         rmSync(skillDir);
@@ -281,6 +291,7 @@ export class SkillManager {
         this.configStore?.save(this.enabledSkills);
         return;
       }
+      assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
       rmSync(skillDir, { recursive: true });
     }
     this.enabledSkills.delete(name);

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -8,6 +8,7 @@ import {
   readdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -54,13 +55,20 @@ function assertNoSymlink(path: string, label: string): void {
   }
 }
 
-function writeFileNoFollow(path: string, content: string): void {
+function writeFileAtomicNoFollow(path: string, content: string): void {
   const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
-  const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow, 0o600);
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
+  let fd: number | undefined;
   try {
+    fd = openSync(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollow, 0o600);
     writeFileSync(fd, content);
-  } finally {
     closeSync(fd);
+    fd = undefined;
+    renameSync(tempPath, path);
+  } catch (err) {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(tempPath, { force: true });
+    throw err;
   }
 }
 
@@ -79,14 +87,14 @@ export class SkillManager {
   private readonly skillsDirReal: string;
 
   constructor(
-    private readonly skillsDir: string,
+    skillsDir: string,
     enabledSkills: Set<string>,
     private readonly configStore?: SkillConfigStore,
   ) {
     this.skillsDirRoot = resolve(skillsDir);
-    mkdirSync(skillsDir, { recursive: true });
-    assertNoSymlink(skillsDir, 'skills root');
-    this.skillsDirReal = realpathSync(skillsDir);
+    mkdirSync(this.skillsDirRoot, { recursive: true });
+    assertNoSymlink(this.skillsDirRoot, 'skills root');
+    this.skillsDirReal = realpathSync(this.skillsDirRoot);
     // Merge: constructor-provided set takes precedence, then persisted defaults
     if (configStore && enabledSkills.size === 0) {
       this.enabledSkills = configStore.getEnabledSkills();
@@ -109,7 +117,7 @@ export class SkillManager {
 
   private skillDirectoryPath(name: string): string {
     this.validateName(name);
-    const skillDir = resolve(this.skillsDir, name);
+    const skillDir = resolve(this.skillsDirRoot, name);
     assertContainedPath(skillDir, this.skillsDirRoot, 'skill directory');
     return skillDir;
   }
@@ -155,25 +163,29 @@ export class SkillManager {
   }
 
   private writeSkillFile(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md', content: string): void {
+    const filePath = this.validateSkillFileTarget(name, fileName);
+    writeFileAtomicNoFollow(filePath, content);
+    const realFilePath = realpathSync(filePath);
+    assertContainedPath(realFilePath, this.skillsDirReal, 'skill file');
+  }
+
+  private validateSkillFileTarget(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md'): string {
     const filePath = this.skillFilePath(name, fileName);
     assertNoSymlink(filePath, 'skill file');
     if (existsSync(filePath) && !lstatSync(filePath).isFile()) {
       throw unsafePathError(filePath, 'skill file target is not a regular file');
     }
-    writeFileNoFollow(filePath, content);
-    const realFilePath = realpathSync(filePath);
-    assertContainedPath(realFilePath, this.skillsDirReal, 'skill file');
+    return filePath;
   }
 
   private removeSkillFile(name: string, fileName: 'tools.json'): void {
-    const filePath = this.skillFilePath(name, fileName);
+    const filePath = this.validateSkillFileTarget(name, fileName);
     if (!existsSync(filePath)) return;
-    assertNoSymlink(filePath, 'skill file');
     rmSync(filePath);
   }
 
   listInstalled(): SkillInfo[] {
-    const entries = readdirSync(this.skillsDir, { withFileTypes: true });
+    const entries = readdirSync(this.skillsDirRoot, { withFileTypes: true });
     return entries
       .filter((e) => e.isDirectory())
       .map((e) => this.readSkillInfo(e.name))
@@ -192,21 +204,24 @@ export class SkillManager {
         SkillToolManifestSchema.parse(catalogEntry.toolDefinitions),
       )
       : undefined;
+    this.validateSkillFileTarget(catalogEntry.name, 'mcp.json');
+    const toolsPath = this.validateSkillFileTarget(catalogEntry.name, 'tools.json');
+    if (!tools && existsSync(toolsPath)) {
+      this.removeSkillFile(catalogEntry.name, 'tools.json');
+    }
+
     this.writeSkillFile(
       catalogEntry.name,
       'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
 
-    const toolsPath = this.skillFilePath(catalogEntry.name, 'tools.json');
     if (tools) {
       this.writeSkillFile(
         catalogEntry.name,
         'tools.json',
         JSON.stringify(tools, null, 2),
       );
-    } else if (existsSync(toolsPath)) {
-      this.removeSkillFile(catalogEntry.name, 'tools.json');
     }
   }
 
@@ -215,16 +230,16 @@ export class SkillManager {
     const mcpConfig = McpConfigSchema.parse({
       mcpServers: { [name]: serverConfig },
     });
+    this.validateSkillFileTarget(name, 'mcp.json');
+    const toolsPath = this.validateSkillFileTarget(name, 'tools.json');
+    if (existsSync(toolsPath)) {
+      this.removeSkillFile(name, 'tools.json');
+    }
     this.writeSkillFile(
       name,
       'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
-
-    const toolsPath = this.skillFilePath(name, 'tools.json');
-    if (existsSync(toolsPath)) {
-      this.removeSkillFile(name, 'tools.json');
-    }
   }
 
   enable(name: string): void {
@@ -244,7 +259,12 @@ export class SkillManager {
     this.validateName(name);
     const skillDir = this.skillDirectoryPath(name);
     if (existsSync(skillDir)) {
-      assertNoSymlink(skillDir, 'skill directory');
+      if (lstatSync(skillDir).isSymbolicLink()) {
+        rmSync(skillDir);
+        this.enabledSkills.delete(name);
+        this.configStore?.save(this.enabledSkills);
+        return;
+      }
       rmSync(skillDir, { recursive: true });
     }
     this.enabledSkills.delete(name);

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -136,6 +136,9 @@ export class SkillManager {
   }
 
   private assertSkillsRootStable(): void {
+    if (!existsSync(this.skillsDirRoot)) {
+      mkdirSync(this.skillsDirRoot, { recursive: true });
+    }
     assertNoSymlink(this.skillsDirRoot, 'skills root');
     if (realpathSync(this.skillsDirRoot) !== this.skillsDirReal) {
       throw unsafePathError(this.skillsDirRoot, 'skills root changed after initialization');

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -13,7 +13,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import type {
   McpConfig,
   SkillInfo,
@@ -38,6 +38,10 @@ function unsafePathError(path: string, reason: string): Error {
   return new Error(`Unsafe skill path '${path}': ${reason}`);
 }
 
+export function isUnsafeSkillPathError(err: unknown): boolean {
+  return err instanceof Error && err.message.startsWith('Unsafe skill path ');
+}
+
 function assertContainedPath(candidate: string, root: string, label: string): void {
   if (!isContainedPath(candidate, root)) {
     throw unsafePathError(candidate, `${label} escapes ${root}`);
@@ -55,15 +59,24 @@ function assertNoSymlink(path: string, label: string): void {
   }
 }
 
-function writeFileAtomicNoFollow(path: string, content: string): void {
+function assertParentStillContained(path: string, root: string): void {
+  const parent = dirname(path);
+  assertNoSymlink(parent, 'skill directory');
+  assertContainedPath(realpathSync(parent), root, 'skill directory');
+}
+
+function writeFileAtomicNoFollow(path: string, content: string, root: string): void {
   const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
   const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
   let fd: number | undefined;
   try {
+    assertParentStillContained(path, root);
     fd = openSync(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollow, 0o600);
+    assertParentStillContained(path, root);
     writeFileSync(fd, content);
     closeSync(fd);
     fd = undefined;
+    assertParentStillContained(path, root);
     renameSync(tempPath, path);
   } catch (err) {
     if (fd !== undefined) closeSync(fd);
@@ -164,7 +177,7 @@ export class SkillManager {
 
   private writeSkillFile(name: string, fileName: 'mcp.json' | 'tools.json' | 'context.md', content: string): void {
     const filePath = this.validateSkillFileTarget(name, fileName);
-    writeFileAtomicNoFollow(filePath, content);
+    writeFileAtomicNoFollow(filePath, content, this.skillsDirReal);
     const realFilePath = realpathSync(filePath);
     assertContainedPath(realFilePath, this.skillsDirReal, 'skill file');
   }
@@ -206,15 +219,17 @@ export class SkillManager {
       : undefined;
     this.validateSkillFileTarget(catalogEntry.name, 'mcp.json');
     const toolsPath = this.validateSkillFileTarget(catalogEntry.name, 'tools.json');
-    if (!tools && existsSync(toolsPath)) {
-      this.removeSkillFile(catalogEntry.name, 'tools.json');
-    }
+    const shouldRemoveStaleTools = !tools && existsSync(toolsPath);
 
     this.writeSkillFile(
       catalogEntry.name,
       'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
+
+    if (shouldRemoveStaleTools) {
+      this.removeSkillFile(catalogEntry.name, 'tools.json');
+    }
 
     if (tools) {
       this.writeSkillFile(
@@ -232,14 +247,15 @@ export class SkillManager {
     });
     this.validateSkillFileTarget(name, 'mcp.json');
     const toolsPath = this.validateSkillFileTarget(name, 'tools.json');
-    if (existsSync(toolsPath)) {
-      this.removeSkillFile(name, 'tools.json');
-    }
+    const shouldRemoveStaleTools = existsSync(toolsPath);
     this.writeSkillFile(
       name,
       'mcp.json',
       JSON.stringify(mcpConfig, null, 2),
     );
+    if (shouldRemoveStaleTools) {
+      this.removeSkillFile(name, 'tools.json');
+    }
   }
 
   enable(name: string): void {

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -137,6 +137,9 @@ export class SkillManager {
 
   private assertSkillsRootStable(): void {
     if (!existsSync(this.skillsDirRoot)) {
+      const parent = dirname(this.skillsDirRoot);
+      assertNoSymlink(parent, 'skills root parent');
+      assertContainedPath(this.skillsDirReal, realpathSync(parent), 'skills root');
       mkdirSync(this.skillsDirRoot, { recursive: true });
     }
     assertNoSymlink(this.skillsDirRoot, 'skills root');
@@ -213,7 +216,14 @@ export class SkillManager {
     const entries = readdirSync(this.skillsDirRoot, { withFileTypes: true });
     return entries
       .filter((e) => e.isDirectory())
-      .map((e) => this.readSkillInfo(e.name))
+      .map((e) => {
+        try {
+          return this.readSkillInfo(e.name);
+        } catch (err) {
+          if (isUnsafeSkillPathError(err)) return null;
+          throw err;
+        }
+      })
       .filter((info): info is SkillInfo => info !== null);
   }
 
@@ -326,23 +336,23 @@ export class SkillManager {
 
   readMcpConfig(name: string): McpConfig | null {
     const configPath = this.resolveSkillFilePath(name, 'mcp.json');
-    if (!existsSync(configPath)) return null;
     assertNoSymlink(configPath, 'skill file');
+    if (!existsSync(configPath)) return null;
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
     return McpConfigSchema.parse(raw);
   }
 
   readContext(name: string): string | null {
     const contextPath = this.resolveSkillFilePath(name, 'context.md');
-    if (!existsSync(contextPath)) return null;
     assertNoSymlink(contextPath, 'skill file');
+    if (!existsSync(contextPath)) return null;
     return readFileSync(contextPath, 'utf-8');
   }
 
   readTools(name: string): ToolDefinition[] {
     const toolsPath = this.resolveSkillFilePath(name, 'tools.json');
-    if (!existsSync(toolsPath)) return [];
     assertNoSymlink(toolsPath, 'skill file');
+    if (!existsSync(toolsPath)) return [];
     const raw = JSON.parse(readFileSync(toolsPath, 'utf-8'));
     return requireSecurityReviewByDefault(SkillToolManifestSchema.parse(raw));
   }

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -71,6 +71,23 @@ describe('Skill API routes', () => {
       expect(body.skills).toHaveLength(1);
       expect(body.skills[0].name).toBe('github');
     });
+
+    it('skips unsafe skill entries without returning a 500', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+      mkdirSync(join(skillsDir, 'poisoned'), { recursive: true });
+      symlinkSync(join(tempDir, 'outside-mcp.json'), join(skillsDir, 'poisoned', 'mcp.json'));
+
+      const res = await app.request('/api/skills');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.skills.map((skill: { name: string }) => skill.name)).toEqual(['github']);
+    });
   });
 
   describe('GET /api/skills/catalog/:provider', () => {
@@ -411,6 +428,23 @@ describe('Skill API routes', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: 'new context' }),
       });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Unsafe skill path');
+      expect(JSON.stringify(body)).not.toContain(skillsDir);
+      expect(JSON.stringify(body)).not.toContain(outsideContext);
+    });
+
+    it('returns generic unsafe path errors for unsafe context reads', async () => {
+      mkdirSync(join(skillsDir, 'github'), { recursive: true });
+      writeFileSync(join(skillsDir, 'github', 'mcp.json'), JSON.stringify({
+        mcpServers: { github: { command: 'github-mcp' } },
+      }));
+      const outsideContext = join(tempDir, 'outside-context.md');
+      symlinkSync(outsideContext, join(skillsDir, 'github', 'context.md'));
+
+      const res = await app.request('/api/skills/github/context');
 
       expect(res.status).toBe(400);
       const body = await res.json();

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Hono } from 'hono';
@@ -168,6 +168,24 @@ describe('Skill API routes', () => {
       const body = await res.json();
       expect(body.error.code).toBe('INTERNAL_ERROR');
       expect(JSON.stringify(body)).not.toContain('EACCES');
+    });
+
+    it('returns 400 for unsafe skill install paths', async () => {
+      const outsideDir = join(tempDir, 'outside-skill');
+      mkdirSync(outsideDir, { recursive: true });
+      symlinkSync(outsideDir, join(skillsDir, 'escaped'), 'dir');
+
+      const res = await app.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          custom: { name: 'escaped', config: { command: 'node' } },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Unsafe skill path');
     });
 
     it('returns 400 when neither provided', async () => {

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -185,7 +185,9 @@ describe('Skill API routes', () => {
 
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toContain('Unsafe skill path');
+      expect(body.error).toBe('Unsafe skill install path');
+      expect(JSON.stringify(body)).not.toContain(skillsDir);
+      expect(JSON.stringify(body)).not.toContain(outsideDir);
     });
 
     it('returns 400 when neither provided', async () => {

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -397,5 +397,26 @@ describe('Skill API routes', () => {
       expect(await res.json()).toEqual({ error: 'Invalid JSON' });
       expect(writeContextSpy).not.toHaveBeenCalled();
     });
+
+    it('returns generic unsafe path errors for unsafe context writes', async () => {
+      mkdirSync(join(skillsDir, 'github'), { recursive: true });
+      writeFileSync(join(skillsDir, 'github', 'mcp.json'), JSON.stringify({
+        mcpServers: { github: { command: 'github-mcp' } },
+      }));
+      const outsideContext = join(tempDir, 'outside-context.md');
+      symlinkSync(outsideContext, join(skillsDir, 'github', 'context.md'));
+
+      const res = await app.request('/api/skills/github/context', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'new context' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Unsafe skill path');
+      expect(JSON.stringify(body)).not.toContain(skillsDir);
+      expect(JSON.stringify(body)).not.toContain(outsideContext);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -478,15 +478,16 @@ describe('SkillManager', () => {
 
     it('resolves relative skills roots once at construction time', async () => {
       const originalCwd = process.cwd();
+      const otherCwd = mkdtempSync(join(tempDir, 'other-cwd-'));
       try {
         process.chdir(tempDir);
         const relativeManager = new SkillManager('relative-skills', new Set());
-        process.chdir(tmpdir());
+        process.chdir(otherCwd);
 
         await relativeManager.installCustom('github', { command: 'node' });
 
         expect(existsSync(join(tempDir, 'relative-skills', 'github', 'mcp.json'))).toBe(true);
-        expect(existsSync(join(tmpdir(), 'relative-skills', 'github', 'mcp.json'))).toBe(false);
+        expect(existsSync(join(otherCwd, 'relative-skills', 'github', 'mcp.json'))).toBe(false);
       } finally {
         process.chdir(originalCwd);
       }

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -492,5 +492,27 @@ describe('SkillManager', () => {
         process.chdir(originalCwd);
       }
     });
+
+    it('rejects installs if the skills root is replaced with a symlink before directory creation', async () => {
+      const outsideRoot = join(tempDir, 'outside-root');
+      mkdirSync(outsideRoot, { recursive: true });
+      rmSync(skillsDir, { recursive: true, force: true });
+      symlinkSync(outsideRoot, skillsDir, 'dir');
+
+      await expect(manager.installCustom('escaped-root', { command: 'node' }))
+        .rejects.toThrow(/Unsafe skill path/);
+
+      expect(existsSync(join(outsideRoot, 'escaped-root'))).toBe(false);
+    });
+
+    it('rejects recursive removal if the skills root was replaced with a symlink', () => {
+      const outsideRoot = join(tempDir, 'outside-root');
+      mkdirSync(join(outsideRoot, 'github'), { recursive: true });
+      rmSync(skillsDir, { recursive: true, force: true });
+      symlinkSync(outsideRoot, skillsDir, 'dir');
+
+      expect(() => manager.remove('github')).toThrow(/Unsafe skill path/);
+      expect(existsSync(join(outsideRoot, 'github'))).toBe(true);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -493,6 +493,14 @@ describe('SkillManager', () => {
       }
     });
 
+    it('recreates a missing skills root before installing', async () => {
+      rmSync(skillsDir, { recursive: true, force: true });
+
+      await manager.installCustom('recreated-root', { command: 'node' });
+
+      expect(existsSync(join(skillsDir, 'recreated-root', 'mcp.json'))).toBe(true);
+    });
+
     it('rejects installs if the skills root is replaced with a symlink before directory creation', async () => {
       const outsideRoot = join(tempDir, 'outside-root');
       mkdirSync(outsideRoot, { recursive: true });

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, linkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { McpConfigSchema } from '@franken/types';
@@ -424,6 +424,72 @@ describe('SkillManager', () => {
 
       await expect(manager.installCustom('file-skill', { command: 'node' }))
         .rejects.toThrow(/not a directory/);
+    });
+
+    it('replaces hard-linked skill files without truncating the linked target', async () => {
+      const outsideFile = join(tempDir, 'other-profile-mcp.json');
+      writeFileSync(outsideFile, 'do not overwrite');
+      mkdirSync(join(skillsDir, 'github'), { recursive: true });
+      linkSync(outsideFile, join(skillsDir, 'github', 'mcp.json'));
+
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+
+      expect(readFileSync(outsideFile, 'utf-8')).toBe('do not overwrite');
+      expect(manager.exists('github')).toBe(true);
+    });
+
+    it('rejects stale unsafe tools manifests before changing mcp.json', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'old-server' },
+        authFields: [],
+      });
+      const before = readFileSync(join(skillsDir, 'github', 'mcp.json'), 'utf-8');
+      symlinkSync(join(tempDir, 'outside-tools.json'), join(skillsDir, 'github', 'tools.json'));
+
+      await expect(manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'new-server' },
+        authFields: [],
+      })).rejects.toThrow(/Unsafe skill path/);
+
+      expect(readFileSync(join(skillsDir, 'github', 'mcp.json'), 'utf-8')).toBe(before);
+    });
+
+    it('removes a symlinked skill entry without deleting its target', () => {
+      const outsideDir = join(tempDir, 'other-profile-skill');
+      mkdirSync(outsideDir, { recursive: true });
+      symlinkSync(outsideDir, join(skillsDir, 'escaped'), 'dir');
+
+      expect(() => manager.remove('escaped')).not.toThrow();
+      expect(existsSync(join(skillsDir, 'escaped'))).toBe(false);
+      expect(existsSync(outsideDir)).toBe(true);
+    });
+
+    it('resolves relative skills roots once at construction time', async () => {
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(tempDir);
+        const relativeManager = new SkillManager('relative-skills', new Set());
+        process.chdir(tmpdir());
+
+        await relativeManager.installCustom('github', { command: 'node' });
+
+        expect(existsSync(join(tempDir, 'relative-skills', 'github', 'mcp.json'))).toBe(true);
+        expect(existsSync(join(tmpdir(), 'relative-skills', 'github', 'mcp.json'))).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { McpConfigSchema } from '@franken/types';
@@ -362,8 +362,12 @@ describe('SkillManager', () => {
       expect(() => manager.remove('../../tmp')).toThrow('Invalid skill name');
     });
 
-    it('rejects names with slashes', () => {
-      expect(() => manager.enable('foo/bar')).toThrow('Invalid skill name');
+    it('rejects names with slashes', async () => {
+      await expect(manager.installCustom('foo/bar', { command: 'node' })).rejects.toThrow(/Invalid skill name/);
+    });
+
+    it('rejects absolute path names', async () => {
+      await expect(manager.installCustom(join(tempDir, 'outside-skill'), { command: 'node' })).rejects.toThrow(/Invalid skill name/);
     });
 
     it('rejects names with dots only', () => {
@@ -377,6 +381,49 @@ describe('SkillManager', () => {
 
     it('exists returns false for invalid names without throwing', () => {
       expect(manager.exists('../etc')).toBe(false);
+    });
+
+    it('rejects installing into a symlinked skill directory without writing outside the skills root', async () => {
+      const outsideDir = join(tempDir, 'other-profile-skill');
+      mkdirSync(outsideDir, { recursive: true });
+      symlinkSync(outsideDir, join(skillsDir, 'escaped'), 'dir');
+
+      await expect(manager.installCustom('escaped', { command: 'node' }))
+        .rejects.toThrow(/Unsafe skill path/);
+
+      expect(existsSync(join(outsideDir, 'mcp.json'))).toBe(false);
+    });
+
+    it('rejects catalog installs when mcp.json is a symlink outside the skill directory', async () => {
+      const outsideFile = join(tempDir, 'other-profile-mcp.json');
+      mkdirSync(join(skillsDir, 'github'), { recursive: true });
+      symlinkSync(outsideFile, join(skillsDir, 'github', 'mcp.json'));
+
+      await expect(manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      })).rejects.toThrow(/Unsafe skill path/);
+
+      expect(existsSync(outsideFile)).toBe(false);
+    });
+
+    it('rejects context writes when context.md is a symlink outside the skill directory', async () => {
+      await manager.installCustom('github', { command: 'node' });
+      const outsideFile = join(tempDir, 'outside-context.md');
+      symlinkSync(outsideFile, join(skillsDir, 'github', 'context.md'));
+
+      expect(() => manager.writeContext('github', '# escaped')).toThrow(/Unsafe skill path/);
+      expect(existsSync(outsideFile)).toBe(false);
+    });
+
+    it('rejects installing when the target skill path is an existing file', async () => {
+      writeFileSync(join(skillsDir, 'file-skill'), 'not a directory');
+
+      await expect(manager.installCustom('file-skill', { command: 'node' }))
+        .rejects.toThrow(/not a directory/);
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -59,6 +59,20 @@ describe('SkillManager', () => {
       mkdirSync(join(skillsDir, 'empty-dir'), { recursive: true });
       expect(manager.listInstalled()).toEqual([]);
     });
+
+    it('skips skills with unsafe MCP files instead of breaking the entire list', async () => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+      mkdirSync(join(skillsDir, 'poisoned'), { recursive: true });
+      symlinkSync(join(tempDir, 'outside-mcp.json'), join(skillsDir, 'poisoned', 'mcp.json'));
+
+      expect(manager.listInstalled().map((skill) => skill.name)).toEqual(['github']);
+    });
   });
 
   describe('install()', () => {
@@ -511,6 +525,24 @@ describe('SkillManager', () => {
         .rejects.toThrow(/Unsafe skill path/);
 
       expect(existsSync(join(outsideRoot, 'escaped-root'))).toBe(false);
+    });
+
+    it('rejects recreating a missing skills root after a symlinked parent is repointed', async () => {
+      const trustedParent = join(tempDir, 'trusted-parent');
+      const attackerParent = join(tempDir, 'attacker-parent');
+      const parentLink = join(tempDir, 'parent-link');
+      mkdirSync(trustedParent, { recursive: true });
+      mkdirSync(attackerParent, { recursive: true });
+      symlinkSync(trustedParent, parentLink, 'dir');
+      const symlinkParentManager = new SkillManager(join(parentLink, 'skills'), new Set());
+
+      rmSync(join(trustedParent, 'skills'), { recursive: true, force: true });
+      rmSync(parentLink, { force: true });
+      symlinkSync(attackerParent, parentLink, 'dir');
+
+      await expect(symlinkParentManager.installCustom('escaped-root', { command: 'node' }))
+        .rejects.toThrow(/Unsafe skill path/);
+      expect(existsSync(join(attackerParent, 'skills', 'escaped-root'))).toBe(false);
     });
 
     it('rejects recursive removal if the skills root was replaced with a symlink', () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-15 — Skill installer path hardening review fixes
 - For installer path hardening, guard every public surface that can surface unsafe-path errors, not just install routes; context/read/write routes should return generic unsafe-path messages and tests should assert absolute roots/targets are not leaked.
-- If an installer snapshots a root realpath at construction, handle missing-root recovery explicitly by recreating the root and then rechecking for symlink/replacement before creating child directories.
+- If an installer snapshots a root realpath at construction, handle missing-root recovery explicitly: revalidate the missing root's parent before `mkdir`, reject symlinked/repointed parents, then recheck the recreated root before creating child directories.
 - When Codex reaches the configured review-invocation cap with new findings, fix/reply/resolve and stop for explicit approval before triggering another review; do not merge on stale clean signals after the head changed.
 
 ## 2026-07-15 — Beast process cleanup review fixes

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,10 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-15 — Skill installer path hardening review fixes
+- For installer path hardening, guard every public surface that can surface unsafe-path errors, not just install routes; context/read/write routes should return generic unsafe-path messages and tests should assert absolute roots/targets are not leaked.
+- If an installer snapshots a root realpath at construction, handle missing-root recovery explicitly by recreating the root and then rechecking for symlink/replacement before creating child directories.
+- When Codex reaches the configured review-invocation cap with new findings, fix/reply/resolve and stop for explicit approval before triggering another review; do not merge on stale clean signals after the head changed.
+
 ## 2026-07-15 — Beast process cleanup review fixes
 - For Beast cleanup paths, treat persisted process-group ownership as verified only when the stored start-time token matches the current `/proc` start time; missing or unreadable start times should fail closed to direct-PID signaling to avoid killing a PID-reused process group.
 - Keep cleanup ownership delegated through execution-mode wrappers: container executors must forward `cleanupPendingRun()` so queued container runs can be cancelled before an attempt exists.


### PR DESCRIPTION
## Summary
- centralizes SkillManager path resolution and containment checks under the configured skills root
- rejects symlinked skill directories/files and conflicting non-directory targets before installer writes/removes
- adds regression coverage for traversal names, absolute paths, symlink escapes, and file conflicts

## Test Plan
- [x] npm run test -- --filter=@franken/orchestrator -- tests/unit/skills/skill-manager.test.ts
- [x] npm run typecheck -- --filter=@franken/orchestrator
- [x] npm run build -- --filter=@franken/orchestrator
- [x] npm run lint -- --filter=@franken/orchestrator (passes with existing warnings)

Closes #1671
