### PR TITLE
feat(onboarding): add repository ownership manifest

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -113,6 +113,10 @@ Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. 
   frankenbeast --help
   ```
 
+## Repository ownership
+
+Read the [repository ownership manifest](docs/onboarding/repository-ownership.md) before assigning repository-wide or cross-package work. It maps current package and documentation surfaces to primary owners, escalation owners, verification commands, and PM/worker handoff notes so agents do not guess ownership from path names alone.
+
 ## Architecture reading path
 
 Use this path when you are new to Frankenbeast or when an agent handoff says "read the architecture docs first." It is intentionally ordered from current implementation to deeper historical context.

--- a/docs/onboarding/repository-ownership.manifest.json
+++ b/docs/onboarding/repository-ownership.manifest.json
@@ -1,0 +1,127 @@
+{
+  "schemaVersion": 1,
+  "defaultOwner": "core-maintainers",
+  "unknownPathPolicy": "For unknown or cross-cutting paths, start with docs/CONTRACT_MATRIX.md and docs/RAMP_UP.md, then list every plausible manifest entry in the PM/worker handoff instead of guessing a single owner.",
+  "entries": [
+    {
+      "id": "types-contracts",
+      "name": "Shared types and cross-package contracts",
+      "paths": ["packages/franken-types/**", "docs/CONTRACT_MATRIX.md"],
+      "primaryOwner": "types-contracts-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Branded ids, Result helpers, shared DTOs, public package exports, and contract-matrix alignment."],
+      "verification": ["npm run build --workspace @franken/types", "npm run typecheck"],
+      "handoffNotes": ["Call out downstream packages that import generated dist paths before changing public exports."]
+    },
+    {
+      "id": "brain-memory",
+      "name": "Brain and memory systems",
+      "paths": ["packages/franken-brain/**"],
+      "primaryOwner": "memory-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Working memory, episodic memory, semantic memory, PII guards, and memory API behavior."],
+      "verification": ["npm test --workspace @franken/brain", "npm run typecheck --workspace @franken/brain"],
+      "handoffNotes": ["Mention persistence/backward-compatibility expectations when changing serialized memory state."]
+    },
+    {
+      "id": "planner-recovery",
+      "name": "Planner, task graphs, and recovery",
+      "paths": ["packages/franken-planner/**"],
+      "primaryOwner": "planner-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Plan graphs, topological execution order, recursive expansion, recovery checkpoints, and planner integration tests."],
+      "verification": ["npm test --workspace @franken/planner", "npm run test:integration --workspace @franken/planner"],
+      "handoffNotes": ["State whether a change affects linear, parallel, recursive, or recovery flows."]
+    },
+    {
+      "id": "observer-telemetry",
+      "name": "Observer, tracing, and evaluation telemetry",
+      "paths": ["packages/franken-observer/**"],
+      "primaryOwner": "observer-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Trace storage, token/cost accounting, circuit breakers, evaluation fixtures, and telemetry adapters."],
+      "verification": ["npm test --workspace @franken/observer", "npm run test:eval --workspace @franken/observer"],
+      "handoffNotes": ["Include data-retention and schema-migration impact when persistence code changes."]
+    },
+    {
+      "id": "critique-evaluation",
+      "name": "Critique and evaluation pipeline",
+      "paths": ["packages/franken-critique/**"],
+      "primaryOwner": "critique-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Self-critique evaluators, conciseness/scoring rules, lesson recording, and critique package public contracts."],
+      "verification": ["npm test --workspace @franken/critique", "npm run typecheck --workspace @franken/critique"],
+      "handoffNotes": ["Keep evaluator fixtures deterministic and explain expected false-positive handling."]
+    },
+    {
+      "id": "governor-approval",
+      "name": "Governor and approval policy",
+      "paths": ["packages/franken-governor/**"],
+      "primaryOwner": "governor-maintainers",
+      "escalationOwner": "security-maintainers",
+      "responsibilities": ["HITL approval gates, policy manifests, signed requests, budget/skill/confidence triggers, and approval-channel adapters."],
+      "verification": ["npm test --workspace @franken/governor", "npm run typecheck --workspace @franken/governor"],
+      "handoffNotes": ["Flag any change that alters destructive-action approvals, signature validation, or default-deny behavior."]
+    },
+    {
+      "id": "web-dashboard",
+      "name": "Web dashboard and browser UX",
+      "paths": ["packages/franken-web/**"],
+      "primaryOwner": "web-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["React dashboard, Vite proxy config, browser-side API clients, chat UI, beast controls, and accessibility behavior."],
+      "verification": ["npm test --workspace @franken/web", "npm run build --workspace @franken/web"],
+      "handoffNotes": ["Identify the backend route or same-origin proxy path for every new browser call."]
+    },
+    {
+      "id": "orchestrator-runtime",
+      "name": "Orchestrator runtime, CLI, and HTTP services",
+      "paths": ["packages/franken-orchestrator/**"],
+      "primaryOwner": "orchestrator-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Beast Loop runtime, CLI, chat server, beasts daemon, comms gateway, security middleware, provider registry, and closure PR creation."],
+      "verification": ["npm test --workspace @franken/orchestrator", "npm run typecheck --workspace @franken/orchestrator"],
+      "handoffNotes": ["Call out whether changes affect CLI, HTTP, WebSocket/SSE, provider execution, or persisted runtime state."]
+    },
+    {
+      "id": "mcp-suite",
+      "name": "MCP suite and external agent adapters",
+      "paths": ["packages/franken-mcp-suite/**"],
+      "primaryOwner": "mcp-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["MCP tool registry/server/proxy integrations, generated client configs, hook scripts, and governed-project setup flows."],
+      "verification": ["npm test --workspace @franken/mcp-suite", "npm run build --workspace @franken/mcp-suite"],
+      "handoffNotes": ["Separate published-package setup paths from local-checkout development paths."]
+    },
+    {
+      "id": "live-bench",
+      "name": "Live benchmark harness",
+      "paths": ["packages/live-bench/**"],
+      "primaryOwner": "benchmark-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["Live benchmark corpus loading, workspace provisioning, evidence manifests, scorer compatibility, and live-test gates."],
+      "verification": ["npm test --workspace @franken/live-bench", "npm run test:live:bench"],
+      "handoffNotes": ["State whether tool-call evidence is supported or intentionally unsupported for the scorer path."]
+    },
+    {
+      "id": "onboarding-docs",
+      "name": "Onboarding, contributor guidance, and repository documentation",
+      "paths": ["docs/onboarding/**", "ONBOARDING.md", "README.md", "docs/RAMP_UP.md", "docs/guides/**"],
+      "primaryOwner": "docs-onboarding-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["First-run setup, architecture reading path, operator guides, quickstart copy, and agent handoff guidance."],
+      "verification": ["npm run test:root -- tests/docs-issue-1773.test.ts", "npm run test:root -- tests/docs-issue-1774.test.ts tests/docs-issue-1776.test.ts"],
+      "handoffNotes": ["Keep docs tied to live scripts and package names; do not describe future plans as current behavior."]
+    },
+    {
+      "id": "repo-automation",
+      "name": "Repository automation, CI, release, and root guardrails",
+      "paths": [".github/**", "scripts/**", "package.json", "package-lock.json", "turbo.json", "tests/**"],
+      "primaryOwner": "repo-automation-maintainers",
+      "escalationOwner": "core-maintainers",
+      "responsibilities": ["GitHub workflows, release automation, dependency policy, root guard tests, package-manager checks, and CI entrypoints."],
+      "verification": ["npm run test:root", "npm run lint", "npm run typecheck"],
+      "handoffNotes": ["When root guardrails change, update both implementation scripts and tests that parse workflow/package metadata."]
+    }
+  ]
+}

--- a/docs/onboarding/repository-ownership.md
+++ b/docs/onboarding/repository-ownership.md
@@ -1,0 +1,39 @@
+# Repository ownership manifest
+
+Frankenbeast keeps a structured repository ownership manifest at `docs/onboarding/repository-ownership.manifest.json`. Use it before assigning repository-wide or cross-package work so PMs, workers, and reviewers can route changes to the right maintainer surface without rediscovering package boundaries.
+
+## How to use the manifest
+
+1. Match every touched path against the manifest `entries[].paths` globs.
+2. Put the matching `id`, `primaryOwner`, and `escalationOwner` in the issue, PR, or Kanban handoff.
+3. Run the listed `verification` commands when the touched area is in scope, or explain why a narrower command is safer.
+4. Include the `handoffNotes` when creating worker prompts so agents know the local pitfalls for that ownership area.
+
+## PM/worker handoff
+
+Use this compact shape in issue and PR handoffs:
+
+```text
+Ownership entries: orchestrator-runtime, repo-automation
+Primary owners: orchestrator-maintainers, repo-automation-maintainers
+Escalation owner: core-maintainers
+Verification: npm test --workspace @franken/orchestrator; npm run test:root
+Notes: touches HTTP runtime and root CI guardrails; verify both package behavior and workflow metadata tests.
+```
+
+If a change spans multiple owners, list every touched manifest entry and do not collapse the work to the first path that matched. Cross-package contract changes usually include both the package owner and `types-contracts`.
+
+## Unknown or cross-cutting paths
+
+Do not guess an owner from package names alone. For unknown paths, first read `docs/CONTRACT_MATRIX.md`, `docs/RAMP_UP.md`, and nearby package READMEs, then assign `core-maintainers` as the default escalation owner until the manifest is updated.
+
+Negative/edge cases:
+
+- Do not assign browser work to `orchestrator-runtime` just because the browser calls an orchestrator route; include both `web-dashboard` and `orchestrator-runtime` when both sides change.
+- Do not assign shared DTO or export changes only to the consuming package; include `types-contracts` when `packages/franken-types/**` changes.
+- Do not treat historical `docs/plans/**` ownership as live runtime ownership without verifying current package boundaries.
+- Do not broaden a one-issue worker into adjacent owners just because the manifest names them; open a follow-up or PM routing decision instead.
+
+## Maintaining the manifest
+
+When repository structure changes, update `docs/onboarding/repository-ownership.manifest.json` and this guide in the same PR. Keep entries deterministic and LLM-friendly: stable lowercase ids, explicit path globs, a primary owner, an escalation owner, responsibilities, verification commands, and handoff notes.

--- a/tests/docs-issue-1773.test.ts
+++ b/tests/docs-issue-1773.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const manifestPath = 'docs/onboarding/repository-ownership.manifest.json';
+const guidePath = 'docs/onboarding/repository-ownership.md';
+
+type OwnershipEntry = {
+  id: string;
+  name: string;
+  paths: string[];
+  primaryOwner: string;
+  escalationOwner: string;
+  responsibilities: string[];
+  verification: string[];
+  handoffNotes: string[];
+};
+
+type OwnershipManifest = {
+  schemaVersion: number;
+  defaultOwner: string;
+  unknownPathPolicy: string;
+  entries: OwnershipEntry[];
+};
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function readManifest(): OwnershipManifest {
+  return JSON.parse(readText(manifestPath)) as OwnershipManifest;
+}
+
+describe('issue #1773 repository ownership manifest', () => {
+  it('adds a structured, LLM-friendly repository ownership manifest with deterministic owner fields', () => {
+    const manifest = readManifest();
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.defaultOwner).toBe('core-maintainers');
+    expect(manifest.unknownPathPolicy).toContain('docs/CONTRACT_MATRIX.md');
+    expect(manifest.entries.length).toBeGreaterThanOrEqual(8);
+
+    for (const entry of manifest.entries) {
+      expect(entry.id).toMatch(/^[a-z0-9-]+$/);
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.primaryOwner.length).toBeGreaterThan(0);
+      expect(entry.escalationOwner.length).toBeGreaterThan(0);
+      expect(entry.paths.length).toBeGreaterThan(0);
+      expect(entry.responsibilities.length).toBeGreaterThan(0);
+      expect(entry.verification.length).toBeGreaterThan(0);
+      expect(entry.handoffNotes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers the current package inventory and onboarding docs without overlapping package owners', () => {
+    const manifest = readManifest();
+    const allPaths = manifest.entries.flatMap((entry) => entry.paths);
+
+    for (const requiredPath of [
+      'packages/franken-types/**',
+      'packages/franken-brain/**',
+      'packages/franken-planner/**',
+      'packages/franken-observer/**',
+      'packages/franken-critique/**',
+      'packages/franken-governor/**',
+      'packages/franken-web/**',
+      'packages/franken-orchestrator/**',
+      'packages/franken-mcp-suite/**',
+      'packages/live-bench/**',
+      'docs/onboarding/**',
+      'ONBOARDING.md',
+    ]) {
+      expect(allPaths).toContain(requiredPath);
+    }
+
+    const packagePaths = allPaths.filter((path) => path.startsWith('packages/'));
+    expect(new Set(packagePaths).size).toBe(packagePaths.length);
+  });
+
+  it('documents use, edge cases, and the onboarding entrypoint for operators and PM handoffs', () => {
+    const guide = readText(guidePath);
+    const onboarding = readText('ONBOARDING.md');
+
+    for (const requiredText of [
+      '# Repository ownership manifest',
+      'docs/onboarding/repository-ownership.manifest.json',
+      'Unknown or cross-cutting paths',
+      'PM/worker handoff',
+      'Do not guess an owner from package names alone.',
+      'If a change spans multiple owners, list every touched manifest entry',
+    ]) {
+      expect(guide).toContain(requiredText);
+    }
+
+    expect(onboarding).toContain('[repository ownership manifest](docs/onboarding/repository-ownership.md)');
+    expect(onboarding).toContain('before assigning repository-wide or cross-package work');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a structured JSON repository ownership manifest for package, docs, automation, and onboarding areas.
- Document how PMs/workers should use the manifest for handoffs, unknown paths, and cross-owner changes.
- Link the manifest from ONBOARDING.md and add deterministic coverage for required fields, package coverage, and edge-case guidance.

## Test Plan
- npm run test:root -- tests/docs-issue-1773.test.ts
- npm run test:root -- tests/docs-issue-1773.test.ts tests/docs-issue-1774.test.ts tests/docs-issue-1776.test.ts
- npm run typecheck
- npm run build
- npm run lint

Closes #1773
