### PR TITLE
docs(onboarding): add test command decision tree

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -105,6 +105,8 @@ Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. 
   npm test
   ```
 
+  If you are unsure which narrower command fits your change, follow the [test command decision tree](docs/onboarding/test-command-decision-tree.md) before broadening to package or CI-level gates.
+
 - [ ] Optionally link the local CLIs for iterative development:
 
   ```bash

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -88,6 +88,8 @@ npm test
 
 Root scripts currently include `build`, `typecheck`, `test`, `test:ci`, `test:integration`, `test:eval`, `test:e2e`, `test:live:bench`, `test:root`, `test:root:watch`, and `test:coverage`. Older `build:all` / `test:all` commands are not root scripts. Use `test:ci` for the same root-plus-package test target that CI runs locally; it first builds the shared `@franken/types` workspace so fresh checkouts can resolve workspace package exports, and it intentionally excludes Docker smoke, security, dependency, lint, live benchmark, and the broader orchestrator E2E gate that remains a separate CI step. CI runs a deterministic orchestrator E2E smoke subset through the dedicated `ci:test:e2e` retry-wrapped step so the decision is visible outside the aggregate `test:ci` command. `test:integration` runs deterministic workspace integration suites through Turborepo, while `test:eval` and `test:live:bench` are explicit opt-ins outside default `npm test`; `test:live:bench` delegates to the gated `@franken/live-bench` `test:live` task, which sets `FBEAST_LIVE_BENCH_E2E=1`.
 
+When a worker or contributor needs a narrower verification command, use the [test command decision tree](../onboarding/test-command-decision-tree.md) before broadening to package-level or CI-equivalent gates.
+
 ## 5. Try the orchestrator CLI
 
 The repository root is private and does not publish a root `frankenbeast` binary

--- a/docs/onboarding/test-command-decision-tree.md
+++ b/docs/onboarding/test-command-decision-tree.md
@@ -1,0 +1,76 @@
+# Test command decision tree
+
+Use this decision tree before handing a branch to review. Pick the narrowest command that proves the touched surface, then add the next broader gate when the change crosses a package or root boundary.
+
+## Quick decision tree
+
+1. **Did you only change onboarding/docs copy?**
+   - Run the focused docs verifier for the issue or file you touched, for example:
+     ```bash
+     npm run test:root -- tests/docs-issue-1772.test.ts
+     ```
+   - If the doc references a live root script, also verify the script exists in `package.json` or run the nearest metadata guard that checks it.
+
+2. **Did you change root scripts, CI metadata, Turbo config, or repository guardrails?**
+   - Run the focused root test that covers the changed metadata:
+     ```bash
+     npm run test:root -- tests/<focused-root-test>.test.ts
+     ```
+   - Add the relevant root guard when the change affects it:
+     ```bash
+     npm run lint
+     npm run typecheck
+     ```
+
+3. **Did you change one package's runtime or tests?**
+   - Run that package's targeted test and typecheck scripts:
+     ```bash
+     npm test --workspace @franken/<package>
+     npm run typecheck --workspace @franken/<package>
+     ```
+   - If the package consumes generated workspace exports, build its dependencies first. A common fresh-checkout prerequisite is:
+     ```bash
+     npm run build --workspace @franken/types
+     ```
+
+4. **Did you change shared types or cross-package contracts?**
+   - Build the shared types package, then run the consuming package checks named by the ownership manifest:
+     ```bash
+     npm run build --workspace @franken/types
+     npm run typecheck
+     ```
+
+5. **Did you change integration, eval, E2E, or live-benchmark behavior?**
+   - Use the explicit opt-in suite for that surface instead of assuming default `npm test` covers it:
+     ```bash
+     npm run test:integration
+     npm run test:eval
+     npm run test:e2e
+     npm run test:live:bench
+     ```
+
+6. **Are you preparing a CI-equivalent local handoff?**
+   - Use the aggregate CI test target after the narrower checks pass:
+     ```bash
+     npm run test:ci
+     ```
+   - `test:ci` intentionally excludes Docker smoke, security/dependency audits, lint, live benchmarks, and the broader orchestrator E2E gate; run those separately when you changed those surfaces.
+
+## Negative and edge cases
+
+- Do not use `npm run build:all` or `npm run test:all`; they are not root scripts in this repository.
+- Do not use `test:eval`, `test:e2e`, or `test:live:bench` as default smoke checks. They are opt-in suites for changes that touch those surfaces.
+- Do not treat a dry-run task graph as enough evidence by itself. Pair dry-run selection with at least one real command when the touched surface is executable.
+- Do not run package scripts from a stale shell directory. Prefix directory-sensitive commands with the repository root or package path when handing commands to another worker.
+- Do not broaden a docs-only issue into package refactors just to make a test command exist; add a focused docs verifier instead.
+
+## PM/worker handoff shape
+
+Include the decision, exact command, and result in PRs and Kanban handoffs:
+
+```text
+Test decision: docs-only onboarding change, so focused root docs verifier plus no package runtime gate.
+Commands: npm run test:root -- tests/docs-issue-1772.test.ts
+Result: passed locally.
+Broader gates skipped: package typecheck/build not touched; test:ci left to CI.
+```

