### PR TITLE
fix(orchestrator): validate cached llm entries on read

### DIFF
--- a/packages/franken-orchestrator/src/cache/llm-cache-store.ts
+++ b/packages/franken-orchestrator/src/cache/llm-cache-store.ts
@@ -62,12 +62,31 @@ export class LlmCacheStore {
   private async read(filePath: string): Promise<StoredCacheEntry | undefined> {
     try {
       const raw = await readFile(filePath, 'utf8');
-      return JSON.parse(raw) as StoredCacheEntry;
+      const stored = JSON.parse(raw) as unknown;
+
+      if (!this.isValidStoredCacheEntry(stored)) {
+        return undefined;
+      }
+
+      return stored;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) {
+      if ((error as { code?: string }).code === 'ENOENT' || error instanceof SyntaxError) {
         return undefined;
       }
       throw error;
     }
+  }
+
+  private isValidStoredCacheEntry(value: unknown): value is StoredCacheEntry {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const entry = value as Partial<StoredCacheEntry>;
+    return (
+      typeof entry.schemaVersion === 'number' &&
+      entry.schemaVersion === this.options.schemaVersion &&
+      typeof entry.content === 'string'
+    );
   }
 }

--- a/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LlmCacheStore } from '../../../src/cache/llm-cache-store.js';
+import { encodeCachePathSegment } from '../../../src/cache/llm-cache-types.js';
 
 describe('LlmCacheStore', () => {
   let workDir: string | undefined;
@@ -37,6 +38,59 @@ describe('LlmCacheStore', () => {
         provider: 'claude',
       },
     });
+  });
+
+  it('invalidates cache entries when schema version changes', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-llm-cache-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+
+    const store = new LlmCacheStore(rootDir, { schemaVersion: 1 });
+    await store.saveProjectEntry('frankenbeast', 'stable:skills', {
+      content: 'stable prompt',
+      fingerprint: 'fp-project-stable',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      metadata: {
+        kind: 'project',
+        provider: 'claude',
+      },
+    });
+
+    const reloaded = new LlmCacheStore(rootDir, { schemaVersion: 2 });
+    await expect(reloaded.loadProjectEntry('frankenbeast', 'stable:skills')).resolves.toBeUndefined();
+  });
+
+  it('invalidates cache entries when stored shape is invalid', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-llm-cache-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const store = new LlmCacheStore(rootDir, { schemaVersion: 1 });
+    const path = join(
+      rootDir,
+      'project',
+      encodeCachePathSegment('frankenbeast'),
+      'stable',
+      `${encodeCachePathSegment('project:broken')}.json`,
+    );
+
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          content: null,
+          fingerprint: 'fp-broken',
+          createdAt: '2026-03-13T00:00:00.000Z',
+          metadata: {
+            kind: 'project',
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    await expect(store.loadProjectEntry('frankenbeast', 'project:broken')).resolves.toBeUndefined();
   });
 
   it('isolates work entries by work id', async () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -249,3 +249,8 @@
 - 2026-07-15 — Webhook egress allowlists: match exact public HTTPS targets, reject credentials/query/fragment/path traversal, mirror private-host aliases from the orchestrator egress policy, resolve DNS before every network attempt including retries, and add regression tests for DNS rebinding-style private answers.
 - 2026-07-15 — MCP memory scoping: avoid encoding agent scope solely in user-visible keys or summaries. Store explicit scope metadata, use reversible internal key encoding for physical storage, keep logical keys in query/frontload output, and fetch/filter uncapped episodic rows before applying visible result limits so other agents' rows cannot starve the requested scope.
 - 2026-07-15 — DR backup review hardening: encrypted state backups should back up only the requested state tree plus explicit sibling DBs, never keys/cache/old artifacts; reject live SQLite sidecars (`-wal`, `-shm`, `-journal`), validate dry-run restore targets, and quarantine approval ledgers rather than reactivating stale approvals.
+
+## 2026-07-16 — LlmCacheStore read-path schema validation
+- For JSON cache stores, validate both schemaVersion and the runtime shape (`content` type) before returning entries, otherwise stale/malformed files can be reused as cache hits.
+- Add regression tests that write an explicitly mismatched schema version and a wrong-shaped payload to prove stale cache entries are rejected.
+- Keep Codex review follow-ups separate from CI: CI green + no fresh Codex findings is not sufficient when Codex usage-limited responses occur; treat limits as blocked merge gates and retry only after credits reset.


### PR DESCRIPTION
## Bug Description
- `LlmCacheStore` writes a `schemaVersion` with cached entries but reads the JSON payload without validating that it matches the current schema or that `content` is the expected string type.
- This means stale or malformed cache files could be treated as valid, causing runtime parse errors to surface only after cache reads.

## Root Cause
- `llm-cache-store.ts` used a direct `JSON.parse` cast to `StoredCacheEntry` and returned the object without checking the payload shape.
- The `schemaVersion` write path had no corresponding guard on read.

## Fix
- Added runtime validation in `LlmCacheStore.loadProjectEntry` and `loadSessionEntry`:
  - invalid JSON returns `undefined`.
  - wrong type shapes (missing `content`, non-string `content`, missing/invalid `schemaVersion`) return `undefined`.
  - mismatched `schemaVersion` returns `undefined`.
- Added regression tests in `llm-cache-store.test.ts` for:
  - schema version mismatch returning `undefined`.
  - malformed cache payloads returning `undefined`.
- Added a shared-lesson note to `tasks/resolve-issues-shared-lessons.md` for cache schema validation.

## Validation
- Ran targeted tests: `npm run test --workspace @franken/orchestrator -- tests/unit/cache/llm-cache-store.test.ts`
- Ran `npm run typecheck --workspace @franken/orchestrator` (fails in the worktree due shared workspace dependency environment; request re-check in CI/after dependency build).

Closes #2312
