### PR TITLE
docs(onboarding): map agent roles to repository responsibilities

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -119,6 +119,8 @@ Read each badge as `[onboarding:<current>/<total>:<stage>] <state> - <detail>`. 
 
 Read the [repository ownership manifest](docs/onboarding/repository-ownership.md) before assigning repository-wide or cross-package work. It maps current package and documentation surfaces to primary owners, escalation owners, verification commands, and PM/worker handoff notes so agents do not guess ownership from path names alone.
 
+Read the [agent role responsibility map](docs/onboarding/agent-role-responsibility-map.md) when assigning, resuming, reviewing, or recovering agent work. It maps PM shards, issue workers, doctors, reviewers, and docs workers to repository responsibilities, required handoff fields, verification commands, and explicit `mustNotOwn` boundaries.
+
 ## Coding-agent PR etiquette
 
 Read the [coding-agent PR etiquette guide](docs/onboarding/coding-agent-pr-etiquette.md) before opening, updating, or merging agent-authored pull requests. It defines one-issue/one-PR scope, required PR body evidence, current-head CI/Codex expectations, negative cases that prevent duplicate work, and handoff fields for blocked PRs.

--- a/docs/onboarding/agent-role-responsibility-map.manifest.json
+++ b/docs/onboarding/agent-role-responsibility-map.manifest.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": 1,
+  "ownershipManifest": "docs/onboarding/repository-ownership.manifest.json",
+  "handoffRequiredFields": [
+    "agentRole",
+    "ownershipEntries",
+    "primaryOwners",
+    "escalationOwner",
+    "verification",
+    "handoffNotes"
+  ],
+  "roleMappings": [
+    {
+      "roleId": "pm-shard",
+      "roleName": "PM shard / orchestrator",
+      "whenToUse": "Creates one-issue worker cards, prevents duplicate ownership, and routes cross-package or ambiguous work before implementation begins.",
+      "owns": [
+        "issue inventory",
+        "worker capacity and refill decisions",
+        "dependency ordering",
+        "duplicate PR and worktree guards",
+        "handoff completeness"
+      ],
+      "repositoryResponsibilities": [
+        {
+          "ownershipEntryId": "repo-automation",
+          "reason": "PMs maintain assignment metadata, root guardrails, and workflow evidence for issue-to-PR swarms."
+        },
+        {
+          "ownershipEntryId": "onboarding-docs",
+          "reason": "PMs keep onboarding handoffs aligned with current repository ownership guidance."
+        }
+      ],
+      "mustNotOwn": [
+        "Unreviewed implementation changes inside package owners' code paths",
+        "Merging a worker PR without current CI and Codex gate evidence"
+      ],
+      "handoffNotes": [
+        "List every matched ownership entry rather than only the first glob match.",
+        "Name the active worker card, branch, PR, and blocker before refilling capacity."
+      ],
+      "verification": ["gh issue list --repo djm204/frankenbeast --state open", "gh pr list --repo djm204/frankenbeast --state open"]
+    },
+    {
+      "roleId": "issue-worker",
+      "roleName": "One-issue implementation worker",
+      "whenToUse": "Implements exactly one GitHub issue in one branch/worktree/PR after the PM assigns a scoped repository owner surface.",
+      "owns": [
+        "smallest scoped implementation or documentation change",
+        "targeted tests or deterministic verifier",
+        "PR body with Closes #<issue>",
+        "current-head Codex review loop until clean or blocked"
+      ],
+      "repositoryResponsibilities": [
+        {
+          "ownershipEntryId": "repo-automation",
+          "reason": "Workers often add or update root tests, CI guardrails, or verification fixtures."
+        }
+      ],
+      "mustNotOwn": [
+        "Adjacent open issues",
+        "Broad refactors outside the assigned ownership entries",
+        "Another worker's dirty worktree or active PR"
+      ],
+      "handoffNotes": [
+        "Copy the matched ownership ids, primary owners, escalation owner, verification commands, and local pitfalls into the PR or Kanban handoff.",
+        "If a touched path matches multiple owners, keep all owners in scope or stop for a PM split decision."
+      ],
+      "verification": ["npm run test:root -- tests/docs-issue-1766.test.ts"]
+    },
+    {
+      "roleId": "doctor-recovery",
+      "roleName": "Doctor / recovery worker",
+      "whenToUse": "Diagnoses blocked, crashed, stale, or churned cards and restores the existing scoped owner path without duplicating work.",
+      "owns": [
+        "live task and PR evidence",
+        "blocked-command reproduction",
+        "safe unblock or exact blocker handoff",
+        "stale worktree triage"
+      ],
+      "repositoryResponsibilities": [
+        {
+          "ownershipEntryId": "onboarding-docs",
+          "reason": "Doctors maintain recovery guidance and stalled-worker operational docs."
+        },
+        {
+          "ownershipEntryId": "repo-automation",
+          "reason": "Doctors verify CI, branch, PR, and workflow state before resuming automation."
+        }
+      ],
+      "mustNotOwn": [
+        "Starting a replacement worker before proving the current owner is stale",
+        "Bypassing usage-limit, approval, CI, or Codex gates"
+      ],
+      "handoffNotes": [
+        "Record PID/heartbeat, worktree, branch, PR, checks, Codex status, and the exact next safe action.",
+        "Prefer treating the underlying blocker over reporting that a card is merely blocked."
+      ],
+      "verification": ["git worktree list --porcelain", "gh pr view <pr> --repo djm204/frankenbeast --json headRefOid,mergeStateStatus,statusCheckRollup"]
+    },
+    {
+      "roleId": "reviewer",
+      "roleName": "Reviewer / Codex-gate closer",
+      "whenToUse": "Audits a PR after implementation and drives review comments, unresolved threads, and CI failures to a terminal state.",
+      "owns": [
+        "review findings",
+        "unresolved review-thread audit",
+        "CI failure diagnosis",
+        "merge readiness evidence"
+      ],
+      "repositoryResponsibilities": [
+        {
+          "ownershipEntryId": "repo-automation",
+          "reason": "Reviewers verify root workflow, CI, and test evidence before merge."
+        }
+      ],
+      "mustNotOwn": [
+        "Accepting stale clean reviews from older commits",
+        "Changing package behavior outside review findings without assigning the package owner"
+      ],
+      "handoffNotes": [
+        "Tie each finding to current head SHA and resolved-thread state.",
+        "When a review fix touches package code, include that package's ownership entry in the handoff."
+      ],
+      "verification": ["gh pr checks <pr> --repo djm204/frankenbeast", "bash ~/.hermes/skills/codex-review-loop/scripts/codex-review-loop.sh poll --repo djm204/frankenbeast --pr <pr> --since <timestamp>"]
+    },
+    {
+      "roleId": "docs-onboarding-worker",
+      "roleName": "Docs/onboarding worker",
+      "whenToUse": "Updates onboarding, operator guides, repository maps, and deterministic documentation fixtures.",
+      "owns": [
+        "onboarding entrypoints",
+        "operator-facing examples",
+        "documentation fixtures and manifest validation",
+        "negative guidance for ambiguous ownership"
+      ],
+      "repositoryResponsibilities": [
+        {
+          "ownershipEntryId": "onboarding-docs",
+          "reason": "This role is the primary owner for onboarding and contributor guidance."
+        },
+        {
+          "ownershipEntryId": "repo-automation",
+          "reason": "Documentation verifiers and root doc tests live under repo automation."
+        }
+      ],
+      "mustNotOwn": [
+        "Describing future plans as current behavior",
+        "Updating docs without a deterministic verifier when the issue requires test-backed behavior"
+      ],
+      "handoffNotes": [
+        "Link from ONBOARDING.md when the guidance is part of first-run or agent handoff flow.",
+        "Keep structured manifests in sync with prose docs."
+      ],
+      "verification": ["npm run test:root -- tests/docs-issue-1766.test.ts"]
+    }
+  ]
+}