--- a/docs/onboarding/test-command-decision-tree.md
+++ b/docs/onboarding/test-command-decision-tree.md
@@ -23,14 +23,19 @@ Use this decision tree before handing a branch to review. Pick the narrowest com
      ```
 
 3. **Did you change one package's runtime or tests?**
-   - Run that package's targeted test and typecheck scripts:
+   - Run that package's targeted test, typecheck, and build scripts when they exist:
      ```bash
      npm test --workspace @franken/<package>
      npm run typecheck --workspace @franken/<package>
+     npm run build --workspace @franken/<package>
      ```
    - If the package consumes generated workspace exports, build its dependencies first. A common fresh-checkout prerequisite is:
      ```bash
      npm run build --workspace @franken/types
+     ```
+   - If the package owns an integration suite, prefer its workspace integration script over the root aggregate:
+     ```bash
+     npm run test:integration --workspace @franken/<package>
      ```
 
 4. **Did you change shared types or cross-package contracts?**
@@ -48,13 +53,23 @@ Use this decision tree before handing a branch to review. Pick the narrowest com
      npm run test:e2e
      npm run test:live:bench
      ```
+   - For package-owned integration suites outside the root aggregate filters, run the package script directly:
+     ```bash
+     npm run test:integration --workspace @franken/<package>
+     ```
+   - For root-level E2E tests under `tests/integration/`, run the root suite with the E2E flag or the exact file:
+     ```bash
+     E2E=true npm run test:root
+     E2E=true npm run test:root -- tests/integration/e2e-beast-loop.test.ts
+     ```
 
 6. **Are you preparing a CI-equivalent local handoff?**
-   - Use the aggregate CI test target after the narrower checks pass:
+   - Use the aggregate CI test target and the separate CI E2E smoke gate after the narrower checks pass:
      ```bash
      npm run test:ci
+     npm run ci:test:e2e
      ```
-   - `test:ci` intentionally excludes Docker smoke, security/dependency audits, lint, live benchmarks, and the broader orchestrator E2E gate; run those separately when you changed those surfaces.
+   - `test:ci` intentionally excludes Docker smoke, security/dependency audits, lint, live benchmarks, and the broader orchestrator E2E gate; `ci:test:e2e` covers the dedicated CI E2E smoke step. Run the other excluded gates separately when you changed those surfaces.
 
 ## Negative and edge cases
 

