### PR TITLE
docs(onboarding): add local service dependency explainer

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -195,6 +195,9 @@ Edge case: many older diagrams and `docs/plans/` files describe target or histor
 
 ## Optional services
 
+Before starting Docker or blocking on optional infrastructure, read the [local service dependency explainer](docs/onboarding/local-service-dependencies.md).
+It maps ChromaDB, Grafana, Tempo, provider credentials, and secret backends to the capabilities that actually require them, with health checks and PM/worker handoff fields.
+
 - [ ] Configure `.env` before starting the full compose stack.
   - Keep `CHROMA_URL=http://localhost:8000` unless ChromaDB runs elsewhere.
   - Uncomment `GRAFANA_USER=admin` and set a unique `GRAFANA_PASSWORD`; the old `admin/admin` default is intentionally rejected.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -62,6 +62,9 @@ ${EDITOR:-vi} .env
 
 ## 3. Optional: start infrastructure
 
+Read the [local service dependency explainer](../onboarding/local-service-dependencies.md) before starting Docker.
+It explains which services are optional and how to health-check them so a docs test, typecheck, or CLI-help failure does not turn into an unnecessary compose dependency.
+
 ```bash
 # The bootstrap script validates Grafana credentials before starting compose.
 npm run bootstrap -- --with-docker

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -8,7 +8,7 @@
       "requiredFor": ["semantic memory scripts", "local memory seeding", "semantic-memory verification"],
       "notRequiredFor": ["workspace install", "root unit tests", "orchestrator CLI help", "dashboard shell startup", "file-backed MCP memory"],
       "startCommand": "docker compose up -d chromadb",
-      "healthCheck": "curl -fsS http://localhost:8000/api/v2/heartbeat",
+      "healthCheck": "set -a; [ ! -f .env ] || . ./.env; set +a; curl -fsS \"${CHROMA_URL:-http://localhost:8000}/api/v2/heartbeat\"",
       "env": ["CHROMA_URL=http://localhost:8000"],
       "failureSymptom": "Semantic memory seed or verification scripts fail with connection refused, unavailable Chroma endpoint, or missing v2 tenant/database API errors.",
       "handoffNote": "Mention whether CHROMA_URL is set, whether the v2 heartbeat responded, and whether the work uses semantic-memory scripts rather than file-backed MCP memory."
@@ -18,9 +18,9 @@
       "name": "Grafana",
       "requiredFor": ["local dashboards", "operator-facing observability UI"],
       "notRequiredFor": ["trace collection", "root unit tests", "CLI planning and run commands"],
-      "startCommand": "GRAFANA_USER=admin GRAFANA_PASSWORD=<unique-password> docker compose up -d grafana",
+      "startCommand": "GRAFANA_USER=admin GRAFANA_PASSWORD=replace-with-unique-password docker compose up -d grafana",
       "healthCheck": "curl -fsS http://localhost:3000/api/health",
-      "env": ["GRAFANA_USER=admin", "GRAFANA_PASSWORD=<unique-password>"],
+      "env": ["GRAFANA_USER=admin", "GRAFANA_PASSWORD=replace-with-unique-password"],
       "failureSymptom": "Dashboard links or Grafana panels are unavailable even though application tests and traces still run.",
       "handoffNote": "Record that Grafana credentials were set to a non-default password before starting compose."
     },
@@ -41,7 +41,7 @@
       "requiredFor": ["local chat", "agent execution", "dashboard chat turns", "Beast runs against real providers"],
       "notRequiredFor": ["documentation tests", "static typecheck", "most package unit tests"],
       "startCommand": "Install and authenticate at least one configured provider CLI, or export the API key for an API-backed provider.",
-      "healthCheck": "command -v claude || command -v codex || command -v gemini || test -n \"${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}\"",
+      "healthCheck": "Run a real smoke call through the selected configured provider; for API-backed providers require that provider's API key, and for CLI-backed providers require that provider's authenticated no-op prompt to succeed.",
       "env": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"],
       "failureSymptom": "Provider resolution fails, local chat cannot produce a turn, or Beast runs stop before model invocation.",
       "handoffNote": "Name the selected provider path and whether it is CLI-authenticated or API-key backed."
@@ -52,7 +52,7 @@
       "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
       "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
       "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
-      "healthCheck": "test -f .fbeast/config.json && (test -f .fbeast/secrets.enc || test -n \"${BW_SESSION:-}\" || op account get >/dev/null 2>&1 || security find-generic-password -s frankenbeast >/dev/null 2>&1)",
+      "healthCheck": "node -e \"const fs=require('node:fs'),cp=require('node:child_process'); const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { process.exit(0); } else process.exit(1);\"",
       "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
       "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
       "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault plus FRANKENBEAST_PASSPHRASE, BW_SESSION, op CLI session, or OS keychain availability."

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "defaultPolicy": "Most local services are optional. Start only the service tied to the capability you are testing, then verify its health before blaming provider or agent code.",
+  "services": [
+    {
+      "id": "chromadb",
+      "name": "ChromaDB",
+      "requiredFor": ["semantic memory", "local memory seeding", "memory-backed MCP workflows"],
+      "notRequiredFor": ["workspace install", "root unit tests", "orchestrator CLI help", "dashboard shell startup"],
+      "startCommand": "docker compose up -d chroma",
+      "healthCheck": "curl -fsS http://localhost:8000/api/v2/heartbeat || curl -fsS http://localhost:8000/api/v1/heartbeat",
+      "env": ["CHROMA_URL=http://localhost:8000"],
+      "failureSymptom": "Semantic memory seed, lookup, or MCP memory tools fail with connection refused or unavailable Chroma endpoint errors.",
+      "handoffNote": "Mention whether CHROMA_URL is set and whether the heartbeat endpoint responded before assigning memory-related work."
+    },
+    {
+      "id": "grafana",
+      "name": "Grafana",
+      "requiredFor": ["local dashboards", "operator-facing observability UI"],
+      "notRequiredFor": ["trace collection", "root unit tests", "CLI planning and run commands"],
+      "startCommand": "GRAFANA_USER=admin GRAFANA_PASSWORD=<unique-password> docker compose up -d grafana",
+      "healthCheck": "curl -fsS http://localhost:3000/api/health",
+      "env": ["GRAFANA_USER=admin", "GRAFANA_PASSWORD=<unique-password>"],
+      "failureSymptom": "Dashboard links or Grafana panels are unavailable even though application tests and traces still run.",
+      "handoffNote": "Record that Grafana credentials were set to a non-default password before starting compose."
+    },
+    {
+      "id": "tempo",
+      "name": "Tempo",
+      "requiredFor": ["local distributed trace viewing", "OTLP trace export smoke tests"],
+      "notRequiredFor": ["SQLite observer storage", "root unit tests", "MCP initialization"],
+      "startCommand": "docker compose up -d tempo",
+      "healthCheck": "curl -fsS http://localhost:3200/ready",
+      "env": ["OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318"],
+      "failureSymptom": "Trace export or Grafana trace panels cannot reach Tempo, while local SQLite traces may still be present.",
+      "handoffNote": "Check both Tempo readiness on 3200 and OTLP/HTTP target 4318 when debugging trace export."
+    },
+    {
+      "id": "provider-cli",
+      "name": "AI provider CLI or API credentials",
+      "requiredFor": ["local chat", "agent execution", "dashboard chat turns", "Beast runs against real providers"],
+      "notRequiredFor": ["documentation tests", "static typecheck", "most package unit tests"],
+      "startCommand": "Install and authenticate at least one configured provider CLI, or export the API key for an API-backed provider.",
+      "healthCheck": "command -v claude || command -v codex || command -v gemini || test -n \"${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}\"",
+      "env": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"],
+      "failureSymptom": "Provider resolution fails, local chat cannot produce a turn, or Beast runs stop before model invocation.",
+      "handoffNote": "Name the selected provider path and whether it is CLI-authenticated or API-key backed."
+    },
+    {
+      "id": "secret-backend",
+      "name": "Secret backend",
+      "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
+      "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
+      "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
+      "healthCheck": "test -f .fbeast/config.json && (test -f .fbeast/secrets.enc || true)",
+      "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
+      "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
+      "handoffNote": "Record the configured network.secureBackend and whether existing secret refs were re-stored after backend changes."
+    }
+  ],
+  "edgeCases": [
+    {
+      "case": "Docker is not installed",
+      "expectedAction": "Use npm run bootstrap -- --no-docker and skip ChromaDB, Grafana, and Tempo unless the issue explicitly touches those services."
+    },
+    {
+      "case": "Only root tests are failing",
+      "expectedAction": "Do not start optional compose services as a default fix; root documentation and unit tests should explain service requirements without depending on live services."
+    },
+    {
+      "case": "A URL env var points to a remote service",
+      "expectedAction": "Treat the service as externally managed; verify the URL and credentials rather than starting the local compose service on the same port."
+    }
+  ]
+}

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -37,14 +37,14 @@
     },
     {
       "id": "provider-cli",
-      "name": "AI provider CLI or API credentials",
-      "requiredFor": ["local chat through CLI-backed providers", "agent execution", "dashboard chat turns through CLI-backed providers", "explicit API-backed provider-registry integrations"],
+      "name": "AI provider CLI credentials",
+      "requiredFor": ["local chat through CLI-backed providers", "agent execution", "dashboard chat turns through CLI-backed providers", "normal frankenbeast run paths"],
       "notRequiredFor": ["documentation tests", "static typecheck", "most package unit tests"],
-      "startCommand": "For chat surfaces and normal frankenbeast run/agent execution, install and authenticate a configured CLI provider. For explicitly API-backed provider-registry integrations, export the API key for the selected API-backed provider.",
-      "healthCheck": "Run a real smoke call through the selected configured provider; chat surfaces and normal frankenbeast run/agent execution require a CLI-backed provider with an authenticated no-op prompt, while explicitly API-backed provider-registry integrations may use that provider's API key.",
+      "startCommand": "Install and authenticate a configured CLI provider (claude, codex, or gemini) for chat surfaces and normal frankenbeast run/agent execution. API keys are only sufficient for code paths that explicitly bypass the CLI registry and construct API-backed provider adapters directly.",
+      "healthCheck": "Run a real smoke call through the selected configured CLI-backed provider; chat surfaces and normal frankenbeast run/agent execution require a CLI-backed provider with an authenticated no-op prompt. Do not treat ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, or GEMINI_API_KEY alone as healthy for Beast run paths.",
       "env": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"],
-      "failureSymptom": "Provider resolution fails, local chat or frankenbeast run cannot produce a turn because only API-backed providers are configured, or API-backed integration paths stop before model invocation.",
-      "handoffNote": "Name the selected provider path and whether the surface requires CLI authentication or is an explicitly API-key backed provider-registry integration."
+      "failureSymptom": "Provider resolution fails before model invocation, local chat or frankenbeast run cannot produce a turn because an API-backed provider type was selected for a CLI-registry path, or an explicit low-level API integration lacks its API key.",
+      "handoffNote": "Name the selected provider path, the CLI binary/auth smoke result required by the surface, and whether any separate API-key-only integration was deliberately exercised outside normal Beast run/chat paths."
     },
     {
       "id": "secret-backend",
@@ -52,10 +52,10 @@
       "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
       "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
       "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
-      "healthCheck": "node --input-type=module -e \"import fs from 'node:fs'; import cp from 'node:child_process'; const run=(cmd,args)=>{const r=cp.spawnSync(cmd,args,{encoding:'utf8'}); return {exitCode:r.status ?? 1,stdout:r.stdout ?? '',stderr:r.stderr ?? ''};}; const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); const { LocalEncryptedStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/local-encrypted-store.js'); await new LocalEncryptedStore({ projectRoot: process.cwd(), passphrase: process.env.FRANKENBEAST_PASSPHRASE }).keys(); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); const { BitwardenStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/bitwarden-store.js'); const s=new BitwardenStore(run); if (!(await s.detect()).available) process.exit(1); cp.execFileSync('bw',['list','items','--search','frankenbeast'],{stdio:'ignore'}); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { const { OsKeychainStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/os-keychain-store.js'); const s=new OsKeychainStore({runner:run}); if (!(await s.detect()).available) process.exit(1); await s.keys(); } else process.exit(1);\"",
+      "healthCheck": "node --input-type=module -e \"import fs from 'node:fs'; const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const backend=cfg.network?.secureBackend ?? 'local-encrypted'; const { createSecretStore, SecretResolver } = await import('./packages/franken-orchestrator/dist/network/secret-store.js'); const store=createSecretStore(backend,{projectRoot:process.cwd(),passphrase:process.env.FRANKENBEAST_PASSPHRASE}); const detection=await store.detect(); if(!detection.available) throw new Error(detection.reason ?? ('secret backend '+backend+' unavailable')); await store.keys(); const refs=[cfg.network?.operatorTokenRef,cfg.comms?.orchestratorTokenRef,cfg.comms?.slack?.botTokenRef,cfg.comms?.slack?.signingSecretRef,cfg.comms?.discord?.botTokenRef,cfg.comms?.telegram?.botTokenRef,cfg.comms?.whatsapp?.accessTokenRef,cfg.comms?.whatsapp?.appSecretRef,cfg.comms?.whatsapp?.verifyTokenRef].filter(Boolean); for (const ref of refs) { const value=await store.resolve(ref); if(!value) throw new Error('secret ref '+ref+' did not resolve through '+backend); } await new SecretResolver(store).resolveAll(cfg);\"",
       "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
       "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
-      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault decrypted with FRANKENBEAST_PASSPHRASE, Bitwarden CLI session listed items with BW_SESSION, op CLI session, or OS keychain detection succeeded."
+      "handoffNote": "Record the configured network.secureBackend and backend-specific proof: detect() succeeded, keys() worked, configured secret refs resolved through store.resolve(), and SecretResolver.resolveAll(config) completed for local-encrypted, Bitwarden, 1Password, or OS keychain."
     }
   ],
   "edgeCases": [

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -38,13 +38,13 @@
     {
       "id": "provider-cli",
       "name": "AI provider CLI or API credentials",
-      "requiredFor": ["local chat through CLI-backed providers", "agent execution", "dashboard chat turns through CLI-backed providers", "Beast runs against real providers"],
+      "requiredFor": ["local chat through CLI-backed providers", "agent execution", "dashboard chat turns through CLI-backed providers", "explicit API-backed provider-registry integrations"],
       "notRequiredFor": ["documentation tests", "static typecheck", "most package unit tests"],
-      "startCommand": "For chat surfaces, install and authenticate a configured CLI provider. For provider-registry Beast runs, export the API key for the selected API-backed provider.",
-      "healthCheck": "Run a real smoke call through the selected configured provider; chat surfaces require a CLI-backed provider with an authenticated no-op prompt, while provider-registry Beast runs may use API-backed providers with that provider's API key.",
+      "startCommand": "For chat surfaces and normal frankenbeast run/agent execution, install and authenticate a configured CLI provider. For explicitly API-backed provider-registry integrations, export the API key for the selected API-backed provider.",
+      "healthCheck": "Run a real smoke call through the selected configured provider; chat surfaces and normal frankenbeast run/agent execution require a CLI-backed provider with an authenticated no-op prompt, while explicitly API-backed provider-registry integrations may use that provider's API key.",
       "env": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"],
-      "failureSymptom": "Provider resolution fails, local chat cannot produce a turn because only API-backed providers are configured, or Beast runs stop before model invocation.",
-      "handoffNote": "Name the selected provider path and whether the surface requires CLI authentication or supports API-key backed provider-registry execution."
+      "failureSymptom": "Provider resolution fails, local chat or frankenbeast run cannot produce a turn because only API-backed providers are configured, or API-backed integration paths stop before model invocation.",
+      "handoffNote": "Name the selected provider path and whether the surface requires CLI authentication or is an explicitly API-key backed provider-registry integration."
     },
     {
       "id": "secret-backend",
@@ -52,10 +52,10 @@
       "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
       "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
       "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
-      "healthCheck": "node --input-type=module -e \"import fs from 'node:fs'; import cp from 'node:child_process'; const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); const { LocalEncryptedStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/local-encrypted-store.js'); await new LocalEncryptedStore({ projectRoot: process.cwd(), passphrase: process.env.FRANKENBEAST_PASSPHRASE }).keys(); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { process.exit(0); } else process.exit(1);\"",
+      "healthCheck": "node --input-type=module -e \"import fs from 'node:fs'; import cp from 'node:child_process'; const run=(cmd,args)=>{const r=cp.spawnSync(cmd,args,{encoding:'utf8'}); return {exitCode:r.status ?? 1,stdout:r.stdout ?? '',stderr:r.stderr ?? ''};}; const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); const { LocalEncryptedStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/local-encrypted-store.js'); await new LocalEncryptedStore({ projectRoot: process.cwd(), passphrase: process.env.FRANKENBEAST_PASSPHRASE }).keys(); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); const { BitwardenStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/bitwarden-store.js'); const s=new BitwardenStore(run); if (!(await s.detect()).available) process.exit(1); cp.execFileSync('bw',['list','items','--search','frankenbeast'],{stdio:'ignore'}); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { const { OsKeychainStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/os-keychain-store.js'); const s=new OsKeychainStore({runner:run}); if (!(await s.detect()).available) process.exit(1); await s.keys(); } else process.exit(1);\"",
       "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
       "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
-      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault decrypted with FRANKENBEAST_PASSPHRASE, BW_SESSION, op CLI session, or OS keychain availability."
+      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault decrypted with FRANKENBEAST_PASSPHRASE, Bitwarden CLI session listed items with BW_SESSION, op CLI session, or OS keychain detection succeeded."
     }
   ],
   "edgeCases": [

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -5,13 +5,13 @@
     {
       "id": "chromadb",
       "name": "ChromaDB",
-      "requiredFor": ["semantic memory", "local memory seeding", "memory-backed MCP workflows"],
-      "notRequiredFor": ["workspace install", "root unit tests", "orchestrator CLI help", "dashboard shell startup"],
-      "startCommand": "docker compose up -d chroma",
-      "healthCheck": "curl -fsS http://localhost:8000/api/v2/heartbeat || curl -fsS http://localhost:8000/api/v1/heartbeat",
+      "requiredFor": ["semantic memory scripts", "local memory seeding", "semantic-memory verification"],
+      "notRequiredFor": ["workspace install", "root unit tests", "orchestrator CLI help", "dashboard shell startup", "file-backed MCP memory"],
+      "startCommand": "docker compose up -d chromadb",
+      "healthCheck": "curl -fsS http://localhost:8000/api/v2/heartbeat",
       "env": ["CHROMA_URL=http://localhost:8000"],
-      "failureSymptom": "Semantic memory seed, lookup, or MCP memory tools fail with connection refused or unavailable Chroma endpoint errors.",
-      "handoffNote": "Mention whether CHROMA_URL is set and whether the heartbeat endpoint responded before assigning memory-related work."
+      "failureSymptom": "Semantic memory seed or verification scripts fail with connection refused, unavailable Chroma endpoint, or missing v2 tenant/database API errors.",
+      "handoffNote": "Mention whether CHROMA_URL is set, whether the v2 heartbeat responded, and whether the work uses semantic-memory scripts rather than file-backed MCP memory."
     },
     {
       "id": "grafana",
@@ -52,10 +52,10 @@
       "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
       "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
       "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
-      "healthCheck": "test -f .fbeast/config.json && (test -f .fbeast/secrets.enc || true)",
+      "healthCheck": "test -f .fbeast/config.json && (test -f .fbeast/secrets.enc || test -n \"${BW_SESSION:-}\" || op account get >/dev/null 2>&1 || security find-generic-password -s frankenbeast >/dev/null 2>&1)",
       "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
       "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
-      "handoffNote": "Record the configured network.secureBackend and whether existing secret refs were re-stored after backend changes."
+      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault plus FRANKENBEAST_PASSPHRASE, BW_SESSION, op CLI session, or OS keychain availability."
     }
   ],
   "edgeCases": [

--- a/docs/onboarding/local-service-dependencies.manifest.json
+++ b/docs/onboarding/local-service-dependencies.manifest.json
@@ -18,9 +18,9 @@
       "name": "Grafana",
       "requiredFor": ["local dashboards", "operator-facing observability UI"],
       "notRequiredFor": ["trace collection", "root unit tests", "CLI planning and run commands"],
-      "startCommand": "GRAFANA_USER=admin GRAFANA_PASSWORD=replace-with-unique-password docker compose up -d grafana",
+      "startCommand": "GRAFANA_USER=admin GRAFANA_PASSWORD=\"$(openssl rand -base64 24)\" docker compose up -d --no-deps grafana",
       "healthCheck": "curl -fsS http://localhost:3000/api/health",
-      "env": ["GRAFANA_USER=admin", "GRAFANA_PASSWORD=replace-with-unique-password"],
+      "env": ["GRAFANA_USER=admin", "GRAFANA_PASSWORD=<generated-unique-password>"],
       "failureSymptom": "Dashboard links or Grafana panels are unavailable even though application tests and traces still run.",
       "handoffNote": "Record that Grafana credentials were set to a non-default password before starting compose."
     },
@@ -38,13 +38,13 @@
     {
       "id": "provider-cli",
       "name": "AI provider CLI or API credentials",
-      "requiredFor": ["local chat", "agent execution", "dashboard chat turns", "Beast runs against real providers"],
+      "requiredFor": ["local chat through CLI-backed providers", "agent execution", "dashboard chat turns through CLI-backed providers", "Beast runs against real providers"],
       "notRequiredFor": ["documentation tests", "static typecheck", "most package unit tests"],
-      "startCommand": "Install and authenticate at least one configured provider CLI, or export the API key for an API-backed provider.",
-      "healthCheck": "Run a real smoke call through the selected configured provider; for API-backed providers require that provider's API key, and for CLI-backed providers require that provider's authenticated no-op prompt to succeed.",
+      "startCommand": "For chat surfaces, install and authenticate a configured CLI provider. For provider-registry Beast runs, export the API key for the selected API-backed provider.",
+      "healthCheck": "Run a real smoke call through the selected configured provider; chat surfaces require a CLI-backed provider with an authenticated no-op prompt, while provider-registry Beast runs may use API-backed providers with that provider's API key.",
       "env": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"],
-      "failureSymptom": "Provider resolution fails, local chat cannot produce a turn, or Beast runs stop before model invocation.",
-      "handoffNote": "Name the selected provider path and whether it is CLI-authenticated or API-key backed."
+      "failureSymptom": "Provider resolution fails, local chat cannot produce a turn because only API-backed providers are configured, or Beast runs stop before model invocation.",
+      "handoffNote": "Name the selected provider path and whether the surface requires CLI authentication or supports API-key backed provider-registry execution."
     },
     {
       "id": "secret-backend",
@@ -52,10 +52,10 @@
       "requiredFor": ["operator token lookup", "stored provider credentials", "Beast controls after init"],
       "notRequiredFor": ["repository bootstrap", "docs-only checks", "unit tests with injected secrets"],
       "startCommand": "node packages/franken-orchestrator/dist/cli/run.js init",
-      "healthCheck": "node -e \"const fs=require('node:fs'),cp=require('node:child_process'); const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { process.exit(0); } else process.exit(1);\"",
+      "healthCheck": "node --input-type=module -e \"import fs from 'node:fs'; import cp from 'node:child_process'; const cfg=JSON.parse(fs.readFileSync('.fbeast/config.json','utf8')); const b=cfg.network?.secureBackend ?? 'local-encrypted'; if (b === 'local-encrypted') { if (!fs.existsSync('.fbeast/secrets.enc') || !process.env.FRANKENBEAST_PASSPHRASE) process.exit(1); const { LocalEncryptedStore } = await import('./packages/franken-orchestrator/dist/network/secret-backends/local-encrypted-store.js'); await new LocalEncryptedStore({ projectRoot: process.cwd(), passphrase: process.env.FRANKENBEAST_PASSPHRASE }).keys(); } else if (b === 'bitwarden') { if (!process.env.BW_SESSION) process.exit(1); } else if (b === '1password') { cp.execFileSync('op',['account','get'],{stdio:'ignore'}); } else if (b === 'os-keychain') { process.exit(0); } else process.exit(1);\"",
       "env": ["FRANKENBEAST_PASSPHRASE", "BW_SESSION"],
       "failureSymptom": "Runtime config contains secret refs but commands cannot resolve operator tokens or provider credentials.",
-      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault plus FRANKENBEAST_PASSPHRASE, BW_SESSION, op CLI session, or OS keychain availability."
+      "handoffNote": "Record the configured network.secureBackend and the backend-specific proof: local encrypted vault decrypted with FRANKENBEAST_PASSPHRASE, BW_SESSION, op CLI session, or OS keychain availability."
     }
   ],
   "edgeCases": [

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -13,7 +13,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 | Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
 | Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
 | Local chat, agent execution, dashboard chat turns | CLI-backed provider login | Yes for chat surfaces that use the CLI registry | selected CLI-backed provider smoke call; do not rely on `command -v` alone |
-| Provider-registry Beast runs | API-backed provider keys or CLI-backed provider login | Yes for real model calls | selected provider smoke call using that provider path |
+| Explicit API-backed provider-registry integrations | API-backed provider keys or CLI-backed provider login | Yes for real model calls | selected provider smoke call using that provider path; do not treat normal `frankenbeast run` as API-key-only |
 | Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and a backend-specific decrypt/session check succeeds |
 
 ## Service details
@@ -62,10 +62,10 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 ### Provider CLI or API-backed providers
 
-- Local chat, agent execution, and dashboard chat surfaces currently resolve providers through the CLI provider registry. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) before expecting those chat paths to start.
-- Provider-registry Beast runs may use either a CLI-backed provider or an API-backed provider with an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`; scope API-key-only guidance to those Beast/provider-registry paths.
+- Local chat, normal `frankenbeast run`/agent execution, and dashboard chat surfaces currently resolve providers through the CLI provider registry. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) before expecting those paths to start.
+- Only code paths that explicitly use API-backed provider-registry integrations may rely on an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`; do not document API-key-only setup as sufficient for normal `frankenbeast run` or chat surfaces.
 - Not required for: docs-only tests, static typecheck, and most package unit tests.
-- Failure symptom: provider resolution fails before a model call, chat startup rejects API-only provider types such as `anthropic-api`, `openai-api`, or `gemini-api`, or Beast execution stops with missing provider credentials.
+- Failure symptom: provider resolution fails before a model call, chat or normal `frankenbeast run` rejects API-only provider types such as `anthropic-api`, `openai-api`, or `gemini-api`, or an explicitly API-backed integration stops with missing provider credentials.
 
 ### Secret backend
 
@@ -77,7 +77,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 - Required for: stored operator tokens, stored provider credentials, and runtime paths that resolve secret refs.
 - Not required for: repository bootstrap, docs-only checks, or tests that inject secrets directly.
-- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: for `local-encrypted`, instantiate `LocalEncryptedStore` and run a decrypting call such as `keys()` with `FRANKENBEAST_PASSPHRASE`; use `BW_SESSION` for Bitwarden, an authenticated `op` CLI session for 1Password, or OS keychain availability.
+- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: for `local-encrypted`, instantiate `LocalEncryptedStore` and run a decrypting call such as `keys()` with `FRANKENBEAST_PASSPHRASE`; for Bitwarden, require `BW_SESSION`, confirm `bw` is installed, and run a `bw list items --search frankenbeast` probe so stale sessions fail; for 1Password, require an authenticated `op` CLI session; for OS keychain, instantiate `OsKeychainStore`, run its platform detection, and fail when `secret-tool`/`security`/`cmdkey` is unavailable.
 - Edge case: changing `network.secureBackend` does not migrate existing secret refs. Re-store or migrate secrets after switching between `local-encrypted`, `os-keychain`, `1password`, and `bitwarden`.
 
 ## Negative guidance

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -9,7 +9,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 | Capability being exercised | Local service dependency | Required? | Verification |
 | --- | --- | --- | --- |
 | Repository install, docs checks, root unit tests | None beyond Node.js and npm | No Docker required | `npm run bootstrap -- --no-docker`; `npm run test:root` |
-| Semantic memory and memory-backed MCP flows | ChromaDB | Yes when using local semantic memory | `curl -fsS http://localhost:8000/api/v2/heartbeat` or the v1 heartbeat fallback |
+| Semantic-memory seed and verification scripts | ChromaDB | Yes when using local semantic memory scripts | `curl -fsS http://localhost:8000/api/v2/heartbeat` |
 | Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
 | Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
 | Local chat, Beast runs, dashboard chat turns | Provider CLI login or API-backed provider keys | Yes for real model calls | `command -v claude || command -v codex || command -v gemini`, or exported provider API key |