--- a/docs/onboarding/agent-role-responsibility-map.md
+++ b/docs/onboarding/agent-role-responsibility-map.md
@@ -1,0 +1,48 @@
+# Agent role responsibility map
+
+Frankenbeast keeps a structured agent-role map at `docs/onboarding/agent-role-responsibility-map.manifest.json`. Use it with the repository ownership manifest before assigning or resuming agent work: the role map says what each agent type owns, and the ownership manifest says which repository surfaces and verification commands belong in the handoff.
+
+## How to use the role map
+
+1. Identify the active agent role in the Kanban card, PM update, PR review, or issue handoff.
+2. Match every touched path against `docs/onboarding/repository-ownership.manifest.json`.
+3. Combine the role's `owns` / `mustNotOwn` lists with every matched ownership entry.
+4. Copy the required fields into the handoff so the next agent has a deterministic owner map instead of prose-only context.
+5. Run the role verifier and the matched repository-owner verifier, or record why a narrower command is safer.
+
+## Role-to-repository handoff shape
+
+Use this compact shape in Kanban comments, issue comments, and PR bodies:
+
+```text
+Agent role: issue-worker
+Ownership entries: onboarding-docs, repo-automation
+Primary owners: docs-onboarding-maintainers, repo-automation-maintainers
+Escalation owner: core-maintainers
+Verification: npm run test:root -- tests/docs-issue-1766.test.ts
+Notes: docs/onboarding guidance plus root doc verifier; no package runtime owner is touched.
+```
+
+The handoff should include all required fields from the role manifest: `agentRole`, `ownershipEntries`, `primaryOwners`, `escalationOwner`, `verification`, and `handoffNotes`.
+
+## Current agent role responsibilities
+
+| Agent role | Owns | Repository owner entries to consider first | Must not own |
+| --- | --- | --- | --- |
+| PM shard / orchestrator | Issue inventory, worker capacity, duplicate-work guards, dependency ordering, handoff completeness. | `repo-automation`, `onboarding-docs`, plus every owner matched by assigned issue paths. | Unreviewed package implementation or merging without current CI and Codex evidence. |
+| One-issue implementation worker | The smallest scoped implementation/docs change, targeted verifier, one PR, and current-head Codex loop. | Every owner matched by touched paths; `repo-automation` when tests, scripts, package metadata, or CI are touched. | Adjacent issues, broad refactors, or another worker's dirty worktree/active PR. |
+| Doctor / recovery worker | Live evidence, blocked-command reproduction, safe unblock, stale worktree triage, and exact next-action handoff. | `onboarding-docs` for recovery guides and `repo-automation` for branch/CI/PR state, plus the original worker's matched owners. | Replacement work before proving the owner is stale, or bypassing approval/Codex/CI gates. |
+| Reviewer / Codex-gate closer | Review findings, unresolved-thread audits, CI diagnosis, and merge-readiness evidence. | `repo-automation` for checks and review automation, plus any package owner touched by review fixes. | Stale all-clears from older commits or package behavior changes without matching owner scope. |
+| Docs/onboarding worker | Onboarding entrypoints, operator examples, documentation fixtures, structured manifest validation, and ambiguity guardrails. | `onboarding-docs` and `repo-automation` when verifiers live under `tests/**`. | Future-state docs without live evidence or docs-only changes with no deterministic verifier when the issue requires one. |
+
+## Edge cases and negative guidance
+
+- Do not let the first matching path hide additional owners. A browser change that also updates an orchestrator route needs both `web-dashboard` and `orchestrator-runtime` in the handoff.
+- Do not let the agent role override repository ownership. An issue worker can own execution of one PR, but package maintainers still own the package surface it touches.
+- Do not use PM or doctor roles as permission to broaden scope. If the original issue maps to multiple unrelated owners, stop for a PM split decision instead of merging unrelated work into one PR.
+- Do not treat docs tests as owned only by docs. Files under `tests/**`, CI workflows, root scripts, and package metadata also involve `repo-automation`.
+- Do not respawn a worker or create a duplicate branch until live Kanban, GitHub, and worktree evidence proves there is no active owner.
+
+## Maintaining the role map
+
+Update `docs/onboarding/agent-role-responsibility-map.manifest.json`, this guide, and the matching docs verifier whenever Frankenbeast adds a durable agent role or changes the repository ownership manifest. Keep role ids stable, lowercase, and LLM-friendly; keep `mustNotOwn` explicit so failure modes are actionable rather than silently ambiguous.

