### PR TITLE
feat(onboarding): add issue worktree bootstrap helper

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -127,6 +127,17 @@ Read the [coding-agent PR etiquette guide](docs/onboarding/coding-agent-pr-etiqu
 
 Read the [PM-swarm runtime glossary](docs/onboarding/pm-swarm-runtime-glossary.md) before interpreting PM-swarm Kanban comments, liveness reports, doctor treatment notes, or issue-worker handoffs. It defines the runtime vocabulary used to decode liveness, refill, Codex, approval-cop, and worker handoff terms without creating duplicate branches, worktrees, or PRs.
 
+## Issue worktree bootstrap
+
+When a PM or issue handoff gives you one GitHub issue to fix, start from a dedicated branch/worktree instead of the main checkout:
+
+```bash
+npm run issue:worktree -- --dry-run --issue 1769 --title "feat(onboarding): add issue-to-worktree bootstrap helper"
+npm run issue:worktree -- --issue 1769 --title "feat(onboarding): add issue-to-worktree bootstrap helper"
+```
+
+The helper prints structured issue, branch, worktree path, duplicate-PR check, and verification commands before it mutates anything. By default it creates `../resolve-wt/issue-<number>` from the selected remote's `main` branch, uses a `resolve/issue-<number>-<slug>` branch, and configures the worktree commit identity as `David Mendez <me@davidmendez.dev>`. Use `--reuse --branch <existing-branch>` only when resuming an already-created issue branch; never use it to combine unrelated issues.
+
 ## Architecture reading path
 
 Use this path when you are new to Frankenbeast or when an agent handoff says "read the architecture docs first." It is intentionally ordered from current implementation to deeper historical context.

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -42,6 +42,17 @@ The `frankenbeast issues` subcommand runs a 4-stage pipeline:
 
 Each issue gets its own git branch (`issue-{number}`) and PR with `Fixes #{number}` in the body.
 
+## Issue-to-worktree bootstrap helper
+
+For one-issue/one-PR worker handoffs, use the root helper before coding so branch and worktree names are deterministic and easy for PM/liveness tooling to audit:
+
+```bash
+npm run issue:worktree -- --dry-run --issue 1769 --title "feat(onboarding): add issue-to-worktree bootstrap helper"
+npm run issue:worktree -- --issue 1769 --title "feat(onboarding): add issue-to-worktree bootstrap helper"
+```
+
+The dry run emits the issue number, `resolve/issue-<number>-<slug>` branch, target `../resolve-wt/issue-<number>` worktree, duplicate open-PR check, and exact git verification commands. A real run fetches the base ref, creates the branch/worktree from the selected remote's `main` branch, and configures the worktree commit identity as `David Mendez <me@davidmendez.dev>`. If a previous worker already created the branch, pass `--reuse --branch <existing-branch>` to attach a worktree without creating a duplicate branch; the helper rejects invalid issue numbers, unsafe branch names, and malformed `OWNER/REPO` values before running git.
+
 ## Examples
 
 ### Fix all critical issues

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "turbo run build",
     "bootstrap": "bash scripts/bootstrap.sh",
     "bootstrap:dry-run": "tsx scripts/verify-setup.ts --dry-run --env-file .env.example",
+    "issue:worktree": "node scripts/issue-worktree-bootstrap.mjs",
     "typecheck": "turbo run typecheck",
     "audit:security": "node scripts/check-package-manager.mjs && npm audit --audit-level=moderate",
     "audit:dependencies": "node scripts/check-package-manager.mjs && npm audit",

--- a/scripts/issue-worktree-bootstrap.mjs
+++ b/scripts/issue-worktree-bootstrap.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_REPO = 'djm204/frankenbeast';
+const DEFAULT_REMOTE = 'origin';
+const DEFAULT_BASE_BRANCH = 'main';
+const DEFAULT_WORKTREE_ROOT = '../resolve-wt';
+
+export function slugifyTitle(title) {
+  const slug = String(title ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '')
+    .replace(/-{2,}/gu, '-');
+
+  return slug || 'issue-worktree';
+}
+
+export function parseIssueNumber(value) {
+  const text = String(value ?? '').trim().replace(/^#/u, '');
+  if (!/^\d+$/u.test(text)) {
+    throw new Error('Issue number must be a positive integer, optionally prefixed with #.');
+  }
+  const issue = Number.parseInt(text, 10);
+  if (!Number.isSafeInteger(issue) || issue <= 0) {
+    throw new Error('Issue number must be a positive integer.');
+  }
+  return issue;
+}
+
+export function buildIssueWorktreePlan(options) {
+  const issue = parseIssueNumber(options.issue);
+  const titleSlug = slugifyTitle(options.title ?? `issue-${issue}`).slice(0, 96).replace(/-+$/u, '') || 'issue-worktree';
+  const branch = options.branch ?? `resolve/issue-${issue}-${titleSlug}`;
+  const remote = options.remote ?? DEFAULT_REMOTE;
+  const base = options.base ?? `${remote}/${DEFAULT_BASE_BRANCH}`;
+  const repo = options.repo ?? DEFAULT_REPO;
+  const worktreeRoot = options.worktreeRoot ?? DEFAULT_WORKTREE_ROOT;
+  const worktreePath = resolve(options.cwd ?? process.cwd(), worktreeRoot, `issue-${issue}`);
+  const reuse = Boolean(options.reuse);
+
+  if (!/^[A-Za-z0-9_.-]+$/u.test(remote)) {
+    throw new Error(`Unsafe remote name: ${remote}`);
+  }
+  if (!/^[-./A-Za-z0-9_]+$/u.test(base) || base.includes('..') || base.startsWith('-') || base.endsWith('/')) {
+    throw new Error(`Unsafe base ref: ${base}`);
+  }
+  if (!/^[-./A-Za-z0-9_]+$/u.test(branch) || branch.includes('..') || branch.startsWith('-') || branch.endsWith('/')) {
+    throw new Error(`Unsafe branch name for issue #${issue}: ${branch}`);
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repo)) {
+    throw new Error(`Repository must be OWNER/REPO, got: ${repo}`);
+  }
+
+  const preflight = [
+    ['git', 'rev-parse', '--is-inside-work-tree'],
+    ['git', 'fetch', remote, base.replace(new RegExp(`^${remote}/`, 'u'), '')],
+  ];
+  const duplicateChecks = [
+    ['gh', 'pr', 'list', '--repo', repo, '--state', 'open', '--search', `${issue} in:body`, '--json', 'number,title,headRefName,url'],
+    ['git', 'branch', '--all', '--list', branch, `remotes/${remote}/${branch}`],
+  ];
+  const create = reuse
+    ? [['git', 'worktree', 'add', worktreePath, branch]]
+    : [['git', 'worktree', 'add', '-b', branch, worktreePath, base]];
+  const verify = [
+    ['git', '-C', worktreePath, 'status', '--short', '--branch'],
+    ['git', '-C', worktreePath, 'config', 'extensions.worktreeConfig', 'true'],
+    ['git', '-C', worktreePath, 'config', '--worktree', 'user.name', 'David Mendez'],
+    ['git', '-C', worktreePath, 'config', '--worktree', 'user.email', 'me@davidmendez.dev'],
+  ];
+
+  return {
+    issue,
+    titleSlug,
+    repo,
+    branch,
+    remote,
+    base,
+    worktreePath,
+    reuse,
+    commands: {
+      preflight,
+      duplicateChecks,
+      create,
+      verify,
+    },
+  };
+}
+
+function quote(arg) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/u.test(arg)) return arg;
+  return `'${arg.replace(/'/gu, `'"'"'`)}'`;
+}
+
+function formatCommand(command) {
+  return command.map((arg) => quote(String(arg))).join(' ');
+}
+
+function runCommand(command, cwd) {
+  const result = spawnSync(command[0], command.slice(1), { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || '').trim();
+    throw new Error(`Command failed (${formatCommand(command)}): ${detail}`);
+  }
+  return result.stdout.trim();
+}
+
+function assertNoDuplicateIssueWork(plan) {
+  const [openPrCommand, branchCommand] = plan.commands.duplicateChecks;
+  const openPrOutput = runCommand(openPrCommand, process.cwd());
+  const openPrs = JSON.parse(openPrOutput || '[]');
+  if (Array.isArray(openPrs) && openPrs.length > 0) {
+    const summary = openPrs
+      .map((pr) => `#${pr.number ?? '?'} ${pr.headRefName ?? ''} ${pr.url ?? ''}`.trim())
+      .join('; ');
+    throw new Error(`Issue #${plan.issue} already appears in an open PR: ${summary}`);
+  }
+
+  const existingBranches = runCommand(branchCommand, process.cwd());
+  if (existingBranches && !plan.reuse) {
+    throw new Error(`Branch already exists for issue #${plan.issue}: ${plan.branch}. Use --reuse to attach a worktree to it.`);
+  }
+}
+
+export function renderPlan(plan) {
+  return [
+    `Issue: #${plan.issue}`,
+    `Repository: ${plan.repo}`,
+    `Branch: ${plan.branch}`,
+    `Worktree: ${plan.worktreePath}`,
+    `Base: ${plan.base}`,
+    `Reuse existing branch: ${plan.reuse ? 'yes' : 'no'}`,
+    '',
+    'Commands:',
+    ...Object.entries(plan.commands).flatMap(([section, commands]) => [
+      `## ${section}`,
+      ...commands.map((command) => formatCommand(command)),
+    ]),
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    switch (arg) {
+      case '--issue': options.issue = readValue(); break;
+      case '--title': options.title = readValue(); break;
+      case '--repo': options.repo = readValue(); break;
+      case '--branch': options.branch = readValue(); break;
+      case '--base': options.base = readValue(); break;
+      case '--remote': options.remote = readValue(); break;
+      case '--worktree-root': options.worktreeRoot = readValue(); break;
+      case '--reuse': options.reuse = true; break;
+      case '--dry-run': options.dryRun = true; break;
+      case '--json': options.json = true; break;
+      case '-h':
+      case '--help':
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function usage() {
+  return `Usage: node scripts/issue-worktree-bootstrap.mjs --issue <number> --title <issue title> [options]\n\nCreates a deterministic issue branch/worktree for one-issue/one-PR workers.\n\nOptions:\n  --dry-run               Print planned commands without executing them.\n  --json                  Print structured JSON instead of human text.\n  --repo OWNER/REPO       Repository used for duplicate-PR checks (default: ${DEFAULT_REPO}).\n  --branch NAME           Override generated branch name.\n  --base REF              Base ref for new worktrees (default: <remote>/${DEFAULT_BASE_BRANCH}).\n  --remote NAME           Git remote to fetch (default: ${DEFAULT_REMOTE}).\n  --worktree-root PATH    Directory that receives issue-<number> (default: ${DEFAULT_WORKTREE_ROOT}).\n  --reuse                 Add a worktree for an existing local branch instead of creating a branch.\n  -h, --help              Show this help.\n`;
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+      return;
+    }
+    const plan = buildIssueWorktreePlan({ ...options, cwd: process.cwd() });
+    if (options.dryRun) {
+      if (options.json) {
+        console.log(JSON.stringify({ dryRun: true, ...plan }, null, 2));
+      } else {
+        console.log(renderPlan(plan));
+      }
+      return;
+    }
+    if (!options.json) {
+      console.log(renderPlan(plan));
+    }
+
+    if (existsSync(plan.worktreePath) && !plan.reuse) {
+      throw new Error(`Refusing to overwrite existing worktree path: ${plan.worktreePath}. Use --reuse only for an existing branch.`);
+    }
+    mkdirSync(resolve(plan.worktreePath, '..'), { recursive: true });
+
+    for (const command of plan.commands.preflight) runCommand(command, process.cwd());
+    assertNoDuplicateIssueWork(plan);
+    for (const command of plan.commands.create) runCommand(command, process.cwd());
+    for (const command of plan.commands.verify) runCommand(command, process.cwd());
+    if (options.json) {
+      console.log(JSON.stringify({ status: 'ready', dryRun: false, ...plan }, null, 2));
+    } else {
+      console.log(`[issue-worktree] ready: ${plan.worktreePath}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[issue-worktree] ERROR: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/issue-worktree-bootstrap.mjs
+++ b/scripts/issue-worktree-bootstrap.mjs
@@ -60,6 +60,7 @@ export function buildIssueWorktreePlan(options) {
   const preflight = [
     ['git', 'rev-parse', '--is-inside-work-tree'],
     ['git', 'fetch', remote, base.replace(new RegExp(`^${remote}/`, 'u'), '')],
+    ['git', 'fetch', remote, `+refs/heads/*:refs/remotes/${remote}/*`],
   ];
   const duplicateChecks = [
     ['gh', 'pr', 'list', '--repo', repo, '--state', 'open', '--search', `${issue} in:body`, '--json', 'number,title,headRefName,url'],
@@ -111,12 +112,20 @@ function runCommand(command, cwd) {
   return result.stdout.trim();
 }
 
+export function findConflictingIssuePrs(plan, openPrs) {
+  if (!Array.isArray(openPrs)) return [];
+  return plan.reuse
+    ? openPrs.filter((pr) => pr.headRefName !== plan.branch)
+    : openPrs;
+}
+
 function assertNoDuplicateIssueWork(plan) {
   const [openPrCommand, branchCommand] = plan.commands.duplicateChecks;
   const openPrOutput = runCommand(openPrCommand, process.cwd());
   const openPrs = JSON.parse(openPrOutput || '[]');
-  if (Array.isArray(openPrs) && openPrs.length > 0) {
-    const summary = openPrs
+  const conflictingPrs = findConflictingIssuePrs(plan, openPrs);
+  if (conflictingPrs.length > 0) {
+    const summary = conflictingPrs
       .map((pr) => `#${pr.number ?? '?'} ${pr.headRefName ?? ''} ${pr.url ?? ''}`.trim())
       .join('; ');
     throw new Error(`Issue #${plan.issue} already appears in an open PR: ${summary}`);

--- a/tests/unit/issue-worktree-bootstrap.test.ts
+++ b/tests/unit/issue-worktree-bootstrap.test.ts
@@ -1,0 +1,156 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildIssueWorktreePlan,
+  parseIssueNumber,
+  renderPlan,
+  slugifyTitle,
+} from '../../scripts/issue-worktree-bootstrap.mjs';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/issue-worktree-bootstrap.mjs');
+
+describe('issue-to-worktree bootstrap helper', () => {
+  it('derives deterministic branch and worktree names from issue metadata', () => {
+    const plan = buildIssueWorktreePlan({
+      issue: '#1769',
+      title: 'feat(onboarding): add issue-to-worktree bootstrap helper',
+      cwd: '/repo',
+    });
+
+    expect(plan.issue).toBe(1769);
+    expect(plan.titleSlug).toBe('feat-onboarding-add-issue-to-worktree-bootstrap-helper');
+    expect(plan.branch).toBe('resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper');
+    expect(plan.worktreePath).toBe('/resolve-wt/issue-1769');
+    expect(plan.commands.duplicateChecks.map((command) => command.join(' '))).toContain(
+      'gh pr list --repo djm204/frankenbeast --state open --search 1769 in:body --json number,title,headRefName,url',
+    );
+    expect(plan.commands.duplicateChecks.map((command) => command.join(' '))).toContain(
+      'git branch --all --list resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper remotes/origin/resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper',
+    );
+    expect(plan.commands.create).toEqual([
+      [
+        'git',
+        'worktree',
+        'add',
+        '-b',
+        'resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper',
+        '/resolve-wt/issue-1769',
+        'origin/main',
+      ],
+    ]);
+    expect(plan.commands.verify).toContainEqual([
+      'git',
+      '-C',
+      '/resolve-wt/issue-1769',
+      'config',
+      '--worktree',
+      'user.email',
+      'me@davidmendez.dev',
+    ]);
+  });
+
+  it('supports existing-branch reuse without creating a duplicate branch', () => {
+    const plan = buildIssueWorktreePlan({
+      issue: 1769,
+      title: 'worktree bootstrap',
+      branch: 'resolve/issue-1769-custom',
+      worktreeRoot: '.worktrees',
+      cwd: '/repo',
+      reuse: true,
+    });
+
+    expect(plan.worktreePath).toBe('/repo/.worktrees/issue-1769');
+    expect(plan.commands.create).toEqual([
+      ['git', 'worktree', 'add', '/repo/.worktrees/issue-1769', 'resolve/issue-1769-custom'],
+    ]);
+  });
+
+  it('derives remote-specific default bases and caps long title slugs', () => {
+    const plan = buildIssueWorktreePlan({
+      issue: 2000,
+      title: 'a'.repeat(256),
+      remote: 'upstream',
+      cwd: '/repo',
+    });
+
+    expect(plan.base).toBe('upstream/main');
+    expect(plan.commands.preflight).toContainEqual(['git', 'fetch', 'upstream', 'main']);
+    expect(plan.titleSlug).toHaveLength(96);
+    expect(plan.branch).toHaveLength('resolve/issue-2000-'.length + 96);
+  });
+
+  it('rejects invalid issue numbers and unsafe refs before building commands', () => {
+    expect(() => parseIssueNumber('abc')).toThrow(/positive integer/u);
+    expect(() => buildIssueWorktreePlan({ issue: 0, title: 'bad' })).toThrow(/positive integer/u);
+    expect(() => buildIssueWorktreePlan({ issue: 1, title: 'bad', branch: '../main' })).toThrow(/Unsafe branch/u);
+    expect(() => buildIssueWorktreePlan({ issue: 1, title: 'bad', branch: '-main' })).toThrow(/Unsafe branch/u);
+    expect(() => buildIssueWorktreePlan({ issue: 1, title: 'bad', base: '-main' })).toThrow(/Unsafe base/u);
+    expect(() => buildIssueWorktreePlan({ issue: 1, title: 'bad', repo: 'not-a-repo' })).toThrow(/OWNER\/REPO/u);
+  });
+
+  it('renders copyable dry-run commands and structured fields for PM handoffs', () => {
+    const plan = buildIssueWorktreePlan({
+      issue: 1769,
+      title: 'feat(onboarding): add issue-to-worktree bootstrap helper',
+      cwd: '/repo',
+    });
+    const output = renderPlan(plan);
+
+    expect(output).toContain('Issue: #1769');
+    expect(output).toContain('Branch: resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper');
+    expect(output).toContain('Worktree: /resolve-wt/issue-1769');
+    expect(output).toContain('git worktree add -b resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper /resolve-wt/issue-1769 origin/main');
+  });
+
+  it('prints JSON in dry-run mode without requiring git or GitHub mutation', () => {
+    const result = spawnSync(process.execPath, [
+      SCRIPT,
+      '--dry-run',
+      '--json',
+      '--issue', '1769',
+      '--title', 'feat(onboarding): add issue-to-worktree bootstrap helper',
+      '--worktree-root', '.worktrees',
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      dryRun: boolean;
+      issue: number;
+      branch: string;
+      worktreePath: string;
+      commands: { duplicateChecks: string[][] };
+    };
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.issue).toBe(1769);
+    expect(parsed.branch).toBe('resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper');
+    expect(parsed.worktreePath).toBe(resolve(ROOT, '.worktrees', 'issue-1769'));
+    expect(parsed.commands.duplicateChecks[0]).toContain('gh');
+  });
+
+  it('keeps slug fallback deterministic for punctuation-only titles', () => {
+    expect(slugifyTitle('!!!')).toBe('issue-worktree');
+  });
+
+  it('documents the helper in package scripts and onboarding guides', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const onboarding = readFileSync(resolve(ROOT, 'ONBOARDING.md'), 'utf8');
+    const issueGuide = readFileSync(resolve(ROOT, 'docs/guides/fix-github-issues.md'), 'utf8');
+
+    expect(packageJson.scripts?.['issue:worktree']).toBe('node scripts/issue-worktree-bootstrap.mjs');
+    for (const doc of [onboarding, issueGuide]) {
+      expect(doc).toContain('npm run issue:worktree -- --dry-run --issue 1769');
+      expect(doc).toContain('resolve/issue-<number>-<slug>');
+      expect(doc).toContain('David Mendez <me@davidmendez.dev>');
+      expect(doc).toContain('--reuse --branch <existing-branch>');
+    }
+  });
+});

--- a/tests/unit/issue-worktree-bootstrap.test.ts
+++ b/tests/unit/issue-worktree-bootstrap.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildIssueWorktreePlan,
+  findConflictingIssuePrs,
   parseIssueNumber,
   renderPlan,
   slugifyTitle,
@@ -31,6 +32,12 @@ describe('issue-to-worktree bootstrap helper', () => {
     expect(plan.commands.duplicateChecks.map((command) => command.join(' '))).toContain(
       'git branch --all --list resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper remotes/origin/resolve/issue-1769-feat-onboarding-add-issue-to-worktree-bootstrap-helper',
     );
+    expect(plan.commands.preflight).toContainEqual([
+      'git',
+      'fetch',
+      'origin',
+      '+refs/heads/*:refs/remotes/origin/*',
+    ]);
     expect(plan.commands.create).toEqual([
       [
         'git',
@@ -66,6 +73,14 @@ describe('issue-to-worktree bootstrap helper', () => {
     expect(plan.worktreePath).toBe('/repo/.worktrees/issue-1769');
     expect(plan.commands.create).toEqual([
       ['git', 'worktree', 'add', '/repo/.worktrees/issue-1769', 'resolve/issue-1769-custom'],
+    ]);
+    expect(findConflictingIssuePrs(plan, [
+      { number: 2337, headRefName: 'resolve/issue-1769-custom', url: 'https://example.test/pr/2337' },
+    ])).toEqual([]);
+    expect(findConflictingIssuePrs(plan, [
+      { number: 2338, headRefName: 'resolve/issue-1769-other', url: 'https://example.test/pr/2338' },
+    ])).toEqual([
+      { number: 2338, headRefName: 'resolve/issue-1769-other', url: 'https://example.test/pr/2338' },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Adds `scripts/issue-worktree-bootstrap.mjs` and `npm run issue:worktree` for deterministic one-issue worktree setup.
- Emits structured dry-run output with branch/worktree/duplicate-check/verification commands and rejects invalid issue/ref/repo inputs.
- Documents the helper in onboarding and the GitHub issue-fixing guide.

## Verification
- `npm run test:root -- tests/unit/issue-worktree-bootstrap.test.ts`
- `node scripts/issue-worktree-bootstrap.mjs --dry-run --json --issue 1769 --title 'feat(onboarding): add issue-to-worktree bootstrap helper'`
- `npm run lint` (passes; existing warnings only)
- `npm run typecheck`
- `npm run build`

Closes #1769