@@ -22,14 +22,14 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 - Start only when you are using semantic memory locally:
 
   ```bash
-  docker compose up -d chroma
+  docker compose up -d chromadb
   export CHROMA_URL=http://localhost:8000
-  curl -fsS http://localhost:8000/api/v2/heartbeat || curl -fsS http://localhost:8000/api/v1/heartbeat
+  curl -fsS http://localhost:8000/api/v2/heartbeat
   ```
 
-- Required for: `npm run local:seed`, memory-backed MCP workflows, and semantic-memory verification.
-- Not required for: repository install, root documentation tests, CLI help output, or dashboard shell startup.
-- Failure symptom: memory seed/lookup errors mention connection refused or an unavailable Chroma endpoint.
+- Required for: `npm run local:seed`, `npm run local:verify-setup`, and semantic-memory verification that talks to ChromaDB.
+- Not required for: repository install, root documentation tests, CLI help output, dashboard shell startup, or file-backed MCP memory tools.
+- Failure symptom: memory seed/verification errors mention connection refused, an unavailable Chroma endpoint, or a missing v2 tenant/database API.
 
 ### Grafana
 
@@ -73,6 +73,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 - Required for: stored operator tokens, stored provider credentials, and runtime paths that resolve secret refs.
 - Not required for: repository bootstrap, docs-only checks, or tests that inject secrets directly.
+- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: local encrypted vault plus `FRANKENBEAST_PASSPHRASE`, `BW_SESSION` for Bitwarden, an authenticated `op` CLI session for 1Password, or OS keychain availability.
 - Edge case: changing `network.secureBackend` does not migrate existing secret refs. Re-store or migrate secrets after switching between `local-encrypted`, `os-keychain`, `1password`, and `bitwarden`.
 
 ## Negative guidance

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -9,10 +9,10 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 | Capability being exercised | Local service dependency | Required? | Verification |
 | --- | --- | --- | --- |
 | Repository install, docs checks, root unit tests | None beyond Node.js and npm | No Docker required | `npm run bootstrap -- --no-docker`; `npm run test:root` |
-| Semantic-memory seed and verification scripts | ChromaDB | Yes when using local semantic memory scripts | `curl -fsS http://localhost:8000/api/v2/heartbeat` |
+| Semantic-memory seed scripts | ChromaDB | Yes when using local semantic memory scripts | `curl -fsS "${CHROMA_URL:-http://localhost:8000}/api/v2/heartbeat"` |
 | Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
 | Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
-| Local chat, Beast runs, dashboard chat turns | Provider CLI login or API-backed provider keys | Yes for real model calls | `command -v claude || command -v codex || command -v gemini`, or exported provider API key |
+| Local chat, Beast runs, dashboard chat turns | Provider CLI login or API-backed provider keys | Yes for real model calls | selected provider smoke call; do not rely on `command -v` alone |
 | Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and required backend session/passphrase is available |
 
 ## Service details