--- a/tests/docs-issue-1766.test.ts
+++ b/tests/docs-issue-1766.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const roleMapPath = 'docs/onboarding/agent-role-responsibility-map.manifest.json';
+const roleGuidePath = 'docs/onboarding/agent-role-responsibility-map.md';
+const ownershipManifestPath = 'docs/onboarding/repository-ownership.manifest.json';
+
+type OwnershipManifest = {
+  entries: Array<{ id: string; primaryOwner: string; escalationOwner: string }>;
+};
+
+type RoleMapping = {
+  roleId: string;
+  roleName: string;
+  whenToUse: string;
+  owns: string[];
+  repositoryResponsibilities: Array<{ ownershipEntryId: string; reason: string }>;
+  mustNotOwn: string[];
+  handoffNotes: string[];
+  verification: string[];
+};
+
+type AgentRoleMap = {
+  schemaVersion: number;
+  ownershipManifest: string;
+  handoffRequiredFields: string[];
+  roleMappings: RoleMapping[];
+};
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readText(relativePath)) as T;
+}
+
+describe('issue #1766 agent role responsibility map', () => {
+  it('adds a deterministic role map that references the repository ownership manifest', () => {
+    const roleMap = readJson<AgentRoleMap>(roleMapPath);
+    const ownership = readJson<OwnershipManifest>(ownershipManifestPath);
+    const ownershipIds = new Set(ownership.entries.map((entry) => entry.id));
+
+    expect(roleMap.schemaVersion).toBe(1);
+    expect(roleMap.ownershipManifest).toBe(ownershipManifestPath);
+    expect(roleMap.roleMappings.map((role) => role.roleId)).toEqual([
+      'pm-shard',
+      'issue-worker',
+      'doctor-recovery',
+      'reviewer',
+      'docs-onboarding-worker',
+    ]);
+
+    for (const role of roleMap.roleMappings) {
+      expect(role.roleId).toMatch(/^[a-z0-9-]+$/);
+      expect(role.roleName.length).toBeGreaterThan(0);
+      expect(role.whenToUse.length).toBeGreaterThan(0);
+      expect(role.owns.length).toBeGreaterThan(0);
+      expect(role.repositoryResponsibilities.length).toBeGreaterThan(0);
+      expect(role.mustNotOwn.length).toBeGreaterThan(0);
+      expect(role.handoffNotes.length).toBeGreaterThan(0);
+      expect(role.verification.length).toBeGreaterThan(0);
+
+      for (const responsibility of role.repositoryResponsibilities) {
+        expect(ownershipIds.has(responsibility.ownershipEntryId)).toBe(true);
+        expect(responsibility.reason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('requires role handoffs to carry owner, escalation, verification, and notes fields', () => {
+    const roleMap = readJson<AgentRoleMap>(roleMapPath);
+
+    expect(roleMap.handoffRequiredFields).toEqual([
+      'agentRole',
+      'ownershipEntries',
+      'primaryOwners',
+      'escalationOwner',
+      'verification',
+      'handoffNotes',
+    ]);
+
+    const issueWorker = roleMap.roleMappings.find((role) => role.roleId === 'issue-worker');
+    expect(issueWorker).toBeDefined();
+    expect(issueWorker?.verification).toContain('npm run test:root -- tests/docs-issue-1766.test.ts');
+    expect(issueWorker?.mustNotOwn.join(' ')).toContain('Adjacent open issues');
+  });
+
+  it('documents use, onboarding entrypoint, and negative edge cases for ambiguous ownership', () => {
+    const guide = readText(roleGuidePath);
+    const onboarding = readText('ONBOARDING.md');
+
+    for (const requiredText of [
+      '# Agent role responsibility map',
+      'docs/onboarding/agent-role-responsibility-map.manifest.json',
+      'Agent role: issue-worker',
+      'Do not let the first matching path hide additional owners.',
+      'Do not let the agent role override repository ownership.',
+      'Do not respawn a worker or create a duplicate branch until live Kanban, GitHub, and worktree evidence proves there is no active owner.',
+    ]) {
+      expect(guide).toContain(requiredText);
+    }
+
+    expect(onboarding).toContain('[agent role responsibility map](docs/onboarding/agent-role-responsibility-map.md)');
+    expect(onboarding).toContain('required handoff fields');
+  });
+});


### PR DESCRIPTION
## Summary
- add a structured agent-role responsibility manifest for PMs, issue workers, doctors, reviewers, and docs/onboarding workers
- document required role-to-repository handoff fields, verification expectations, and negative ownership edge cases
- link the new role map from ONBOARDING.md and cover it with a deterministic docs verifier

## Verification
- npm ci
- npm run test:root -- tests/docs-issue-1766.test.ts
- npm run test:root -- tests/docs-issue-1766.test.ts tests/docs-issue-1773.test.ts
- npm run lint

Closes #1766
