### PR TITLE
feat(onboarding): add bootstrap progress status badges

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -53,6 +53,18 @@ Use this checklist for a first local checkout or when rebuilding a development e
   ./scripts/bootstrap.sh --dry-run
   ```
 
+### Progress badges and status output
+
+The bootstrap script prints deterministic status badges as it advances through onboarding:
+
+```text
+[onboarding:1/6:prerequisites] start - checking Node.js, npm, and Corepack
+[onboarding:1/6:prerequisites] ok - Node.js v22.13.0 satisfies the repository engine range
+[onboarding:6/6:done] complete - onboarding bootstrap reached 6/6 steps
+```
+
+Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. Automation can key on the stable `onboarding` prefix, fraction, stage, and state values (`start`, `ok`, `error`, `complete`) while humans can follow the detail text. If a prerequisite or option validation fails, the script emits an `error` badge before the normal `[bootstrap] ERROR` line so PM/liveness tooling can identify the failed stage without parsing prose.
+
 - [ ] Review `.env` and fill in only the values you need:
 
   ```bash

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -63,7 +63,7 @@ The bootstrap script prints deterministic status badges as it advances through o
 [onboarding:6/6:done] complete - onboarding bootstrap reached 6/6 steps
 ```
 
-Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. Automation can key on the stable `onboarding` prefix, fraction, stage, and state values (`start`, `ok`, `error`, `complete`) while humans can follow the detail text. If a prerequisite or option validation fails, the script emits an `error` badge before the normal `[bootstrap] ERROR` line so PM/liveness tooling can identify the failed stage without parsing prose.
+Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. Automation can key on the stable `onboarding` prefix, fraction, stage, and state values (`start`, `ok`, `error`, `complete`) while humans can follow the detail text. If option parsing fails before the first stage, the stage is `args`; otherwise `error` badges keep the active stage name so PM/liveness tooling can identify the failed stage without parsing prose.
 
 - [ ] Review `.env` and fill in only the values you need:
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,6 +5,8 @@ DRY_RUN=0
 START_DOCKER=0
 PROMPT_DOCKER=1
 ASSUME_YES=0
+ONBOARDING_TOTAL_STEPS=6
+ONBOARDING_STEP=0
 
 usage() {
   cat <<'USAGE'
@@ -30,7 +32,25 @@ USAGE
 }
 
 log() { printf '[bootstrap] %s\n' "$*"; }
-fail() { printf '[bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
+status() {
+  local state="$1"
+  local label="$2"
+  shift 2
+  printf '[onboarding:%s/%s:%s] %s' "$ONBOARDING_STEP" "$ONBOARDING_TOTAL_STEPS" "$label" "$state"
+  if [[ "$#" -gt 0 ]]; then
+    printf ' - %s' "$*"
+  fi
+  printf '\n'
+}
+step() {
+  ONBOARDING_STEP=$((ONBOARDING_STEP + 1))
+  status start "$1" "$2"
+}
+fail() {
+  status error failed "$*" >&2
+  printf '[bootstrap] ERROR: %s\n' "$*" >&2
+  exit 1
+}
 run() {
   if [[ "$DRY_RUN" -eq 1 ]]; then
     log "dry-run: $*"
@@ -53,6 +73,7 @@ done
 
 cd "$(dirname "$0")/.."
 
+step prerequisites "checking Node.js, npm, and Corepack"
 command -v node >/dev/null 2>&1 || fail "Node.js is required. Install Node.js >=22.13.0 <23 or >=24.0.0 <26."
 command -v npm >/dev/null 2>&1 || fail "npm is required. Enable Corepack and activate the repository packageManager pin."
 command -v corepack >/dev/null 2>&1 || fail "Corepack is required. Install it with: npm install -g corepack"
@@ -66,8 +87,9 @@ if (!ok) {
   process.exit(1);
 }
 NODE
-log "Node.js $(node --version) satisfies the repository engine range."
+status ok prerequisites "Node.js $(node --version) satisfies the repository engine range"
 
+step package-manager "activating pinned npm version"
 expected_pm="$(node -p "require('./package.json').packageManager")"
 expected_npm="${expected_pm#npm@}"
 actual_npm="$(npm --version)"
@@ -85,7 +107,9 @@ if [[ "$actual_npm" != "$expected_npm" ]]; then
 else
   log "npm $actual_npm matches packageManager $expected_pm."
 fi
+status ok package-manager "npm $actual_npm matches $expected_pm"
 
+step env-file "creating or validating local environment defaults"
 [[ -f .env.example ]] || fail ".env.example is missing; cannot bootstrap local environment."
 if [[ ! -f .env ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -124,7 +148,9 @@ if [[ -n "$default_keys" && -f .env ]]; then
     log ".env includes documented defaults."
   fi
 fi
+status ok env-file "local environment defaults are present or planned"
 
+step docker "evaluating optional Docker services"
 if [[ "$PROMPT_DOCKER" -eq 1 && "$ASSUME_YES" -eq 0 && "$DRY_RUN" -eq 0 && -t 0 ]]; then
   read -r -p "Start optional Docker compose services now? [y/N] " docker_answer
   case "$docker_answer" in
@@ -151,13 +177,26 @@ if [[ "$START_DOCKER" -eq 1 ]]; then
     command -v docker >/dev/null 2>&1 || fail "Docker is required for --services/--with-docker. Install Docker or rerun with --no-docker."
   fi
 fi
+if [[ "$START_DOCKER" -eq 1 ]]; then
+  status ok docker "optional services enabled"
+else
+  status ok docker "optional services skipped"
+fi
 
+step dependencies "installing workspace dependencies"
 run npm ci
+status ok dependencies "npm dependencies installed or dry-run planned"
 
+step services "starting requested optional services"
 if [[ "$START_DOCKER" -eq 1 ]]; then
   run docker compose up -d
 else
   log "Skipping optional Docker compose services. Use --services or --with-docker to start them."
+fi
+if [[ "$START_DOCKER" -eq 1 ]]; then
+  status ok services "optional services started or dry-run planned"
+else
+  status ok services "optional services intentionally skipped"
 fi
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -165,3 +204,4 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
 else
   log "Bootstrap completed successfully."
 fi
+status complete done "onboarding bootstrap reached $ONBOARDING_TOTAL_STEPS/$ONBOARDING_TOTAL_STEPS steps"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -105,8 +105,8 @@ if [[ "$actual_npm" != "$expected_npm" ]]; then
     package_manager_status="npm $actual_npm would be changed to $expected_pm by Corepack"
   else
     log "Activating repository package manager pin $expected_pm with Corepack."
-    corepack prepare "$expected_pm" --activate
-    corepack enable npm
+    run corepack prepare "$expected_pm" --activate
+    run corepack enable npm
     actual_npm="$(npm --version)"
     [[ "$actual_npm" == "$expected_npm" ]] || fail "npm $actual_npm does not match packageManager $expected_pm after Corepack activation."
     package_manager_status="npm $actual_npm matches $expected_pm"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,6 +7,7 @@ PROMPT_DOCKER=1
 ASSUME_YES=0
 ONBOARDING_TOTAL_STEPS=6
 ONBOARDING_STEP=0
+ONBOARDING_STAGE=args
 
 usage() {
   cat <<'USAGE'
@@ -44,10 +45,11 @@ status() {
 }
 step() {
   ONBOARDING_STEP=$((ONBOARDING_STEP + 1))
+  ONBOARDING_STAGE="$1"
   status start "$1" "$2"
 }
 fail() {
-  status error failed "$*" >&2
+  status error "$ONBOARDING_STAGE" "$*" >&2
   printf '[bootstrap] ERROR: %s\n' "$*" >&2
   exit 1
 }
@@ -55,7 +57,7 @@ run() {
   if [[ "$DRY_RUN" -eq 1 ]]; then
     log "dry-run: $*"
   else
-    "$@"
+    "$@" || fail "Command failed: $*"
   fi
 }
 
@@ -78,7 +80,7 @@ command -v node >/dev/null 2>&1 || fail "Node.js is required. Install Node.js >=
 command -v npm >/dev/null 2>&1 || fail "npm is required. Enable Corepack and activate the repository packageManager pin."
 command -v corepack >/dev/null 2>&1 || fail "Corepack is required. Install it with: npm install -g corepack"
 
-node <<'NODE'
+if ! node <<'NODE'
 const version = process.versions.node.split('.').map(Number);
 const [major, minor, patch] = version;
 const ok = (major === 22 && (minor > 13 || (minor === 13 && patch >= 0))) || (major >= 24 && major < 26);
@@ -87,27 +89,33 @@ if (!ok) {
   process.exit(1);
 }
 NODE
+then
+  fail "Node.js is outside the supported range. Install Node.js >=22.13.0 <23 or >=24.0.0 <26."
+fi
 status ok prerequisites "Node.js $(node --version) satisfies the repository engine range"
 
 step package-manager "activating pinned npm version"
 expected_pm="$(node -p "require('./package.json').packageManager")"
 expected_npm="${expected_pm#npm@}"
 actual_npm="$(npm --version)"
+package_manager_status="npm $actual_npm matches $expected_pm"
 if [[ "$actual_npm" != "$expected_npm" ]]; then
   if [[ "$DRY_RUN" -eq 1 ]]; then
     log "dry-run: npm $actual_npm does not match packageManager $expected_pm; a real bootstrap would run corepack prepare \"$expected_pm\" --activate and corepack enable npm"
+    package_manager_status="npm $actual_npm would be changed to $expected_pm by Corepack"
   else
     log "Activating repository package manager pin $expected_pm with Corepack."
     corepack prepare "$expected_pm" --activate
     corepack enable npm
     actual_npm="$(npm --version)"
     [[ "$actual_npm" == "$expected_npm" ]] || fail "npm $actual_npm does not match packageManager $expected_pm after Corepack activation."
+    package_manager_status="npm $actual_npm matches $expected_pm"
     log "npm $actual_npm matches packageManager $expected_pm."
   fi
 else
   log "npm $actual_npm matches packageManager $expected_pm."
 fi
-status ok package-manager "npm $actual_npm matches $expected_pm"
+status ok package-manager "$package_manager_status"
 
 step env-file "creating or validating local environment defaults"
 [[ -f .env.example ]] || fail ".env.example is missing; cannot bootstrap local environment."

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -271,6 +271,29 @@ describe('local setup scripts', () => {
       rmSync(mismatchRoot, { recursive: true, force: true });
     }
 
+    const corepackFailureRoot = mkdtempSync(join(tmpdir(), 'franken-bootstrap-corepack-failure-'));
+    try {
+      const binDir = join(corepackFailureRoot, 'bin');
+      mkdirSync(join(corepackFailureRoot, 'scripts'));
+      mkdirSync(binDir);
+      writeFileSync(join(corepackFailureRoot, 'scripts/bootstrap.sh'), script);
+      writeFileSync(join(corepackFailureRoot, 'package.json'), JSON.stringify({ packageManager: 'npm@11.5.1' }));
+      writeFileSync(join(corepackFailureRoot, '.env.example'), 'CHROMA_URL=http://localhost:8000\n');
+      writeFileSync(join(binDir, 'npm'), '#!/usr/bin/env bash\nprintf "10.0.0\\n"\n', { mode: 0o755 });
+      writeFileSync(join(binDir, 'corepack'), '#!/usr/bin/env bash\nexit 42\n', { mode: 0o755 });
+
+      const corepackFailure = spawnSync('bash', [join(corepackFailureRoot, 'scripts/bootstrap.sh'), '--no-docker'], {
+        cwd: corepackFailureRoot,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+        timeout: 60_000,
+      });
+      expect(corepackFailure.status).toBe(1);
+      expect(corepackFailure.stderr).toContain('[onboarding:2/6:package-manager] error - Command failed: corepack prepare npm@11.5.1 --activate');
+    } finally {
+      rmSync(corepackFailureRoot, { recursive: true, force: true });
+    }
+
     const dependencyFailureRoot = mkdtempSync(join(tmpdir(), 'franken-bootstrap-dependency-failure-'));
     try {
       const binDir = join(dependencyFailureRoot, 'bin');

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -245,7 +245,58 @@ describe('local setup scripts', () => {
       timeout: 60_000,
     });
     expect(invalidArgument.status).not.toBe(0);
-    expect(invalidArgument.stderr).toContain('[onboarding:0/6:failed] error - Unknown argument: --definitely-not-a-real-option');
+    expect(invalidArgument.stderr).toContain('[onboarding:0/6:args] error - Unknown argument: --definitely-not-a-real-option');
+
+    const mismatchRoot = mkdtempSync(join(tmpdir(), 'franken-bootstrap-npm-mismatch-'));
+    try {
+      const binDir = join(mismatchRoot, 'bin');
+      mkdirSync(join(mismatchRoot, 'scripts'));
+      mkdirSync(binDir);
+      writeFileSync(join(mismatchRoot, 'scripts/bootstrap.sh'), script);
+      writeFileSync(join(mismatchRoot, 'package.json'), JSON.stringify({ packageManager: 'npm@11.5.1' }));
+      writeFileSync(join(mismatchRoot, '.env.example'), 'CHROMA_URL=http://localhost:8000\n');
+      writeFileSync(join(binDir, 'npm'), '#!/usr/bin/env bash\nprintf "10.0.0\\n"\n', { mode: 0o755 });
+      writeFileSync(join(binDir, 'corepack'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+
+      const mismatchDryRun = spawnSync('bash', [join(mismatchRoot, 'scripts/bootstrap.sh'), '--dry-run', '--no-docker'], {
+        cwd: mismatchRoot,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+        timeout: 60_000,
+      });
+      expect(mismatchDryRun.status, mismatchDryRun.stderr || mismatchDryRun.stdout).toBe(0);
+      expect(mismatchDryRun.stdout).toContain('[onboarding:2/6:package-manager] ok - npm 10.0.0 would be changed to npm@11.5.1 by Corepack');
+      expect(mismatchDryRun.stdout).not.toContain('[onboarding:2/6:package-manager] ok - npm 10.0.0 matches npm@11.5.1');
+    } finally {
+      rmSync(mismatchRoot, { recursive: true, force: true });
+    }
+
+    const dependencyFailureRoot = mkdtempSync(join(tmpdir(), 'franken-bootstrap-dependency-failure-'));
+    try {
+      const binDir = join(dependencyFailureRoot, 'bin');
+      mkdirSync(join(dependencyFailureRoot, 'scripts'));
+      mkdirSync(binDir);
+      writeFileSync(join(dependencyFailureRoot, 'scripts/bootstrap.sh'), script);
+      writeFileSync(join(dependencyFailureRoot, 'package.json'), JSON.stringify({ packageManager: 'npm@11.5.1' }));
+      writeFileSync(join(dependencyFailureRoot, '.env.example'), 'CHROMA_URL=http://localhost:8000\n');
+      writeFileSync(
+        join(binDir, 'npm'),
+        '#!/usr/bin/env bash\nif [[ "$1" == "--version" ]]; then printf "11.5.1\\n"; exit 0; fi\nexit 42\n',
+        { mode: 0o755 },
+      );
+      writeFileSync(join(binDir, 'corepack'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+
+      const dependencyFailure = spawnSync('bash', [join(dependencyFailureRoot, 'scripts/bootstrap.sh'), '--no-docker'], {
+        cwd: dependencyFailureRoot,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+        timeout: 60_000,
+      });
+      expect(dependencyFailure.status).toBe(1);
+      expect(dependencyFailure.stderr).toContain('[onboarding:5/6:dependencies] error - Command failed: npm ci');
+    } finally {
+      rmSync(dependencyFailureRoot, { recursive: true, force: true });
+    }
 
     const servicesDryRun = spawnSync('bash', [scriptPath, '--dry-run', '--services'], {
       cwd: ROOT,

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -213,6 +213,8 @@ describe('local setup scripts', () => {
     expect(script).toContain('GRAFANA_USER=admin');
     expect(script).toContain('npm ci');
     expect(script).toContain('docker compose up -d');
+    expect(script).toContain('[onboarding:%s/%s:%s] %s');
+    expect(script).toContain('status complete done');
     expect(readme).toContain('## 🚀 One-click onboarding');
     expect(readme).toContain('[Frankenbeast onboarding checklist](ONBOARDING.md)');
     expect(readme).toContain('[`scripts/bootstrap.sh`](scripts/bootstrap.sh)');
@@ -233,6 +235,17 @@ describe('local setup scripts', () => {
     expect(dryRun.status, dryRun.stderr || dryRun.stdout).toBe(0);
     expect(dryRun.stdout).toMatch(/dry-run: would copy \.env\.example to \.env|\.env already exists; leaving it unchanged\./);
     expect(dryRun.stdout).toContain('dry-run: npm ci');
+    expect(dryRun.stdout).toContain('[onboarding:1/6:prerequisites] start - checking Node.js, npm, and Corepack');
+    expect(dryRun.stdout).toContain('[onboarding:6/6:services] ok - optional services intentionally skipped');
+    expect(dryRun.stdout).toContain('[onboarding:6/6:done] complete - onboarding bootstrap reached 6/6 steps');
+
+    const invalidArgument = spawnSync('bash', [scriptPath, '--definitely-not-a-real-option'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    expect(invalidArgument.status).not.toBe(0);
+    expect(invalidArgument.stderr).toContain('[onboarding:0/6:failed] error - Unknown argument: --definitely-not-a-real-option');
 
     const servicesDryRun = spawnSync('bash', [scriptPath, '--dry-run', '--services'], {
       cwd: ROOT,


### PR DESCRIPTION
## Summary
- Add deterministic `[onboarding:<current>/<total>:<stage>] <state>` status badges to `scripts/bootstrap.sh`.
- Emit explicit error badges before bootstrap failures so PM/liveness tooling can identify failed onboarding stages.
- Document badge interpretation in `ONBOARDING.md` and cover success plus invalid-option failure output in tests.

Closes #1777

## Verification
- `npm run test:root -- tests/local-setup-scripts.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `bash -n scripts/bootstrap.sh`
- `bash scripts/bootstrap.sh --dry-run`
