### PR TITLE
feat(memory): expire temporary operational facts

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -90,7 +90,7 @@ That means the current path is:
 
 - real ingestion sanitization through `MiddlewareChainFirewallAdapter` (the security middleware chain)
 - real local skill discovery through `SkillManagerAdapter`; `cli:*` execution is dispatched by `CliSkillExecutor`, MCP execution requires an `IMcpModule`, and non-CLI `function`/`llm` execution still requires an `ISkillsModule.execute(...)` implementation outside `SkillManagerAdapter`
-- real episodic memory persistence through `SqliteBrainMemoryAdapter` (`@franken/brain`)
+- real episodic memory persistence through `SqliteBrainMemoryAdapter` (`@franken/brain`); working-memory entries that represent temporary operational facts may include an `expiresAt` timestamp and are purged lazily on read/list/hydration after that TTL passes
 - graph-builder-driven planning for chunk files or design-doc decomposition; the planner port itself is `stubPlanner`, which throws if invoked
 - real plan critique through `CritiquePortAdapter` over `@franken/critique`, and real HITL approval through `GovernorPortAdapter` over the governor's `ApprovalGateway`/`CliChannel` (non-TTY runs default to reject). If either safety module is enabled but not installed, the dep factory fails closed unless `FRANKENBEAST_ALLOW_MISSING_SAFETY_MODULES=1`
 - real reflection heartbeat through `ReflectionHeartbeatAdapter`; `McpSdkAdapter` is always constructed but fails closed until an MCP transport is configured
@@ -420,7 +420,7 @@ flowchart TD
 | `.fbeast/.build/beasts.db` | agent, dispatch, run, interview services | dashboard Beast pages, process executor | tracked agents, runs, attempts, events, interview sessions |
 | `.fbeast/.build/beasts/logs/*` | process executor, run service | dashboard logs panel | per-attempt structured log lines |
 | `.fbeast/.build/build-traces.db` | observer bridge / trace viewer | trace viewer | spans, token usage, cost telemetry |
-| `.fbeast/beast.db` | episodic memory adapter (`SqliteBrainMemoryAdapter` over `SqliteBrain`) | hydration and trace recording | episodic execution memory |
+| `.fbeast/beast.db` | episodic memory adapter (`SqliteBrainMemoryAdapter` over `SqliteBrain`) | hydration and trace recording | episodic execution memory plus working-memory facts; temporary operational working facts with `expiresAt` are TTL-purged |
 | `.fbeast/.build/*.checkpoint` | execution phase, issue runner | resume logic | task completion markers and recovery checkpoints |
 | `.fbeast/.build/chunk-sessions/*` | MartinLoop | MartinLoop, renderer, compactor | canonical chunk conversation state |
 | `.fbeast/.build/chunk-session-snapshots/*` | MartinLoop | recovery and rollback | pre-compaction rollback points |
@@ -626,7 +626,7 @@ The target goal is one canonical service control model across CLI and dashboard,
 | Area | Current | Target |
 |---|---|---|
 | Ingestion | real firewall (`MiddlewareChainFirewallAdapter`) wired unconditionally | fully wired firewall in all entry modes |
-| Memory | real SQLite-backed episodic memory (`SqliteBrainMemoryAdapter`) | full working + episodic + semantic memory |
+| Memory | real SQLite-backed episodic memory (`SqliteBrainMemoryAdapter`) with TTL cleanup for temporary operational working facts | full working + episodic + semantic memory |
 | Planning | graph-builder driven; the planner port is a stub that throws if invoked | planner owns graph generation with critique loop |
 | Critique | real critique loop (`CritiquePortAdapter` over `@franken/critique`); graph-builder plans included since #462 | real critique loop with escalation |
 | Execution | real CLI execution, chunk sessions, checkpoints, observer | same plus broader tool and policy integrations |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -148,7 +148,7 @@ frankenbeast/
 ├── docker-compose.yml           # optional ChromaDB/Grafana/Tempo stack
 ├── docs/
 ├── packages/
-│   ├── franken-brain/           # @franken/brain: SQLite-backed working/episodic/recovery memory
+│   ├── franken-brain/           # @franken/brain: SQLite-backed working/episodic/recovery memory; temporary working facts can carry expiresAt TTL metadata
 │   ├── franken-planner/         # @franken/planner: DAG planning primitives and strategies
 │   ├── franken-observer/        # trace/cost/eval/loop observability
 │   ├── franken-critique/        # critique pipeline and correction requests

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -383,6 +383,21 @@ function stringifyWorkingMemoryValue(key: string, value: unknown): string {
   );
 }
 