--- a/tests/docs-issue-1772.test.ts
+++ b/tests/docs-issue-1772.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const guidePath = 'docs/onboarding/test-command-decision-tree.md';
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('issue #1772 onboarding test command decision tree', () => {
+  it('documents a focused command decision tree for common change surfaces', () => {
+    const guide = readText(guidePath);
+
+    for (const requiredText of [
+      '# Test command decision tree',
+      'Did you only change onboarding/docs copy?',
+      'Did you change root scripts, CI metadata, Turbo config, or repository guardrails?',
+      "Did you change one package's runtime or tests?",
+      'Did you change shared types or cross-package contracts?',
+      'Did you change integration, eval, E2E, or live-benchmark behavior?',
+      'Are you preparing a CI-equivalent local handoff?',
+      'PM/worker handoff shape',
+    ]) {
+      expect(guide).toContain(requiredText);
+    }
+  });
+
+  it('anchors decisions to live root scripts instead of stale command names', () => {
+    const guide = readText(guidePath);
+    const packageJson = JSON.parse(readText('package.json')) as { scripts?: Record<string, string> };
+
+    for (const command of [
+      'test:root',
+      'test:ci',
+      'test:integration',
+      'test:eval',
+      'test:e2e',
+      'test:live:bench',
+      'typecheck',
+      'lint',
+    ]) {
+      expect(packageJson.scripts?.[command], `package.json should define ${command}`).toBeTruthy();
+      expect(guide).toContain(`npm run ${command}`);
+    }
+
+    expect(packageJson.scripts?.['build:all']).toBeUndefined();
+    expect(packageJson.scripts?.['test:all']).toBeUndefined();
+    expect(guide).toContain('Do not use `npm run build:all` or `npm run test:all`');
+  });
+
+  it('covers explicit negative and edge cases so workers do not overclaim verification', () => {
+    const guide = readText(guidePath);
+
+    for (const requiredText of [
+      'Do not use `npm run build:all` or `npm run test:all`',
+      'Do not use `test:eval`, `test:e2e`, or `test:live:bench` as default smoke checks.',
+      'Do not treat a dry-run task graph as enough evidence by itself.',
+      'Do not run package scripts from a stale shell directory.',
+      'Broader gates skipped:',
+    ]) {
+      expect(guide).toContain(requiredText);
+    }
+  });
+
+  it('links the decision tree from onboarding and quickstart entrypoints', () => {
+    expect(readText('ONBOARDING.md')).toContain('[test command decision tree](docs/onboarding/test-command-decision-tree.md)');
+    expect(readText('docs/guides/quickstart.md')).toContain('[test command decision tree](../onboarding/test-command-decision-tree.md)');
+  });
+});

--- a/tests/docs-issue-1772.test.ts
+++ b/tests/docs-issue-1772.test.ts
@@ -38,6 +38,7 @@ describe('issue #1772 onboarding test command decision tree', () => {
       'test:eval',
       'test:e2e',
       'test:live:bench',
+      'ci:test:e2e',
       'typecheck',
       'lint',
     ]) {
@@ -58,6 +59,10 @@ describe('issue #1772 onboarding test command decision tree', () => {
       'Do not use `test:eval`, `test:e2e`, or `test:live:bench` as default smoke checks.',
       'Do not treat a dry-run task graph as enough evidence by itself.',
       'Do not run package scripts from a stale shell directory.',
+      'npm run build --workspace @franken/<package>',
+      'npm run test:integration --workspace @franken/<package>',
+      'E2E=true npm run test:root -- tests/integration/e2e-beast-loop.test.ts',
+      'npm run ci:test:e2e',
       'Broader gates skipped:',
     ]) {
       expect(guide).toContain(requiredText);


### PR DESCRIPTION
## Summary
- add a dedicated onboarding test command decision tree for docs, root guardrails, packages, contracts, opt-in suites, and CI-equivalent handoffs
- link the guide from ONBOARDING and the quickstart verification section
- add a root docs verifier covering live root script names and negative/edge cases

## Verification
- npm run test:root -- tests/docs-issue-1772.test.ts
- npm run test:root -- tests/docs-issue-1772.test.ts tests/docs-issue-1773.test.ts

Closes #1772