@@ -22,13 +22,15 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 - Start only when you are using semantic memory locally:
 
   ```bash
+  set -a; [ ! -f .env ] || . ./.env; set +a
   docker compose up -d chromadb
-  export CHROMA_URL=http://localhost:8000
-  curl -fsS http://localhost:8000/api/v2/heartbeat
+  export CHROMA_URL=${CHROMA_URL:-http://localhost:8000}
+  curl -fsS "$CHROMA_URL/api/v2/heartbeat"
   ```
 
-- Required for: `npm run local:seed`, `npm run local:verify-setup`, and semantic-memory verification that talks to ChromaDB.
+- Required for: `npm run local:seed` and semantic-memory checks that talk directly to ChromaDB.
 - Not required for: repository install, root documentation tests, CLI help output, dashboard shell startup, or file-backed MCP memory tools.
+- Full-stack probe: `npm run local:verify-setup` checks ChromaDB, Grafana, and Tempo together; do not use it as a Chroma-only health check unless all optional services are intentionally running.
 - Failure symptom: memory seed/verification errors mention connection refused, an unavailable Chroma endpoint, or a missing v2 tenant/database API.
 
 ### Grafana
@@ -36,7 +38,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 - Start only when you need the observability UI:
 
   ```bash
-  GRAFANA_USER=admin GRAFANA_PASSWORD=<unique-password> docker compose up -d grafana
+  GRAFANA_USER=admin GRAFANA_PASSWORD=replace-with-unique-password docker compose up -d grafana
   curl -fsS http://localhost:3000/api/health
   ```
 

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -13,7 +13,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 | Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
 | Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
 | Local chat, agent execution, dashboard chat turns | CLI-backed provider login | Yes for chat surfaces that use the CLI registry | selected CLI-backed provider smoke call; do not rely on `command -v` alone |
