### PR TITLE
docs(onboarding): add stalled worker troubleshooting guide

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -232,6 +232,8 @@ Edge case: many older diagrams and `docs/plans/` files describe target or histor
 
 ## Troubleshooting
 
+If a PM, liveness monitor, or operator reports a stalled worker, use the dedicated [troubleshooting guide for stalled workers](docs/guides/troubleshooting-stalled-workers.md) before respawning or deleting worktrees. It walks through live task/PR evidence, active versus blocked versus stale classifications, safe recovery actions, and the handoff fields future workers need.
+
 - [ ] `npm install` fails with an engine error:
   - Check `node --version` against the root `engines.node` range.
   - Re-run the Corepack commands in the prerequisites section and `npm run check:package-manager`.

--- a/docs/guides/troubleshooting-stalled-workers.md
+++ b/docs/guides/troubleshooting-stalled-workers.md
@@ -1,0 +1,84 @@
+# Troubleshooting stalled workers
+
+Use this guide when a PM, liveness monitor, or operator sees a worker that has stopped making visible progress. The goal is to classify the worker before taking action so recovery does not duplicate PRs, overwrite active work, or hide a real blocker.
+
+## Fast triage checklist
+
+1. **Identify the owner and scope.** Record the Kanban task id, issue number, branch, worktree path, linked PR, and current assignee.
+2. **Read the live task state.** Inspect the task status, latest run, comments, parent handoff, PID, and heartbeat timestamp before editing files or spawning a replacement.
+3. **Check for active ownership.** Compare the task branch and issue number with open PRs and existing worktrees. If a PR already owns the issue, resume that PR instead of creating a second branch.
+4. **Classify the stall.** Use the status table below to decide whether the worker is active, blocked, stale, or unsafe to touch.
+5. **Record the decision.** Leave a comment or handoff with the evidence, exact next action, and any blocked command or external gate.
+
+## Classification table
+
+| Signal | Classification | Safe next action |
+| --- | --- | --- |
+| Recent heartbeat, live PID, or fresh PR/CI/Codex activity | Active worker | Do not respawn. Nudge only with a specific next step if the worker is clearly idle. |
+| `blocked` status with a concrete reason such as usage limits, denied approval, missing credentials, or review-required | Blocked worker | Resolve the named blocker or wait for the requested human decision; do not bypass the gate. |
+| No live PID, stale heartbeat, no recent comments, and no linked PR or dirty worktree with unpushed changes | Stale worker | Reclaim or respawn from the recorded task context, then re-check issue/PR ownership before editing. |
+| Dirty worktree, ahead commits, open PR, unresolved Codex thread, or in-flight CI on the same branch | In-flight recovery | Continue from that branch/worktree and preserve evidence; do not start a parallel implementation. |
+| Unknown state, conflicting ownership evidence, or mutation approval ambiguity | Unsafe to touch | Freeze destructive actions and escalate with the exact evidence needed to choose an owner. |
+
+## Read-only evidence to collect first
+
+Prefer read-only inspection until the classification is clear:
+
+```bash
+# Replace values with the affected task, worktree, and repository.
+hermes kanban show <task-id> --json
+git -C <worktree> status --short --branch
+git -C <worktree> log --oneline --decorate -5
+gh pr list --repo djm204/frankenbeast --state open --search "<issue-number> in:body" --json number,title,headRefName,headRefOid,url,statusCheckRollup
+```
+
+If the task has an open PR, also inspect review and CI state before changing code:
+
+```bash
+gh pr view <pr-number> --repo djm204/frankenbeast --json number,state,mergeStateStatus,headRefName,headRefOid,reviewDecision,statusCheckRollup,url
+gh pr checks <pr-number> --repo djm204/frankenbeast
+```
+
+## Recovery actions by outcome
+
+### Active worker
+
+- Do not create a duplicate card, branch, worktree, or PR.
+- If progress is unclear, leave a narrow comment naming the exact missing next step, such as "poll Codex review for PR #123" or "push the already-committed branch".
+- Re-check later instead of force-stopping the worker.
+
+### Blocked worker
+
+- Treat usage-limit comments, denied approval prompts, missing credentials, and explicit `review-required:` handoffs as blockers, not failures.
+- Preserve the blocked command, tests already run, current head SHA, and remaining gate.
+- Resume only after the blocker is resolved or a human records an explicit override.
+
+### Stale worker
+
+- Confirm there is no live PID, fresh heartbeat, open PR, or dirty/ahead worktree for the issue.
+- Reclaim or unblock the task through the Kanban workflow with a comment explaining the stale evidence.
+- Start from the recorded issue branch and shared lessons, then re-run ownership checks before editing.
+
+### In-flight recovery
+
+- Continue from the existing branch/worktree.
+- Inspect local ahead/behind state before pushing; use `--force-with-lease` only when intentionally replacing a known stale remote head.
+- If Codex or CI is already in progress, poll the current round instead of triggering duplicate review requests.
+
+## Edge cases that must stay explicit
+
+- Do not merge on Codex silence, usage-limit text, or an all-clear from an older head.
+- Do not respawn a worker just because a PM liveness file is stale; verify the live Kanban task and PR state first.
+- Do not delete dirty worktrees until their commits are pushed, abandoned by an explicit owner decision, or safely copied into the recovery handoff.
+- Do not broaden a one-issue worker into adjacent issues while recovering it.
+
+## Handoff template
+
+```text
+Stalled-worker triage for <task-id> / issue #<number>
+Classification: active | blocked | stale | in-flight recovery | unsafe
+Evidence: <PID/heartbeat, task status, branch/worktree, PR/CI/Codex state>
+Decision: <resume existing PR, unblock/reclaim, wait for approval, or escalate>
+Next safe command: <single command or "none until human decision">
+Owner: <profile/person expected to act next>
+```

