### PR TITLE
feat(onboarding): add first-run checklist generator

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -61,6 +61,15 @@ Use this checklist for a first local checkout or when rebuilding a development e
 
   The command prints stable `[new-worker-preflight:<check>] ok|warn|fail - ...` badges by default, or a JSON object with `ok` and `checks` when `--json` is supplied. Use `npm --silent` or `node scripts/new-worker-preflight.mjs --json` for machine-parsed JSON so npm lifecycle banners do not prefix stdout. It verifies the supported Node.js/npm pin, required `git`/`gh`/`jq` commands, GitHub CLI authentication for `github.com`, the project git identity (`David Mendez <me@davidmendez.dev>`), Frankenbeast repository root, and whether the current worktree already has uncommitted files. Use `--skip-github-auth` only for offline docs/tests; run without it before opening PRs.
 
+- [ ] Generate a guided checklist when you need a smaller first-run path than the full document. Pick the persona that matches the work:
+
+  ```bash
+  npm run first-run:checklist -- --persona operator
+  npm --silent run first-run:checklist -- --persona coding-agent --json
+  ```
+
+  The generator prints deterministic Markdown by default, or JSON with `persona`, `root`, `items`, `docs`, and `nextAction` for PM/liveness tooling. It never mutates files or runs setup commands; it points each checklist item at the command and docs to run next. Valid personas are `operator`, `coding-agent`, and `contributor`; unknown personas fail closed with an explicit error instead of falling back to a misleading generic checklist.
+
 ### Progress badges and status output
 
 The bootstrap script prints deterministic status badges as it advances through onboarding:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Starting from a fresh checkout? Use the [Frankenbeast onboarding checklist](ONBO
 npm run bootstrap -- --no-docker
 ```
 
-The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. New issue workers can run `npm --silent run new-worker:preflight -- --json` before coding to verify the local Node/npm/git/gh/jq toolchain, GitHub authentication, project git identity, repository root, and worktree cleanliness with parseable structured output for PM handoffs. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
+The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh), which validates Node.js, npm/Corepack, `.env` defaults, dependencies, and optional Docker services. If you want persona-specific guidance before running setup commands, generate a deterministic first-run checklist with `npm run first-run:checklist -- --persona operator` or `npm --silent run first-run:checklist -- --persona coding-agent --json`. New issue workers can run `npm --silent run new-worker:preflight -- --json` before coding to verify the local Node/npm/git/gh/jq toolchain, GitHub authentication, project git identity, repository root, and worktree cleanliness with parseable structured output for PM handoffs. Pass `--services` when you want bootstrap to start the optional Docker compose stack after dependency installation. To preview the checks without changing files or installing packages, run:
 
 ```bash
 ./scripts/bootstrap.sh --dry-run

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -20,6 +20,15 @@ For CI-style validation without mutating files or installing dependencies, run:
 ./scripts/bootstrap.sh --dry-run
 ```
 
+If you are not sure which first-run steps apply to your role, generate a guided checklist before mutating the checkout:
+
+```bash
+npm run first-run:checklist -- --persona contributor
+npm --silent run first-run:checklist -- --persona coding-agent --json
+```
+
+The generator is read-only and returns deterministic Markdown or JSON checklist items with commands, docs, required/optional status, and the next action.
+
 If Corepack is not available yet, install it first with `npm install -g corepack`; the bootstrap script then activates and verifies the root `packageManager` pin.
 
 Dependency locking is centralized at the workspace root: commit updates to the root `package-lock.json` only. Package workspaces under `packages/*` must not carry their own nested `package-lock.json` files; run installs from the repository root so npm records workspace dependency changes in the root lockfile. Standalone example projects under `examples/` may keep their own lockfiles because they are scaffolded outside the monorepo workspace.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "new-worker:preflight": "node scripts/new-worker-preflight.mjs",
+    "first-run:checklist": "node scripts/first-run-checklist.mjs",
     "test": "turbo run test",
     "test:integration": "turbo run test:integration --filter=@franken/brain --filter=@franken/critique --filter=@franken/governor --filter=@franken/observer",
     "test:eval": "turbo run test:eval --filter=@franken/observer",

--- a/scripts/first-run-checklist.mjs
+++ b/scripts/first-run-checklist.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PERSONAS = new Set(['operator', 'coding-agent', 'contributor']);
+
+function usage() {
+  console.info(`Usage: npm run first-run:checklist -- [--persona operator|coding-agent|contributor] [--json] [--root <path>]
+
+Generates a deterministic first-run checklist tailored to the selected persona.
+The checklist is guidance only: it does not mutate files, install dependencies, or contact services.
+
+Examples:
+  npm run first-run:checklist -- --persona operator
+  npm --silent run first-run:checklist -- --persona coding-agent --json
+
+Human output is Markdown grouped by phase. JSON output is { persona, root, items, docs, nextAction }.`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    persona: 'contributor',
+    json: false,
+    root: process.cwd(),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--persona') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--persona requires operator, coding-agent, or contributor');
+      options.persona = value;
+      i += 1;
+      continue;
+    }
+    if (arg?.startsWith('--persona=')) {
+      const value = arg.slice('--persona='.length);
+      if (!value) throw new Error('--persona requires operator, coding-agent, or contributor');
+      options.persona = value;
+      continue;
+    }
+    if (arg === '--root') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      i += 1;
+      continue;
+    }
+    if (arg?.startsWith('--root=')) {
+      const value = arg.slice('--root='.length);
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      continue;
+    }
+    if (arg === '-h' || arg === '--help') {
+      usage();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!PERSONAS.has(options.persona)) {
+    throw new Error(`Unknown persona: ${options.persona}. Expected one of: ${[...PERSONAS].join(', ')}`);
+  }
+
+  return options;
+}
+
+function readManifest(root) {
+  try {
+    return JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function requireFrankenbeastRoot(root) {
+  const manifest = readManifest(root);
+  if (manifest?.name !== 'frankenbeast') {
+    throw new Error(`${root} is not a Frankenbeast checkout; run from the repository root or pass --root <path>`);
+  }
+  return manifest;
+}
+
+function item(id, phase, title, detail, command, docs, personas = [...PERSONAS], required = true) {
+  return { id, phase, title, detail, command, docs, personas, required };
+}
+
+function buildCatalog(manifest) {
+  const npmPin = typeof manifest.packageManager === 'string' ? manifest.packageManager : 'the repository npm pin';
+  return [
+    item(
+      'toolchain-node-npm',
+      'Prerequisites',
+      'Confirm the supported Node.js and npm toolchain',
+      `Use Node.js >=22.13.0 <23 or >=24.0.0 <26 and ${npmPin}; engine-strict makes unsupported versions fail early.`,
+      'node --version && npm --version',
+      ['ONBOARDING.md#prerequisites', '.nvmrc', 'package.json'],
+    ),
+    item(
+      'bootstrap-default',
+      'Bootstrap',
+      'Run the canonical first-run bootstrap path',
+      'Creates .env from .env.example when needed, validates defaults, installs dependencies, and skips optional Docker services by default.',
+      'npm run bootstrap -- --no-docker',
+      ['ONBOARDING.md#bootstrap', 'docs/guides/quickstart.md'],
+    ),
+    item(
+      'worker-preflight',
+      'Worker readiness',
+      'Generate machine-readable worker preflight evidence before coding',
+      'Verifies git, gh, jq, GitHub auth, project git identity, Frankenbeast root, and clean worktree status.',
+      'npm --silent run new-worker:preflight -- --json',
+      ['ONBOARDING.md#bootstrap'],
+      ['coding-agent'],
+    ),
+    item(
+      'operator-secrets',
+      'Runtime configuration',
+      'Choose secret storage and fill only needed local runtime values',
+      'Decide local encrypted file, OS keychain, 1Password, or Bitwarden before init; keep Beast operator tokens server-side.',
+      '$EDITOR .env',
+      ['ONBOARDING.md#bootstrap', 'ONBOARDING.md#beast-controls-in-the-dashboard'],
+      ['operator', 'contributor'],
+    ),
+    item(
+      'optional-services',
+      'Optional services',
+      'Start optional local infrastructure only when needed',
+      'Docker services are only needed for local ChromaDB, Grafana, and Tempo workflows; set Grafana credentials before starting them.',
+      'npm run bootstrap -- --services',
+      ['ONBOARDING.md#optional-services', 'docs/guides/quickstart.md'],
+      ['operator'],
+      false,
+    ),
+    item(
+      'standard-verification',
+      'Verification',
+      'Run the standard local verification gates',
+      'Build, typecheck, and tests catch drift after bootstrap; use the test command decision tree when a narrower gate is enough.',
+      'npm run build && npm run typecheck && npm test',
+      ['ONBOARDING.md#bootstrap', 'docs/onboarding/test-command-decision-tree.md'],
+    ),
+    item(
+      'architecture-reading-path',
+      'Orientation',
+      'Read current architecture docs before changing package boundaries',
+      'Start with current implementation docs and only then branch into historical plans or ADRs.',
+      undefined,
+      ['ONBOARDING.md#architecture-reading-path', 'docs/RAMP_UP.md', 'docs/ARCHITECTURE.md'],
+      ['coding-agent', 'contributor'],
+    ),
+    item(
+      'pr-etiquette',
+      'Contribution workflow',
+      'Review coding-agent PR etiquette before opening or updating PRs',
+      'Keeps one-issue/one-PR scope, current-head CI/Codex evidence, and blocked handoff fields consistent.',
+      undefined,
+      ['docs/onboarding/coding-agent-pr-etiquette.md'],
+      ['coding-agent'],
+    ),
+  ];
+}
+
+function buildChecklist(options) {
+  const root = resolve(options.root);
+  const manifest = requireFrankenbeastRoot(root);
+  const items = buildCatalog(manifest).filter((entry) => entry.personas.includes(options.persona));
+  return {
+    persona: options.persona,
+    root,
+    items,
+    docs: ['ONBOARDING.md', 'docs/guides/quickstart.md', 'docs/RAMP_UP.md'],
+    nextAction: options.persona === 'coding-agent'
+      ? 'Run the worker preflight JSON command, attach it to the issue/PR handoff, then choose the narrowest verification gate for your change.'
+      : 'Work through required items in phase order, then run optional items only when the matching workflow needs them.',
+  };
+}
+
+function renderMarkdown(checklist) {
+  const lines = [
+    `# Frankenbeast first-run checklist (${checklist.persona})`,
+    '',
+    `Repository root: \`${checklist.root}\``,
+    '',
+    'This generated checklist is deterministic guidance. It does not mutate files or run setup commands for you.',
+    '',
+  ];
+  const phases = [...new Set(checklist.items.map((entry) => entry.phase))];
+  for (const phase of phases) {
+    lines.push(`## ${phase}`);
+    for (const entry of checklist.items.filter((candidate) => candidate.phase === phase)) {
+      const required = entry.required ? 'required' : 'optional';
+      lines.push(`- [ ] **${entry.title}** (${entry.id}, ${required})`);
+      lines.push(`  - Why: ${entry.detail}`);
+      if (entry.command) lines.push(`  - Command: \`${entry.command}\``);
+      lines.push(`  - Docs: ${entry.docs.map((doc) => `\`${doc}\``).join(', ')}`);
+    }
+    lines.push('');
+  }
+  lines.push(`Next action: ${checklist.nextAction}`);
+  return lines.join('\n');
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const checklist = buildChecklist(options);
+  console.info(options.json ? JSON.stringify(checklist, null, 2) : renderMarkdown(checklist));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`first-run checklist failed: ${message}`);
+  process.exit(2);
+}

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -209,15 +209,69 @@ describe('local setup scripts', () => {
     expect(manifest.scripts?.['local:seed']).toBe('tsx scripts/seed.ts');
     expect(manifest.scripts?.['local:verify-setup']).toBe('tsx scripts/verify-setup.ts');
     expect(manifest.scripts?.['new-worker:preflight']).toBe('node scripts/new-worker-preflight.mjs');
+    expect(manifest.scripts?.['first-run:checklist']).toBe('node scripts/first-run-checklist.mjs');
     expect(readme).toContain('npm run local:seed');
     expect(readme).toContain('npm run local:verify-setup');
     expect(readme).toContain('npm --silent run new-worker:preflight -- --json');
+    expect(readme).toContain('npm run first-run:checklist -- --persona operator');
     expect(onboarding).toContain('npm run local:seed');
     expect(onboarding).toContain('npm run local:verify-setup');
     expect(onboarding).toContain('npm --silent run new-worker:preflight -- --json');
+    expect(onboarding).toContain('npm --silent run first-run:checklist -- --persona coding-agent --json');
+    expect(onboarding).toContain('Valid personas are `operator`, `coding-agent`, and `contributor`');
     expect(onboarding).toContain('[new-worker-preflight:<check>] ok|warn|fail');
+    expect(read('docs/guides/quickstart.md')).toContain('npm run first-run:checklist -- --persona contributor');
     expect(seedScript).toContain('Usage: npm run local:seed');
     expect(verifyScript).toContain('Usage: npm run local:verify-setup');
+  });
+
+  it('first-run checklist generator emits persona-specific structured output', () => {
+    const result = spawnSync(process.execPath, ['scripts/first-run-checklist.mjs', '--json', '--persona', 'coding-agent'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const checklist = JSON.parse(result.stdout) as {
+      persona: string;
+      items: Array<{ id: string; phase: string; command?: string; docs: string[]; required: boolean }>;
+      nextAction: string;
+    };
+    expect(checklist.persona).toBe('coding-agent');
+    expect(checklist.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'worker-preflight', command: 'npm --silent run new-worker:preflight -- --json' }),
+      expect.objectContaining({ id: 'architecture-reading-path', phase: 'Orientation' }),
+      expect.objectContaining({ id: 'pr-etiquette', required: true }),
+    ]));
+    expect(checklist.items).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'optional-services' }),
+      expect.objectContaining({ id: 'operator-secrets' }),
+    ]));
+    expect(checklist.nextAction).toContain('worker preflight JSON command');
+  });
+
+  it('first-run checklist generator renders human Markdown for operators', () => {
+    const result = spawnSync(process.execPath, ['scripts/first-run-checklist.mjs', '--persona=operator'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('# Frankenbeast first-run checklist (operator)');
+    expect(result.stdout).toContain('- [ ] **Start optional local infrastructure only when needed** (optional-services, optional)');
+    expect(result.stdout).toContain('Command: `npm run bootstrap -- --services`');
+    expect(result.stdout).not.toContain('coding-agent PR etiquette');
+  });
+
+  it('first-run checklist generator fails closed for unknown personas', () => {
+    const result = spawnSync(process.execPath, ['scripts/first-run-checklist.mjs', '--persona', 'wizard'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown persona: wizard');
+    expect(result.stdout).toBe('');
   });
 
   it('new-worker preflight emits structured success output for a ready worker environment', () => {


### PR DESCRIPTION
## Summary
- Add a deterministic `first-run:checklist` generator for operator, coding-agent, and contributor personas.
- Document the guided checklist path in README, ONBOARDING, and quickstart docs.
- Cover Markdown/JSON output, persona filtering, docs links, and invalid-persona failures in root setup tests.

## Test Plan
- npm run test:root -- tests/local-setup-scripts.test.ts
- node scripts/first-run-checklist.mjs --persona coding-agent --json
- npm run lint
- npm run typecheck
- npm run build
- git diff --check

Closes #1765