-| Explicit API-backed provider-registry integrations | API-backed provider keys or CLI-backed provider login | Yes for real model calls | selected provider smoke call using that provider path; do not treat normal `frankenbeast run` as API-key-only |
+| Low-level API adapter integrations that bypass normal Beast run/chat paths | API-backed provider keys | Yes only for that explicit integration | adapter-specific API smoke call; do not treat normal `frankenbeast run` or chat as API-key-only |
 | Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and a backend-specific decrypt/session check succeeds |
 
 ## Service details
@@ -60,12 +60,13 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 - Not required for: SQLite observer adapters, most package tests, or MCP initialization.
 - Edge case: verify readiness on port `3200` and the OTLP/HTTP target on `4318` when debugging trace export.
 
-### Provider CLI or API-backed providers
+### Provider CLI credentials
 
 - Local chat, normal `frankenbeast run`/agent execution, and dashboard chat surfaces currently resolve providers through the CLI provider registry. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) before expecting those paths to start.
-- Only code paths that explicitly use API-backed provider-registry integrations may rely on an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`; do not document API-key-only setup as sufficient for normal `frankenbeast run` or chat surfaces.
+- Do not advertise API-key-only setup for Beast run/chat paths: selecting `anthropic-api`, `openai-api`, or `gemini-api` still fails the CLI-registry preflight before model invocation on those surfaces.
+- Exported keys such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY` are sufficient only for low-level code paths that explicitly bypass the CLI registry and construct API-backed provider adapters directly. Name that path in the handoff if you rely on it.
 - Not required for: docs-only tests, static typecheck, and most package unit tests.
-- Failure symptom: provider resolution fails before a model call, chat or normal `frankenbeast run` rejects API-only provider types such as `anthropic-api`, `openai-api`, or `gemini-api`, or an explicitly API-backed integration stops with missing provider credentials.
+- Failure symptom: provider resolution fails before a model call, chat or normal `frankenbeast run` rejects API-only provider types such as `anthropic-api`, `openai-api`, or `gemini-api`, or an explicit low-level API integration stops with missing provider credentials.
 
 ### Secret backend
 
@@ -77,7 +78,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 - Required for: stored operator tokens, stored provider credentials, and runtime paths that resolve secret refs.
 - Not required for: repository bootstrap, docs-only checks, or tests that inject secrets directly.
-- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: for `local-encrypted`, instantiate `LocalEncryptedStore` and run a decrypting call such as `keys()` with `FRANKENBEAST_PASSPHRASE`; for Bitwarden, require `BW_SESSION`, confirm `bw` is installed, and run a `bw list items --search frankenbeast` probe so stale sessions fail; for 1Password, require an authenticated `op` CLI session; for OS keychain, instantiate `OsKeychainStore`, run its platform detection, and fail when `secret-tool`/`security`/`cmdkey` is unavailable.
+- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: for `local-encrypted`, instantiate the runtime store and run decrypting calls such as `detect()`, `keys()`, and `resolve()` for configured refs with `FRANKENBEAST_PASSPHRASE`; for Bitwarden, require `BW_SESSION`, confirm `bw` is installed, run `detect()`, `keys()`, and resolve each configured secret ref so stale sessions fail; for 1Password, require an authenticated `op` CLI session and resolve configured refs; for OS keychain, instantiate `OsKeychainStore`, run its platform detection, fail when `secret-tool`/`security`/`cmdkey` is unavailable, and resolve configured refs through the same store used at runtime.
 - Edge case: changing `network.secureBackend` does not migrate existing secret refs. Re-store or migrate secrets after switching between `local-encrypted`, `os-keychain`, `1password`, and `bitwarden`.
 
 ## Negative guidance

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -1,0 +1,98 @@
+# Local service dependency explainer
+
+Use this guide before telling a newcomer, PM, or worker to start every local service. Frankenbeast has a small core bootstrap path and several optional services. Most onboarding failures are faster to diagnose when the handoff says which service is actually required, how to verify it, and which failures are out of scope.
+
+Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
+
+## Fast decision table
+
+| Capability being exercised | Local service dependency | Required? | Verification |
+| --- | --- | --- | --- |
+| Repository install, docs checks, root unit tests | None beyond Node.js and npm | No Docker required | `npm run bootstrap -- --no-docker`; `npm run test:root` |
+| Semantic memory and memory-backed MCP flows | ChromaDB | Yes when using local semantic memory | `curl -fsS http://localhost:8000/api/v2/heartbeat` or the v1 heartbeat fallback |
+| Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
+| Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
+| Local chat, Beast runs, dashboard chat turns | Provider CLI login or API-backed provider keys | Yes for real model calls | `command -v claude || command -v codex || command -v gemini`, or exported provider API key |
+| Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and required backend session/passphrase is available |
+
+## Service details
+
+### ChromaDB
+
+- Start only when you are using semantic memory locally:
+
+  ```bash
+  docker compose up -d chroma
+  export CHROMA_URL=http://localhost:8000
+  curl -fsS http://localhost:8000/api/v2/heartbeat || curl -fsS http://localhost:8000/api/v1/heartbeat
+  ```
+
+- Required for: `npm run local:seed`, memory-backed MCP workflows, and semantic-memory verification.
+- Not required for: repository install, root documentation tests, CLI help output, or dashboard shell startup.
+- Failure symptom: memory seed/lookup errors mention connection refused or an unavailable Chroma endpoint.
+
+### Grafana
+
+- Start only when you need the observability UI:
+
+  ```bash
+  GRAFANA_USER=admin GRAFANA_PASSWORD=<unique-password> docker compose up -d grafana
+  curl -fsS http://localhost:3000/api/health
+  ```
+
+- Required for: local Grafana panels and operator-facing dashboard views.
+- Not required for: trace collection itself, SQLite observer storage, root unit tests, or CLI planning/runs.
+- Edge case: the old `admin/admin` default is intentionally rejected. Set a unique `GRAFANA_PASSWORD` before starting compose.
+
+### Tempo
+
+- Start when you need local trace export or trace panels:
+
+  ```bash
+  docker compose up -d tempo
+  curl -fsS http://localhost:3200/ready
+  ```
+
+- Required for: OTLP trace export smoke tests and Grafana trace exploration.
+- Not required for: SQLite observer adapters, most package tests, or MCP initialization.
+- Edge case: verify readiness on port `3200` and the OTLP/HTTP target on `4318` when debugging trace export.
+
+### Provider CLI or API-backed providers
+
+- Local chat, Beast runs, and dashboard chat need at least one real provider path. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) or configure an API-backed provider with an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`.
+- Not required for: docs-only tests, static typecheck, and most package unit tests.
+- Failure symptom: provider resolution fails before a model call, or chat/Beast execution stops with missing provider credentials.
+
+### Secret backend
+
+- Choose the backend before the first init whenever possible:
+
+  ```bash
+  node packages/franken-orchestrator/dist/cli/run.js init
+  ```
+
+- Required for: stored operator tokens, stored provider credentials, and runtime paths that resolve secret refs.
+- Not required for: repository bootstrap, docs-only checks, or tests that inject secrets directly.
+- Edge case: changing `network.secureBackend` does not migrate existing secret refs. Re-store or migrate secrets after switching between `local-encrypted`, `os-keychain`, `1password`, and `bitwarden`.
+
+## Negative guidance
+
+- Do not start the full Docker stack just because a docs test, static typecheck, or CLI help command failed.
+- Do not assume Docker is required for onboarding. `npm run bootstrap -- --no-docker` is the default first-run path.
+- Do not overwrite a remote service URL by starting a local container on the same port. If `CHROMA_URL` or another URL points away from localhost, verify that external dependency instead.
+- Do not mark a PM/worker blocked on "local services" without naming the exact service id, health-check command, observed result, and capability being tested.
+
+## PM/worker handoff template
+
+```text
+Local service dependency check:
+- Capability under test:
+- Required service id from docs/onboarding/local-service-dependencies.manifest.json:
+- Start command needed, if local:
+- Health check run and result:
+- Env/config values verified:
+- Not required services intentionally skipped:
+- Next safe action:
+```
+
+For issue handoffs, point workers to this guide plus the JSON manifest instead of repeating prose. Automation should read the manifest when it needs stable service ids, commands, and edge-case handling.

--- a/docs/onboarding/local-service-dependencies.md
+++ b/docs/onboarding/local-service-dependencies.md
@@ -12,8 +12,9 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 | Semantic-memory seed scripts | ChromaDB | Yes when using local semantic memory scripts | `curl -fsS "${CHROMA_URL:-http://localhost:8000}/api/v2/heartbeat"` |
 | Local observability dashboards | Grafana | Yes for dashboard viewing only | `curl -fsS http://localhost:3000/api/health` |
 | Distributed trace viewing/export smoke tests | Tempo | Yes for OTLP trace export | `curl -fsS http://localhost:3200/ready` |