--- a/tests/docs-issue-1774.test.ts
+++ b/tests/docs-issue-1774.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+const guidePath = 'docs/guides/troubleshooting-stalled-workers.md';
+
+describe('issue #1774 stalled-worker onboarding guide', () => {
+  it('links the dedicated stalled-worker troubleshooting guide from onboarding', () => {
+    const onboarding = readDoc('ONBOARDING.md');
+
+    expect(onboarding).toContain('[troubleshooting guide for stalled workers](docs/guides/troubleshooting-stalled-workers.md)');
+    expect(onboarding).toContain('before respawning or deleting worktrees');
+  });
+
+  it('documents deterministic evidence, classifications, and handoff fields for stalled workers', () => {
+    const guide = readDoc(guidePath);
+
+    for (const requiredHeading of [
+      '# Troubleshooting stalled workers',
+      '## Fast triage checklist',
+      '## Classification table',
+      '## Read-only evidence to collect first',
+      '## Recovery actions by outcome',
+      '## Handoff template',
+    ]) {
+      expect(guide).toContain(requiredHeading);
+    }
+
+    for (const classification of [
+      'Active worker',
+      'Blocked worker',
+      'Stale worker',
+      'In-flight recovery',
+      'Unsafe to touch',
+    ]) {
+      expect(guide).toContain(classification);
+    }
+
+    for (const evidence of [
+      'Kanban task id',
+      'heartbeat timestamp',
+      'open PRs',
+      'worktree',
+      'Codex',
+      'statusCheckRollup',
+    ]) {
+      expect(guide).toContain(evidence);
+    }
+
+    expect(guide).toContain('Classification: active | blocked | stale | in-flight recovery | unsafe');
+    expect(guide).toContain('Next safe command:');
+  });
+
+  it('keeps negative recovery guidance explicit so stale checks do not create duplicate work', () => {
+    const guide = readDoc(guidePath);
+
+    for (const guardrail of [
+      'Do not create a duplicate card, branch, worktree, or PR.',
+      'Do not merge on Codex silence, usage-limit text, or an all-clear from an older head.',
+      'Do not respawn a worker just because a PM liveness file is stale',
+      'Do not delete dirty worktrees until their commits are pushed',
+      'Do not broaden a one-issue worker into adjacent issues while recovering it.',
+    ]) {
+      expect(guide).toContain(guardrail);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated stalled-worker troubleshooting guide for onboarding and PM/liveness recovery.
- Link the guide from ONBOARDING.md before existing local setup troubleshooting items.
- Add deterministic docs tests covering the guide link, evidence/classification sections, and duplicate-work guardrails.

## Verification
- npm run test:root -- tests/docs-issue-1774.test.ts
- npm run typecheck
- npm run build
- npm run lint

Closes #1774
