### PR TITLE
docs(onboarding): add architecture reading path

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -101,6 +101,20 @@ Use this checklist for a first local checkout or when rebuilding a development e
   frankenbeast --help
   ```
 
+## Architecture reading path
+
+Use this path when you are new to Frankenbeast or when an agent handoff says "read the architecture docs first." It is intentionally ordered from current implementation to deeper historical context.
+
+1. **Current implementation before history** — start with [`docs/RAMP_UP.md`](docs/RAMP_UP.md) for the shortest current package map, Beast Loop summary, CLI/runtime wiring notes, known limitations, and build/test commands.
+2. **Repository-level model** — read [`README.md#architecture`](README.md#architecture) for the public Beast Loop diagram and current 10-package workspace framing.
+3. **Detailed architecture** — read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), especially the System Overview, package table, Beast Loop, Current Local CLI Path, orchestrator internals, and dashboard/control-plane sections. Use the package inventory tables as authoritative when diagrams still use MOD labels.
+4. **Runtime handoff flow** — read [`docs/DATA_FLOW.md`](docs/DATA_FLOW.md) to connect user input, planning, execution, observer/cost records, and closure artifacts.
+5. **Port and package boundaries** — read [`docs/CONTRACT_MATRIX.md`](docs/CONTRACT_MATRIX.md) before changing cross-package interfaces or assuming a module owns a capability.
+6. **Consolidation rationale** — read [ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md) to understand why formerly separate MOD packages were consolidated into the orchestrator or MCP suite.
+7. **Topic-specific ADRs/guides** — only after the current path above, branch into relevant ADRs under `docs/adr/` or operational guides under `docs/guides/`.
+
+Edge case: many older diagrams and `docs/plans/` files describe target or historical architecture. Do not start with `docs/plans/` when onboarding, and do not treat a plan diagram as live behavior until you verify it against the current package inventory in `docs/RAMP_UP.md` and `docs/ARCHITECTURE.md`.
+
 ## Run UI
 
 ### Dashboard chat against the local backend

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Frankenbeast is a safety framework that enforces guardrails *outside* the LLM's 
 
 ## 🚀 One-click onboarding
 
-Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBOARDING.md) for prerequisites, environment setup, and first-run validation, then run the repository bootstrap script:
+Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBOARDING.md) for prerequisites, environment setup, and first-run validation. If you are trying to understand the system before changing it, follow the [Architecture reading path](ONBOARDING.md#architecture-reading-path) so you read current implementation docs before historical plans. Then run the repository bootstrap script:
 
 ```bash
 npm run bootstrap -- --no-docker

--- a/tests/docs-issue-1776.test.ts
+++ b/tests/docs-issue-1776.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  expect(startIndex, `${start} section is missing`).toBeGreaterThanOrEqual(0);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex, `${end} section is missing after ${start}`).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}
+
+describe('issue #1776 newcomer architecture reading path', () => {
+  it('adds a dedicated ordered architecture reading path to onboarding', () => {
+    const onboarding = readText('ONBOARDING.md');
+    const section = sectionBetween(onboarding, '## Architecture reading path', '## Run UI');
+
+    const orderedSteps = [
+      '[`docs/RAMP_UP.md`](docs/RAMP_UP.md)',
+      '[`README.md#architecture`](README.md#architecture)',
+      '[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)',
+      '[`docs/DATA_FLOW.md`](docs/DATA_FLOW.md)',
+      '[`docs/CONTRACT_MATRIX.md`](docs/CONTRACT_MATRIX.md)',
+      '[ADR-031](docs/adr/031-architecture-consolidation-provider-agnostic.md)',
+    ];
+
+    let previousIndex = -1;
+    for (const step of orderedSteps) {
+      const index = section.indexOf(step);
+      expect(index, `${step} is missing from architecture reading path`).toBeGreaterThan(previousIndex);
+      previousIndex = index;
+    }
+
+    expect(section).toContain('Current implementation before history');
+    expect(section).toContain('Use the package inventory tables as authoritative');
+  });
+
+  it('documents the edge case for target-state diagrams and historical plans', () => {
+    const section = sectionBetween(readText('ONBOARDING.md'), '## Architecture reading path', '## Run UI');
+
+    expect(section).toContain('Do not start with `docs/plans/`');
+    expect(section).toContain('target or historical architecture');
+    expect(section).toContain('verify it against the current package inventory');
+  });
+
+  it('links the newcomer path from the README onboarding entrypoint', () => {
+    const readme = readText('README.md');
+
+    expect(readme).toContain('[Architecture reading path](ONBOARDING.md#architecture-reading-path)');
+    expect(readme).toContain('current implementation docs before historical plans');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a dedicated newcomer architecture reading path to `ONBOARDING.md`.
- Links the path from the README onboarding entrypoint.
- Adds a root docs regression covering ordered current-doc reading and the historical/target-plan edge case.

## Verification
- `npm run test:root -- tests/docs-issue-1776.test.ts` (3 passed)
- `npm run typecheck` (17/17 Turbo tasks successful)
- `npm run lint` (10/10 Turbo tasks successful; existing warnings only)
- `npm run build` (10/10 Turbo tasks successful)
- `git diff --check`

Closes #1776
