### PR TITLE
feat(onboarding): add new-worker preflight command

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -56,10 +56,10 @@ Use this checklist for a first local checkout or when rebuilding a development e
 - [ ] New issue workers: before coding, run the environment preflight from the repository root or issue worktree:
 
   ```bash
-  npm run new-worker:preflight -- --json
+  npm --silent run new-worker:preflight -- --json
   ```
 
-  The command prints stable `[new-worker-preflight:<check>] ok|warn|fail - ...` badges by default, or a JSON object with `ok` and `checks` when `--json` is supplied. It verifies the supported Node.js/npm pin, required `git`/`gh`/`jq` commands, GitHub CLI authentication, the project git identity (`David Mendez <me@davidmendez.dev>`), repository root, and whether the current worktree already has uncommitted files. Use `--skip-github-auth` only for offline docs/tests; run without it before opening PRs.
+  The command prints stable `[new-worker-preflight:<check>] ok|warn|fail - ...` badges by default, or a JSON object with `ok` and `checks` when `--json` is supplied. Use `npm --silent` or `node scripts/new-worker-preflight.mjs --json` for machine-parsed JSON so npm lifecycle banners do not prefix stdout. It verifies the supported Node.js/npm pin, required `git`/`gh`/`jq` commands, GitHub CLI authentication for `github.com`, the project git identity (`David Mendez <me@davidmendez.dev>`), Frankenbeast repository root, and whether the current worktree already has uncommitted files. Use `--skip-github-auth` only for offline docs/tests; run without it before opening PRs.
 
 ### Progress badges and status output
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -53,6 +53,14 @@ Use this checklist for a first local checkout or when rebuilding a development e
   ./scripts/bootstrap.sh --dry-run
   ```
 
+- [ ] New issue workers: before coding, run the environment preflight from the repository root or issue worktree:
+
+  ```bash
+  npm run new-worker:preflight -- --json
+  ```
+
+  The command prints stable `[new-worker-preflight:<check>] ok|warn|fail - ...` badges by default, or a JSON object with `ok` and `checks` when `--json` is supplied. It verifies the supported Node.js/npm pin, required `git`/`gh`/`jq` commands, GitHub CLI authentication, the project git identity (`David Mendez <me@davidmendez.dev>`), repository root, and whether the current worktree already has uncommitted files. Use `--skip-github-auth` only for offline docs/tests; run without it before opening PRs.
+
 ### Progress badges and status output
 
 The bootstrap script prints deterministic status badges as it advances through onboarding:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBO
 npm run bootstrap -- --no-docker
 ```
 
-The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. New issue workers can run `npm run new-worker:preflight -- --json` before coding to verify the local Node/npm/git/gh/jq toolchain, GitHub authentication, project git identity, repository root, and worktree cleanliness with structured output for PM handoffs. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
+The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. New issue workers can run `npm --silent run new-worker:preflight -- --json` before coding to verify the local Node/npm/git/gh/jq toolchain, GitHub authentication, project git identity, repository root, and worktree cleanliness with parseable structured output for PM handoffs. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
 
 ```bash
 ./scripts/bootstrap.sh --dry-run

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBO
 npm run bootstrap -- --no-docker
 ```
 
