### PR TITLE
feat(memory): add duplicate memory report

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -50,7 +50,7 @@ export type BeastAction =
 
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
-export type MemoryAction = 'snapshot-diff' | 'verify-backup' | undefined;
+export type MemoryAction = 'snapshot-diff' | 'verify-backup' | 'duplicate-report' | undefined;
 export type DrAction = 'backup' | 'list' | 'verify' | 'restore' | 'restore-dry-run' | undefined;
 
 export interface CliArgs {
@@ -63,6 +63,7 @@ export interface CliArgs {
   memorySnapshotBefore?: string | undefined;
   memorySnapshotAfter?: string | undefined;
   memoryBackupPath?: string | undefined;
+  memoryDuplicateReportPath?: string | undefined;
   drAction?: DrAction;
   drBackupManifestPath?: string | undefined;
   drLiveManifestPath?: string | undefined;
@@ -116,7 +117,7 @@ export interface CliArgs {
 
 const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'dr', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
-const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup']);
+const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup', 'duplicate-report']);
 const VALID_DR_ACTIONS = new Set(['backup', 'list', 'verify', 'restore', 'restore-dry-run']);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
@@ -242,6 +243,8 @@ Network Commands:
 Memory Commands:
   memory snapshot-diff <before> <after>
                                   Print a structured JSON diff between two BrainSnapshot files
+  memory duplicate-report <snapshot.json>
+                                  Print duplicate working/episodic memory consolidation candidates as structured JSON
   memory verify-backup <backup.sqlite>
                                   Verify a read-only SQLite memory backup and print structured JSON
 
@@ -535,6 +538,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let memorySnapshotBefore: string | undefined;
   let memorySnapshotAfter: string | undefined;
   let memoryBackupPath: string | undefined;
+  let memoryDuplicateReportPath: string | undefined;
   let drAction: DrAction;
   let drBackupManifestPath: string | undefined;
   let drLiveManifestPath: string | undefined;
@@ -578,6 +582,11 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       memoryBackupPath = positionals[1];
       if (positionals.length > 2) {
         throw new TypeError(`Unexpected argument '${positionals[2]}'. memory verify-backup accepts exactly one backup file`);
+      }
+    } else if (memoryAction === 'duplicate-report') {
+      memoryDuplicateReportPath = positionals[1];
+      if (positionals.length > 2) {
+        throw new TypeError(`Unexpected argument '${positionals[2]}'. memory duplicate-report accepts exactly one snapshot file`);
       }
     } else {
       memorySnapshotBefore = positionals[1];
@@ -743,6 +752,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     memorySnapshotBefore,
     memorySnapshotAfter,
     memoryBackupPath,
+    memoryDuplicateReportPath,
     drAction,
     drBackupManifestPath,
     drLiveManifestPath,

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -445,7 +445,8 @@ export function generateDuplicateMemoryReport(path: string, snapshot: BrainSnaps
 
   const workingGroups = buildDuplicateGroups(workingCandidates);
   const episodicGroups = buildDuplicateGroups(episodicCandidates);
-  const groups = [...workingGroups, ...episodicGroups];
+  const groups = [...workingGroups, ...episodicGroups]
+    .map((group, index) => ({ ...group, id: `dup-${String(index + 1).padStart(3, '0')}` }));
   const duplicateEntries = groups.reduce((total, group) => total + group.entries.length, 0);
 
   return {

--- a/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
+++ b/packages/franken-orchestrator/src/cli/memory-snapshot-diff.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import Database from 'better-sqlite3';
 import { BrainSnapshotSchema, ExecutionStateSchema, type BrainSnapshot, type EpisodicEvent } from '@franken/types';
@@ -70,6 +71,39 @@ export interface MemorySnapshotDiffReport {
   };
 }
 
+export interface DuplicateMemoryReportEntry {
+  readonly kind: 'working' | 'episodic';
+  readonly key?: string;
+  readonly eventId?: number;
+  readonly eventKey?: string;
+  readonly type?: EpisodicEvent['type'];
+  readonly createdAt?: string;
+}
+
+export interface DuplicateMemoryReportGroup {
+  readonly id: string;
+  readonly normalizedHash: string;
+  readonly normalizedPreview: string;
+  readonly suggestedCanonical: DuplicateMemoryReportEntry;
+  readonly entries: DuplicateMemoryReportEntry[];
+}
+
+export interface DuplicateMemoryConsolidationReport {
+  readonly ok: true;
+  readonly command: 'memory duplicate-report';
+  readonly snapshot: { readonly path: string; readonly timestamp: string };
+  readonly summary: {
+    readonly duplicateGroups: number;
+    readonly duplicateEntries: number;
+    readonly workingDuplicateGroups: number;
+    readonly workingDuplicateEntries: number;
+    readonly episodicDuplicateGroups: number;
+    readonly episodicDuplicateEntries: number;
+  };
+  readonly groups: DuplicateMemoryReportGroup[];
+  readonly guidance: string[];
+}
+
 export interface MemoryBackupVerificationReport {
   readonly ok: true;
   readonly command: 'memory verify-backup';
@@ -93,10 +127,11 @@ export interface MemoryBackupVerificationReport {
 }
 
 export interface MemoryCommandDeps {
-  readonly action: 'snapshot-diff' | 'verify-backup' | undefined;
+  readonly action: 'snapshot-diff' | 'verify-backup' | 'duplicate-report' | undefined;
   readonly beforePath?: string | undefined;
   readonly afterPath?: string | undefined;
   readonly backupPath?: string | undefined;
+  readonly snapshotPath?: string | undefined;
   readonly print: (message: string) => void;
 }
 
@@ -318,6 +353,123 @@ function readSchemaStores(db: Database.Database, tables: Set<string>): MemoryBac
   });
 }
 
+
+function normalizedMemoryText(value: unknown): string {
+  return stableStringify(value)
+    .toLowerCase()
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function hashNormalizedText(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function previewNormalizedText(text: string): string {
+  return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+}
+
+function episodicDuplicatePayload(event: EpisodicEvent): unknown {
+  return {
+    type: event.type,
+    step: event.step ?? null,
+    summary: event.summary,
+    details: event.details ?? null,
+  };
+}
+
+function makeEventEntry(event: EpisodicEvent, index: number): DuplicateMemoryReportEntry {
+  return {
+    kind: 'episodic',
+    ...(event.id !== undefined ? { eventId: event.id } : {}),
+    eventKey: eventDiffKey(event, index),
+    type: event.type,
+    createdAt: event.createdAt,
+  };
+}
+
+function sortEntries(entries: DuplicateMemoryReportEntry[]): DuplicateMemoryReportEntry[] {
+  return [...entries].sort((left, right) => {
+    const leftKey = left.kind === 'working'
+      ? `0:${left.key ?? ''}`
+      : `1:${left.createdAt ?? ''}:${left.eventId ?? ''}:${left.eventKey ?? ''}`;
+    const rightKey = right.kind === 'working'
+      ? `0:${right.key ?? ''}`
+      : `1:${right.createdAt ?? ''}:${right.eventId ?? ''}:${right.eventKey ?? ''}`;
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+function buildDuplicateGroups(groups: Map<string, DuplicateMemoryReportEntry[]>): DuplicateMemoryReportGroup[] {
+  return Array.from(groups.entries())
+    .filter(([, entries]) => entries.length > 1)
+    .map(([normalized, entries], index) => {
+      const sortedEntries = sortEntries(entries);
+      const normalizedHash = hashNormalizedText(normalized);
+      return {
+        id: `dup-${String(index + 1).padStart(3, '0')}`,
+        normalizedHash,
+        normalizedPreview: previewNormalizedText(normalized),
+        suggestedCanonical: sortedEntries[0]!,
+        entries: sortedEntries,
+      };
+    })
+    .sort((left, right) => {
+      const leftFirst = left.entries[0];
+      const rightFirst = right.entries[0];
+      const leftKey = leftFirst?.kind === 'working' ? leftFirst.key ?? '' : leftFirst?.eventKey ?? '';
+      const rightKey = rightFirst?.kind === 'working' ? rightFirst.key ?? '' : rightFirst?.eventKey ?? '';
+      return leftKey.localeCompare(rightKey) || left.normalizedHash.localeCompare(right.normalizedHash);
+    })
+    .map((group, index) => ({ ...group, id: `dup-${String(index + 1).padStart(3, '0')}` }));
+}
+
+export function generateDuplicateMemoryReport(path: string, snapshot: BrainSnapshot): DuplicateMemoryConsolidationReport {
+  const workingCandidates = new Map<string, DuplicateMemoryReportEntry[]>();
+  for (const [key, value] of Object.entries(snapshot.working)) {
+    const normalized = normalizedMemoryText(value);
+    if (normalized.length === 0) continue;
+    const entries = workingCandidates.get(normalized) ?? [];
+    entries.push({ kind: 'working', key });
+    workingCandidates.set(normalized, entries);
+  }
+
+  const episodicCandidates = new Map<string, DuplicateMemoryReportEntry[]>();
+  snapshot.episodic.forEach((event, index) => {
+    const normalized = normalizedMemoryText(episodicDuplicatePayload(event));
+    if (normalized.length === 0) return;
+    const entries = episodicCandidates.get(normalized) ?? [];
+    entries.push(makeEventEntry(event, index));
+    episodicCandidates.set(normalized, entries);
+  });
+
+  const workingGroups = buildDuplicateGroups(workingCandidates);
+  const episodicGroups = buildDuplicateGroups(episodicCandidates);
+  const groups = [...workingGroups, ...episodicGroups];
+  const duplicateEntries = groups.reduce((total, group) => total + group.entries.length, 0);
+
+  return {
+    ok: true,
+    command: 'memory duplicate-report',
+    snapshot: { path, timestamp: snapshot.timestamp },
+    summary: {
+      duplicateGroups: groups.length,
+      duplicateEntries,
+      workingDuplicateGroups: workingGroups.length,
+      workingDuplicateEntries: workingGroups.reduce((total, group) => total + group.entries.length, 0),
+      episodicDuplicateGroups: episodicGroups.length,
+      episodicDuplicateEntries: episodicGroups.reduce((total, group) => total + group.entries.length, 0),
+    },
+    groups,
+    guidance: groups.length > 0
+      ? [
+        'Review each group before deleting memory; the suggestedCanonical entry is deterministic, not an automatic deletion decision.',
+        'Consolidate duplicates by preserving the canonical fact/event and removing or merging the remaining entries through the normal memory deletion/review workflow.',
+      ]
+      : ['No duplicate working-memory values or episodic event payloads were found in this snapshot.'],
+  };
+}
+
 export function diffMemorySnapshots(
   beforePath: string,
   before: BrainSnapshot,
@@ -446,7 +598,7 @@ async function readSnapshot(path: string): Promise<BrainSnapshot> {
 }
 
 export async function handleMemoryCommand(deps: MemoryCommandDeps): Promise<void> {
-  const { action, beforePath, afterPath, backupPath, print } = deps;
+  const { action, beforePath, afterPath, backupPath, snapshotPath, print } = deps;
   if (action === 'verify-backup') {
     if (!backupPath) {
       throw new Error('memory verify-backup requires one SQLite backup file: <backup.sqlite>');
@@ -454,8 +606,16 @@ export async function handleMemoryCommand(deps: MemoryCommandDeps): Promise<void
     print(JSON.stringify(verifyMemoryBackup(backupPath), null, 2));
     return;
   }
+  if (action === 'duplicate-report') {
+    if (!snapshotPath) {
+      throw new Error('memory duplicate-report requires one BrainSnapshot JSON file: <snapshot.json>');
+    }
+    const snapshot = await readSnapshot(snapshotPath);
+    print(JSON.stringify(generateDuplicateMemoryReport(snapshotPath, snapshot), null, 2));
+    return;
+  }
   if (action !== 'snapshot-diff') {
-    throw new Error('Usage: frankenbeast memory snapshot-diff <before-snapshot.json> <after-snapshot.json> OR frankenbeast memory verify-backup <backup.sqlite>');
+    throw new Error('Usage: frankenbeast memory snapshot-diff <before-snapshot.json> <after-snapshot.json> OR frankenbeast memory duplicate-report <snapshot.json> OR frankenbeast memory verify-backup <backup.sqlite>');
   }
   if (!beforePath || !afterPath) {
     throw new Error('memory snapshot-diff requires two BrainSnapshot JSON files: <before> <after>');

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1404,6 +1404,7 @@ export async function main(): Promise<void> {
         beforePath: args.memorySnapshotBefore,
         afterPath: args.memorySnapshotAfter,
         backupPath: args.memoryBackupPath,
+        snapshotPath: args.memoryDuplicateReportPath,
         print: printLine,
       });
     } catch (err) {

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -190,6 +190,7 @@ describe('generateDuplicateMemoryReport', () => {
       suggestedCanonical: { kind: 'working', key: 'alpha' },
       entries: [{ kind: 'working', key: 'alpha' }, { kind: 'working', key: 'beta' }],
     });
+    expect(report.groups[1]).toMatchObject({ id: 'dup-002' });
     expect(report.groups[1]?.entries.map((entry) => entry.eventId)).toEqual([11, 12]);
     expect(report.groups[0]?.normalizedHash).toMatch(/^[a-f0-9]{64}$/);
     expect(report.guidance.join(' ')).toContain('Review each group before deleting memory');

--- a/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/memory-snapshot-diff.test.ts
@@ -6,7 +6,7 @@ import Database from 'better-sqlite3';
 import { SqliteBrain } from '@franken/brain';
 import type { BrainSnapshot } from '@franken/types';
 import { parseArgs } from '../../../src/cli/args.js';
-import { diffMemorySnapshots, handleMemoryCommand, verifyMemoryBackup } from '../../../src/cli/memory-snapshot-diff.js';
+import { diffMemorySnapshots, generateDuplicateMemoryReport, handleMemoryCommand, verifyMemoryBackup } from '../../../src/cli/memory-snapshot-diff.js';
 
 const baseSnapshot: BrainSnapshot = {
   version: 1,
@@ -65,6 +65,20 @@ describe('memory snapshot-diff CLI args', () => {
   it('rejects extra verify-backup positionals with actionable guidance', () => {
     expect(() => parseArgs(['memory', 'verify-backup', 'backup.sqlite', 'extra'])).toThrow(
       /memory verify-backup accepts exactly one backup file/,
+    );
+  });
+
+  it('parses the memory duplicate-report command and snapshot path', () => {
+    const args = parseArgs(['memory', 'duplicate-report', 'snapshot.json']);
+
+    expect(args.subcommand).toBe('memory');
+    expect(args.memoryAction).toBe('duplicate-report');
+    expect(args.memoryDuplicateReportPath).toBe('snapshot.json');
+  });
+
+  it('rejects extra duplicate-report positionals with actionable guidance', () => {
+    expect(() => parseArgs(['memory', 'duplicate-report', 'snapshot.json', 'extra'])).toThrow(
+      /memory duplicate-report accepts exactly one snapshot file/,
     );
   });
 });
@@ -127,6 +141,69 @@ describe('diffMemorySnapshots', () => {
   });
 });
 
+
+describe('generateDuplicateMemoryReport', () => {
+  it('reports deterministic working and episodic consolidation candidates', () => {
+    const snapshot: BrainSnapshot = {
+      ...baseSnapshot,
+      working: {
+        alpha: { fact: 'Operator prefers terse updates' },
+        beta: { fact: 'Operator prefers terse updates' },
+        gamma: { fact: 'Different fact' },
+      },
+      episodic: [
+        {
+          id: 11,
+          type: 'observation',
+          summary: 'User prefers concise updates',
+          details: { source: 'profile' },
+          createdAt: '2026-07-11T00:00:01.000Z',
+        },
+        {
+          id: 12,
+          type: 'observation',
+          summary: 'User prefers concise updates',
+          details: { source: 'profile' },
+          createdAt: '2026-07-11T00:00:02.000Z',
+        },
+        {
+          id: 13,
+          type: 'decision',
+          summary: 'Keep separate decisions distinct',
+          createdAt: '2026-07-11T00:00:03.000Z',
+        },
+      ],
+    };
+
+    const report = generateDuplicateMemoryReport('snapshot.json', snapshot);
+
+    expect(report.summary).toEqual({
+      duplicateGroups: 2,
+      duplicateEntries: 4,
+      workingDuplicateGroups: 1,
+      workingDuplicateEntries: 2,
+      episodicDuplicateGroups: 1,
+      episodicDuplicateEntries: 2,
+    });
+    expect(report.groups[0]).toMatchObject({
+      id: 'dup-001',
+      suggestedCanonical: { kind: 'working', key: 'alpha' },
+      entries: [{ kind: 'working', key: 'alpha' }, { kind: 'working', key: 'beta' }],
+    });
+    expect(report.groups[1]?.entries.map((entry) => entry.eventId)).toEqual([11, 12]);
+    expect(report.groups[0]?.normalizedHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(report.guidance.join(' ')).toContain('Review each group before deleting memory');
+  });
+
+  it('returns an explicit empty report when no duplicates exist', () => {
+    const report = generateDuplicateMemoryReport('snapshot.json', baseSnapshot);
+
+    expect(report.summary.duplicateGroups).toBe(0);
+    expect(report.groups).toEqual([]);
+    expect(report.guidance[0]).toContain('No duplicate');
+  });
+});
+
 describe('handleMemoryCommand', () => {
   it('prints JSON diff for valid snapshot files', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'memory-snapshot-diff-'));
@@ -153,6 +230,36 @@ describe('handleMemoryCommand', () => {
       command: 'memory snapshot-diff',
       summary: { workingAdded: 1 },
     });
+  });
+
+  it('prints JSON duplicate report for a valid snapshot file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memory-duplicate-report-'));
+    const snapshotPath = join(dir, 'snapshot.json');
+    await writeFile(snapshotPath, JSON.stringify({
+      ...baseSnapshot,
+      working: { one: 'same', two: 'same' },
+    }));
+    const printed: string[] = [];
+
+    await handleMemoryCommand({
+      action: 'duplicate-report',
+      snapshotPath,
+      print: (message) => printed.push(message),
+    });
+
+    expect(printed).toHaveLength(1);
+    expect(JSON.parse(printed[0]!)).toMatchObject({
+      ok: true,
+      command: 'memory duplicate-report',
+      summary: { duplicateGroups: 1, workingDuplicateEntries: 2 },
+    });
+  });
+
+  it('requires a snapshot path for duplicate-report', async () => {
+    await expect(handleMemoryCommand({
+      action: 'duplicate-report',
+      print: () => undefined,
+    })).rejects.toThrow(/memory duplicate-report requires one BrainSnapshot JSON file/);
   });
 
   it('fails with actionable guidance when a snapshot is invalid', async () => {


### PR DESCRIPTION
## Summary
- Adds `frankenbeast memory duplicate-report <snapshot.json>` for structured duplicate-memory consolidation candidates.
- Reports duplicate working-memory values and episodic event payloads with deterministic group IDs, hashes, canonical suggestions, and operator guidance.
- Wires CLI parsing/help and tests success plus explicit edge/failure cases.

## Verification
- `npm run test --workspace @franken/orchestrator -- tests/unit/cli/memory-snapshot-diff.test.ts` (28 tests passed)
- `npm run typecheck --workspace @franken/orchestrator` (passed after building workspace dependencies)
- `npm run build --workspace @franken/orchestrator` (passed)
- `npm run lint --workspace @franken/orchestrator` (passed with existing warnings)
- CLI smoke: `node packages/franken-orchestrator/dist/cli/run.js memory duplicate-report <snapshot.json>` produced structured duplicate summary

Closes #1844