+function readWorkingMemoryExpiresAt(value: unknown): string | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const expiresAt = (value as { expiresAt?: unknown }).expiresAt;
+  return typeof expiresAt === 'string' ? expiresAt : undefined;
+}
+
+function isExpiredWorkingMemoryValue(value: unknown, nowMs = Date.now()): boolean {
+  const expiresAt = readWorkingMemoryExpiresAt(value);
+  if (!expiresAt) return false;
+  const expiresAtMs = Date.parse(expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
+}
+
 class SqliteWorkingMemory implements IWorkingMemory {
   private store = new Map<string, unknown>();
   private sizes = new Map<string, number>();
@@ -431,9 +446,14 @@ class SqliteWorkingMemory implements IWorkingMemory {
     }
 
     const prepared: Array<[string, unknown, string, number]> = [];
+    const expiredKeys: string[] = [];
     let total = 0;
     for (const row of rows) {
       const parsed = parseStoredWorkingMemoryValue(row.value);
+      if (isExpiredWorkingMemoryValue(parsed)) {
+        expiredKeys.push(row.key);
+        continue;
+      }
       const { normalized, serialized, size } = this.prepareEntry(
         row.key,
         parsed,
@@ -441,6 +461,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       total += size;
       prepared.push([row.key, normalized, serialized, size]);
     }
+    this.deleteExpiredPersistedKeys(expiredKeys);
     if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
       throw new WorkingMemoryLimitError(
         `Persisted working memory is ${total} bytes, exceeding maxTotalBytes (${this.limits.maxTotalBytes})`,
@@ -650,6 +671,10 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const prepared: Array<[string, unknown, string, number]> = [];
     let total = 0;
     for (const [key, value] of this.store) {
+      if (isExpiredWorkingMemoryValue(value)) {
+        this.deleteExpiredPersistedKeys([key]);
+        continue;
+      }
       const { normalized, serialized, size } = this.prepareEntry(key, value);
       try {
         assertNotDeletionGuarded(this.db, key, serialized, this.encryption);
@@ -701,8 +726,25 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   get(key: string): unknown {
-    if (this.expireRuntimeKeyIfGuarded(key)) return undefined;
+    if (this.expireRuntimeKeyIfUnavailable(key)) return undefined;
     return cloneStoredWorkingMemoryValue(this.store.get(key));
+  }
+
+  private expireRuntimeKeyIfUnavailable(key: string): boolean {
+    return this.expireRuntimeKeyIfTtlExpired(key) || this.expireRuntimeKeyIfGuarded(key);
+  }
+
+  private expireRuntimeKeyIfTtlExpired(key: string): boolean {
+    const value = this.store.get(key);
+    if (!isExpiredWorkingMemoryValue(value)) return false;
+    this.totalBytes -= this.sizes.get(key) ?? 0;
+    this.store.delete(key);
+    this.sizes.delete(key);
+    this.serialized.delete(key);
+    this.dirtyKeys.delete(key);
+    this.deletedKeys.delete(key);
+    this.deleteExpiredPersistedKeys([key]);
+    return true;
   }
 
   private expireRuntimeKeyIfGuarded(key: string): boolean {
@@ -742,7 +784,18 @@ class SqliteWorkingMemory implements IWorkingMemory {
 
   private expireRuntimeKeysMatchingCurrentGuards(): void {
     for (const key of Array.from(this.store.keys())) {
-      this.expireRuntimeKeyIfGuarded(key);
+      this.expireRuntimeKeyIfUnavailable(key);
+    }
+  }
+
+  private deleteExpiredPersistedKeys(keys: readonly string[]): void {
+    if (keys.length === 0) return;
+    const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
+    for (const key of keys) {
+      deleteKey.run(key);
+      this.persistedSerialized.delete(key);
+      this.deletedKeys.delete(key);
+      this.dirtyKeys.delete(key);
     }
   }
 
@@ -818,13 +871,20 @@ class SqliteWorkingMemory implements IWorkingMemory {
 
   snapshotIncludingPersistedEntries(options: { expireRuntimeGuardedEntries?: boolean } = {}): Array<{ key: string; value: unknown; source: 'persisted' | 'runtime' }> {
     const result: Array<{ key: string; value: unknown; source: 'persisted' | 'runtime' }> = [];
+    const expiredPersistedKeys: string[] = [];
     for (const { key, value: serialized } of this.loadPersistedSerializedFromDb()) {
+      const value = parseStoredWorkingMemoryValue(serialized);
+      if (isExpiredWorkingMemoryValue(value)) {
+        expiredPersistedKeys.push(key);
+        continue;
+      }
       result.push({
         key,
-        value: parseStoredWorkingMemoryValue(serialized),
+        value,
         source: 'persisted',
       });
     }
+    this.deleteExpiredPersistedKeys(expiredPersistedKeys);
     for (const [key, value] of Object.entries(this.snapshotEntries({ expireGuardedEntries: options.expireRuntimeGuardedEntries ?? true }))) {
       result.push({
         key,
@@ -916,7 +976,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   has(key: string): boolean {
-    if (this.expireRuntimeKeyIfGuarded(key)) return false;
+    if (this.expireRuntimeKeyIfUnavailable(key)) return false;
     return this.store.has(key);
   }
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -383,18 +383,17 @@ function stringifyWorkingMemoryValue(key: string, value: unknown): string {
   );
 }
 
-function readWorkingMemoryExpiresAt(value: unknown): string | undefined {
+function isTemporaryOperationalWorkingMemoryValue(value: unknown): value is { expiresAt: string } {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
+    return false;
   }
-  const expiresAt = (value as { expiresAt?: unknown }).expiresAt;
-  return typeof expiresAt === 'string' ? expiresAt : undefined;
+  const record = value as { category?: unknown; expiresAt?: unknown };
+  return record.category === 'temporary-operational' && typeof record.expiresAt === 'string';
 }
 
 function isExpiredWorkingMemoryValue(value: unknown, nowMs = Date.now()): boolean {
-  const expiresAt = readWorkingMemoryExpiresAt(value);
-  if (!expiresAt) return false;
-  const expiresAtMs = Date.parse(expiresAt);
+  if (!isTemporaryOperationalWorkingMemoryValue(value)) return false;
+  const expiresAtMs = Date.parse(value.expiresAt);
   return Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
 }
 
@@ -439,19 +438,14 @@ class SqliteWorkingMemory implements IWorkingMemory {
   /** Hydrate in-memory state from persisted SQLite working_memory rows. */
   private loadFromDb(): void {
     const rows = this.loadPersistedSerializedFromDb();
-    if (rows.length > this.limits.maxEntries) {
-      throw new WorkingMemoryLimitError(
-        `Persisted working memory has ${rows.length} entries, exceeding maxEntries (${this.limits.maxEntries})`,
-      );
-    }
 
     const prepared: Array<[string, unknown, string, number]> = [];
-    const expiredKeys: string[] = [];
+    const expiredRows: Array<{ key: string; serialized: string }> = [];
     let total = 0;
     for (const row of rows) {
       const parsed = parseStoredWorkingMemoryValue(row.value);
       if (isExpiredWorkingMemoryValue(parsed)) {
-        expiredKeys.push(row.key);
+        expiredRows.push({ key: row.key, serialized: row.value });
         continue;
       }
       const { normalized, serialized, size } = this.prepareEntry(
@@ -461,7 +455,12 @@ class SqliteWorkingMemory implements IWorkingMemory {
       total += size;
       prepared.push([row.key, normalized, serialized, size]);
     }
-    this.deleteExpiredPersistedKeys(expiredKeys);
+    this.deleteExpiredPersistedRows(expiredRows);
+    if (prepared.length > this.limits.maxEntries) {
+      throw new WorkingMemoryLimitError(
+        `Persisted working memory has ${prepared.length} entries after TTL cleanup, exceeding maxEntries (${this.limits.maxEntries})`,
+      );
+    }
     if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
       throw new WorkingMemoryLimitError(
         `Persisted working memory is ${total} bytes, exceeding maxTotalBytes (${this.limits.maxTotalBytes})`,
@@ -672,7 +671,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     let total = 0;
     for (const [key, value] of this.store) {
       if (isExpiredWorkingMemoryValue(value)) {
-        this.deleteExpiredPersistedKeys([key]);
+        this.deleteExpiredPersistedRows([{ key, serialized: this.serialized.get(key) }]);
         continue;
       }
       const { normalized, serialized, size } = this.prepareEntry(key, value);
@@ -737,13 +736,14 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private expireRuntimeKeyIfTtlExpired(key: string): boolean {
     const value = this.store.get(key);
     if (!isExpiredWorkingMemoryValue(value)) return false;
+    const serialized = this.serialized.get(key);
     this.totalBytes -= this.sizes.get(key) ?? 0;
     this.store.delete(key);
     this.sizes.delete(key);
     this.serialized.delete(key);
     this.dirtyKeys.delete(key);
     this.deletedKeys.delete(key);
-    this.deleteExpiredPersistedKeys([key]);
+    this.deleteExpiredPersistedRows([{ key, serialized }]);
     return true;
   }
 
@@ -788,10 +788,28 @@ class SqliteWorkingMemory implements IWorkingMemory {
     }
   }
 
-  private deleteExpiredPersistedKeys(keys: readonly string[]): void {
-    if (keys.length === 0) return;
+  private deleteExpiredPersistedRows(rows: ReadonlyArray<{ key: string; serialized: string | undefined }>): void {
+    if (rows.length === 0) return;
+    const selectValue = this.db.prepare(`SELECT value FROM working_memory WHERE key = ?`);
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
-    for (const key of keys) {
+    for (const { key, serialized } of rows) {
+      const row = selectValue.get(key) as { value: string } | undefined;
+      if (row === undefined) {
+        this.persistedSerialized.delete(key);
+        this.deletedKeys.delete(key);
+        this.dirtyKeys.delete(key);
+        continue;
+      }
+      const currentSerialized = this.encryption?.decrypt(row.value) ?? row.value;
+      if (serialized !== undefined && currentSerialized !== serialized) {
+        this.persistedSerialized.set(key, currentSerialized);
+        continue;
+      }
+      const parsed = parseStoredWorkingMemoryValue(currentSerialized);
+      if (!isExpiredWorkingMemoryValue(parsed)) {
+        this.persistedSerialized.set(key, currentSerialized);
+        continue;
+      }
       deleteKey.run(key);
       this.persistedSerialized.delete(key);
       this.deletedKeys.delete(key);
@@ -869,13 +887,15 @@ class SqliteWorkingMemory implements IWorkingMemory {
     return this.store.delete(key);
   }
 
-  snapshotIncludingPersistedEntries(options: { expireRuntimeGuardedEntries?: boolean } = {}): Array<{ key: string; value: unknown; source: 'persisted' | 'runtime' }> {
+  snapshotIncludingPersistedEntries(options: { expireRuntimeGuardedEntries?: boolean; expirePersistedTtlEntries?: boolean } = {}): Array<{ key: string; value: unknown; source: 'persisted' | 'runtime' }> {
     const result: Array<{ key: string; value: unknown; source: 'persisted' | 'runtime' }> = [];
-    const expiredPersistedKeys: string[] = [];
+    const expiredPersistedRows: Array<{ key: string; serialized: string }> = [];
     for (const { key, value: serialized } of this.loadPersistedSerializedFromDb()) {
       const value = parseStoredWorkingMemoryValue(serialized);
       if (isExpiredWorkingMemoryValue(value)) {
-        expiredPersistedKeys.push(key);
+        if (options.expirePersistedTtlEntries ?? true) {
+          expiredPersistedRows.push({ key, serialized });
+        }
         continue;
       }
       result.push({
@@ -884,7 +904,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         source: 'persisted',
       });
     }
-    this.deleteExpiredPersistedKeys(expiredPersistedKeys);
+    this.deleteExpiredPersistedRows(expiredPersistedRows);
     for (const [key, value] of Object.entries(this.snapshotEntries({ expireGuardedEntries: options.expireRuntimeGuardedEntries ?? true }))) {
       result.push({
         key,
@@ -2425,7 +2445,7 @@ export class SqliteBrain implements IBrain {
     if (dryRun) {
       const workingMatches = memoryType === 'episodic'
         ? []
-        : this.matchingWorkingKeys(normalizedSelector, { expireRuntimeGuards: false });
+        : this.matchingWorkingKeys(normalizedSelector, { expireRuntimeGuards: false, expirePersistedTtlEntries: false });
       deletedWorkingKeys = new Set(workingMatches.map(match => match.key));
       const reviewMatches = memoryType === 'episodic'
         ? []
@@ -2538,12 +2558,15 @@ export class SqliteBrain implements IBrain {
         episodic: episodicMatchCount,
         derived: episodicMatchCount + checkpointMatchCount + reviewMatchCount,
       },
-      remainingReferences: this.countRemainingReferences(normalizedSelector, { expireRuntimeGuards: false }),
+      remainingReferences: this.countRemainingReferences(normalizedSelector, { expireRuntimeGuards: false, expirePersistedTtlEntries: false }),
     };
   }
 
-  private matchingWorkingKeys(selector: NormalizedRightToForgetSelector, options: { expireRuntimeGuards?: boolean } = {}): Array<{ key: string; source: 'persisted' | 'runtime' }> {
-    return this.working.snapshotIncludingPersistedEntries({ expireRuntimeGuardedEntries: options.expireRuntimeGuards ?? true })
+  private matchingWorkingKeys(selector: NormalizedRightToForgetSelector, options: { expireRuntimeGuards?: boolean; expirePersistedTtlEntries?: boolean } = {}): Array<{ key: string; source: 'persisted' | 'runtime' }> {
+    return this.working.snapshotIncludingPersistedEntries({
+      expireRuntimeGuardedEntries: options.expireRuntimeGuards ?? true,
+      expirePersistedTtlEntries: options.expirePersistedTtlEntries ?? true,
+    })
       .filter(({ key, value }) => workingEntryMatchesSelector(key, value, selector))
       .map(({ key, source }) => ({ key, source }));
   }
@@ -2680,12 +2703,15 @@ export class SqliteBrain implements IBrain {
     return `${NEVER_STORE_REDACTED_VALUE}:${suffix}`;
   }
 
-  private countRemainingReferences(selector: NormalizedRightToForgetSelector, options: { expireRuntimeGuards?: boolean } = {}): number {
+  private countRemainingReferences(selector: NormalizedRightToForgetSelector, options: { expireRuntimeGuards?: boolean; expirePersistedTtlEntries?: boolean } = {}): number {
     const memoryType = selector.type ?? 'all';
     let count = 0;
     if (memoryType !== 'episodic') {
       count += new Set([
-        ...this.matchingWorkingKeys(selector, { expireRuntimeGuards: options.expireRuntimeGuards ?? true }).map(match => match.key),
+        ...this.matchingWorkingKeys(selector, {
+          expireRuntimeGuards: options.expireRuntimeGuards ?? true,
+          expirePersistedTtlEntries: options.expirePersistedTtlEntries ?? true,
+        }).map(match => match.key),
         ...SqliteBrain.matchingLiveWorkingKeys(this.dbPath, selector, { expireRuntimeGuards: options.expireRuntimeGuards ?? true }),
       ]).size;
     }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -383,12 +383,29 @@ function stringifyWorkingMemoryValue(key: string, value: unknown): string {
   );
 }
 
+function workingMemoryStringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isTemporaryOperationalMarker(value: unknown): boolean {
+  const normalized = workingMemoryStringField(value)?.trim().toLowerCase();
+  return normalized === 'temporary-operational' || normalized === 'transient-operational';
+}
+
 function isTemporaryOperationalWorkingMemoryValue(value: unknown): value is { expiresAt: string } {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     return false;
   }
-  const record = value as { category?: unknown; expiresAt?: unknown };
-  return record.category === 'temporary-operational' && typeof record.expiresAt === 'string';
+  const record = value as { category?: unknown; kind?: unknown; type?: unknown; scope?: unknown; expiresAt?: unknown };
+  return (
+    typeof record.expiresAt === 'string'
+    && (
+      isTemporaryOperationalMarker(record.category)
+      || isTemporaryOperationalMarker(record.kind)
+      || isTemporaryOperationalMarker(record.type)
+      || isTemporaryOperationalMarker(record.scope)
+    )
+  );
 }
 
 function isExpiredWorkingMemoryValue(value: unknown, nowMs = Date.now()): boolean {
@@ -823,7 +840,16 @@ class SqliteWorkingMemory implements IWorkingMemory {
       deleteKey.run(key);
       this.persistedSerialized.delete(key);
       this.deletedKeys.delete(key);
-      this.dirtyKeys.delete(key);
+      const currentRuntimeSerialized = this.serialized.get(key);
+      if (currentRuntimeSerialized === undefined || currentRuntimeSerialized === currentSerialized) {
+        this.dirtyKeys.delete(key);
+      }
+    }
+  }
+
+  private expireRuntimeTtlKeys(): void {
+    for (const key of Array.from(this.store.keys())) {
+      this.expireRuntimeKeyIfTtlExpired(key);
     }
   }
 
@@ -852,6 +878,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   set(key: string, value: unknown): void {
     const { normalized, serialized, size } = this.prepareEntry(key, value);
     assertNotDeletionGuarded(this.db, key, serialized, this.encryption);
+    this.expireRuntimeTtlKeys();
 
     if (!this.store.has(key) && this.store.size >= this.limits.maxEntries) {
       throw new WorkingMemoryLimitError(

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -671,7 +671,17 @@ class SqliteWorkingMemory implements IWorkingMemory {
     let total = 0;
     for (const [key, value] of this.store) {
       if (isExpiredWorkingMemoryValue(value)) {
-        this.deleteExpiredPersistedRows([{ key, serialized: this.serialized.get(key) }]);
+        const runtimeSerialized = this.serialized.get(key);
+        const persistedSerialized = this.persistedSerialized.get(key);
+        this.deleteExpiredPersistedRows([{ key, serialized: runtimeSerialized }]);
+        if (persistedSerialized !== undefined && persistedSerialized !== runtimeSerialized) {
+          const persistedValue = parseStoredWorkingMemoryValue(persistedSerialized);
+          if (!isExpiredWorkingMemoryValue(persistedValue)) {
+            const preparedPersisted = this.prepareEntry(key, persistedValue);
+            total += preparedPersisted.size;
+            prepared.push([key, preparedPersisted.normalized, preparedPersisted.serialized, preparedPersisted.size]);
+          }
+        }
         continue;
       }
       const { normalized, serialized, size } = this.prepareEntry(key, value);
@@ -895,8 +905,8 @@ class SqliteWorkingMemory implements IWorkingMemory {
       if (isExpiredWorkingMemoryValue(value)) {
         if (options.expirePersistedTtlEntries ?? true) {
           expiredPersistedRows.push({ key, serialized });
+          continue;
         }
-        continue;
       }
       result.push({
         key,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -602,6 +602,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   persistKeyAfterCommit(key: string, value: unknown): (() => void) | void {
     const { normalized, serialized, size } = this.prepareEntry(key, value);
     assertNotDeletionGuarded(this.db, key, serialized, this.encryption);
+    this.expireRuntimeTtlKeys();
 
     if (!this.store.has(key) && this.store.size >= this.limits.maxEntries) {
       throw new WorkingMemoryLimitError(
@@ -771,6 +772,18 @@ class SqliteWorkingMemory implements IWorkingMemory {
     this.dirtyKeys.delete(key);
     this.deletedKeys.delete(key);
     this.deleteExpiredPersistedRows([{ key, serialized }]);
+    const persisted = this.persistedSerialized.get(key);
+    if (persisted !== undefined && persisted !== serialized) {
+      const parsed = parseStoredWorkingMemoryValue(persisted);
+      if (!isExpiredWorkingMemoryValue(parsed)) {
+        const { normalized, serialized: restoredSerialized, size } = this.prepareEntry(key, parsed);
+        this.store.set(key, normalized);
+        this.sizes.set(key, size);
+        this.serialized.set(key, restoredSerialized);
+        this.totalBytes += size;
+        return false;
+      }
+    }
     return true;
   }
 
@@ -2506,7 +2519,7 @@ export class SqliteBrain implements IBrain {
       const tx = this.db.transaction(() => {
         const workingMatches = memoryType === 'episodic'
           ? []
-          : this.matchingWorkingKeys(normalizedSelector, { expireRuntimeGuards: true });
+          : this.matchingWorkingKeys(normalizedSelector, { expireRuntimeGuards: true, expirePersistedTtlEntries: false });
         const persistedWorkingMatches = new Set(workingMatches.filter(match => match.source === 'persisted').map(match => match.key));
         runtimeWorkingKeysToDelete = new Set(workingMatches.filter(match => match.source === 'runtime').map(match => match.key));
         deletedWorkingKeys = new Set(workingMatches.map(match => match.key));

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -389,7 +389,13 @@ function workingMemoryStringField(value: unknown): string | undefined {
 
 function isTemporaryOperationalMarker(value: unknown): boolean {
   const normalized = workingMemoryStringField(value)?.trim().toLowerCase();
-  return normalized === 'temporary-operational' || normalized === 'transient-operational';
+  return (
+    normalized === 'temporary-operational'
+    || normalized === 'operational-temporary'
+    || normalized === 'temp-operational'
+    || normalized === 'operational-temp'
+    || normalized === 'transient-operational'
+  );
 }
 
 function isTemporaryOperationalWorkingMemoryValue(value: unknown): value is { expiresAt: string } {
@@ -472,7 +478,20 @@ class SqliteWorkingMemory implements IWorkingMemory {
       total += size;
       prepared.push([row.key, normalized, serialized, size]);
     }
-    this.deleteExpiredPersistedRows(expiredRows);
+    const preservedRows = this.deleteExpiredPersistedRows(expiredRows);
+    const preparedKeys = new Set(prepared.map(([key]) => key));
+    for (const row of preservedRows) {
+      if (preparedKeys.has(row.key)) continue;
+      const parsed = parseStoredWorkingMemoryValue(row.serialized);
+      if (isExpiredWorkingMemoryValue(parsed)) continue;
+      const { normalized, serialized, size } = this.prepareEntry(
+        row.key,
+        parsed,
+      );
+      total += size;
+      prepared.push([row.key, normalized, serialized, size]);
+      preparedKeys.add(row.key);
+    }
     if (prepared.length > this.limits.maxEntries) {
       throw new WorkingMemoryLimitError(
         `Persisted working memory has ${prepared.length} entries after TTL cleanup, exceeding maxEntries (${this.limits.maxEntries})`,
@@ -828,8 +847,11 @@ class SqliteWorkingMemory implements IWorkingMemory {
     }
   }
 
-  private deleteExpiredPersistedRows(rows: ReadonlyArray<{ key: string; serialized: string | undefined }>): void {
-    if (rows.length === 0) return;
+  private deleteExpiredPersistedRows(
+    rows: ReadonlyArray<{ key: string; serialized: string | undefined }>,
+  ): Array<{ key: string; serialized: string }> {
+    const preservedRows: Array<{ key: string; serialized: string }> = [];
+    if (rows.length === 0) return preservedRows;
     const selectValue = this.db.prepare(`SELECT value FROM working_memory WHERE key = ?`);
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
     for (const { key, serialized } of rows) {
@@ -843,11 +865,13 @@ class SqliteWorkingMemory implements IWorkingMemory {
       const currentSerialized = this.encryption?.decrypt(row.value) ?? row.value;
       if (serialized !== undefined && currentSerialized !== serialized) {
         this.persistedSerialized.set(key, currentSerialized);
+        preservedRows.push({ key, serialized: currentSerialized });
         continue;
       }
       const parsed = parseStoredWorkingMemoryValue(currentSerialized);
       if (!isExpiredWorkingMemoryValue(parsed)) {
         this.persistedSerialized.set(key, currentSerialized);
+        preservedRows.push({ key, serialized: currentSerialized });
         continue;
       }
       deleteKey.run(key);
@@ -858,6 +882,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         this.dirtyKeys.delete(key);
       }
     }
+    return preservedRows;
   }
 
   private expireRuntimeTtlKeys(): void {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -123,21 +123,46 @@ describe('SqliteBrain', () => {
     });
 
     it('does not expire durable working facts that only describe an expiresAt field', () => {
-      brain.working.set('cert:deadline', {
-        value: 'certificate rotation deadline',
-        category: 'asset-metadata',
+      brain.working.set('certificate', {
+        value: 'renews next year',
+        category: 'asset',
         expiresAt: '2026-01-01T00:00:00.000Z',
       });
 
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
       try {
-        expect(brain.working.get('cert:deadline')).toEqual({
-          value: 'certificate rotation deadline',
-          category: 'asset-metadata',
+        expect(brain.working.get('certificate')).toEqual({
+          value: 'renews next year',
+          category: 'asset',
           expiresAt: '2026-01-01T00:00:00.000Z',
         });
-        expect(brain.working.keys()).toEqual(['cert:deadline']);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('expires temporary operational alias markers consistently', () => {
+      brain.working.set('kind:temp', {
+        value: 'short-lived kind',
+        kind: 'transient-operational',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.working.set('type:temp', {
+        value: 'short-lived type',
+        type: 'temporary-operational',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.working.set('scope:temp', {
+        value: 'short-lived scope',
+        scope: 'transient-operational',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+      try {
+        expect(brain.working.keys()).toEqual([]);
       } finally {
         vi.useRealTimers();
       }
@@ -196,7 +221,7 @@ describe('SqliteBrain', () => {
         });
       }
       originalBrain.working.set('op:active', {
-        value: 'current job output',
+        value: 'fresh',
         category: 'temporary-operational',
         expiresAt: '2099-01-01T00:10:00.000Z',
       });
@@ -212,6 +237,25 @@ describe('SqliteBrain', () => {
         hydratedBrain.close();
         vi.useRealTimers();
         rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('expires runtime temporary facts before enforcing new-entry limits', () => {
+      const limitedBrain = new SqliteBrain(':memory:', { maxEntries: 1 });
+      limitedBrain.working.set('op:expired', {
+        value: 'stale runtime entry',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      try {
+        expect(() => limitedBrain.working.set('op:new', 'fresh runtime entry')).not.toThrow();
+        expect(limitedBrain.working.keys()).toEqual(['op:new']);
+      } finally {
+        limitedBrain.close();
+        vi.useRealTimers();
       }
     });
 
@@ -279,6 +323,37 @@ describe('SqliteBrain', () => {
       } finally {
         staleBrain.close();
         vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps dirty replacements flushable after pruning expired persisted rows', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-dirty-'));
+      const dbPath = join(dir, 'brain.db');
+      const brain = new SqliteBrain(dbPath);
+      brain.working.set('op:key', {
+        value: 'old temporary persisted value',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      brain.flush();
+      brain.working.set('op:key', { value: 'new durable replacement', category: 'lesson' });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      try {
+        brain.rightToForget({ category: 'unrelated' });
+        brain.flush();
+      } finally {
+        brain.close();
+        vi.useRealTimers();
+      }
+
+      const rehydrated = new SqliteBrain(dbPath);
+      try {
+        expect(rehydrated.working.get('op:key')).toEqual({ value: 'new durable replacement', category: 'lesson' });
+      } finally {
+        rehydrated.close();
         rmSync(dir, { recursive: true, force: true });
       }
     });

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -294,6 +294,39 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('counts expired persisted facts deleted by right-to-forget', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-delete-count-'));
+      const dbPath = join(dir, 'brain.db');
+      const originalBrain = new SqliteBrain(dbPath);
+      originalBrain.working.set('op:expired', {
+        value: 'stale job output',
+        category: 'temporary-operational',
+        sourceScope: 'delete-count-test',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      originalBrain.flush();
+      originalBrain.close();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      const deleteBrain = new SqliteBrain(dbPath, undefined, { hydrateWorkingMemoryFromDb: false });
+      try {
+        const report = deleteBrain.rightToForget({ sourceScope: 'delete-count-test' });
+        expect(report.deleted.working).toBe(1);
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          const rows = db.prepare('SELECT key FROM working_memory ORDER BY key').all() as Array<{ key: string }>;
+          expect(rows).toEqual([]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        deleteBrain.close();
+        vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('does not let stale runtime TTL cleanup delete a newer persisted value for the same key', () => {
       const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-race-'));
       const dbPath = join(dir, 'brain.db');
@@ -313,7 +346,9 @@ describe('SqliteBrain', () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
       try {
-        expect(staleBrain.working.has('op:key')).toBe(false);
+        expect(staleBrain.working.has('op:key')).toBe(true);
+        expect(staleBrain.working.get('op:key')).toEqual({ value: 'new durable fact', category: 'lesson' });
+        staleBrain.flush();
         const verifier = new SqliteBrain(dbPath);
         try {
           expect(verifier.working.get('op:key')).toEqual({ value: 'new durable fact', category: 'lesson' });
@@ -1619,6 +1654,33 @@ describe('SqliteBrain', () => {
         reviewer: 'operator',
         note: 'Verified in repository settings.',
       });
+    });
+
+    it('prunes expired temporary facts before approved working-memory writes enforce limits', () => {
+      const limitedBrain = new SqliteBrain(':memory:', { maxEntries: 1 });
+      limitedBrain.working.set('op:expired', {
+        value: 'stale runtime entry',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      const candidate = limitedBrain.memoryReview.propose({
+        targetStore: 'working',
+        key: 'env.repo.default-branch',
+        value: 'main',
+        source: 'repo-config',
+        confidence: 0.8,
+        reason: 'Observed from GitHub repository metadata.',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      try {
+        expect(() => limitedBrain.memoryReview.approve(candidate.id, { reviewer: 'operator' })).not.toThrow();
+        expect(limitedBrain.working.keys()).toEqual(['env.repo.default-branch']);
+      } finally {
+        limitedBrain.close();
+        vi.useRealTimers();
+      }
     });
 
     it('edits a candidate before approval and writes the edited memory', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -158,6 +158,16 @@ describe('SqliteBrain', () => {
         scope: 'transient-operational',
         expiresAt: '2026-01-01T00:00:00.000Z',
       });
+      brain.working.set('category:operational-temp', {
+        value: 'short-lived category',
+        category: 'operational-temporary',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.working.set('kind:temp-alias', {
+        value: 'short-lived temp alias',
+        kind: 'temp-operational',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
 
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -122,6 +122,27 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('does not expire durable working facts that only describe an expiresAt field', () => {
+      brain.working.set('cert:deadline', {
+        value: 'certificate rotation deadline',
+        category: 'asset-metadata',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+      try {
+        expect(brain.working.get('cert:deadline')).toEqual({
+          value: 'certificate rotation deadline',
+          category: 'asset-metadata',
+          expiresAt: '2026-01-01T00:00:00.000Z',
+        });
+        expect(brain.working.keys()).toEqual(['cert:deadline']);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('purges expired persisted working facts during hydration', () => {
       const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-'));
       const dbPath = join(dir, 'brain.db');
@@ -158,6 +179,107 @@ describe('SqliteBrain', () => {
         }
       } finally {
         hydratedBrain.close();
+        vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('prunes expired persisted facts before enforcing persisted entry limits', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      const originalBrain = new SqliteBrain(dbPath, {
+        workingMemoryLimits: { maxEntries: 5 },
+      });
+      for (let index = 0; index < 4; index += 1) {
+        originalBrain.working.set(`op:expired:${index}`, {
+          value: `stale ${index}`,
+          category: 'temporary-operational',
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        });
+      }
+      originalBrain.working.set('op:active', {
+        value: 'current job output',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:10:00.000Z',
+      });
+      originalBrain.flush();
+      originalBrain.close();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      const hydratedBrain = new SqliteBrain(dbPath, {
+        workingMemoryLimits: { maxEntries: 3 },
+      });
+      try {
+        expect(hydratedBrain.working.keys()).toEqual(['op:active']);
+      } finally {
+        hydratedBrain.close();
+        vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps right-to-forget dry runs read-only for expired persisted facts', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-dryrun-'));
+      const dbPath = join(dir, 'brain.db');
+      const originalBrain = new SqliteBrain(dbPath);
+      originalBrain.working.set('op:expired', {
+        value: 'stale job output',
+        category: 'temporary-operational',
+        sourceScope: 'dry-run-test',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      originalBrain.flush();
+      originalBrain.close();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      const dryRunBrain = new SqliteBrain(dbPath, undefined, { hydrateWorkingMemoryFromDb: false });
+      try {
+        const report = dryRunBrain.rightToForget({ sourceScope: 'dry-run-test', dryRun: true });
+        expect(report.dryRun).toBe(true);
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          const rows = db.prepare('SELECT key FROM working_memory ORDER BY key').all() as Array<{ key: string }>;
+          expect(rows.map(row => row.key)).toEqual(['op:expired']);
+        } finally {
+          db.close();
+        }
+      } finally {
+        dryRunBrain.close();
+        vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not let stale runtime TTL cleanup delete a newer persisted value for the same key', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-race-'));
+      const dbPath = join(dir, 'brain.db');
+      const staleBrain = new SqliteBrain(dbPath);
+      staleBrain.working.set('op:key', {
+        value: 'old temporary overlay',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      staleBrain.flush();
+
+      const freshBrain = new SqliteBrain(dbPath);
+      freshBrain.working.set('op:key', { value: 'new durable fact', category: 'lesson' });
+      freshBrain.flush();
+      freshBrain.close();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      try {
+        expect(staleBrain.working.has('op:key')).toBe(false);
+        const verifier = new SqliteBrain(dbPath);
+        try {
+          expect(verifier.working.get('op:key')).toEqual({ value: 'new durable fact', category: 'lesson' });
+        } finally {
+          verifier.close();
+        }
+      } finally {
+        staleBrain.close();
         vi.useRealTimers();
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { BrainSnapshotSchema } from '@franken/types';
 import type {
   EpisodicEvent,
@@ -71,6 +71,96 @@ describe('SqliteBrain', () => {
       expect(brain.working.has('x')).toBe(true);
       expect(brain.working.has('y')).toBe(false);
       expect(brain.working.keys()).toEqual(['x']);
+    });
+
+    it('expires temporary operational working facts after their expiresAt timestamp', () => {
+      brain.working.set('session:temp', {
+        value: 'temporary process id',
+        category: 'temporary-operational',
+        sourceScope: 'runtime',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.working.set('lesson:durable', {
+        value: 'durable lesson',
+        category: 'lesson',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+      try {
+        expect(brain.working.get('session:temp')).toBeUndefined();
+        expect(brain.working.has('session:temp')).toBe(false);
+        expect(brain.working.keys()).toEqual(['lesson:durable']);
+        expect(brain.working.snapshot()).toEqual({
+          'lesson:durable': { value: 'durable lesson', category: 'lesson' },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not expire durable episodic memories when working facts expire', () => {
+      brain.working.set('handoff:temp', {
+        value: 'temporary handoff',
+        category: 'temporary-operational',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.episodic.record({
+        type: 'learning',
+        summary: 'Durable lesson survives working TTL cleanup',
+        details: { category: 'lesson' },
+        createdAt: '2025-12-31T23:59:00.000Z',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'));
+      try {
+        expect(brain.working.has('handoff:temp')).toBe(false);
+        expect(brain.episodic.recall('Durable lesson', 5)).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('purges expired persisted working facts during hydration', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-'));
+      const dbPath = join(dir, 'brain.db');
+      const originalBrain = new SqliteBrain(dbPath);
+      originalBrain.working.set('op:expired', {
+        value: 'stale job output',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      originalBrain.working.set('op:active', {
+        value: 'current job output',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:10:00.000Z',
+      });
+      originalBrain.flush();
+      originalBrain.close();
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      const hydratedBrain = new SqliteBrain(dbPath);
+      try {
+        expect(hydratedBrain.working.has('op:expired')).toBe(false);
+        expect(hydratedBrain.working.get('op:active')).toEqual({
+          value: 'current job output',
+          category: 'temporary-operational',
+          expiresAt: '2099-01-01T00:10:00.000Z',
+        });
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          const rows = db.prepare('SELECT key FROM working_memory ORDER BY key').all() as Array<{ key: string }>;
+          expect(rows.map(row => row.key)).toEqual(['op:active']);
+        } finally {
+          db.close();
+        }
+      } finally {
+        hydratedBrain.close();
+        vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('delete() removes a key and returns true', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -187,9 +187,7 @@ describe('SqliteBrain', () => {
     it('prunes expired persisted facts before enforcing persisted entry limits', () => {
       const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-limit-'));
       const dbPath = join(dir, 'brain.db');
-      const originalBrain = new SqliteBrain(dbPath, {
-        workingMemoryLimits: { maxEntries: 5 },
-      });
+      const originalBrain = new SqliteBrain(dbPath, { maxEntries: 5 });
       for (let index = 0; index < 4; index += 1) {
         originalBrain.working.set(`op:expired:${index}`, {
           value: `stale ${index}`,
@@ -207,9 +205,7 @@ describe('SqliteBrain', () => {
 
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
-      const hydratedBrain = new SqliteBrain(dbPath, {
-        workingMemoryLimits: { maxEntries: 3 },
-      });
+      const hydratedBrain = new SqliteBrain(dbPath, { maxEntries: 3 });
       try {
         expect(hydratedBrain.working.keys()).toEqual(['op:active']);
       } finally {
@@ -238,6 +234,8 @@ describe('SqliteBrain', () => {
       try {
         const report = dryRunBrain.rightToForget({ sourceScope: 'dry-run-test', dryRun: true });
         expect(report.dryRun).toBe(true);
+        expect(report.deleted.working).toBe(1);
+        expect(report.remainingReferences).toBeGreaterThanOrEqual(1);
         const db = new Database(dbPath, { readonly: true });
         try {
           const rows = db.prepare('SELECT key FROM working_memory ORDER BY key').all() as Array<{ key: string }>;
@@ -281,6 +279,46 @@ describe('SqliteBrain', () => {
       } finally {
         staleBrain.close();
         vi.useRealTimers();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('restores durable persisted values when unflushed temporary overlays expire during flush', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'franken-memory-ttl-overlay-'));
+      const dbPath = join(dir, 'brain.db');
+      const brain = new SqliteBrain(dbPath);
+      brain.working.set('shared:key', { value: 'durable asset', category: 'asset', expiresAt: '2099-01-01T00:00:00.000Z' });
+      brain.flush();
+
+      brain.working.set('shared:key', {
+        value: 'temporary overlay',
+        category: 'temporary-operational',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2099-01-01T00:00:01.000Z'));
+      try {
+        brain.flush();
+        expect(brain.working.get('shared:key')).toEqual({
+          value: 'durable asset',
+          category: 'asset',
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        });
+      } finally {
+        brain.close();
+        vi.useRealTimers();
+      }
+
+      const rehydrated = new SqliteBrain(dbPath);
+      try {
+        expect(rehydrated.working.get('shared:key')).toEqual({
+          value: 'durable asset',
+          category: 'asset',
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        });
+      } finally {
+        rehydrated.close();
         rmSync(dir, { recursive: true, force: true });
       }
     });

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -231,6 +231,7 @@ describe("createBrainAdapter", () => {
     mockBrain.working.snapshot.mockReturnValue({
       asset: { value: "certificate metadata", category: "asset", expiresAt: "2099-01-01T00:00:00.000Z" },
       tmp: { value: "runtime status", category: "temporary-operational", expiresAt: "2099-01-01T00:00:00.000Z" },
+      tmpAlias: { value: "aliased runtime status", category: "operational-temporary", expiresAt: "2099-01-01T00:00:00.000Z" },
     });
 
     const result = await brain.query({ query: "", type: "working", limit: 5 });
@@ -238,6 +239,7 @@ describe("createBrainAdapter", () => {
     expect(result).toEqual([
       { key: "asset", value: JSON.stringify({ value: "certificate metadata", category: "asset", expiresAt: "2099-01-01T00:00:00.000Z" }), type: "working" },
       { key: "tmp", value: "runtime status (expires 2099-01-01T00:00:00.000Z)", type: "working" },
+      { key: "tmpAlias", value: "aliased runtime status (expires 2099-01-01T00:00:00.000Z)", type: "working" },
     ]);
   });
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -213,6 +213,18 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.flush).not.toHaveBeenCalled();
   });
 
+  it("rejects ttlMs for episodic memory because episodic records are durable", async () => {
+    const brain = createBrainAdapter("/tmp/beast.db");
+    const mockBrain = brainInstances[0];
+
+    await expect(
+      brain.store({ key: "evt-ttl", value: "should stay durable", type: "episodic", ttlMs: 60_000 }),
+    ).rejects.toThrow("ttlMs is only supported for working memory");
+
+    expect(mockBrain.episodic.record).not.toHaveBeenCalled();
+    expect(mockBrain.working.set).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe query limits before reading memory", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
     const mockBrain = brainInstances[0];

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -179,6 +179,40 @@ describe("createBrainAdapter", () => {
     expect(episodicResult.some((row) => row.type === "episodic")).toBe(true);
   });
 
+  it("stores temporary operational working facts with expiresAt metadata when ttlMs is provided", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      const brain = createBrainAdapter("/tmp/beast.db");
+      await brain.store({ key: "run:tmp", value: "short-lived status", type: "working", ttlMs: 60_000 });
+
+      const mockBrain = brainInstances[0];
+      expect(mockBrain.working.set).toHaveBeenCalledWith("run:tmp", {
+        value: "short-lived status",
+        category: "temporary-operational",
+        sourceScope: "mcp-memory-store",
+        expiresAt: "2026-01-01T00:01:00.000Z",
+      });
+      expect(mockBrain.flush).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects unsafe working-memory TTLs before writing memory", async () => {
+    const brain = createBrainAdapter("/tmp/beast.db");
+    const mockBrain = brainInstances[0];
+
+    for (const invalidTtlMs of [NaN, Infinity, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      await expect(
+        brain.store({ key: "run:tmp", value: "status", type: "working", ttlMs: invalidTtlMs as number }),
+      ).rejects.toThrow("ttlMs must be a positive integer");
+    }
+
+    expect(mockBrain.working.set).not.toHaveBeenCalled();
+    expect(mockBrain.flush).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe query limits before reading memory", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
     const mockBrain = brainInstances[0];

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -225,6 +225,22 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.working.set).not.toHaveBeenCalled();
   });
 
+  it("does not label durable working values with expiresAt fields as TTL-expiring", async () => {
+    const brain = createBrainAdapter("/tmp/beast.db");
+    const mockBrain = brainInstances[0];
+    mockBrain.working.snapshot.mockReturnValue({
+      asset: { value: "certificate metadata", category: "asset", expiresAt: "2099-01-01T00:00:00.000Z" },
+      tmp: { value: "runtime status", category: "temporary-operational", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const result = await brain.query({ query: "", type: "working", limit: 5 });
+
+    expect(result).toEqual([
+      { key: "asset", value: JSON.stringify({ value: "certificate metadata", category: "asset", expiresAt: "2099-01-01T00:00:00.000Z" }), type: "working" },
+      { key: "tmp", value: "runtime status (expires 2099-01-01T00:00:00.000Z)", type: "working" },
+    ]);
+  });
+
   it("rejects unsafe query limits before reading memory", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
     const mockBrain = brainInstances[0];

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -54,6 +54,7 @@ export interface BrainAdapter {
     value: string;
     type: string;
     agentId?: string;
+    ttlMs?: number;
   }): Promise<void>;
   frontload(input?: MemoryScopeInput): Promise<BrainFrontloadSection[]>;
   forget(key: string, input?: AgentScopedInput): Promise<boolean>;
@@ -67,8 +68,24 @@ const DEFAULT_QUERY_LIMIT = 20;
 const MAX_QUERY_LIMIT = 1000;
 const AGENT_WORKING_KEY_PREFIX = "__fbeast_agent_memory__/";
 const AGENT_MEMORY_SCOPE_MARKER = "fbeast:agent-memory";
+const MAX_OPERATIONAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
 type SupportedMemoryType = (typeof SUPPORTED_MEMORY_TYPES)[number];
+
+function resolveOperationalTtlMs(ttlMs: number | undefined): number | undefined {
+  if (ttlMs === undefined) return undefined;
+  if (
+    !Number.isFinite(ttlMs) ||
+    !Number.isSafeInteger(ttlMs) ||
+    ttlMs < 1 ||
+    ttlMs > MAX_OPERATIONAL_TTL_MS
+  ) {
+    throw new Error(
+      `ttlMs must be a positive integer no greater than ${MAX_OPERATIONAL_TTL_MS}`,
+    );
+  }
+  return ttlMs;
+}
 
 function resolveAgentId(agentId: string | undefined): string | undefined {
   if (agentId === undefined) return undefined;
@@ -89,6 +106,9 @@ interface AgentScopedWorkingValue {
   __fbeastMemoryScope: typeof AGENT_MEMORY_SCOPE_MARKER;
   agentId: string;
   value: string;
+  expiresAt?: string;
+  category?: string;
+  sourceScope?: string;
 }
 
 function isAgentScopedWorkingValue(
@@ -114,21 +134,57 @@ function scopedWorkingKey(key: string, agentId: string | undefined): string {
 function scopedWorkingValue(
   value: string,
   agentId: string | undefined,
-): string | AgentScopedWorkingValue {
+  ttlMs: number | undefined,
+): string | AgentScopedWorkingValue | { value: string; category: string; sourceScope: string; expiresAt: string } {
+  const expiresAt =
+    ttlMs === undefined ? undefined : new Date(Date.now() + ttlMs).toISOString();
   const resolvedAgentId = resolveAgentId(agentId);
-  return resolvedAgentId
+
+  if (resolvedAgentId) {
+    return {
+      __fbeastMemoryScope: AGENT_MEMORY_SCOPE_MARKER,
+      agentId: resolvedAgentId,
+      value,
+      ...(expiresAt
+        ? { category: "temporary-operational", sourceScope: "mcp-memory-store", expiresAt }
+        : {}),
+    };
+  }
+
+  return expiresAt
     ? {
-        __fbeastMemoryScope: AGENT_MEMORY_SCOPE_MARKER,
-        agentId: resolvedAgentId,
         value,
+        category: "temporary-operational",
+        sourceScope: "mcp-memory-store",
+        expiresAt,
       }
     : value;
+}
+
+function unwrapWorkingMemoryValue(value: unknown): { text: string; expiresAt?: string } {
+  if (isAgentScopedWorkingValue(value)) {
+    return {
+      text: value.value,
+      ...(typeof value.expiresAt === "string" ? { expiresAt: value.expiresAt } : {}),
+    };
+  }
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as { value?: unknown; expiresAt?: unknown };
+    if ("value" in record && typeof record.expiresAt === "string") {
+      return {
+        text: typeof record.value === "string" ? record.value : JSON.stringify(record.value),
+        expiresAt: record.expiresAt,
+      };
+    }
+  }
+  return { text: typeof value === "string" ? value : JSON.stringify(value) };
 }
 
 function parseScopedWorkingEntry(
   key: string,
   value: unknown,
-): { key: string; value: string; agentId?: string } {
+): { key: string; value: string; agentId?: string; expiresAt?: string } {
+  const unwrapped = unwrapWorkingMemoryValue(value);
   if (
     key.startsWith(AGENT_WORKING_KEY_PREFIX) &&
     isAgentScopedWorkingValue(value)
@@ -139,8 +195,9 @@ function parseScopedWorkingEntry(
       try {
         return {
           key: decodeScopeComponent(rest.slice(slash + 1)),
-          value: value.value,
+          value: unwrapped.text,
           agentId: value.agentId,
+          ...(unwrapped.expiresAt ? { expiresAt: unwrapped.expiresAt } : {}),
         };
       } catch {
         // Fall through to treating malformed reserved keys as ordinary shared keys.
@@ -149,8 +206,13 @@ function parseScopedWorkingEntry(
   }
   return {
     key,
-    value: typeof value === "string" ? value : JSON.stringify(value),
+    value: unwrapped.text,
+    ...(unwrapped.expiresAt ? { expiresAt: unwrapped.expiresAt } : {}),
   };
+}
+
+function formatWorkingEntryValue(entry: { value: string; expiresAt?: string }): string {
+  return entry.expiresAt ? `${entry.value} (expires ${entry.expiresAt})` : entry.value;
 }
 
 function parseAgentFromEpisodicDetails(
@@ -300,14 +362,15 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
         const query = input.query.toLowerCase();
         for (const [key, value] of Object.entries(snapshot)) {
           const entry = parseScopedWorkingEntry(key, value);
+          const formattedValue = formatWorkingEntryValue(entry);
           if (!canReadMemoryEntry(entry.agentId, readScope)) continue;
           if (
             entry.key.toLowerCase().includes(query) ||
-            entry.value.toLowerCase().includes(query)
+            formattedValue.toLowerCase().includes(query)
           ) {
             results.push({
               key: entry.key,
-              value: entry.value,
+              value: formattedValue,
               type: "working",
             });
           }
@@ -331,9 +394,10 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
         return;
       }
 
+      const ttlMs = resolveOperationalTtlMs(input.ttlMs);
       brain.working.set(
         scopedWorkingKey(input.key, input.agentId),
-        scopedWorkingValue(input.value, input.agentId),
+        scopedWorkingValue(input.value, input.agentId, ttlMs),
       );
       brain.flush();
     },
@@ -347,7 +411,7 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
       const workingEntries = Object.entries(snapshot)
         .map(([k, v]) => parseScopedWorkingEntry(k, v))
         .filter((entry) => canReadMemoryEntry(entry.agentId, readScope))
-        .map((entry) => `${entry.key}: ${entry.value}`);
+        .map((entry) => `${entry.key}: ${formatWorkingEntryValue(entry)}`);
       if (workingEntries.length > 0) {
         sections.push({ type: "working", entries: workingEntries });
       }

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -382,6 +382,9 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
 
     async store(input) {
       const memoryType = resolveMemoryType(input.type);
+      if (input.ttlMs !== undefined && memoryType !== 'working') {
+        throw new Error('ttlMs is only supported for working memory entries');
+      }
 
       if (memoryType === "episodic") {
         const details = scopedEpisodicDetails(input.agentId);

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -72,6 +72,17 @@ const MAX_OPERATIONAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
 type SupportedMemoryType = (typeof SUPPORTED_MEMORY_TYPES)[number];
 
+function isTemporaryOperationalValue(record: Record<string, unknown>): boolean {
+  const markers = [record.category, record.kind, record.type, record.scope];
+  return markers.some(
+    (marker) =>
+      typeof marker === "string" &&
+      /^(temporary[-_\s]?operational|operational[-_\s]?temporary|transient[-_\s]?operational)$/i.test(
+        marker.trim(),
+      ),
+  );
+}
+
 function resolveOperationalTtlMs(ttlMs: number | undefined): number | undefined {
   if (ttlMs === undefined) return undefined;
   if (
@@ -163,14 +174,15 @@ function scopedWorkingValue(
 
 function unwrapWorkingMemoryValue(value: unknown): { text: string; expiresAt?: string } {
   if (isAgentScopedWorkingValue(value)) {
+    const record = value as unknown as Record<string, unknown>;
     return {
       text: value.value,
-      ...(typeof value.expiresAt === "string" ? { expiresAt: value.expiresAt } : {}),
+      ...(typeof value.expiresAt === "string" && isTemporaryOperationalValue(record) ? { expiresAt: value.expiresAt } : {}),
     };
   }
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-    const record = value as { value?: unknown; expiresAt?: unknown };
-    if ("value" in record && typeof record.expiresAt === "string") {
+    const record = value as Record<string, unknown> & { value?: unknown; expiresAt?: unknown };
+    if ('value' in record && typeof record.expiresAt === 'string' && isTemporaryOperationalValue(record)) {
       return {
         text: typeof record.value === "string" ? record.value : JSON.stringify(record.value),
         expiresAt: record.expiresAt,

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -77,7 +77,7 @@ function isTemporaryOperationalValue(record: Record<string, unknown>): boolean {
   return markers.some(
     (marker) =>
       typeof marker === "string" &&
-      /^(temporary[-_\s]?operational|operational[-_\s]?temporary|transient[-_\s]?operational)$/i.test(
+      /^(temporary[-_\s]?operational|operational[-_\s]?temporary|temp[-_\s]?operational|operational[-_\s]?temp|transient[-_\s]?operational)$/i.test(
         marker.trim(),
       ),
   );

--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -26,7 +26,7 @@ describe("Memory Server", () => {
       (t) => t.name === "fbeast_memory_store",
     )!;
     expect(storeTool.description).toBe(
-      "Store key/value in working or episodic memory",
+      "Store memory; optional TTL for temporary working facts",
     );
   });
 

--- a/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
@@ -44,6 +44,23 @@ describe('TOOL_REGISTRY', () => {
     expect(stubNames.size).toBe(EXPECTED_COUNT);
   });
 
+  it('rejects episodic TTL stores before invoking the registry adapter handler', async () => {
+    const brain = {
+      query: vi.fn(),
+      store: vi.fn(),
+      frontload: vi.fn(),
+      forget: vi.fn(),
+      rightToForget: vi.fn(),
+    };
+    const handler = TOOL_REGISTRY.get('fbeast_memory_store')!.makeHandler({ brain } as unknown as AdapterSet);
+
+    const result = await handler({ key: 'evt', value: 'durable event', type: 'episodic', ttlMs: '60000' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('ttlMs is only supported for working memory');
+    expect(brain.store).not.toHaveBeenCalled();
+  });
+
   it('rejects invalid observer log arguments before invoking the registry adapter handler', async () => {
     const observer = {
       log: vi.fn().mockResolvedValue({ id: 42, hash: 'abc123' }),

--- a/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
@@ -54,7 +54,7 @@ describe('TOOL_REGISTRY', () => {
     };
     const handler = TOOL_REGISTRY.get('fbeast_memory_store')!.makeHandler({ brain } as unknown as AdapterSet);
 
-    const result = await handler({ key: 'evt', value: 'durable event', type: 'episodic', ttlMs: '60000' });
+    const result = await handler({ key: 'evt', value: 'durable event', type: 'episodic', ttlMs: 60000 });
 
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain('ttlMs is only supported for working memory');

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -134,6 +134,9 @@ const TOOLS: ToolFull[] = [
       if (ttlMs !== undefined && (!Number.isFinite(ttlMs) || !Number.isSafeInteger(ttlMs) || ttlMs < 1)) {
         return { content: [{ type: 'text', text: 'Error: fbeast_memory_store ttlMs must be a positive integer number of milliseconds' }], isError: true };
       }
+      if (ttlMs !== undefined && type !== 'working') {
+        return { content: [{ type: 'text', text: 'Error: fbeast_memory_store ttlMs is only supported for working memory entries' }], isError: true };
+      }
       await brain.store({
         key,
         value,

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -110,7 +110,7 @@ const TOOLS: ToolFull[] = [
   {
     name: 'fbeast_memory_store',
     server: 'memory',
-    description: 'Store key/value in working or episodic memory',
+    description: 'Store memory; optional TTL for temporary working facts',
     inputSchema: {
       type: 'object',
       properties: {
@@ -118,6 +118,7 @@ const TOOLS: ToolFull[] = [
         value: { type: 'string', description: 'Content to store' },
         type: { type: 'string', description: 'Memory type: working or episodic', enum: ['working', 'episodic'] },
         agentId: { type: 'string', description: 'Optional agent id; when provided, the stored entry is namespaced for that agent and visible through readScope=agent for the same agent' },
+        ttlMs: { type: 'integer', description: 'Optional positive millisecond TTL for temporary operational working-memory facts' },
       },
       required: ['key', 'value', 'type'],
     },
@@ -129,8 +130,18 @@ const TOOLS: ToolFull[] = [
       if (!agentId.ok) {
         return { content: [{ type: 'text', text: `Error: fbeast_memory_store ${agentId.message}` }], isError: true };
       }
-      await brain.store(agentId.value ? { key, value, type, agentId: agentId.value } : { key, value, type });
-      return { content: [{ type: 'text', text: `Stored memory: ${key}` }] };
+      const ttlMs = args['ttlMs'] === undefined ? undefined : Number(args['ttlMs']);
+      if (ttlMs !== undefined && (!Number.isFinite(ttlMs) || !Number.isSafeInteger(ttlMs) || ttlMs < 1)) {
+        return { content: [{ type: 'text', text: 'Error: fbeast_memory_store ttlMs must be a positive integer number of milliseconds' }], isError: true };
+      }
+      await brain.store({
+        key,
+        value,
+        type,
+        ...(agentId.value ? { agentId: agentId.value } : {}),
+        ...(ttlMs === undefined ? {} : { ttlMs }),
+      });
+      return { content: [{ type: 'text', text: ttlMs === undefined ? `Stored memory: ${key}` : `Stored temporary memory: ${key} (ttlMs=${ttlMs})` }] };
     },
   },
   {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -10,6 +10,10 @@
 - If an installer snapshots a root realpath at construction, handle missing-root recovery explicitly: revalidate the missing root's parent before `mkdir`, reject symlinked/repointed parents, then recheck the recreated root before creating child directories.
 - When Codex reaches the configured review-invocation cap with new findings, fix/reply/resolve and stop for explicit approval before triggering another review; do not merge on stale clean signals after the head changed.
 
+## 2026-07-15 — Memory TTL policy
+- For temporary operational facts, keep TTL metadata on working-memory values (`expiresAt`) and enforce expiration on all read/list/hydration paths; also filter expired runtime rows before flush so stale operational state cannot be re-persisted.
+- When verifying workspace package typechecks in a fresh worktree, build dependency packages (or run root `npm run build`) before package-local `tsc --noEmit`; otherwise unresolved workspace package declarations can look like feature regressions.
+
 ## 2026-07-15 — Beast process cleanup review fixes
 - For Beast cleanup paths, treat persisted process-group ownership as verified only when the stored start-time token matches the current `/proc` start time; missing or unreadable start times should fail closed to direct-PID signaling to avoid killing a PID-reused process group.
 - Keep cleanup ownership delegated through execution-mode wrappers: container executors must forward `cleanupPendingRun()` so queued container runs can be cancelled before an attempt exists.


### PR DESCRIPTION
## Summary
- Adds `expiresAt`-based TTL cleanup for temporary operational working-memory facts in `@franken/brain`.
- Exposes optional `ttlMs` on the MCP memory store path and documents the operator-facing behavior.
- Adds regression tests for expired working facts, durable episodic retention, persisted hydration cleanup, MCP adapter TTL storage, and unsafe TTL rejection.

Closes #1848

## Verification
- `npm --prefix packages/franken-brain test -- tests/unit/sqlite-brain.test.ts`
- `npm --prefix packages/franken-mcp-suite test -- src/adapters/brain-adapter.test.ts src/shared/tool-registry.test.ts`
- `npm run build`
- `npm test --workspace @franken/brain`
- `npm test --workspace @franken/mcp-suite`
- `npm run typecheck --workspace @franken/brain && npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/brain && npm run lint --workspace @franken/mcp-suite` (passes with existing warnings in mcp-suite tests/config/tool-registry)
- `git diff --check`
