### PR TITLE
fix: preserve Codex hooks backup on invalid JSON

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -22,6 +22,10 @@ function jsonBackups(dir: string): string[] {
   return readdirSync(dir).filter((name) => name.startsWith('settings.json.invalid-'));
 }
 
+function hooksBackups(dir: string): string[] {
+  return readdirSync(dir).filter((name) => name.startsWith('hooks.json.invalid-'));
+}
+
 describe('fbeast init', () => {
   const dirs: string[] = [];
 
@@ -400,6 +404,28 @@ describe('fbeast init', () => {
     expect(content).not.toContain('You have access to fbeast MCP tools');
     expect(content).toContain('<!-- fbeast-start -->');
     expect(content).toContain('<!-- fbeast-end -->');
+  });
+
+  it('backs up invalid Codex hooks.json and initializes with Codex hooks entries', () => {
+    const root = tmpDir();
+    dirs.push(root);
+    const codexDir = join(root, '.codex');
+    const hooksPath = join(codexDir, 'hooks.json');
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(hooksPath, '{ invalid json');
+
+    const mockSpawn = () => ({ status: 0 });
+
+    runInit({ root, claudeDir: codexDir, hooks: true, client: 'codex', spawn: mockSpawn });
+
+    const hooks = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    expect(Array.isArray(hooks.hooks.PreToolUse)).toBe(true);
+    expect(Array.isArray(hooks.hooks.PostToolUse)).toBe(true);
+    expect(hooks.hooks.PreToolUse[0].hooks[0].command).toContain('fbeast-codex-pre-tool.sh');
+
+    const backups = hooksBackups(codexDir);
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(codexDir, backups[0]!), 'utf-8')).toBe('{ invalid json');
   });
 
   it('merges fbeast section into existing AGENTS.md without clobbering it', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -381,10 +381,9 @@ function writeCodexHooks(root: string, scripts: { preTool: string; postTool: str
   mkdirSync(codexDir, { recursive: true });
   const hooksPath = join(codexDir, 'hooks.json');
 
-  let existing: Record<string, unknown> = {};
-  if (existsSync(hooksPath)) {
-    try { existing = JSON.parse(readFileSync(hooksPath, 'utf-8')); } catch { /* ignore */ }
-  }
+  const existing: Record<string, unknown> = existsSync(hooksPath)
+    ? readJsonObjectFileOrRecover(hooksPath, readFileSync(hooksPath, 'utf-8'))
+    : {};
 
   const existingHooks = isObjectRecord(existing['hooks']) ? existing['hooks'] : {};
 
@@ -408,7 +407,7 @@ function writeCodexHooks(root: string, scripts: { preTool: string; postTool: str
     ],
   };
 
-  writeFileSync(hooksPath, JSON.stringify(existing, null, 2) + '\n');
+  writeJsonFileAtomic(hooksPath, existing);
 }
 
 const AGENTS_MD_START = '<!-- fbeast-start -->';

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -78,6 +78,10 @@
 ## 2026-07-13 — Operator session-token review hardening
 - Approval-session tokens must be scoped to the policy actually approved: skill triggers can use selected tool scope, but budget/custom/non-skill approvals should stay task-scoped even when a tool is selected so same-tool actions in other tasks do not bypass prompts.
 - Never reuse an approval-session token for fail-closed trigger-evaluation errors; even a valid same-scope token must fall back to a fresh operator prompt when evaluator context/logic throws.
+
+## 2026-07-16 — Codex usage-limit handling in init Codex hooks fixes
+- When Codex responds with usage-limit comments after `@codex review`, treat it as a hard stop for that review round and do not keep triggering repeated reviews.
+- For `writeCodexHooks` recovery work, prefer recover+backup flows on malformed existing JSON so user hooks are not silently dropped, and add tests that explicitly assert backup creation and hook-preserving write paths.
 - When a gateway returns an issued approval token, the planner/CoT path needs an explicit state handoff into later rationales; otherwise adapter-level token issuance is documented but not usable by normal planner executions.
 - Multi-policy approval prompts must surface every fired policy reason, not just a preferred non-skill trigger, so operators see destructive/HITL skill risk alongside budget or other policy risk.
 - If a CoT rationale can carry reusable approval tokens, keep candidate token IDs per prior approval rather than a single overwrite slot; the governor can validate candidates against the current scope and ignore non-matching tokens.


### PR DESCRIPTION
## Summary
- Update Codex hook initialization to use recoverable JSON parsing when .codex/hooks.json is malformed.
- Persist hooks atomically using writeJsonFileAtomic for safer writes.
- Add coverage for invalid hooks file recovery and ensure a backup file is produced.

## Test Plan
- npm install (package dependencies)
- npm test src/cli/init.test.ts

Closes #2315