-| Local chat, Beast runs, dashboard chat turns | Provider CLI login or API-backed provider keys | Yes for real model calls | selected provider smoke call; do not rely on `command -v` alone |
-| Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and required backend session/passphrase is available |
+| Local chat, agent execution, dashboard chat turns | CLI-backed provider login | Yes for chat surfaces that use the CLI registry | selected CLI-backed provider smoke call; do not rely on `command -v` alone |
+| Provider-registry Beast runs | API-backed provider keys or CLI-backed provider login | Yes for real model calls | selected provider smoke call using that provider path |
+| Operator token and stored credentials | Configured secret backend | Yes when runtime resolves secret refs | `.fbeast/config.json` names the backend and a backend-specific decrypt/session check succeeds |
 
 ## Service details
 
@@ -38,13 +39,13 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 - Start only when you need the observability UI:
 
   ```bash
-  GRAFANA_USER=admin GRAFANA_PASSWORD=replace-with-unique-password docker compose up -d grafana
+  GRAFANA_USER=admin GRAFANA_PASSWORD="$(openssl rand -base64 24)" docker compose up -d --no-deps grafana
   curl -fsS http://localhost:3000/api/health
   ```
 
 - Required for: local Grafana panels and operator-facing dashboard views.
 - Not required for: trace collection itself, SQLite observer storage, root unit tests, or CLI planning/runs.
-- Edge case: the old `admin/admin` default is intentionally rejected. Set a unique `GRAFANA_PASSWORD` before starting compose.
+- Edge case: the old `admin/admin` default is intentionally rejected. Generate a unique `GRAFANA_PASSWORD` before starting compose, and use `--no-deps` when you want Grafana without also starting Tempo through Docker Compose dependencies.
 
 ### Tempo
 
@@ -61,9 +62,10 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 ### Provider CLI or API-backed providers
 
-- Local chat, Beast runs, and dashboard chat need at least one real provider path. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) or configure an API-backed provider with an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`.
+- Local chat, agent execution, and dashboard chat surfaces currently resolve providers through the CLI provider registry. Install and authenticate a supported CLI (`claude`, `codex`, or `gemini`) before expecting those chat paths to start.
+- Provider-registry Beast runs may use either a CLI-backed provider or an API-backed provider with an exported key such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY`; scope API-key-only guidance to those Beast/provider-registry paths.
 - Not required for: docs-only tests, static typecheck, and most package unit tests.
-- Failure symptom: provider resolution fails before a model call, or chat/Beast execution stops with missing provider credentials.
+- Failure symptom: provider resolution fails before a model call, chat startup rejects API-only provider types such as `anthropic-api`, `openai-api`, or `gemini-api`, or Beast execution stops with missing provider credentials.
 
 ### Secret backend
 
@@ -75,7 +77,7 @@ Structured source: `docs/onboarding/local-service-dependencies.manifest.json`.
 
 - Required for: stored operator tokens, stored provider credentials, and runtime paths that resolve secret refs.
 - Not required for: repository bootstrap, docs-only checks, or tests that inject secrets directly.
-- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: local encrypted vault plus `FRANKENBEAST_PASSPHRASE`, `BW_SESSION` for Bitwarden, an authenticated `op` CLI session for 1Password, or OS keychain availability.
+- Health check: verify `.fbeast/config.json`, then prove the selected backend is usable: for `local-encrypted`, instantiate `LocalEncryptedStore` and run a decrypting call such as `keys()` with `FRANKENBEAST_PASSPHRASE`; use `BW_SESSION` for Bitwarden, an authenticated `op` CLI session for 1Password, or OS keychain availability.
 - Edge case: changing `network.secureBackend` does not migrate existing secret refs. Re-store or migrate secrets after switching between `local-encrypted`, `os-keychain`, `1password`, and `bitwarden`.
 
 ## Negative guidance

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const manifestPath = 'docs/onboarding/local-service-dependencies.manifest.json';
+const guidePath = 'docs/onboarding/local-service-dependencies.md';
+
+type LocalService = {
+  id: string;
+  name: string;
+  requiredFor: string[];
+  notRequiredFor: string[];
+  startCommand: string;
+  healthCheck: string;
+  env: string[];
+  failureSymptom: string;
+  handoffNote: string;
+};
+
+type LocalServiceManifest = {
+  schemaVersion: number;
+  defaultPolicy: string;
+  services: LocalService[];
+  edgeCases: Array<{ case: string; expectedAction: string }>;
+};
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function readManifest(): LocalServiceManifest {
+  return JSON.parse(readText(manifestPath)) as LocalServiceManifest;
+}
+
+describe('issue #1771 local service dependency explainer', () => {
+  it('adds a deterministic manifest for local service dependencies and handoffs', () => {
+    const manifest = readManifest();
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.defaultPolicy).toContain('Most local services are optional');
+
+    const serviceIds = manifest.services.map((service) => service.id);
+    expect(serviceIds).toEqual(['chromadb', 'grafana', 'tempo', 'provider-cli', 'secret-backend']);
+    expect(new Set(serviceIds).size).toBe(serviceIds.length);
+
+    for (const service of manifest.services) {
+      expect(service.id).toMatch(/^[a-z0-9-]+$/);
+      expect(service.name.length).toBeGreaterThan(0);
+      expect(service.requiredFor.length).toBeGreaterThan(0);
+      expect(service.notRequiredFor.length).toBeGreaterThan(0);
+      expect(service.startCommand.length).toBeGreaterThan(0);
+      expect(service.healthCheck.length).toBeGreaterThan(0);
+      expect(service.failureSymptom.length).toBeGreaterThan(0);
+      expect(service.handoffNote.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('documents optional-service edge cases so onboarding failures are explicit', () => {
+    const manifest = readManifest();
+    const guide = readText(guidePath);
+
+    expect(manifest.edgeCases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          case: 'Docker is not installed',
+          expectedAction: expect.stringContaining('npm run bootstrap -- --no-docker'),
+        }),
+        expect.objectContaining({
+          case: 'Only root tests are failing',
+          expectedAction: expect.stringContaining('Do not start optional compose services'),
+        }),
+        expect.objectContaining({
+          case: 'A URL env var points to a remote service',
+          expectedAction: expect.stringContaining('externally managed'),
+        }),
+      ]),
+    );
+
+    for (const requiredText of [
+      '# Local service dependency explainer',
+      'Do not start the full Docker stack just because a docs test, static typecheck, or CLI help command failed.',
+      'Do not assume Docker is required for onboarding.',
+      'Do not overwrite a remote service URL by starting a local container on the same port.',
+      'Local service dependency check:',
+    ]) {
+      expect(guide).toContain(requiredText);
+    }
+  });
+
+  it('links the explainer from the onboarding and quickstart entrypoints', () => {
+    const onboarding = readText('ONBOARDING.md');
+    const quickstart = readText('docs/guides/quickstart.md');
+
+    expect(onboarding).toContain('[local service dependency explainer](docs/onboarding/local-service-dependencies.md)');
+    expect(onboarding).toContain('Before starting Docker or blocking on optional infrastructure');
+    expect(quickstart).toContain('[local service dependency explainer](../onboarding/local-service-dependencies.md)');
+    expect(quickstart).toContain('which services are optional and how to health-check them');
+  });
+});

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -57,15 +57,20 @@ describe('issue #1771 local service dependency explainer', () => {
     expect(secretBackend?.healthCheck).toContain("b === 'local-encrypted'");
     expect(secretBackend?.healthCheck).toContain('.fbeast/secrets.enc');
     expect(secretBackend?.healthCheck).toContain('FRANKENBEAST_PASSPHRASE');
+    expect(secretBackend?.healthCheck).toContain('LocalEncryptedStore');
+    expect(secretBackend?.healthCheck).toContain('.keys()');
     expect(secretBackend?.healthCheck).toContain('BW_SESSION');
     expect(secretBackend?.healthCheck).not.toContain('|| true');
 
     const grafana = manifest.services.find((service) => service.id === 'grafana');
-    expect(grafana?.startCommand).toContain('GRAFANA_PASSWORD=replace-with-unique-password');
-    expect(grafana?.startCommand).not.toContain('<unique-password>');
+    expect(grafana?.startCommand).toContain('openssl rand -base64 24');
+    expect(grafana?.startCommand).toContain('--no-deps grafana');
+    expect(grafana?.startCommand).not.toContain('replace-with-unique-password');
 
     const provider = manifest.services.find((service) => service.id === 'provider-cli');
     expect(provider?.healthCheck).toContain('selected configured provider');
+    expect(provider?.healthCheck).toContain('chat surfaces require a CLI-backed provider');
+    expect(provider?.startCommand).toContain('provider-registry Beast runs');
     expect(provider?.healthCheck).toContain('authenticated no-op prompt');
     expect(provider?.healthCheck).not.toContain('command -v');
 
@@ -108,7 +113,10 @@ describe('issue #1771 local service dependency explainer', () => {
       'Do not assume Docker is required for onboarding.',
       'Do not overwrite a remote service URL by starting a local container on the same port.',
       'Full-stack probe: `npm run local:verify-setup` checks ChromaDB, Grafana, and Tempo together',
-      'selected provider smoke call; do not rely on `command -v` alone',
+      'selected CLI-backed provider smoke call; do not rely on `command -v` alone',
+      'chat surfaces currently resolve providers through the CLI provider registry',
+      'docker compose up -d --no-deps grafana',
+      'run a decrypting call such as `keys()`',
       'Local service dependency check:',
     ]) {
       expect(guide).toContain(requiredText);

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -44,6 +44,20 @@ describe('issue #1771 local service dependency explainer', () => {
     expect(serviceIds).toEqual(['chromadb', 'grafana', 'tempo', 'provider-cli', 'secret-backend']);
     expect(new Set(serviceIds).size).toBe(serviceIds.length);
 
+    const chromadb = manifest.services.find((service) => service.id === 'chromadb');
+    expect(chromadb).toMatchObject({
+      startCommand: 'docker compose up -d chromadb',
+      healthCheck: 'curl -fsS http://localhost:8000/api/v2/heartbeat',
+    });
+    expect(chromadb?.requiredFor).not.toContain('memory-backed MCP workflows');
+    expect(chromadb?.notRequiredFor).toContain('file-backed MCP memory');
+
+    const secretBackend = manifest.services.find((service) => service.id === 'secret-backend');
+    expect(secretBackend?.healthCheck).toContain('test -f .fbeast/config.json');
+    expect(secretBackend?.healthCheck).toContain('.fbeast/secrets.enc');
+    expect(secretBackend?.healthCheck).toContain('BW_SESSION');
+    expect(secretBackend?.healthCheck).not.toContain('|| true');
+
     for (const service of manifest.services) {
       expect(service.id).toMatch(/^[a-z0-9-]+$/);
       expect(service.name.length).toBeGreaterThan(0);

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -59,6 +59,10 @@ describe('issue #1771 local service dependency explainer', () => {
     expect(secretBackend?.healthCheck).toContain('FRANKENBEAST_PASSPHRASE');
     expect(secretBackend?.healthCheck).toContain('LocalEncryptedStore');
     expect(secretBackend?.healthCheck).toContain('.keys()');
+    expect(secretBackend?.healthCheck).toContain('BitwardenStore');
+    expect(secretBackend?.healthCheck).toContain("bw',['list','items','--search','frankenbeast'");
+    expect(secretBackend?.healthCheck).toContain('OsKeychainStore');
+    expect(secretBackend?.healthCheck).toContain('s.detect()');
     expect(secretBackend?.healthCheck).toContain('BW_SESSION');
     expect(secretBackend?.healthCheck).not.toContain('|| true');
 
@@ -69,9 +73,11 @@ describe('issue #1771 local service dependency explainer', () => {
 
     const provider = manifest.services.find((service) => service.id === 'provider-cli');
     expect(provider?.healthCheck).toContain('selected configured provider');
-    expect(provider?.healthCheck).toContain('chat surfaces require a CLI-backed provider');
-    expect(provider?.startCommand).toContain('provider-registry Beast runs');
+    expect(provider?.healthCheck).toContain('chat surfaces and normal frankenbeast run/agent execution require a CLI-backed provider');
+    expect(provider?.startCommand).toContain('explicitly API-backed provider-registry integrations');
+    expect(provider?.startCommand).toContain('normal frankenbeast run/agent execution');
     expect(provider?.healthCheck).toContain('authenticated no-op prompt');
+    expect(provider?.healthCheck).toContain('explicitly API-backed provider-registry integrations');
     expect(provider?.healthCheck).not.toContain('command -v');
 
     for (const service of manifest.services) {
@@ -115,8 +121,10 @@ describe('issue #1771 local service dependency explainer', () => {
       'Full-stack probe: `npm run local:verify-setup` checks ChromaDB, Grafana, and Tempo together',
       'selected CLI-backed provider smoke call; do not rely on `command -v` alone',
       'chat surfaces currently resolve providers through the CLI provider registry',
+      'do not treat normal `frankenbeast run` as API-key-only',
       'docker compose up -d --no-deps grafana',
       'run a decrypting call such as `keys()`',
+      'run a `bw list items --search frankenbeast` probe',
       'Local service dependency check:',
     ]) {
       expect(guide).toContain(requiredText);

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -47,16 +47,27 @@ describe('issue #1771 local service dependency explainer', () => {
     const chromadb = manifest.services.find((service) => service.id === 'chromadb');
     expect(chromadb).toMatchObject({
       startCommand: 'docker compose up -d chromadb',
-      healthCheck: 'curl -fsS http://localhost:8000/api/v2/heartbeat',
+      healthCheck: 'set -a; [ ! -f .env ] || . ./.env; set +a; curl -fsS "${CHROMA_URL:-http://localhost:8000}/api/v2/heartbeat"',
     });
     expect(chromadb?.requiredFor).not.toContain('memory-backed MCP workflows');
     expect(chromadb?.notRequiredFor).toContain('file-backed MCP memory');
 
     const secretBackend = manifest.services.find((service) => service.id === 'secret-backend');
-    expect(secretBackend?.healthCheck).toContain('test -f .fbeast/config.json');
+    expect(secretBackend?.healthCheck).toContain("JSON.parse(fs.readFileSync('.fbeast/config.json'");
+    expect(secretBackend?.healthCheck).toContain("b === 'local-encrypted'");
     expect(secretBackend?.healthCheck).toContain('.fbeast/secrets.enc');
+    expect(secretBackend?.healthCheck).toContain('FRANKENBEAST_PASSPHRASE');
     expect(secretBackend?.healthCheck).toContain('BW_SESSION');
     expect(secretBackend?.healthCheck).not.toContain('|| true');
+
+    const grafana = manifest.services.find((service) => service.id === 'grafana');
+    expect(grafana?.startCommand).toContain('GRAFANA_PASSWORD=replace-with-unique-password');
+    expect(grafana?.startCommand).not.toContain('<unique-password>');
+
+    const provider = manifest.services.find((service) => service.id === 'provider-cli');
+    expect(provider?.healthCheck).toContain('selected configured provider');
+    expect(provider?.healthCheck).toContain('authenticated no-op prompt');
+    expect(provider?.healthCheck).not.toContain('command -v');
 
     for (const service of manifest.services) {
       expect(service.id).toMatch(/^[a-z0-9-]+$/);
@@ -96,6 +107,8 @@ describe('issue #1771 local service dependency explainer', () => {
       'Do not start the full Docker stack just because a docs test, static typecheck, or CLI help command failed.',
       'Do not assume Docker is required for onboarding.',
       'Do not overwrite a remote service URL by starting a local container on the same port.',
+      'Full-stack probe: `npm run local:verify-setup` checks ChromaDB, Grafana, and Tempo together',
+      'selected provider smoke call; do not rely on `command -v` alone',
       'Local service dependency check:',
     ]) {
       expect(guide).toContain(requiredText);

--- a/tests/docs-issue-1771.test.ts
+++ b/tests/docs-issue-1771.test.ts
@@ -54,16 +54,14 @@ describe('issue #1771 local service dependency explainer', () => {
 
     const secretBackend = manifest.services.find((service) => service.id === 'secret-backend');
     expect(secretBackend?.healthCheck).toContain("JSON.parse(fs.readFileSync('.fbeast/config.json'");
-    expect(secretBackend?.healthCheck).toContain("b === 'local-encrypted'");
-    expect(secretBackend?.healthCheck).toContain('.fbeast/secrets.enc');
+    expect(secretBackend?.healthCheck).toContain('createSecretStore');
     expect(secretBackend?.healthCheck).toContain('FRANKENBEAST_PASSPHRASE');
-    expect(secretBackend?.healthCheck).toContain('LocalEncryptedStore');
+    expect(secretBackend?.healthCheck).toContain('store.detect()');
+    expect(secretBackend?.healthCheck).toContain('store.resolve(ref)');
+    expect(secretBackend?.healthCheck).toContain('SecretResolver');
     expect(secretBackend?.healthCheck).toContain('.keys()');
-    expect(secretBackend?.healthCheck).toContain('BitwardenStore');
-    expect(secretBackend?.healthCheck).toContain("bw',['list','items','--search','frankenbeast'");
-    expect(secretBackend?.healthCheck).toContain('OsKeychainStore');
-    expect(secretBackend?.healthCheck).toContain('s.detect()');
-    expect(secretBackend?.healthCheck).toContain('BW_SESSION');
+    expect(secretBackend?.handoffNote).toContain('detect() succeeded');
+    expect(secretBackend?.handoffNote).toContain('configured secret refs resolved through store.resolve()');
     expect(secretBackend?.healthCheck).not.toContain('|| true');
 
     const grafana = manifest.services.find((service) => service.id === 'grafana');
@@ -72,12 +70,13 @@ describe('issue #1771 local service dependency explainer', () => {
     expect(grafana?.startCommand).not.toContain('replace-with-unique-password');
 
     const provider = manifest.services.find((service) => service.id === 'provider-cli');
-    expect(provider?.healthCheck).toContain('selected configured provider');
+    expect(provider?.healthCheck).toContain('selected configured CLI-backed provider');
     expect(provider?.healthCheck).toContain('chat surfaces and normal frankenbeast run/agent execution require a CLI-backed provider');
-    expect(provider?.startCommand).toContain('explicitly API-backed provider-registry integrations');
+    expect(provider?.startCommand).toContain('explicitly bypass the CLI registry');
     expect(provider?.startCommand).toContain('normal frankenbeast run/agent execution');
     expect(provider?.healthCheck).toContain('authenticated no-op prompt');
-    expect(provider?.healthCheck).toContain('explicitly API-backed provider-registry integrations');
+    expect(provider?.healthCheck).toContain('Do not treat ANTHROPIC_API_KEY');
+    expect(provider?.handoffNote).toContain('outside normal Beast run/chat paths');
     expect(provider?.healthCheck).not.toContain('command -v');
 
     for (const service of manifest.services) {
@@ -121,10 +120,10 @@ describe('issue #1771 local service dependency explainer', () => {
       'Full-stack probe: `npm run local:verify-setup` checks ChromaDB, Grafana, and Tempo together',
       'selected CLI-backed provider smoke call; do not rely on `command -v` alone',
       'chat surfaces currently resolve providers through the CLI provider registry',
-      'do not treat normal `frankenbeast run` as API-key-only',
+      'do not treat normal `frankenbeast run` or chat as API-key-only',
       'docker compose up -d --no-deps grafana',
-      'run a decrypting call such as `keys()`',
-      'run a `bw list items --search frankenbeast` probe',
+      'resolve configured refs through the same store used at runtime',
+      'run `detect()`, `keys()`, and resolve each configured secret ref',
       'Local service dependency check:',
     ]) {
       expect(guide).toContain(requiredText);


### PR DESCRIPTION
## Summary
- Add a local service dependency explainer for ChromaDB, Grafana, Tempo, provider credentials, and secret backends
- Add a structured manifest for stable service ids, health checks, edge cases, and PM/worker handoffs
- Link the explainer from onboarding and quickstart docs

## Test Plan
- npm run test:root -- --run tests/docs-issue-1771.test.ts
- npm run lint
- npm run typecheck
- npm run build

Closes #1771