-The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
+The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. New issue workers can run `npm run new-worker:preflight -- --json` before coding to verify the local Node/npm/git/gh/jq toolchain, GitHub authentication, project git identity, repository root, and worktree cleanliness with structured output for PM handoffs. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
 
 ```bash
 ./scripts/bootstrap.sh --dry-run

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "local:seed": "tsx scripts/seed.ts",
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
+    "new-worker:preflight": "node scripts/new-worker-preflight.mjs",
     "test": "turbo run test",
     "test:integration": "turbo run test:integration --filter=@franken/brain --filter=@franken/critique --filter=@franken/governor --filter=@franken/observer",
     "test:eval": "turbo run test:eval --filter=@franken/observer",

--- a/scripts/new-worker-preflight.mjs
+++ b/scripts/new-worker-preflight.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const NODE_RANGE = '>=22.13.0 <23 || >=24.0.0 <26';
+const EXPECTED_GIT_USER = 'David Mendez';
+const EXPECTED_GIT_EMAIL = 'me@davidmendez.dev';
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    skipGithubAuth: false,
+    root: process.cwd(),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--skip-github-auth') {
+      options.skipGithubAuth = true;
+      continue;
+    }
+    if (arg === '--root') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      i += 1;
+      continue;
+    }
+    if (arg?.startsWith('--root=')) {
+      const value = arg.slice('--root='.length);
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      continue;
+    }
+    if (arg === '-h' || arg === '--help') {
+      printUsage();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.info(`Usage: npm run new-worker:preflight -- [--json] [--skip-github-auth] [--root <path>]
+
+Checks a fresh issue worker environment before coding:
+  - supported Node.js runtime (${NODE_RANGE})
+  - npm version matches the root packageManager pin
+  - git, gh, and jq are available
+  - GitHub CLI is authenticated unless --skip-github-auth is set
+  - git user.name/user.email match the project worker identity
+  - command is running inside a Frankenbeast checkout
+
+Human output uses stable badges: [new-worker-preflight:<check-id>] ok|warn|fail - detail.
+JSON output is { ok, checks: [{ id, status, detail, action? }] }.`);
+}
+
+function run(command, args = [], options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: process.platform === 'win32',
+  });
+  const stdout = result.stdout?.trim() ?? '';
+  const stderr = result.stderr?.trim() ?? '';
+  return {
+    status: result.status,
+    error: result.error,
+    stdout,
+    stderr,
+    ok: !result.error && result.status === 0,
+    detail: result.error?.message ?? stderr ?? stdout,
+  };
+}
+
+function nodeMeetsRange(version) {
+  const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number);
+  return (major === 22 && (minor > 13 || (minor === 13 && patch >= 0)))
+    || (major >= 24 && major < 26);
+}
+
+function packageManagerNpmVersion(root) {
+  try {
+    const manifest = JSON.parse(readFileSync(`${root}/package.json`, 'utf8'));
+    return typeof manifest.packageManager === 'string'
+      ? manifest.packageManager.match(/^npm@(\d+\.\d+\.\d+)$/u)?.[1]
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function commandVersion(command, args = ['--version']) {
+  const result = run(command, args);
+  return result.ok
+    ? { id: `${command}-command`, status: 'ok', detail: `${command} available: ${result.stdout.split(/\r?\n/u)[0]}` }
+    : { id: `${command}-command`, status: 'fail', detail: `${command} is not available`, action: `Install ${command} and ensure it is on PATH. ${result.detail}` };
+}
+
+function preflight(options) {
+  const checks = [];
+
+  checks.push(nodeMeetsRange(process.versions.node)
+    ? { id: 'node-version', status: 'ok', detail: `Node.js v${process.versions.node} satisfies ${NODE_RANGE}` }
+    : { id: 'node-version', status: 'fail', detail: `Node.js v${process.versions.node} does not satisfy ${NODE_RANGE}`, action: 'Install the version in .nvmrc or another supported Node.js release before taking a worker card.' });
+
+  const expectedNpm = packageManagerNpmVersion(options.root);
+  const npmVersion = run('npm', ['--version']);
+  if (!expectedNpm) {
+    checks.push({ id: 'npm-package-manager', status: 'fail', detail: 'root package.json is missing packageManager npm@x.y.z', action: 'Run from the Frankenbeast repository root or restore the packageManager field.' });
+  } else if (!npmVersion.ok) {
+    checks.push({ id: 'npm-package-manager', status: 'fail', detail: 'npm is not available', action: `Activate Corepack npm@${expectedNpm}. ${npmVersion.detail}` });
+  } else if (npmVersion.stdout !== expectedNpm) {
+    checks.push({ id: 'npm-package-manager', status: 'fail', detail: `expected npm ${expectedNpm}, found ${npmVersion.stdout}`, action: `Run: corepack enable npm && corepack prepare npm@${expectedNpm} --activate` });
+  } else {
+    checks.push({ id: 'npm-package-manager', status: 'ok', detail: `npm ${npmVersion.stdout} matches packageManager` });
+  }
+
+  checks.push(commandVersion('git'));
+  checks.push(commandVersion('gh'));
+  checks.push(commandVersion('jq'));
+
+  const repoRoot = run('git', ['rev-parse', '--show-toplevel'], { cwd: options.root });
+  if (!repoRoot.ok) {
+    checks.push({ id: 'repository-root', status: 'fail', detail: 'not inside a git checkout', action: 'Clone djm204/frankenbeast and run this command from the repository root or issue worktree.' });
+  } else if (!existsSync(`${repoRoot.stdout}/package.json`) || packageManagerNpmVersion(repoRoot.stdout) === undefined) {
+    checks.push({ id: 'repository-root', status: 'fail', detail: `${repoRoot.stdout} is not the Frankenbeast repository root`, action: 'Run from the Frankenbeast repository root or an isolated issue worktree.' });
+  } else {
+    checks.push({ id: 'repository-root', status: 'ok', detail: repoRoot.stdout });
+  }
+
+  const gitName = run('git', ['config', 'user.name'], { cwd: options.root });
+  const gitEmail = run('git', ['config', 'user.email'], { cwd: options.root });
+  if (gitName.stdout === EXPECTED_GIT_USER && gitEmail.stdout === EXPECTED_GIT_EMAIL) {
+    checks.push({ id: 'git-identity', status: 'ok', detail: `${EXPECTED_GIT_USER} <${EXPECTED_GIT_EMAIL}>` });
+  } else {
+    checks.push({ id: 'git-identity', status: 'fail', detail: `found ${gitName.stdout || '<unset>'} <${gitEmail.stdout || '<unset>'}>`, action: `Run: git config user.name '${EXPECTED_GIT_USER}' && git config user.email '${EXPECTED_GIT_EMAIL}'` });
+  }
+
+  if (options.skipGithubAuth) {
+    checks.push({ id: 'github-auth', status: 'warn', detail: 'skipped by --skip-github-auth', action: 'Run without --skip-github-auth before opening PRs or reading private issues.' });
+  } else {
+    const auth = run('gh', ['auth', 'status'], { cwd: options.root });
+    checks.push(auth.ok
+      ? { id: 'github-auth', status: 'ok', detail: 'gh auth status succeeded' }
+      : { id: 'github-auth', status: 'fail', detail: 'gh auth status failed', action: `Run: gh auth login. ${auth.detail}` });
+  }
+
+  const status = run('git', ['status', '--porcelain'], { cwd: options.root });
+  if (status.ok && status.stdout.length > 0) {
+    checks.push({ id: 'worktree-clean', status: 'warn', detail: 'worktree has uncommitted files', action: 'Start each issue from a fresh isolated worktree, or intentionally continue the existing scoped branch.' });
+  } else if (status.ok) {
+    checks.push({ id: 'worktree-clean', status: 'ok', detail: 'worktree is clean' });
+  }
+
+  return { ok: checks.every((check) => check.status !== 'fail'), checks };
+}
+
+function printHuman(report) {
+  for (const check of report.checks) {
+    const suffix = check.action ? ` Action: ${check.action}` : '';
+    console.info(`[new-worker-preflight:${check.id}] ${check.status} - ${check.detail}${suffix}`);
+  }
+  console.info(report.ok
+    ? 'New-worker preflight passed. Environment is ready for an issue worktree.'
+    : 'New-worker preflight failed. Fix failed checks before taking or continuing an issue worker card.');
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const report = preflight(options);
+  if (options.json) {
+    console.info(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+  process.exit(report.ok ? 0 : 1);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`new-worker preflight failed before checks: ${message}`);
+  process.exit(2);
+}

--- a/scripts/new-worker-preflight.mjs
+++ b/scripts/new-worker-preflight.mjs
@@ -116,7 +116,7 @@ function preflight(options) {
     : { id: 'node-version', status: 'fail', detail: `Node.js v${process.versions.node} does not satisfy ${NODE_RANGE}`, action: 'Install the version in .nvmrc or another supported Node.js release before taking a worker card.' });
 
   const expectedNpm = packageManagerNpmVersion(options.root);
-  const npmVersion = run('npm', ['--version']);
+  const npmVersion = run('npm', ['--version'], { cwd: options.root });
   if (!expectedNpm) {
     checks.push({ id: 'npm-package-manager', status: 'fail', detail: 'root package.json is missing packageManager npm@x.y.z', action: 'Run from the Frankenbeast repository root or restore the packageManager field.' });
   } else if (!npmVersion.ok) {
@@ -158,9 +158,11 @@ function preflight(options) {
   }
 
   const status = run('git', ['status', '--porcelain'], { cwd: options.root });
-  if (status.ok && status.stdout.length > 0) {
+  if (!status.ok) {
+    checks.push({ id: 'worktree-clean', status: 'fail', detail: 'unable to read git worktree status', action: `Repair the git checkout or start from a fresh isolated worktree. ${status.detail}` });
+  } else if (status.stdout.length > 0) {
     checks.push({ id: 'worktree-clean', status: 'warn', detail: 'worktree has uncommitted files', action: 'Start each issue from a fresh isolated worktree, or intentionally continue the existing scoped branch.' });
-  } else if (status.ok) {
+  } else {
     checks.push({ id: 'worktree-clean', status: 'ok', detail: 'worktree is clean' });
   }
 

--- a/scripts/new-worker-preflight.mjs
+++ b/scripts/new-worker-preflight.mjs
@@ -86,15 +86,19 @@ function nodeMeetsRange(version) {
     || (major >= 24 && major < 26);
 }
 
-function packageManagerNpmVersion(root) {
+function rootManifest(root) {
   try {
-    const manifest = JSON.parse(readFileSync(`${root}/package.json`, 'utf8'));
-    return typeof manifest.packageManager === 'string'
-      ? manifest.packageManager.match(/^npm@(\d+\.\d+\.\d+)$/u)?.[1]
-      : undefined;
+    return JSON.parse(readFileSync(`${root}/package.json`, 'utf8'));
   } catch {
     return undefined;
   }
+}
+
+function packageManagerNpmVersion(root) {
+  const manifest = rootManifest(root);
+  return typeof manifest?.packageManager === 'string'
+    ? manifest.packageManager.match(/^npm@(\d+\.\d+\.\d+)$/u)?.[1]
+    : undefined;
 }
 
 function commandVersion(command, args = ['--version']) {
@@ -130,7 +134,7 @@ function preflight(options) {
   const repoRoot = run('git', ['rev-parse', '--show-toplevel'], { cwd: options.root });
   if (!repoRoot.ok) {
     checks.push({ id: 'repository-root', status: 'fail', detail: 'not inside a git checkout', action: 'Clone djm204/frankenbeast and run this command from the repository root or issue worktree.' });
-  } else if (!existsSync(`${repoRoot.stdout}/package.json`) || packageManagerNpmVersion(repoRoot.stdout) === undefined) {
+  } else if (!existsSync(`${repoRoot.stdout}/package.json`) || rootManifest(repoRoot.stdout)?.name !== 'frankenbeast') {
     checks.push({ id: 'repository-root', status: 'fail', detail: `${repoRoot.stdout} is not the Frankenbeast repository root`, action: 'Run from the Frankenbeast repository root or an isolated issue worktree.' });
   } else {
     checks.push({ id: 'repository-root', status: 'ok', detail: repoRoot.stdout });
@@ -147,7 +151,7 @@ function preflight(options) {
   if (options.skipGithubAuth) {
     checks.push({ id: 'github-auth', status: 'warn', detail: 'skipped by --skip-github-auth', action: 'Run without --skip-github-auth before opening PRs or reading private issues.' });
   } else {
-    const auth = run('gh', ['auth', 'status'], { cwd: options.root });
+    const auth = run('gh', ['auth', 'status', '--hostname', 'github.com'], { cwd: options.root });
     checks.push(auth.ok
       ? { id: 'github-auth', status: 'ok', detail: 'gh auth status succeeded' }
       : { id: 'github-auth', status: 'fail', detail: 'gh auth status failed', action: `Run: gh auth login. ${auth.detail}` });

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -37,9 +37,9 @@ function makePreflightFixture(options: { includeJq?: boolean; npmVersion?: strin
   const bin = join(dir, 'bin');
   mkdirSync(root, { recursive: true });
   mkdirSync(bin, { recursive: true });
-  writeFileSync(join(root, 'package.json'), JSON.stringify({ packageManager: 'npm@11.5.1' }));
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'frankenbeast', packageManager: 'npm@11.5.1' }));
   writeExecutable(join(bin, 'npm'), `printf '%s\\n' '${options.npmVersion ?? '11.5.1'}'\n`);
-  writeExecutable(join(bin, 'gh'), `if [ \"$1\" = '--version' ]; then printf 'gh version 2.0.0\\n'; exit 0; fi\nif [ \"$1\" = 'auth' ] && [ \"$2\" = 'status' ]; then printf 'Logged in\\n'; exit 0; fi\nprintf 'unexpected gh args: %s %s\\n' \"$1\" \"$2\" >&2\nexit 1\n`);
+  writeExecutable(join(bin, 'gh'), `if [ \"$1\" = '--version' ]; then printf 'gh version 2.0.0\\n'; exit 0; fi\nif [ \"$1\" = 'auth' ] && [ \"$2\" = 'status' ] && [ \"$3\" = '--hostname' ] && [ \"$4\" = 'github.com' ]; then printf 'Logged in to github.com\\n'; exit 0; fi\nprintf 'unexpected gh args: %s %s %s %s\\n' \"$1\" \"$2\" \"$3\" \"$4\" >&2\nexit 1\n`);
   writeExecutable(join(bin, 'git'), `case \"$1\" in\n  --version) printf 'git version 2.53.0\\n' ;;\n  rev-parse) printf '%s\\n' '${root}' ;;\n  config) if [ \"$2\" = 'user.name' ]; then printf 'David Mendez\\n'; else printf 'me@davidmendez.dev\\n'; fi ;;\n  status) exit 0 ;;\n  *) printf 'unexpected git args: %s %s\\n' \"$1\" \"$2\" >&2; exit 1 ;;\nesac\n`);
   if (options.includeJq !== false) {
     writeExecutable(join(bin, 'jq'), `printf 'jq-1.8.1\\n'\n`);
@@ -210,10 +210,10 @@ describe('local setup scripts', () => {
     expect(manifest.scripts?.['new-worker:preflight']).toBe('node scripts/new-worker-preflight.mjs');
     expect(readme).toContain('npm run local:seed');
     expect(readme).toContain('npm run local:verify-setup');
-    expect(readme).toContain('npm run new-worker:preflight -- --json');
+    expect(readme).toContain('npm --silent run new-worker:preflight -- --json');
     expect(onboarding).toContain('npm run local:seed');
     expect(onboarding).toContain('npm run local:verify-setup');
-    expect(onboarding).toContain('npm run new-worker:preflight -- --json');
+    expect(onboarding).toContain('npm --silent run new-worker:preflight -- --json');
     expect(onboarding).toContain('[new-worker-preflight:<check>] ok|warn|fail');
     expect(seedScript).toContain('Usage: npm run local:seed');
     expect(verifyScript).toContain('Usage: npm run local:verify-setup');
@@ -256,6 +256,28 @@ describe('local setup scripts', () => {
         id: 'jq-command',
         status: 'fail',
         action: expect.stringContaining('Install jq'),
+      }));
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('new-worker preflight rejects npm-managed repositories that are not Frankenbeast', () => {
+    const fixture = makePreflightFixture();
+    try {
+      writeFileSync(join(fixture.root, 'package.json'), JSON.stringify({ name: 'not-frankenbeast', packageManager: 'npm@11.5.1' }));
+      const result = spawnSync(process.execPath, ['scripts/new-worker-preflight.mjs', '--json', '--root', fixture.root], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${fixture.bin}:${process.env.PATH ?? ''}` },
+      });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string; detail: string }> };
+      expect(report.ok).toBe(false);
+      expect(report.checks).toContainEqual(expect.objectContaining({
+        id: 'repository-root',
+        status: 'fail',
+        detail: expect.stringContaining('is not the Frankenbeast repository root'),
       }));
     } finally {
       rmSync(fixture.dir, { recursive: true, force: true });

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -24,6 +24,27 @@ function composeServices(): string[] {
     }
   }
   return [...services].sort();
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}`);
+  chmodSync(path, 0o755);
+}
+
+function makePreflightFixture(options: { includeJq?: boolean; npmVersion?: string } = {}): { dir: string; root: string; bin: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'frankenbeast-new-worker-preflight-'));
+  const root = join(dir, 'repo');
+  const bin = join(dir, 'bin');
+  mkdirSync(root, { recursive: true });
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ packageManager: 'npm@11.5.1' }));
+  writeExecutable(join(bin, 'npm'), `printf '%s\\n' '${options.npmVersion ?? '11.5.1'}'\n`);
+  writeExecutable(join(bin, 'gh'), `if [ \"$1\" = '--version' ]; then printf 'gh version 2.0.0\\n'; exit 0; fi\nif [ \"$1\" = 'auth' ] && [ \"$2\" = 'status' ]; then printf 'Logged in\\n'; exit 0; fi\nprintf 'unexpected gh args: %s %s\\n' \"$1\" \"$2\" >&2\nexit 1\n`);
+  writeExecutable(join(bin, 'git'), `case \"$1\" in\n  --version) printf 'git version 2.53.0\\n' ;;\n  rev-parse) printf '%s\\n' '${root}' ;;\n  config) if [ \"$2\" = 'user.name' ]; then printf 'David Mendez\\n'; else printf 'me@davidmendez.dev\\n'; fi ;;\n  status) exit 0 ;;\n  *) printf 'unexpected git args: %s %s\\n' \"$1\" \"$2\" >&2; exit 1 ;;\nesac\n`);
+  if (options.includeJq !== false) {
+    writeExecutable(join(bin, 'jq'), `printf 'jq-1.8.1\\n'\n`);
+  }
+  return { dir, root, bin };
 }
 
 describe('local setup scripts', () => {
@@ -186,12 +207,59 @@ describe('local setup scripts', () => {
 
     expect(manifest.scripts?.['local:seed']).toBe('tsx scripts/seed.ts');
     expect(manifest.scripts?.['local:verify-setup']).toBe('tsx scripts/verify-setup.ts');
+    expect(manifest.scripts?.['new-worker:preflight']).toBe('node scripts/new-worker-preflight.mjs');
     expect(readme).toContain('npm run local:seed');
     expect(readme).toContain('npm run local:verify-setup');
+    expect(readme).toContain('npm run new-worker:preflight -- --json');
     expect(onboarding).toContain('npm run local:seed');
     expect(onboarding).toContain('npm run local:verify-setup');
+    expect(onboarding).toContain('npm run new-worker:preflight -- --json');
+    expect(onboarding).toContain('[new-worker-preflight:<check>] ok|warn|fail');
     expect(seedScript).toContain('Usage: npm run local:seed');
     expect(verifyScript).toContain('Usage: npm run local:verify-setup');
+  });
+
+  it('new-worker preflight emits structured success output for a ready worker environment', () => {
+    const fixture = makePreflightFixture();
+    try {
+      const result = spawnSync(process.execPath, ['scripts/new-worker-preflight.mjs', '--json', '--root', fixture.root], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${fixture.bin}:${process.env.PATH ?? ''}` },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const report = JSON.parse(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string; detail: string }> };
+      expect(report.ok).toBe(true);
+      expect(report.checks).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 'npm-package-manager', status: 'ok' }),
+        expect.objectContaining({ id: 'git-identity', status: 'ok' }),
+        expect.objectContaining({ id: 'github-auth', status: 'ok' }),
+        expect.objectContaining({ id: 'jq-command', status: 'ok' }),
+      ]));
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('new-worker preflight fails with actionable structured output when a required worker tool is missing', () => {
+    const fixture = makePreflightFixture({ includeJq: false });
+    try {
+      const result = spawnSync(process.execPath, ['scripts/new-worker-preflight.mjs', '--json', '--root', fixture.root], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: fixture.bin },
+      });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string; action?: string }> };
+      expect(report.ok).toBe(false);
+      expect(report.checks).toContainEqual(expect.objectContaining({
+        id: 'jq-command',
+        status: 'fail',
+        action: expect.stringContaining('Install jq'),
+      }));
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
   });
 
   it('provides a one-click bootstrap script and CI dry-run gate', () => {

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -31,7 +31,7 @@ function writeExecutable(path: string, body: string): void {
   chmodSync(path, 0o755);
 }
 
-function makePreflightFixture(options: { includeJq?: boolean; npmVersion?: string } = {}): { dir: string; root: string; bin: string } {
+function makePreflightFixture(options: { includeJq?: boolean; npmVersion?: string; gitStatusFails?: boolean } = {}): { dir: string; root: string; bin: string } {
   const dir = mkdtempSync(join(tmpdir(), 'frankenbeast-new-worker-preflight-'));
   const root = join(dir, 'repo');
   const bin = join(dir, 'bin');
@@ -40,7 +40,8 @@ function makePreflightFixture(options: { includeJq?: boolean; npmVersion?: strin
   writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'frankenbeast', packageManager: 'npm@11.5.1' }));
   writeExecutable(join(bin, 'npm'), `printf '%s\\n' '${options.npmVersion ?? '11.5.1'}'\n`);
   writeExecutable(join(bin, 'gh'), `if [ \"$1\" = '--version' ]; then printf 'gh version 2.0.0\\n'; exit 0; fi\nif [ \"$1\" = 'auth' ] && [ \"$2\" = 'status' ] && [ \"$3\" = '--hostname' ] && [ \"$4\" = 'github.com' ]; then printf 'Logged in to github.com\\n'; exit 0; fi\nprintf 'unexpected gh args: %s %s %s %s\\n' \"$1\" \"$2\" \"$3\" \"$4\" >&2\nexit 1\n`);
-  writeExecutable(join(bin, 'git'), `case \"$1\" in\n  --version) printf 'git version 2.53.0\\n' ;;\n  rev-parse) printf '%s\\n' '${root}' ;;\n  config) if [ \"$2\" = 'user.name' ]; then printf 'David Mendez\\n'; else printf 'me@davidmendez.dev\\n'; fi ;;\n  status) exit 0 ;;\n  *) printf 'unexpected git args: %s %s\\n' \"$1\" \"$2\" >&2; exit 1 ;;\nesac\n`);
+  const statusBranch = options.gitStatusFails ? `printf 'index is unreadable\\n' >&2; exit 2` : 'exit 0';
+  writeExecutable(join(bin, 'git'), `case \"$1\" in\n  --version) printf 'git version 2.53.0\\n' ;;\n  rev-parse) printf '%s\\n' '${root}' ;;\n  config) if [ \"$2\" = 'user.name' ]; then printf 'David Mendez\\n'; else printf 'me@davidmendez.dev\\n'; fi ;;\n  status) ${statusBranch} ;;\n  *) printf 'unexpected git args: %s %s\\n' \"$1\" \"$2\" >&2; exit 1 ;;\nesac\n`);
   if (options.includeJq !== false) {
     writeExecutable(join(bin, 'jq'), `printf 'jq-1.8.1\\n'\n`);
   }
@@ -278,6 +279,28 @@ describe('local setup scripts', () => {
         id: 'repository-root',
         status: 'fail',
         detail: expect.stringContaining('is not the Frankenbeast repository root'),
+      }));
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('new-worker preflight fails when git worktree status cannot be read', () => {
+    const fixture = makePreflightFixture({ gitStatusFails: true });
+    try {
+      const result = spawnSync(process.execPath, ['scripts/new-worker-preflight.mjs', '--json', '--root', fixture.root], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${fixture.bin}:${process.env.PATH ?? ''}` },
+      });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string; detail: string; action?: string }> };
+      expect(report.ok).toBe(false);
+      expect(report.checks).toContainEqual(expect.objectContaining({
+        id: 'worktree-clean',
+        status: 'fail',
+        detail: 'unable to read git worktree status',
+        action: expect.stringContaining('Repair the git checkout'),
       }));
     } finally {
       rmSync(fixture.dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Adds `npm run new-worker:preflight` for fresh issue workers to verify Node/npm, git/gh/jq, GitHub auth, worker git identity, repo root, and worktree cleanliness.
- Emits stable human badges and optional JSON output for PM/worker handoffs.
- Documents the preflight in README/ONBOARDING and covers success/failure paths in local setup tests.

## Test Plan
- npm ci
- npm run test:root -- tests/local-setup-scripts.test.ts
- npm run check:package-manager
- npm run lint
- npm run build
- node scripts/new-worker-preflight.mjs --json --root .

Closes #1767
