### PR TITLE
feat(learning): cluster repeated failure families

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -42,6 +42,10 @@ export type {
   LessonFeedbackSignalSource,
   LessonFeedbackWeight,
   LessonFeedbackWeighting,
+  FailureRecordEvidencePointer,
+  FailureRecordMetadata,
+  FailureCluster,
+  FailureClusterReport,
   CrossTaskBlockerPattern,
   LearningBacklogPriority,
   LearningBacklogPrioritizationItem,
@@ -106,6 +110,7 @@ export {
 export type {
   BlockerPatternObservation,
   BlockerPatternState,
+  FailureClusterState,
   LessonRecorderOptions,
   LessonQuarantineRequest,
   LessonFailureSignal,

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1115,9 +1115,7 @@ export class LessonRecorder {
     }
     if (
       !cluster.observations.some(
-        (observation) =>
-          observation.taskFamily === record.taskFamily &&
-          observation.evidencePointer.id === record.evidencePointer.id,
+        (observation) => observation.taskId === record.taskId,
       )
     ) {
       cluster.observations.push(record);
@@ -1661,6 +1659,9 @@ function createFailureRecordMetadata(options: {
   readonly resolution: string;
   readonly evidenceId: string;
 }): FailureRecordMetadata {
+  const primaryText = options.findings
+    .map((finding) => `${finding.message} ${finding.location ?? ''}`)
+    .join('\n');
   const joinedText = options.findings
     .map(
       (finding) =>
@@ -1672,7 +1673,7 @@ function createFailureRecordMetadata(options: {
   const packageName = inferPackageName(joinedText);
   const toolName = inferToolName(options.evaluatorName, joinedText);
   const errorClass = inferErrorClass(options.findings, joinedText);
-  const rootCause = inferRootCause(joinedText);
+  const rootCause = inferRootCause(primaryText);
   const clusterKey = createFailureClusterKey({
     taskFamily,
     ...(packageName ? { packageName } : {}),
@@ -1683,6 +1684,7 @@ function createFailureRecordMetadata(options: {
 
   return {
     schemaVersion: 'failure-record-v1',
+    taskId: options.taskId,
     taskFamily,
     ...(packageName ? { packageName } : {}),
     ...(toolName ? { toolName } : {}),
@@ -1731,7 +1733,8 @@ function inferTaskFamily(taskId: TaskId, text: string): string {
 }
 
 function inferPackageName(text: string): string | undefined {
-  const workspaceMatch = /\b@franken(?:beast)?\/[a-z0-9-]+\b/i.exec(text)?.[0];
+  const workspaceMatch =
+    /(?:^|[\s([{"'`])(@franken(?:beast)?\/[a-z0-9-]+)\b/i.exec(text)?.[1];
   if (workspaceMatch) {
     return workspaceMatch.toLowerCase();
   }
@@ -1791,7 +1794,12 @@ function inferErrorClass(
 
 function hasTestFailureContext(text: string): boolean {
   const explicitTestFailure =
-    /\b(?:failed test|tests? failed|vitest failed|test runner|runner output)\b/.test(
+    /\b(?:failed test|tests? failed|vitest failed)\b/.test(text);
+  const failedRunnerOutput =
+    /\b(?:failed|failing|broken)\b[\s\S]{0,80}\b(?:test runner|runner output)\b/.test(
+      text,
+    ) ||
+    /\b(?:test runner|runner output)\b[\s\S]{0,80}\b(?:failed|failing|broken)\b/.test(
       text,
     );
   const assertionWords = /\b(?:assertion|expected|received)\b/.test(text);
@@ -1799,7 +1807,11 @@ function hasTestFailureContext(text: string): boolean {
     /\b(?:vitest|jest|mocha|pytest|test\/|tests\/|\.test\.[cm]?[jt]sx?|\.spec\.[cm]?[jt]sx?)\b/.test(
       text,
     );
-  return explicitTestFailure || (assertionWords && testLocationOrRunner);
+  return (
+    explicitTestFailure ||
+    failedRunnerOutput ||
+    (assertionWords && testLocationOrRunner)
+  );
 }
 
 function inferRootCause(text: string): string {
@@ -1809,14 +1821,14 @@ function inferRootCause(text: string): string {
       'verification-evidence',
       /\b(?:verification|evidence|handoff|test command|test result)\b/,
     ],
-    [
-      'missing-required-contract',
-      /\b(?:missing|absent|required|omitted|not included)\b/,
-    ],
     ['type-safety', /\b(?:type|typescript|tsc|declaration|schema)\b/],
     [
       'authentication-or-secret',
       /\b(?:auth|token|credential|secret|permission)\b/,
+    ],
+    [
+      'missing-required-contract',
+      /\b(?:missing|absent|required|omitted|not included)\b/,
     ],
     [
       'timeout-or-liveness',

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -20,6 +20,8 @@ import type {
   LessonFeedbackSignalSource,
   LessonFeedbackWeight,
   LessonFeedbackWeighting,
+  FailureRecordMetadata,
+  FailureCluster,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -52,6 +54,8 @@ const AGENT_IMPROVEMENT_SCORECARD_GUIDANCE =
   'Use this per-agent scorecard in worker retrospectives and PM handoff summaries to compare improvement over time without parsing free-form lesson prose.';
 const LEARNING_BACKLOG_PRIORITIZATION_GUIDANCE =
   'Use this report to sort newly observed learning backlog items before promotion, retirement, or PM routing; higher priority items should receive durable mitigation before low-risk documentation follow-up.';
+const FAILURE_CLUSTER_REPORT_GUIDANCE =
+  'Use this transcript-free report to spot recurring failure families by task family, package/tool, and root cause before routing durable skill, documentation, or test mitigations.';
 const PRIVACY_FILTER_TASK_STATE_REASON =
   'Lesson candidate describes transient task or PR state and is rejected before durable learning.';
 const PRIVACY_FILTER_ADMIT_REASON =
@@ -63,8 +67,10 @@ interface InternalLessonPrivacyRedaction extends LessonPrivacyRedaction {
   readonly original: string;
 }
 
-interface InternalLessonPrivacyFilterDecision
-  extends Omit<LessonPrivacyFilterDecision, 'redactions'> {
+interface InternalLessonPrivacyFilterDecision extends Omit<
+  LessonPrivacyFilterDecision,
+  'redactions'
+> {
   readonly redactions: readonly InternalLessonPrivacyRedaction[];
 }
 
@@ -92,7 +98,8 @@ const PRIVACY_REDACTION_RULES: readonly PrivacyRedactionRule[] = [
   {
     kind: 'secret',
     label: 'github-token',
-    pattern: /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{30,})\b/g,
+    pattern:
+      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{30,})\b/g,
     replacement: '[REDACTED_GITHUB_TOKEN]',
   },
   {
@@ -117,7 +124,8 @@ const PRIVACY_REDACTION_RULES: readonly PrivacyRedactionRule[] = [
   {
     kind: 'secret',
     label: 'connection-string',
-    pattern: /\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis):\/\/[^\s'\")]+/gi,
+    pattern:
+      /\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis):\/\/[^\s'\")]+/gi,
     replacement: '[REDACTED_CONNECTION_STRING]',
   },
   {
@@ -193,6 +201,16 @@ export interface BlockerPatternState {
   readonly observations: BlockerPatternObservation[];
 }
 
+export interface FailureClusterState {
+  readonly key: string;
+  readonly taskFamily: string;
+  readonly packageName?: string;
+  readonly toolName?: string;
+  readonly errorClass: string;
+  readonly rootCause: string;
+  readonly observations: FailureRecordMetadata[];
+}
+
 interface PendingBlockerPatternObservation {
   readonly key: string;
   readonly taskId: TaskId;
@@ -212,6 +230,8 @@ export interface LessonRecorderOptions {
   readonly blockerPatternThreshold?: number;
   /** Shared blocker-pattern state for mining recurrent blockers across recorder instances. */
   readonly blockerPatternStore?: Map<string, BlockerPatternState>;
+  /** Shared failure-cluster state for grouping repeated failures across recorder instances. */
+  readonly failureClusterStore?: Map<string, FailureClusterState>;
   /** Optional per-agent identifier used to attach deterministic improvement scorecards to learned lessons. */
   readonly agentId?: string;
 }
@@ -436,7 +456,10 @@ export function applyHumanFeedbackToLesson(
       'Explicit lesson approval requires at least one evidence item.',
     );
   }
-  if (lesson.lifecycleStatus === 'quarantined' && lesson.quarantine !== undefined) {
+  if (
+    lesson.lifecycleStatus === 'quarantined' &&
+    lesson.quarantine !== undefined
+  ) {
     const unquarantinedLesson = unquarantineLesson(lesson, {
       reviewedAt: observedAt,
       reviewer: request.source,
@@ -606,6 +629,7 @@ export class LessonRecorder {
   private readonly blockerPatternThreshold: number;
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
   private readonly pendingBlockerAdmissions: Map<string, Promise<void>>;
+  private readonly failureClusters: Map<string, FailureClusterState>;
   private readonly agentId?: string;
   private readonly pendingBlockerObservations = new WeakMap<
     CritiqueLesson,
@@ -641,6 +665,7 @@ export class LessonRecorder {
     this.pendingBlockerAdmissions = getPendingBlockerAdmissions(
       this.blockerPatterns,
     );
+    this.failureClusters = options.failureClusterStore ?? new Map();
     if (options.agentId !== undefined) {
       const agentId = options.agentId.trim();
       if (!agentId) {
@@ -722,9 +747,11 @@ export class LessonRecorder {
             (lesson.blockerPatterns?.length ?? 0) > 0;
           const suppression = this.getCooldownSuppression(lesson, cooldownKey);
           if (suppression && !hasMinedBlockerPatterns) {
+            this.commitFailureClusterObservation(lesson, recordingResult);
             this.commitBlockerPatternObservations(lesson);
             recordingResult.suppressedByCooldown.push(suppression);
-            recordingResult.learningBacklogItems.push(
+            addOrReplaceLearningBacklogItem(
+              recordingResult.learningBacklogItems,
               createCooldownSuppressionBacklogItem(suppression),
             );
             admissionSettled?.(false);
@@ -755,6 +782,7 @@ export class LessonRecorder {
         });
         await this.memory.recordLesson(admittedLesson);
         recordingResult.recorded += 1;
+        this.commitFailureClusterObservation(admittedLesson, recordingResult);
         this.commitBlockerPatternObservations(lesson);
         addUniqueBlockerPatterns(
           recordingResult.minedBlockerPatterns,
@@ -868,6 +896,16 @@ export class LessonRecorder {
           evalResult.evaluatorName,
           filteredFindings,
         );
+        const failureRecord = createFailureRecordMetadata({
+          taskId,
+          evaluatorName: evalResult.evaluatorName,
+          findings: filteredFindings,
+          recordedAt,
+          resolution: passingIteration
+            ? `Corrected in iteration ${passingIteration.index}`
+            : 'Unknown correction',
+          evidenceId: `${lessonId}:failure-record`,
+        });
 
         const lesson: CritiqueLesson = {
           evaluatorName: evalResult.evaluatorName,
@@ -908,6 +946,7 @@ export class LessonRecorder {
             evalResult.evaluatorName,
             filteredFindings,
           ),
+          failureRecord,
           ...(failedTestSkillCandidate ? { failedTestSkillCandidate } : {}),
           postPrLessonExtractionTemplate:
             createPostPrLessonExtractionTemplate(),
@@ -1051,6 +1090,55 @@ export class LessonRecorder {
       }
     }
     this.pendingBlockerObservations.delete(lesson);
+  }
+
+  private commitFailureClusterObservation(
+    lesson: CritiqueLesson,
+    recordingResult: MutableLessonRecordingResult,
+  ): void {
+    const record = lesson.failureRecord;
+    if (!record) {
+      return;
+    }
+    let cluster = this.failureClusters.get(record.clusterKey);
+    if (!cluster) {
+      cluster = {
+        key: record.clusterKey,
+        taskFamily: record.taskFamily,
+        ...(record.packageName ? { packageName: record.packageName } : {}),
+        ...(record.toolName ? { toolName: record.toolName } : {}),
+        errorClass: record.errorClass,
+        rootCause: record.rootCause,
+        observations: [],
+      };
+      this.failureClusters.set(record.clusterKey, cluster);
+    }
+    if (
+      !cluster.observations.some(
+        (observation) =>
+          observation.taskFamily === record.taskFamily &&
+          observation.evidencePointer.id === record.evidencePointer.id,
+      )
+    ) {
+      cluster.observations.push(record);
+    }
+
+    const reportCluster = createFailureCluster(cluster);
+    const existingIndex = recordingResult.failureClusters.findIndex(
+      (existing) => existing.key === reportCluster.key,
+    );
+    if (existingIndex >= 0) {
+      recordingResult.failureClusters.splice(existingIndex, 1, reportCluster);
+    } else {
+      recordingResult.failureClusters.push(reportCluster);
+    }
+    sortFailureClusters(recordingResult.failureClusters);
+    if (reportCluster.occurrences >= 2) {
+      addOrReplaceLearningBacklogItem(
+        recordingResult.learningBacklogItems,
+        createFailureClusterBacklogItem(reportCluster),
+      );
+    }
   }
 
   private async withBlockerPatternAdmissionLock<T>(
@@ -1329,6 +1417,7 @@ interface MutableLessonRecordingResult extends LessonRecordingResult {
   suppressedByCooldown: LessonCooldownSuppression[];
   rejectedByPrivacy: LessonPrivacyFilterDecision[];
   minedBlockerPatterns: CrossTaskBlockerPattern[];
+  failureClusters: FailureCluster[];
   learningBacklogItems: LearningBacklogPrioritizationItem[];
 }
 
@@ -1336,6 +1425,7 @@ function createMutableLessonRecordingResult(
   generatedAt: string,
 ): MutableLessonRecordingResult {
   const learningBacklogItems: LearningBacklogPrioritizationItem[] = [];
+  const failureClusters: FailureCluster[] = [];
   const result = {
     recorded: 0,
     suppressedByCooldown: [],
@@ -1345,6 +1435,21 @@ function createMutableLessonRecordingResult(
   Object.defineProperty(result, 'learningBacklogItems', {
     value: learningBacklogItems,
     enumerable: false,
+    writable: false,
+  });
+  Object.defineProperty(result, 'failureClusters', {
+    value: failureClusters,
+    enumerable: false,
+    writable: false,
+  });
+  Object.defineProperty(result, 'failureClusterReport', {
+    value: {
+      schemaVersion: 'failure-cluster-report-v1',
+      generatedAt,
+      guidance: FAILURE_CLUSTER_REPORT_GUIDANCE,
+      clusters: failureClusters,
+    },
+    enumerable: true,
     writable: false,
   });
   Object.defineProperty(result, 'learningBacklogPrioritizationReport', {
@@ -1407,7 +1512,8 @@ function createLessonFeedbackWeighting(
     deduped.set(weight.source, weight);
   }
   const sortedWeights = [...deduped.values()].sort(
-    (left, right) => right.weight - left.weight || left.source.localeCompare(right.source),
+    (left, right) =>
+      right.weight - left.weight || left.source.localeCompare(right.source),
   );
   const primarySource = selectPrimaryFeedbackSource(sortedWeights);
   return {
@@ -1435,15 +1541,14 @@ function selectPrimaryFeedbackSource(
       Date.parse(right.observedAt) - Date.parse(left.observedAt) ||
       right.weight - left.weight,
   )[0];
-  return latestExplicitSignal?.source ?? weights[0]?.source ?? 'inferred-success';
+  return (
+    latestExplicitSignal?.source ?? weights[0]?.source ?? 'inferred-success'
+  );
 }
 
 function summarizeFeedbackSources(
   feedbackWeighting: LessonFeedbackWeighting,
-): readonly Pick<
-  LessonFeedbackWeight,
-  'source' | 'weight' | 'scoreImpact'
->[] {
+): readonly Pick<LessonFeedbackWeight, 'source' | 'weight' | 'scoreImpact'>[] {
   return feedbackWeighting.weights.map(({ source, weight, scoreImpact }) => ({
     source,
     weight,
@@ -1463,13 +1568,16 @@ function createRecordedLessonBacklogItem(
   const suggestionsIncomplete =
     lesson.reviewerFeedback?.suggestionsComplete === false;
   const primaryFeedbackSource = lesson.feedbackWeighting?.primarySource;
-  const hasExplicitCorrection = primaryFeedbackSource === 'explicit-user-correction';
-  const hasExplicitApproval = primaryFeedbackSource === 'explicit-user-approval';
-  const priority = hasExplicitCorrection || hasExplicitApproval || hasCriticalFindings
-    ? 'high'
-    : suggestionsIncomplete
-      ? 'medium'
-      : 'low';
+  const hasExplicitCorrection =
+    primaryFeedbackSource === 'explicit-user-correction';
+  const hasExplicitApproval =
+    primaryFeedbackSource === 'explicit-user-approval';
+  const priority =
+    hasExplicitCorrection || hasExplicitApproval || hasCriticalFindings
+      ? 'high'
+      : suggestionsIncomplete
+        ? 'medium'
+        : 'low';
   const score = hasExplicitCorrection
     ? 120
     : hasExplicitApproval
@@ -1543,6 +1651,245 @@ function createBlockerPatternBacklogItem(
     recommendedAction:
       'Route a durable mitigation owner before accepting more duplicate worker rediscovery for this blocker pattern.',
   };
+}
+
+function createFailureRecordMetadata(options: {
+  readonly taskId: TaskId;
+  readonly evaluatorName: string;
+  readonly findings: readonly SanitizedLessonFinding[];
+  readonly recordedAt: string;
+  readonly resolution: string;
+  readonly evidenceId: string;
+}): FailureRecordMetadata {
+  const joinedText = options.findings
+    .map(
+      (finding) =>
+        `${finding.message} ${finding.location ?? ''} ${finding.suggestion ?? ''}`,
+    )
+    .join('\n');
+  const firstFinding = options.findings[0];
+  const taskFamily = inferTaskFamily(options.taskId, joinedText);
+  const packageName = inferPackageName(joinedText);
+  const toolName = inferToolName(options.evaluatorName, joinedText);
+  const errorClass = inferErrorClass(options.findings, joinedText);
+  const rootCause = inferRootCause(joinedText);
+  const clusterKey = createFailureClusterKey({
+    taskFamily,
+    ...(packageName ? { packageName } : {}),
+    ...(toolName ? { toolName } : {}),
+    errorClass,
+    rootCause,
+  });
+
+  return {
+    schemaVersion: 'failure-record-v1',
+    taskFamily,
+    ...(packageName ? { packageName } : {}),
+    ...(toolName ? { toolName } : {}),
+    errorClass,
+    rootCause,
+    resolution: options.resolution,
+    evidencePointer: {
+      kind: 'review-finding',
+      id: options.evidenceId,
+      ...(firstFinding?.location ? { location: firstFinding.location } : {}),
+    },
+    clusterKey,
+  };
+}
+
+function createFailureClusterKey(parts: {
+  readonly taskFamily: string;
+  readonly packageName?: string;
+  readonly toolName?: string;
+  readonly errorClass: string;
+  readonly rootCause: string;
+}): string {
+  return [
+    'failure-cluster',
+    sanitizeLessonIdPart(parts.taskFamily),
+    sanitizeLessonIdPart(parts.packageName ?? 'repo'),
+    sanitizeLessonIdPart(parts.toolName ?? 'unknown-tool'),
+    sanitizeLessonIdPart(parts.errorClass),
+    stableHash(parts.rootCause).slice(0, 16),
+  ].join(':');
+}
+
+function inferTaskFamily(taskId: TaskId, text: string): string {
+  const explicitFamily =
+    /\b(?:task family|family)\s*[:=]\s*([a-z][a-z0-9 _/-]{2,60})/i.exec(
+      text,
+    )?.[1];
+  const raw = explicitFamily ?? taskId;
+  const normalized = raw
+    .replace(/\bt_[0-9a-f]{6,}\b/gi, ' ')
+    .replace(/\b(?:task|issue|ticket|pr|pull|request)\b/gi, ' ')
+    .replace(/\b\d+\b/g, ' ')
+    .replace(/[-_/]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+  return normalized || 'general';
+}
+
+function inferPackageName(text: string): string | undefined {
+  const workspaceMatch = /\b@franken(?:beast)?\/[a-z0-9-]+\b/i.exec(text)?.[0];
+  if (workspaceMatch) {
+    return workspaceMatch.toLowerCase();
+  }
+  const packagePathMatch = /\bpackages\/([a-z0-9-]+)\b/i.exec(text)?.[1];
+  if (packagePathMatch) {
+    return `packages/${packagePathMatch.toLowerCase()}`;
+  }
+  return undefined;
+}
+
+function inferToolName(
+  evaluatorName: string,
+  text: string,
+): string | undefined {
+  const lower = `${evaluatorName} ${text}`.toLowerCase();
+  const toolPatterns: readonly [string, RegExp][] = [
+    ['vitest', /\bvitest\b|\btest(?:s|ing)?\b/],
+    ['typescript', /\b(?:typescript|tsc|typecheck)\b/],
+    ['eslint', /\b(?:eslint|lint)\b/],
+    ['prettier', /\bprettier\b|\bformat(?:ting)?\b/],
+    ['npm', /\bnpm\b/],
+    ['turbo', /\bturbo\b/],
+    ['codex', /\bcodex\b/],
+    ['github', /\bgithub\b|\bgh\b/],
+    ['docker', /\bdocker\b/],
+  ];
+  return toolPatterns.find(([, pattern]) => pattern.test(lower))?.[0];
+}
+
+function inferErrorClass(
+  findings: readonly SanitizedLessonFinding[],
+  text: string,
+): string {
+  const severity = findings.some((finding) => finding.severity === 'critical')
+    ? 'critical'
+    : findings.some((finding) => finding.severity === 'warning')
+      ? 'warning'
+      : 'info';
+  const lower = text.toLowerCase();
+  if (/\b(?:timeout|timed out|hang|hung)\b/.test(lower)) {
+    return `${severity}:timeout`;
+  }
+  if (
+    /\b(?:assertion|expected|received|failed test|tests? failed|vitest failed)\b/.test(
+      lower,
+    )
+  ) {
+    return `${severity}:test-failure`;
+  }
+  if (/\b(?:type error|typescript|tsc|typecheck)\b/.test(lower)) {
+    return `${severity}:typecheck`;
+  }
+  if (/\b(?:permission|auth|token|credential|secret)\b/.test(lower)) {
+    return `${severity}:auth-or-secret`;
+  }
+  if (/\b(?:missing|absent|required|omitted)\b/.test(lower)) {
+    return `${severity}:missing-contract`;
+  }
+  return `${severity}:review-finding`;
+}
+
+function inferRootCause(text: string): string {
+  const lower = normalizeBlockerFinding(text);
+  const categories: readonly [string, RegExp][] = [
+    [
+      'verification-evidence',
+      /\b(?:verification|evidence|handoff|test command|test result)\b/,
+    ],
+    [
+      'missing-required-contract',
+      /\b(?:missing|absent|required|omitted|not included)\b/,
+    ],
+    ['type-safety', /\b(?:type|typescript|tsc|declaration|schema)\b/],
+    [
+      'authentication-or-secret',
+      /\b(?:auth|token|credential|secret|permission)\b/,
+    ],
+    [
+      'timeout-or-liveness',
+      /\b(?:timeout|timed out|hang|liveness|heartbeat)\b/,
+    ],
+    ['formatting-or-lint', /\b(?:lint|eslint|prettier|format)\b/],
+  ];
+  const matched = categories.find(([, pattern]) => pattern.test(lower))?.[0];
+  if (matched) {
+    return matched;
+  }
+  const terms = extractComparableTerms(lower).slice(0, 6);
+  return terms.length > 0 ? terms.join('-') : 'unspecified-root-cause';
+}
+
+function createFailureCluster(state: FailureClusterState): FailureCluster {
+  const examples = state.observations.slice(-3).map((observation) => ({
+    evidencePointer: observation.evidencePointer,
+    resolution: observation.resolution,
+  }));
+  return {
+    key: state.key,
+    taskFamily: state.taskFamily,
+    ...(state.packageName ? { packageName: state.packageName } : {}),
+    ...(state.toolName ? { toolName: state.toolName } : {}),
+    errorClass: state.errorClass,
+    rootCause: state.rootCause,
+    occurrences: state.observations.length,
+    examples,
+    suggestedActions: createFailureClusterSuggestedActions(state),
+  };
+}
+
+function createFailureClusterSuggestedActions(
+  state: FailureClusterState,
+): readonly string[] {
+  const scope = [state.taskFamily, state.packageName, state.toolName]
+    .filter((value): value is string => Boolean(value))
+    .join(' / ');
+  return [
+    `Add or update regression coverage for ${state.rootCause} in ${scope}.`,
+    `Review package or tool documentation for ${state.errorClass} and add targeted worker guidance if this recurs.`,
+    'Route the top cluster to a PM learning backlog owner before accepting more duplicate rediscovery.',
+  ];
+}
+
+function createFailureClusterBacklogItem(
+  cluster: FailureCluster,
+): LearningBacklogPrioritizationItem {
+  return {
+    id: `failure-cluster:${cluster.key}`,
+    source: 'failure-cluster',
+    priority: cluster.occurrences >= 3 ? 'high' : 'medium',
+    score: Math.min(95, 40 + cluster.occurrences * 20),
+    title: `${cluster.rootCause} in ${cluster.taskFamily}`,
+    rationale: `Failure cluster recurred ${cluster.occurrences} times for ${cluster.errorClass}; PMs should treat it as a systemic learning opportunity instead of an isolated incident.`,
+    recommendedAction: cluster.suggestedActions[0]!,
+  };
+}
+
+function addOrReplaceLearningBacklogItem(
+  target: LearningBacklogPrioritizationItem[],
+  item: LearningBacklogPrioritizationItem,
+): void {
+  const existingIndex = target.findIndex((existing) => existing.id === item.id);
+  if (existingIndex >= 0) {
+    target.splice(existingIndex, 1, item);
+  } else {
+    target.push(item);
+  }
+  sortLearningBacklogItems(target);
+}
+
+function sortFailureClusters(clusters: FailureCluster[]): void {
+  clusters.sort((left, right) => {
+    if (right.occurrences !== left.occurrences) {
+      return right.occurrences - left.occurrences;
+    }
+    return left.key.localeCompare(right.key);
+  });
 }
 
 function sortLearningBacklogItems(
@@ -2023,7 +2370,9 @@ function createLessonPrivacyFilterResult(
     flags: Array.from(flags).sort(),
     redactions,
     originalHash: stableHash(rawText),
-    reason: sensitive ? PRIVACY_FILTER_SENSITIVE_REASON : PRIVACY_FILTER_ADMIT_REASON,
+    reason: sensitive
+      ? PRIVACY_FILTER_SENSITIVE_REASON
+      : PRIVACY_FILTER_ADMIT_REASON,
   };
 
   return {
@@ -2048,11 +2397,14 @@ function createPrivacyDecision(
     CUSTOMER_DATA_PATTERNS.some((pattern) => pattern.test(rawText));
   if (containsCustomerData) {
     flags.add('customer-data');
-    for (const segment of rawText.split('\n').flatMap(extractCustomerSegments)) {
+    for (const segment of rawText
+      .split('\n')
+      .flatMap(extractCustomerSegments)) {
       if (
         redactions.some(
           (redaction) =>
-            redaction.kind === 'customer-data' && redaction.original === segment,
+            redaction.kind === 'customer-data' &&
+            redaction.original === segment,
         )
       ) {
         continue;
@@ -2094,11 +2446,15 @@ function extractCustomerSegments(text: string): string[] {
       /\b[Cc]ustomer(?:\s+account)?(?:\s+[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})?(?:\s+[A-Za-z0-9_.:-]+){1,3}\b|\b[Tt]enant\s+[A-Za-z0-9][A-Za-z0-9_.:-]*(?:\s+(?![A-Za-z0-9._%+-]+@)[A-Za-z0-9_.:-]+){0,3}\b|\b[Cc]lient\s+(?:account|tenant|[A-Z0-9][A-Za-z0-9_.:-]*)(?:\s+(?![A-Za-z0-9._%+-]+@)[A-Za-z0-9_.:-]+){0,3}\b|\b[Aa]ccount\s+[A-Z0-9][A-Za-z0-9_.:-]*(?:\s+(?![A-Za-z0-9._%+-]+@)[A-Za-z0-9_.:-]+){0,3}\b/g,
     ) ?? [];
   return segments.flatMap((segment) => {
-    const emailMatch = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/.exec(segment);
+    const emailMatch = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/.exec(
+      segment,
+    );
     if (!emailMatch) {
       return [segment];
     }
-    const trailingIdentifier = segment.slice(emailMatch.index + emailMatch[0].length).trim();
+    const trailingIdentifier = segment
+      .slice(emailMatch.index + emailMatch[0].length)
+      .trim();
     return trailingIdentifier ? [trailingIdentifier] : [];
   });
 }
@@ -2108,9 +2464,11 @@ function createFindingPrivacyText(finding: {
   readonly location?: string | undefined;
   readonly suggestion?: string | undefined;
 }): string {
-  return [finding.message, finding.suggestion ?? '', finding.location ?? ''].join(
-    '\n',
-  );
+  return [
+    finding.message,
+    finding.suggestion ?? '',
+    finding.location ?? '',
+  ].join('\n');
 }
 
 function mergePrivacyRedactions(
@@ -2149,8 +2507,8 @@ function toPublicPrivacyDecision(
 ): LessonPrivacyFilterDecision {
   return {
     ...decision,
-    redactions: decision.redactions.map(({ original: _original, ...rest }) =>
-      rest,
+    redactions: decision.redactions.map(
+      ({ original: _original, ...rest }) => rest,
     ),
   };
 }
@@ -2181,15 +2539,15 @@ function containsReusableLessonSignal(text: string): boolean {
   if (ENVIRONMENT_FACT_PATTERNS.some((pattern) => pattern.test(text))) {
     return true;
   }
-  if (/\b(?:always|avoid|ensure|prefer|require|validate|verify)\b/i.test(text)) {
+  if (
+    /\b(?:always|avoid|ensure|prefer|require|validate|verify)\b/i.test(text)
+  ) {
     return true;
   }
   if (/\b(?:merged|opened|closed|pushed|committed)\b/i.test(text)) {
     return false;
   }
-  return /\b(?:before|check|run)\b/i.test(
-    text,
-  );
+  return /\b(?:before|check|run)\b/i.test(text);
 }
 
 function collectPrivacyRedactions(
@@ -2346,12 +2704,20 @@ function findContradictoryGuidanceMatch(
   const priorDirectives = createLessonDirectiveClauses(prior);
   for (const lessonDirective of lessonDirectives) {
     for (const priorDirective of priorDirectives) {
-      if (normalizeText(lessonDirective.sourceText) === normalizeText(priorDirective.sourceText)) {
+      if (
+        normalizeText(lessonDirective.sourceText) ===
+        normalizeText(priorDirective.sourceText)
+      ) {
         continue;
       }
-      if (hasDoubleNegativeOppositeDirectivePair(lessonDirective, priorDirective)) {
+      if (
+        hasDoubleNegativeOppositeDirectivePair(lessonDirective, priorDirective)
+      ) {
         return {
-          sharedTerms: sharedDirectiveObjectTerms(lessonDirective, priorDirective),
+          sharedTerms: sharedDirectiveObjectTerms(
+            lessonDirective,
+            priorDirective,
+          ),
           lessonGuidance: lessonDirective.sourceText,
           conflictingGuidance: priorDirective.sourceText,
         };
@@ -2370,7 +2736,14 @@ function findContradictoryGuidanceMatch(
       if (lessonDirective.polarity === priorDirective.polarity) {
         continue;
       }
-      if (hasCompatibleSiblingDirective(lessonDirectives, priorDirectives, lessonDirective, priorDirective)) {
+      if (
+        hasCompatibleSiblingDirective(
+          lessonDirectives,
+          priorDirectives,
+          lessonDirective,
+          priorDirective,
+        )
+      ) {
         continue;
       }
       const opposedGuardSharedTerms = opposedConditionalGuardSharedTerms(
@@ -2397,7 +2770,13 @@ function findContradictoryGuidanceMatch(
       if (hasCompatibleConditionalGuard(lessonDirective, priorDirective)) {
         continue;
       }
-      if (hasDivergentQualifiedGenericObjectPair(lessonDirective, priorDirective, sharedTerms)) {
+      if (
+        hasDivergentQualifiedGenericObjectPair(
+          lessonDirective,
+          priorDirective,
+          sharedTerms,
+        )
+      ) {
         continue;
       }
       if (hasExplicitOppositeDirectivePair(lessonDirective, priorDirective)) {
@@ -2426,7 +2805,10 @@ function hasAuthenticationScopeConflict(
   a: LessonDirectiveClause,
   b: LessonDirectiveClause,
 ): boolean {
-  return hasAuthenticationScopeConflictInOrder(a, b) || hasAuthenticationScopeConflictInOrder(b, a);
+  return (
+    hasAuthenticationScopeConflictInOrder(a, b) ||
+    hasAuthenticationScopeConflictInOrder(b, a)
+  );
 }
 
 function hasAuthenticationScopeConflictInOrder(
@@ -2461,7 +2843,9 @@ function hasDivergentScopeQualifiers(a: string, b: string): boolean {
   const aScopes = extractScopeQualifiers(a);
   const bScopes = extractScopeQualifiers(b);
   return aScopes.some((scope) =>
-    SCOPE_QUALIFIER_OPPOSITES[scope]?.some((opposite) => bScopes.includes(opposite)),
+    SCOPE_QUALIFIER_OPPOSITES[scope]?.some((opposite) =>
+      bScopes.includes(opposite),
+    ),
   );
 }
 
@@ -2481,8 +2865,16 @@ function hasCompatibleSiblingDirective(
     return false;
   }
   return (
-    hasCompatibleSiblingInList(lessonDirectives, currentDirective, priorDirective) ||
-    hasCompatibleSiblingInList(priorDirectives, priorDirective, currentDirective)
+    hasCompatibleSiblingInList(
+      lessonDirectives,
+      currentDirective,
+      priorDirective,
+    ) ||
+    hasCompatibleSiblingInList(
+      priorDirectives,
+      priorDirective,
+      currentDirective,
+    )
   );
 }
 
@@ -2495,13 +2887,16 @@ function hasCompatibleSiblingInList(
     (directive) =>
       directive !== currentDirective &&
       directive.polarity === comparedDirective.polarity &&
-      canonicalComparableText(directive.text) === canonicalComparableText(comparedDirective.text),
+      canonicalComparableText(directive.text) ===
+        canonicalComparableText(comparedDirective.text),
   );
 }
 
 function sharedTextTerms(a: string, b: string): string[] {
   const aTerms = new Set(extractComparableTerms(a));
-  const bTerms = new Set(extractComparableTerms(b).map(canonicalComparableTerm));
+  const bTerms = new Set(
+    extractComparableTerms(b).map(canonicalComparableTerm),
+  );
   return [...aTerms]
     .filter((term) => bTerms.has(canonicalComparableTerm(term)))
     .sort();
@@ -2523,7 +2918,9 @@ function createLessonDirectiveFragments(lesson: CritiqueLesson): string[] {
       if (finding.suggestion) {
         return [finding.suggestion];
       }
-      return isDirectiveLikeFindingMessage(finding.message) ? [finding.message] : [];
+      return isDirectiveLikeFindingMessage(finding.message)
+        ? [finding.message]
+        : [];
     }) ?? [];
   return [lesson.correctionApplied, ...reviewerGuidance].filter(
     (fragment) => normalizeText(fragment).length > 0,
@@ -2539,7 +2936,8 @@ function isDirectiveLikeFindingMessage(message: string): boolean {
   return (
     (startsWithPositiveDirective(normalized) && !looksLikeFailureProse) ||
     startsWithNegativeDirective(normalized) ||
-    (!looksLikeFailureProse && /\b(?:do not|don t|must not|should not|unless|until)\b/i.test(message))
+    (!looksLikeFailureProse &&
+      /\b(?:do not|don t|must not|should not|unless|until)\b/i.test(message))
   );
 }
 
@@ -2593,7 +2991,10 @@ function createDirectiveClauses(fragment: string): LessonDirectiveClause[] {
     },
   ];
 
-  if (guardCondition && (conditionalProhibition || /\b(?:without|unless)\b/i.test(fragment))) {
+  if (
+    guardCondition &&
+    (conditionalProhibition || /\b(?:without|unless)\b/i.test(fragment))
+  ) {
     clauses.push({
       text: `${normalized} ${guardCondition}`,
       sourceText: fragment,
@@ -2603,7 +3004,11 @@ function createDirectiveClauses(fragment: string): LessonDirectiveClause[] {
     });
   }
 
-  if (embeddedNegatedCondition && leadingPolarity === 'positive' && !startsWithDoubleNegativeDirective(normalized)) {
+  if (
+    embeddedNegatedCondition &&
+    leadingPolarity === 'positive' &&
+    !startsWithDoubleNegativeDirective(normalized)
+  ) {
     clauses.push({
       text: embeddedNegatedCondition,
       sourceText: fragment,
@@ -2623,7 +3028,9 @@ function splitDirectiveFragments(fragment: string): string[] {
 }
 
 function splitCoordinatedDirectiveFragment(fragment: string): string[] {
-  const parts = fragment.split(/,?\s+(?:and|then)\s+/i).map((part) => part.trim());
+  const parts = fragment
+    .split(/,?\s+(?:and|then)\s+/i)
+    .map((part) => part.trim());
   if (parts.length <= 1) {
     return parts;
   }
@@ -2632,7 +3039,10 @@ function splitCoordinatedDirectiveFragment(fragment: string): string[] {
   let current = parts[0]!;
   for (const part of parts.slice(1)) {
     const normalizedPart = normalizeText(part);
-    if (startsWithPositiveDirective(normalizedPart) || startsWithNegativeDirective(normalizedPart)) {
+    if (
+      startsWithPositiveDirective(normalizedPart) ||
+      startsWithNegativeDirective(normalizedPart)
+    ) {
       fragments.push(current);
       current = part;
       continue;
@@ -2658,7 +3068,10 @@ function normalizeGuardCondition(value: string): string {
 function extractEmbeddedNegatedCondition(
   normalized: string,
 ): string | undefined {
-  const match = /\b(?:do not|don t|does not|not|never|cannot|can t|must not|should not)\s+(.+)$/i.exec(normalized);
+  const match =
+    /\b(?:do not|don t|does not|not|never|cannot|can t|must not|should not)\s+(.+)$/i.exec(
+      normalized,
+    );
   const condition = match?.[1]?.trim() ?? '';
   return condition.length > 0 ? condition : undefined;
 }
@@ -2672,7 +3085,10 @@ function opposedConditionalGuardSharedTerms(
     return [];
   }
 
-  if (hasComplementaryConditionalGuardPair(a, b) || hasComplementaryConditionalGuardPair(b, a)) {
+  if (
+    hasComplementaryConditionalGuardPair(a, b) ||
+    hasComplementaryConditionalGuardPair(b, a)
+  ) {
     return [];
   }
 
@@ -2715,8 +3131,10 @@ function hasComplementaryConditionalGuardPair(
       maybeProhibition.guardCondition,
       maybeAllowance.guardCondition,
     ) &&
-    sharedTextTerms(maybeProhibition.guardCondition, maybeAllowance.guardCondition)
-      .length >= 1 &&
+    sharedTextTerms(
+      maybeProhibition.guardCondition,
+      maybeAllowance.guardCondition,
+    ).length >= 1 &&
     sharedTextTerms(maybeProhibition.text, maybeAllowance.text).length >=
       MIN_CONTRADICTION_SHARED_TERMS
   );
@@ -2752,7 +3170,10 @@ function hasDivergentConditionalGuardPair(
   if (!a.guardCondition || !b.guardCondition || a.polarity === b.polarity) {
     return false;
   }
-  if (!hasGuardOutcomeWord(a.guardCondition) || !hasGuardOutcomeWord(b.guardCondition)) {
+  if (
+    !hasGuardOutcomeWord(a.guardCondition) ||
+    !hasGuardOutcomeWord(b.guardCondition)
+  ) {
     return false;
   }
 
@@ -2920,7 +3341,8 @@ function hasSharedGuardSubject(
   guardCondition: string,
   comparedDirective: LessonDirectiveClause,
 ): boolean {
-  const comparedGuard = comparedDirective.guardCondition ?? comparedDirective.text;
+  const comparedGuard =
+    comparedDirective.guardCondition ?? comparedDirective.text;
   return (
     sharedTextTerms(
       stripGuardOutcomeWords(guardCondition),
@@ -2935,7 +3357,6 @@ function stripGuardOutcomeWords(text: string): string {
     '',
   );
 }
-
 
 function hasCompatibleWithoutWithPair(
   maybeAllowance: LessonDirectiveClause,
@@ -2952,8 +3373,8 @@ function hasCompatibleWithoutWithPair(
   }
 
   return (
-    sharedTextTerms(maybeAllowance.guardCondition, maybeProhibition.text).length >=
-      1 &&
+    sharedTextTerms(maybeAllowance.guardCondition, maybeProhibition.text)
+      .length >= 1 &&
     sharedTextTerms(maybeAllowance.text, maybeProhibition.text).length >=
       MIN_CONTRADICTION_SHARED_TERMS
   );
@@ -3001,8 +3422,8 @@ function hasCompatibleGuardedAllowancePair(
   }
 
   return (
-    sharedTextTerms(maybeProhibition.guardCondition, maybeAllowance.text).length >=
-      1 &&
+    sharedTextTerms(maybeProhibition.guardCondition, maybeAllowance.text)
+      .length >= 1 &&
     sharedTextTerms(maybeProhibition.text, maybeAllowance.text).length >=
       MIN_CONTRADICTION_SHARED_TERMS
   );
@@ -3019,8 +3440,12 @@ function hasCompatibleValidityQualifierPair(
     return false;
   }
 
-  const validAllowanceMatch = /\b(?:valid|validated)\s+(\w+)\b/i.exec(maybeAllowance.text);
-  const invalidProhibitionMatch = /\b(?:invalid|unvalidated)\s+(\w+)\b/i.exec(maybeProhibition.text);
+  const validAllowanceMatch = /\b(?:valid|validated)\s+(\w+)\b/i.exec(
+    maybeAllowance.text,
+  );
+  const invalidProhibitionMatch = /\b(?:invalid|unvalidated)\s+(\w+)\b/i.exec(
+    maybeProhibition.text,
+  );
   return (
     validAllowanceMatch?.[1] !== undefined &&
     invalidProhibitionMatch?.[1] !== undefined &&
@@ -3037,20 +3462,24 @@ function hasOpposedGuardOutcome(
     /\b(pass|passes|passed|passing|success|succeed|succeeds|valid|validated|approved|granted)\b/.test(
       guardCondition,
     );
-  const guardHasFail = /\b(fail|fails|failed|failing|failure|invalid|missing|absent|lack|lacks|lacked|deny|denies|denied|reject|rejects|rejected|unapproved|unverified|not\s+approved|not\s+granted)\b/.test(
-    guardCondition,
-  );
+  const guardHasFail =
+    /\b(fail|fails|failed|failing|failure|invalid|missing|absent|lack|lacks|lacked|deny|denies|denied|reject|rejects|rejected|unapproved|unverified|not\s+approved|not\s+granted)\b/.test(
+      guardCondition,
+    );
   const requirementHasPass =
     /\b(pass|passes|passed|passing|success|succeed|succeeds|valid|validated|approved|granted)\b/.test(
       requirementText,
     );
   const requirementHasFail =
-    /\b(fail|fails|failed|failing|failure|invalid|missing|absent|lack|lacks|lacked|deny|denies|denied|reject|rejects|rejected|unapproved|unverified|not\s+approved|not\s+granted)\b/.test(requirementText);
+    /\b(fail|fails|failed|failing|failure|invalid|missing|absent|lack|lacks|lacked|deny|denies|denied|reject|rejects|rejected|unapproved|unverified|not\s+approved|not\s+granted)\b/.test(
+      requirementText,
+    );
 
   return (
     (guardHasPass && requirementHasFail) ||
     (guardHasFail && requirementHasPass) ||
-    (requirementHasFail && sharedTextTerms(guardCondition, requirementText).length >= 1)
+    (requirementHasFail &&
+      sharedTextTerms(guardCondition, requirementText).length >= 1)
   );
 }
 
@@ -3089,7 +3518,10 @@ function hasExactTopLevelReversal(
   a: LessonDirectiveClause,
   b: LessonDirectiveClause,
 ): boolean {
-  return hasExactTopLevelReversalInOrder(a, b) || hasExactTopLevelReversalInOrder(b, a);
+  return (
+    hasExactTopLevelReversalInOrder(a, b) ||
+    hasExactTopLevelReversalInOrder(b, a)
+  );
 }
 
 function hasExactTopLevelReversalInOrder(
@@ -3107,7 +3539,9 @@ function hasExactTopLevelReversalInOrder(
     return false;
   }
 
-  const negativeObject = stripLeadingPositiveDirective(stripLeadingDirective(maybeNegative.text));
+  const negativeObject = stripLeadingPositiveDirective(
+    stripLeadingDirective(maybeNegative.text),
+  );
   const positiveObject = stripLeadingDirective(maybePositive.text);
   const negativeAction = leadingDirectiveAction(maybeNegative.text);
   const positiveAction = leadingDirectiveAction(maybePositive.text);
@@ -3142,8 +3576,9 @@ function hasDoubleNegativeOppositeDirectivePairInOrder(
     return false;
   }
   return (
-    canonicalComparableText(stripLeadingPositiveDirective(maybeDoubleNegative.text)) ===
-    canonicalComparableText(stripLeadingDirective(maybeNegative.text))
+    canonicalComparableText(
+      stripLeadingPositiveDirective(maybeDoubleNegative.text),
+    ) === canonicalComparableText(stripLeadingDirective(maybeNegative.text))
   );
 }
 
@@ -3164,7 +3599,9 @@ function leadingDirectiveAction(text: string): string | undefined {
     .replace(/^(?:do not|don t|must not|should not|cannot|can t)\s+/, '')
     .replace(/^(?:should|must)\s+/, '');
   const action = normalizeText(strippedNegation).split(' ').find(Boolean);
-  if (['disallow', 'prohibit', 'forbid', 'deny', 'reject'].includes(action ?? '')) {
+  if (
+    ['disallow', 'prohibit', 'forbid', 'deny', 'reject'].includes(action ?? '')
+  ) {
     return 'allow';
   }
   if (action === 'permit') {
@@ -3181,14 +3618,17 @@ function sharedDirectiveObjectTerms(
   const bObjectTerms = extractComparableTerms(stripLeadingDirective(b.text));
   return aObjectTerms.filter((aTerm) =>
     bObjectTerms.some(
-      (bTerm) => canonicalComparableTerm(aTerm) === canonicalComparableTerm(bTerm),
+      (bTerm) =>
+        canonicalComparableTerm(aTerm) === canonicalComparableTerm(bTerm),
     ),
   );
 }
 
 function stripLeadingDirective(normalized: string): string {
   return stripLeadingPositiveDirective(
-    stripLeadingNegativeDirective(stripLeadingDoubleNegativeDirective(normalized)),
+    stripLeadingNegativeDirective(
+      stripLeadingDoubleNegativeDirective(normalized),
+    ),
   );
 }
 
@@ -3209,7 +3649,9 @@ function hasDivergentQualifiedGenericObjectPair(
   if (sharedTerms.length < MIN_CONTRADICTION_SHARED_TERMS) {
     return false;
   }
-  const sharedCanonicalTerms = new Set(sharedTerms.map(canonicalComparableTerm));
+  const sharedCanonicalTerms = new Set(
+    sharedTerms.map(canonicalComparableTerm),
+  );
   const sharedGenericObjects = [...sharedCanonicalTerms].filter((term) =>
     LESSON_CONTRADICTION_GENERIC_OBJECT_TERMS.has(term),
   );
@@ -3240,7 +3682,10 @@ function hasExplicitOppositeDirectivePairInOrder(
   }
 
   const negativeObject = stripLeadingDirective(maybeNegative.text);
-  if (canonicalComparableText(negativeObject) === canonicalComparableText(maybePositive.text)) {
+  if (
+    canonicalComparableText(negativeObject) ===
+    canonicalComparableText(maybePositive.text)
+  ) {
     return true;
   }
 
@@ -3248,7 +3693,8 @@ function hasExplicitOppositeDirectivePairInOrder(
   return (
     negativeObject.length > 0 &&
     positiveObject.length > 0 &&
-    canonicalComparableText(negativeObject) === canonicalComparableText(positiveObject)
+    canonicalComparableText(negativeObject) ===
+      canonicalComparableText(positiveObject)
   );
 }
 
@@ -3269,8 +3715,11 @@ function startsWithDoubleNegativeDirective(normalized: string): boolean {
 }
 
 function startsWithPositiveDirective(normalized: string): boolean {
-  return startsWithDoubleNegativeDirective(normalized) || /^(allow|enable|enabled|deploy|reuse|use|cache|log|store|record|permit|require|requires|required|run|rotate|should|must)\b/.test(
-    normalized,
+  return (
+    startsWithDoubleNegativeDirective(normalized) ||
+    /^(allow|enable|enabled|deploy|reuse|use|cache|log|store|record|permit|require|requires|required|run|rotate|should|must)\b/.test(
+      normalized,
+    )
   );
 }
 
@@ -3285,8 +3734,14 @@ function stripLeadingNegativeDirective(normalized: string): string {
 
 function stripLeadingPositiveDirective(normalized: string): string {
   return normalized
-    .replace(/^(?:do not|don t|must not|should not|cannot|can t)\s+(?:avoid|reject|forbid|disallow|prohibit|disable|disabled|skip|omit|ignore|bypass|deny)\s+/, '')
-    .replace(/^(?:allow|enable|enabled|deploy|reuse|use|cache|log|store|record|permit|require|requires|required|run|rotate|should|must)\s+/, '')
+    .replace(
+      /^(?:do not|don t|must not|should not|cannot|can t)\s+(?:avoid|reject|forbid|disallow|prohibit|disable|disabled|skip|omit|ignore|bypass|deny)\s+/,
+      '',
+    )
+    .replace(
+      /^(?:allow|enable|enabled|deploy|reuse|use|cache|log|store|record|permit|require|requires|required|run|rotate|should|must)\s+/,
+      '',
+    )
     .trim();
 }
 

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1717,9 +1717,7 @@ function createFailureClusterKey(parts: {
 
 function inferTaskFamily(taskId: TaskId, text: string): string {
   const explicitFamily =
-    /\b(?:task family|family)\s*[:=]\s*([a-z][a-z0-9 _/-]{2,60})/i.exec(
-      text,
-    )?.[1];
+    /\btask[-\s]+family\s*[:=]\s*([a-z][a-z0-9 _/-]{2,60})/i.exec(text)?.[1];
   const raw = explicitFamily ?? taskId;
   const normalized = raw
     .replace(/\bt_[0-9a-f]{6,}\b/gi, ' ')
@@ -1750,7 +1748,7 @@ function inferToolName(
 ): string | undefined {
   const lower = `${evaluatorName} ${text}`.toLowerCase();
   const toolPatterns: readonly [string, RegExp][] = [
-    ['vitest', /\bvitest\b|\btest(?:s|ing)?\b/],
+    ['vitest', /\bvitest\b/],
     ['typescript', /\b(?:typescript|tsc|typecheck)\b/],
     ['eslint', /\b(?:eslint|lint)\b/],
     ['prettier', /\bprettier\b|\bformat(?:ting)?\b/],
@@ -1776,11 +1774,7 @@ function inferErrorClass(
   if (/\b(?:timeout|timed out|hang|hung)\b/.test(lower)) {
     return `${severity}:timeout`;
   }
-  if (
-    /\b(?:assertion|expected|received|failed test|tests? failed|vitest failed)\b/.test(
-      lower,
-    )
-  ) {
+  if (hasTestFailureContext(lower)) {
     return `${severity}:test-failure`;
   }
   if (/\b(?:type error|typescript|tsc|typecheck)\b/.test(lower)) {
@@ -1793,6 +1787,19 @@ function inferErrorClass(
     return `${severity}:missing-contract`;
   }
   return `${severity}:review-finding`;
+}
+
+function hasTestFailureContext(text: string): boolean {
+  const explicitTestFailure =
+    /\b(?:failed test|tests? failed|vitest failed|test runner|runner output)\b/.test(
+      text,
+    );
+  const assertionWords = /\b(?:assertion|expected|received)\b/.test(text);
+  const testLocationOrRunner =
+    /\b(?:vitest|jest|mocha|pytest|test\/|tests\/|\.test\.[cm]?[jt]sx?|\.spec\.[cm]?[jt]sx?)\b/.test(
+      text,
+    );
+  return explicitTestFailure || (assertionWords && testLocationOrRunner);
 }
 
 function inferRootCause(text: string): string {

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -329,6 +329,7 @@ export interface FailureRecordEvidencePointer {
 /** Structured, transcript-free metadata for one recovered failure. */
 export interface FailureRecordMetadata {
   readonly schemaVersion: 'failure-record-v1';
+  readonly taskId: TaskId;
   readonly taskFamily: string;
   readonly packageName?: string;
   readonly toolName?: string;

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -264,11 +264,7 @@ export interface PostPrLessonExtractionTemplate {
 }
 
 export type LessonCandidateCategory =
-  | 'procedure'
-  | 'preference'
-  | 'environment-fact'
-  | 'task-state'
-  | 'discard';
+  'procedure' | 'preference' | 'environment-fact' | 'task-state' | 'discard';
 
 /** Redaction applied before a learned lesson candidate can reach durable memory. */
 export interface LessonPrivacyRedaction {
@@ -323,6 +319,50 @@ export interface LessonCooldownSuppression {
 }
 
 /** A recurring critical finding observed across more than one task. */
+export interface FailureRecordEvidencePointer {
+  /** Non-transcript pointer proving where this failure signal came from. */
+  readonly kind: 'review-finding' | 'test-traceability';
+  readonly id: string;
+  readonly location?: string;
+}
+
+/** Structured, transcript-free metadata for one recovered failure. */
+export interface FailureRecordMetadata {
+  readonly schemaVersion: 'failure-record-v1';
+  readonly taskFamily: string;
+  readonly packageName?: string;
+  readonly toolName?: string;
+  readonly errorClass: string;
+  readonly rootCause: string;
+  readonly resolution: string;
+  readonly evidencePointer: FailureRecordEvidencePointer;
+  readonly clusterKey: string;
+}
+
+/** A repeated failure family suitable for PM learning/doc/test routing. */
+export interface FailureCluster {
+  readonly key: string;
+  readonly taskFamily: string;
+  readonly packageName?: string;
+  readonly toolName?: string;
+  readonly errorClass: string;
+  readonly rootCause: string;
+  readonly occurrences: number;
+  readonly examples: readonly Pick<
+    FailureRecordMetadata,
+    'evidencePointer' | 'resolution'
+  >[];
+  readonly suggestedActions: readonly string[];
+}
+
+/** Transcript-free report of top recurring failure themes. */
+export interface FailureClusterReport {
+  readonly schemaVersion: 'failure-cluster-report-v1';
+  readonly generatedAt: string;
+  readonly guidance: string;
+  readonly clusters: readonly FailureCluster[];
+}
+
 export interface CrossTaskBlockerPattern {
   /** Stable key that identifies equivalent blocker findings across tasks. */
   readonly key: string;
@@ -353,7 +393,10 @@ export interface LearningBacklogPrioritizationItem {
   readonly id: string;
   /** Source signal that created this backlog item. */
   readonly source:
-    'recorded-lesson' | 'cooldown-suppression' | 'blocker-pattern';
+    | 'recorded-lesson'
+    | 'cooldown-suppression'
+    | 'blocker-pattern'
+    | 'failure-cluster';
   /** Coarse priority bucket for operator routing. */
   readonly priority: LearningBacklogPriority;
   /** Numeric score used for deterministic sorting inside a priority bucket. */
@@ -421,6 +464,8 @@ export interface LessonRecordingResult {
   readonly rejectedByPrivacy: readonly LessonPrivacyFilterDecision[];
   /** Cross-task blocker patterns discovered while recording this critique result. */
   readonly minedBlockerPatterns: readonly CrossTaskBlockerPattern[];
+  /** Top recurring task-family failure clusters observed without retaining raw transcripts. */
+  readonly failureClusterReport: FailureClusterReport;
   /** Prioritized PM/liveness follow-up generated from this record call's learning signals. */
   readonly learningBacklogPrioritizationReport: LearningBacklogPrioritizationReport;
 }
@@ -448,6 +493,8 @@ export interface CritiqueLesson {
   readonly rollbackWorkflow?: LessonRollbackWorkflow;
   /** Structured reviewer feedback that produced the lesson and should be reusable in PM handoffs. */
   readonly reviewerFeedback?: ReviewerFeedbackLessonCapture;
+  /** Structured task-family/package/tool/root-cause metadata for clustering recovered failures. */
+  readonly failureRecord?: FailureRecordMetadata;
   /** Present when a recovered failed test is a candidate for future skill creation/update. */
   readonly failedTestSkillCandidate?: FailedTestSkillCandidate;
   /** Structured template for extracting reusable lessons from post-PR review/merge evidence. */

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -2538,6 +2538,49 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('does not count same-task cooldown suppressions as recurrent failure clusters', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      now: (): Date => new Date('2026-07-12T10:00:00.000Z'),
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message:
+              'Vitest failed for packages/franken-critique because verification evidence was omitted',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'fail', 'learning-reviewer', [
+          {
+            message:
+              'Vitest failed for packages/franken-critique because verification evidence was omitted',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(2, 'pass'),
+      ],
+    };
+
+    const summary = await recorder.record(result, 'frontend-auth-101');
+
+    expect(summary.suppressedByCooldown).toHaveLength(1);
+    expect(summary.failureClusterReport.clusters).toEqual([
+      expect.objectContaining({
+        taskFamily: 'frontend auth',
+        occurrences: 1,
+      }),
+    ]);
+    expect(summary.learningBacklogPrioritizationReport.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'failure-cluster' }),
+      ]),
+    );
+  });
+
   it('does not infer arbitrary family prose as an explicit task family', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);
@@ -2574,7 +2617,7 @@ describe('LessonRecorder', () => {
         createIteration(0, 'fail', 'handoff-reviewer', [
           {
             message:
-              'PM handoff omitted the required test command for packages/franken-critique',
+              'PM handoff omitted the required test runner output for packages/franken-critique',
             severity: 'critical',
           },
         ]),
@@ -2593,6 +2636,61 @@ describe('LessonRecorder', () => {
       rootCause: 'verification-evidence',
     });
     expect(recordedLesson.failureRecord?.toolName).toBeUndefined();
+  });
+
+  it('detects scoped package names in failure cluster metadata', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'schema-reviewer', [
+          {
+            message:
+              '@franken/critique omitted required exported type metadata in the public API',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'frontend-auth-204');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      packageName: '@franken/critique',
+    });
+  });
+
+  it('infers root cause from findings before generic suggestions', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'type-reviewer', [
+          {
+            message:
+              'TypeScript declaration for packages/franken-critique omitted a required exported contract',
+            severity: 'critical',
+            suggestion:
+              'Attach verification evidence to the PM handoff after fixing the export.',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'frontend-auth-205');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      errorClass: 'critical:typecheck',
+      rootCause: 'type-safety',
+    });
   });
 
   it('requires test context before classifying expected/received prose as a test failure', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -9,7 +9,10 @@ import {
   unquarantineLesson,
 } from '../../../src/memory/lesson-recorder.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
-import type { MemoryPort, CritiqueLesson } from '../../../src/types/contracts.js';
+import type {
+  MemoryPort,
+  CritiqueLesson,
+} from '../../../src/types/contracts.js';
 import type {
   CritiqueLoopResult,
   CritiqueIteration,
@@ -118,9 +121,7 @@ describe('LessonRecorder', () => {
     expect(JSON.stringify(lesson)).not.toContain(lowercaseBearer);
     expect(JSON.stringify(lesson)).not.toContain(fakeConnectionString);
     expect(lesson.failureDescription).toContain('Bearer [REDACTED_TOKEN]');
-    expect(lesson.failureDescription).toContain(
-      '[REDACTED_CONNECTION_STRING]',
-    );
+    expect(lesson.failureDescription).toContain('[REDACTED_CONNECTION_STRING]');
     expect(lesson.reviewerFeedback?.findings[0]?.suggestion).toContain(
       '[REDACTED_GITHUB_TOKEN]',
     );
@@ -244,10 +245,10 @@ describe('LessonRecorder', () => {
     await firstRecorder.record(createResult(firstEmail), 'privacy-hash-task');
     await secondRecorder.record(createResult(secondEmail), 'privacy-hash-task');
 
-    const firstLesson = (firstPort.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[0]![0];
-    const secondLesson = (secondPort.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[0]![0];
+    const firstLesson = (firstPort.recordLesson as ReturnType<typeof vi.fn>)
+      .mock.calls[0]![0];
+    const secondLesson = (secondPort.recordLesson as ReturnType<typeof vi.fn>)
+      .mock.calls[0]![0];
     expect(JSON.stringify(firstLesson)).not.toContain(firstEmail);
     expect(JSON.stringify(secondLesson)).not.toContain(secondEmail);
     expect(firstLesson.privacyFilter?.originalHash).not.toEqual(
@@ -525,7 +526,9 @@ describe('LessonRecorder', () => {
 
     const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
       .calls[0]![0];
-    expect(lesson.failureDescription).toContain('HTTP client should validate retries');
+    expect(lesson.failureDescription).toContain(
+      'HTTP client should validate retries',
+    );
     expect(lesson.failureDescription).toContain('account for flaky tests');
     expect(lesson.privacyFilter).toEqual(
       expect.objectContaining({
@@ -838,7 +841,10 @@ describe('LessonRecorder', () => {
       ],
     };
 
-    const recording = await recorder.record(result, 'privacy-merge-guidance-task');
+    const recording = await recorder.record(
+      result,
+      'privacy-merge-guidance-task',
+    );
 
     expect(recording.recorded).toBe(1);
     const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
@@ -1627,7 +1633,9 @@ describe('LessonRecorder', () => {
         observedAt: '2026-07-12T01:35:00.000Z',
         evidence: [{ kind: 'operator-report', reference: '   ' }],
       }),
-    ).toThrow('Lesson quarantine evidence reference must be a non-empty string.');
+    ).toThrow(
+      'Lesson quarantine evidence reference must be a non-empty string.',
+    );
     expect(() =>
       applyHumanFeedbackToLesson(lesson, {
         source: 'explicit-user-approval',
@@ -1636,7 +1644,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#blank-reason',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#blank-reason',
           },
         ],
       }),
@@ -1649,7 +1658,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#inferred-runtime',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#inferred-runtime',
           },
         ],
       }),
@@ -1664,7 +1674,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#blank',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#blank',
           },
         ],
         revisedCorrectionApplied: '   ',
@@ -1678,7 +1689,8 @@ describe('LessonRecorder', () => {
       evidence: [
         {
           kind: 'operator-report',
-          reference: 'https://github.com/djm204/frankenbeast/issues/1763#direct',
+          reference:
+            'https://github.com/djm204/frankenbeast/issues/1763#direct',
         },
       ],
     });
@@ -1689,7 +1701,8 @@ describe('LessonRecorder', () => {
       evidence: [
         {
           kind: 'operator-report',
-          reference: 'https://github.com/djm204/frankenbeast/issues/1763#direct',
+          reference:
+            'https://github.com/djm204/frankenbeast/issues/1763#direct',
         },
       ],
     });
@@ -1704,7 +1717,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandbox',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandbox',
           },
         ],
       },
@@ -1715,7 +1729,8 @@ describe('LessonRecorder', () => {
 
     const approvedAfterCorrection = applyHumanFeedbackToLesson(corrected, {
       source: 'explicit-user-approval',
-      reason: 'User approved the revised lesson after reviewing correction evidence.',
+      reason:
+        'User approved the revised lesson after reviewing correction evidence.',
       observedAt: '2026-07-12T01:45:00.000Z',
       evidence: [
         {
@@ -1738,7 +1753,8 @@ describe('LessonRecorder', () => {
 
     const quarantinedCandidate = quarantineLesson(lesson, {
       trigger: 'repeated-failure-threshold',
-      reason: 'Repeated failures paused this candidate before explicit approval.',
+      reason:
+        'Repeated failures paused this candidate before explicit approval.',
       quarantinedAt: '2026-07-12T01:45:00.000Z',
       evidence: [
         {
@@ -1749,7 +1765,8 @@ describe('LessonRecorder', () => {
     });
     const approved = applyHumanFeedbackToLesson(quarantinedCandidate, {
       source: 'explicit-user-approval',
-      reason: 'User approved this lesson for reuse after reviewing the evidence.',
+      reason:
+        'User approved this lesson for reuse after reviewing the evidence.',
       observedAt: '2026-07-12T02:00:00.000Z',
       evidence: [
         {
@@ -1792,7 +1809,8 @@ describe('LessonRecorder', () => {
       evidence: [
         {
           kind: 'operator-report',
-          reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy',
+          reference:
+            'https://github.com/djm204/frankenbeast/issues/1763#legacy',
         },
       ],
     });
@@ -1821,7 +1839,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-quarantine',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-quarantine',
           },
         ],
       },
@@ -1835,7 +1854,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-approval',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#legacy-sandboxed-approval',
           },
         ],
       },
@@ -1854,7 +1874,8 @@ describe('LessonRecorder', () => {
         evidence: [
           {
             kind: 'operator-report',
-            reference: 'https://github.com/djm204/frankenbeast/issues/1763#retired',
+            reference:
+              'https://github.com/djm204/frankenbeast/issues/1763#retired',
           },
         ],
       },
@@ -2431,6 +2452,90 @@ describe('LessonRecorder', () => {
           'Equivalent critique lesson is still inside the learning cooldown window; reuse the existing lesson metadata instead of recording another copy.',
       },
     ]);
+  });
+
+  it('clusters repeated failures by task family, package, tool, and root cause without retaining raw transcripts', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const failureClusterStore = new Map();
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      now: (): Date => now,
+      failureClusterStore,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message:
+              'Vitest failed for packages/franken-critique because verification evidence was omitted from the PM handoff',
+            severity: 'critical',
+            location:
+              'packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const firstSummary = await recorder.record(result, 'frontend-auth-101');
+    now = new Date('2026-07-12T10:00:30.000Z');
+    const secondSummary = await recorder.record(result, 'frontend-auth-102');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      schemaVersion: 'failure-record-v1',
+      taskFamily: 'frontend auth',
+      packageName: 'packages/franken-critique',
+      toolName: 'vitest',
+      errorClass: 'critical:test-failure',
+      rootCause: 'verification-evidence',
+      evidencePointer: {
+        kind: 'review-finding',
+        location:
+          'packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts',
+      },
+    });
+    expect(JSON.stringify(recordedLesson.failureRecord)).not.toContain(
+      'PM handoff',
+    );
+    expect(firstSummary.failureClusterReport.clusters).toEqual([
+      expect.objectContaining({
+        taskFamily: 'frontend auth',
+        occurrences: 1,
+      }),
+    ]);
+    expect(secondSummary.recorded).toBe(0);
+    expect(secondSummary.suppressedByCooldown).toHaveLength(1);
+    expect(secondSummary.failureClusterReport.clusters).toEqual([
+      expect.objectContaining({
+        taskFamily: 'frontend auth',
+        packageName: 'packages/franken-critique',
+        toolName: 'vitest',
+        errorClass: 'critical:test-failure',
+        rootCause: 'verification-evidence',
+        occurrences: 2,
+        examples: expect.arrayContaining([
+          expect.objectContaining({
+            evidencePointer: expect.objectContaining({
+              kind: 'review-finding',
+            }),
+            resolution: 'Corrected in iteration 1',
+          }),
+        ]),
+      }),
+    ]);
+    expect(secondSummary.learningBacklogPrioritizationReport.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'failure-cluster',
+          priority: 'medium',
+          title: 'verification-evidence in frontend auth',
+        }),
+      ]),
+    );
   });
 
   it('records equivalent lessons again after the cooldown expires', async () => {
@@ -3326,7 +3431,10 @@ describe('LessonRecorder', () => {
       verdict: 'pass',
       iterations: [
         createIteration(0, 'fail', 'factuality', [
-          { message: 'Cache guidance allowed unaudited stale responses', severity: 'critical' },
+          {
+            message: 'Cache guidance allowed unaudited stale responses',
+            severity: 'critical',
+          },
         ]),
         createIteration(1, 'pass'),
       ],
@@ -3334,7 +3442,8 @@ describe('LessonRecorder', () => {
 
     await recorder.record(result, 'lesson-task');
 
-    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
     expect(lesson.contradictionReport).toEqual({
       status: 'not_checked',
       guidance:
@@ -3349,8 +3458,10 @@ describe('LessonRecorder', () => {
     const port = createMockMemoryPort();
     port.searchLessons = vi.fn().mockResolvedValue([
       createLesson({
-        failureDescription: 'Cache guidance reused stale responses without checking provenance',
-        correctionApplied: 'Require cache verification and provenance review before reuse',
+        failureDescription:
+          'Cache guidance reused stale responses without checking provenance',
+        correctionApplied:
+          'Require cache verification and provenance review before reuse',
       }),
     ]);
     const recorder = new LessonRecorder(port);
@@ -3359,7 +3470,10 @@ describe('LessonRecorder', () => {
       verdict: 'pass',
       iterations: [
         createIteration(0, 'fail', 'factuality', [
-          { message: 'Cache guidance allowed unaudited stale responses', severity: 'critical' },
+          {
+            message: 'Cache guidance allowed unaudited stale responses',
+            severity: 'critical',
+          },
         ]),
         createIteration(1, 'pass'),
       ],
@@ -3367,14 +3481,18 @@ describe('LessonRecorder', () => {
 
     await recorder.record(result, 'lesson-task');
 
-    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
     expect(port.searchLessons).toHaveBeenCalledWith(
-      expect.stringContaining('Cache guidance allowed unaudited stale responses'),
+      expect.stringContaining(
+        'Cache guidance allowed unaudited stale responses',
+      ),
       10,
     );
     expect(lesson.contradictionReport).toEqual({
       status: 'clear',
-      guidance: 'No deterministic lesson contradiction was detected among comparable prior lessons.',
+      guidance:
+        'No deterministic lesson contradiction was detected among comparable prior lessons.',
       verificationCommand:
         'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts',
       contradictions: [],
@@ -3383,7 +3501,8 @@ describe('LessonRecorder', () => {
 
   it('detects same-evaluator lesson contradictions with shared terms and negated guidance', () => {
     const current = createLesson({
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
     });
     const prior = createLesson({
       testTraceability: [
@@ -3393,7 +3512,9 @@ describe('LessonRecorder', () => {
           evaluatorName: 'factuality',
           failingIteration: 0,
           resolvedIteration: 1,
-          sourceFindingMessages: ['Cache guidance allowed unaudited stale responses'],
+          sourceFindingMessages: [
+            'Cache guidance allowed unaudited stale responses',
+          ],
           testId: 'prior-cache-lesson:regression',
           verificationCommand: 'npm run test --workspace @franken/critique',
         },
@@ -3427,7 +3548,8 @@ describe('LessonRecorder', () => {
             evaluatorName: 'factuality',
             message: 'Cache reuse lacked provenance checks',
             severity: 'critical',
-            suggestion: 'Do not reuse cache responses without provenance checks',
+            suggestion:
+              'Do not reuse cache responses without provenance checks',
           },
         ],
         suggestionsComplete: true,
@@ -3442,7 +3564,8 @@ describe('LessonRecorder', () => {
           {
             sourceIteration: 0,
             evaluatorName: 'factuality',
-            message: 'Cache reuse was allowed without requiring provenance checks',
+            message:
+              'Cache reuse was allowed without requiring provenance checks',
             severity: 'critical',
             suggestion: 'Reuse cache responses',
           },
@@ -3464,7 +3587,8 @@ describe('LessonRecorder', () => {
 
   it('uses stable fallback ids for legacy contradictory lessons', () => {
     const current = createLesson({
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
     });
     const prior = createLesson({
       correctionApplied: 'Reuse cache responses',
@@ -3476,7 +3600,10 @@ describe('LessonRecorder', () => {
     });
 
     const firstReport = detectLessonContradictions(current, [prior]);
-    const secondReport = detectLessonContradictions(current, [unrelated, prior]);
+    const secondReport = detectLessonContradictions(current, [
+      unrelated,
+      prior,
+    ]);
     const secondPriorContradiction = secondReport.contradictions.find(
       (contradiction) =>
         contradiction.conflictingCorrectionApplied === prior.correctionApplied,
@@ -3493,14 +3620,19 @@ describe('LessonRecorder', () => {
 
   it('reports search adapter failures distinctly from missing lesson search', async () => {
     const port = createMockMemoryPort();
-    port.searchLessons = vi.fn().mockRejectedValue(new Error('memory unavailable'));
+    port.searchLessons = vi
+      .fn()
+      .mockRejectedValue(new Error('memory unavailable'));
     const recorder = new LessonRecorder(port);
 
     const result: CritiqueLoopResult = {
       verdict: 'pass',
       iterations: [
         createIteration(0, 'fail', 'factuality', [
-          { message: 'Cache guidance allowed unaudited stale responses', severity: 'critical' },
+          {
+            message: 'Cache guidance allowed unaudited stale responses',
+            severity: 'critical',
+          },
         ]),
         createIteration(1, 'pass'),
       ],
@@ -3575,7 +3707,8 @@ describe('LessonRecorder', () => {
 
   it('distinguishes leading prohibitions from conditional without clauses', () => {
     const current = createLesson({
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
     });
     const prior = createLesson({
       correctionApplied: 'Reuse cache responses without provenance checks',
@@ -3593,23 +3726,30 @@ describe('LessonRecorder', () => {
 
   it('does not contradict compatible conditional provenance guidance', () => {
     const current = createLesson({
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
     });
     const prior = createLesson({
-      correctionApplied: 'Reuse cache responses when provenance checks are present',
+      correctionApplied:
+        'Reuse cache responses when provenance checks are present',
     });
     const requirePrior = createLesson({
       correctionApplied: 'Require provenance checks before cache reuse',
     });
 
-    expect(detectLessonContradictions(current, [prior, requirePrior])).toMatchObject({
+    expect(
+      detectLessonContradictions(current, [prior, requirePrior]),
+    ).toMatchObject({
       status: 'clear',
       contradictions: [],
     });
   });
 
   it('does not contradict with-guarded or if-guarded prerequisite allowances', () => {
-    for (const guardedAllowance of ['Deploy with approval', 'Deploy if approval']) {
+    for (const guardedAllowance of [
+      'Deploy with approval',
+      'Deploy if approval',
+    ]) {
       expect(
         detectLessonContradictions(
           createLesson({ correctionApplied: 'Do not deploy without approval' }),
@@ -3686,14 +3826,19 @@ describe('LessonRecorder', () => {
   it('splits bare conjunction mixed directives before assigning polarity', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not cache tokens and rotate keys' }),
+        createLesson({
+          correctionApplied: 'Do not cache tokens and rotate keys',
+        }),
         [createLesson({ correctionApplied: 'Rotate keys' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
 
   it('does not treat denied or rejected guard outcomes as compatible allowances', () => {
-    for (const guardedAllowance of ['Deploy if approval is denied', 'Deploy if approval rejected']) {
+    for (const guardedAllowance of [
+      'Deploy if approval is denied',
+      'Deploy if approval rejected',
+    ]) {
       expect(
         detectLessonContradictions(
           createLesson({ correctionApplied: 'Do not deploy without approval' }),
@@ -3715,7 +3860,9 @@ describe('LessonRecorder', () => {
   it('does not suppress invalid-object contradictions using unrelated valid qualifiers', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Allow invalid tokens with valid signature' }),
+        createLesson({
+          correctionApplied: 'Allow invalid tokens with valid signature',
+        }),
         [createLesson({ correctionApplied: 'Do not allow invalid tokens' })],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
@@ -3739,7 +3886,11 @@ describe('LessonRecorder', () => {
             suggestionsComplete: false,
           },
         }),
-        [createLesson({ correctionApplied: 'Do not reuse cache without provenance checks' })],
+        [
+          createLesson({
+            correctionApplied: 'Do not reuse cache without provenance checks',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -3796,7 +3947,8 @@ describe('LessonRecorder', () => {
             evaluatorName: 'factuality',
             message: 'Cache reuse lacked provenance checks',
             severity: 'critical',
-            suggestion: 'Do not reuse cache responses without provenance checks',
+            suggestion:
+              'Do not reuse cache responses without provenance checks',
           },
         ],
         suggestionsComplete: true,
@@ -3824,7 +3976,8 @@ describe('LessonRecorder', () => {
       contradictions: [
         expect.objectContaining({
           conflictingCorrectionApplied: 'Corrected in iteration 1',
-          conflictingGuidance: 'Reuse cache responses without provenance checks',
+          conflictingGuidance:
+            'Reuse cache responses without provenance checks',
         }),
       ],
     });
@@ -3842,8 +3995,14 @@ describe('LessonRecorder', () => {
   it('treats mid-clause negation as compatible with equivalent prohibitions', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Allow requests that do not include PII' }),
-        [createLesson({ correctionApplied: 'Do not allow requests that include PII' })],
+        createLesson({
+          correctionApplied: 'Allow requests that do not include PII',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Do not allow requests that include PII',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -3863,8 +4022,14 @@ describe('LessonRecorder', () => {
   it('treats unless guards as compatible conditional guidance', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Avoid cache reuse unless provenance checks pass' }),
-        [createLesson({ correctionApplied: 'Reuse cache when provenance checks pass' })],
+        createLesson({
+          correctionApplied: 'Avoid cache reuse unless provenance checks pass',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Reuse cache when provenance checks pass',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -3873,7 +4038,8 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({
-          correctionApplied: 'Validate provenance and do not reuse cache responses',
+          correctionApplied:
+            'Validate provenance and do not reuse cache responses',
         }),
         [createLesson({ correctionApplied: 'Reuse cache responses' })],
       ),
@@ -3883,8 +4049,14 @@ describe('LessonRecorder', () => {
   it('preserves directive context for short without guard clauses', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Require authentication before API access' }),
-        [createLesson({ correctionApplied: 'Allow API access without authentication' })],
+        createLesson({
+          correctionApplied: 'Require authentication before API access',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Allow API access without authentication',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -3892,8 +4064,14 @@ describe('LessonRecorder', () => {
   it('does not treat opposite conditional outcomes as compatible guards', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Avoid cache reuse unless provenance checks pass' }),
-        [createLesson({ correctionApplied: 'Reuse cache when provenance checks fail' })],
+        createLesson({
+          correctionApplied: 'Avoid cache reuse unless provenance checks pass',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Reuse cache when provenance checks fail',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -3923,7 +4101,11 @@ describe('LessonRecorder', () => {
           correctionApplied:
             'Do not cache unauthenticated profiles; cache profile metadata after validation',
         }),
-        [createLesson({ correctionApplied: 'Cache profile metadata after validation' })],
+        [
+          createLesson({
+            correctionApplied: 'Cache profile metadata after validation',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -3931,14 +4113,18 @@ describe('LessonRecorder', () => {
   it('recognizes embedded never and cannot prohibitions', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Validate headers and never cache tokens' }),
+        createLesson({
+          correctionApplied: 'Validate headers and never cache tokens',
+        }),
         [createLesson({ correctionApplied: 'Cache tokens' })],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
 
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Validate headers and cannot cache tokens' }),
+        createLesson({
+          correctionApplied: 'Validate headers and cannot cache tokens',
+        }),
         [createLesson({ correctionApplied: 'Cache tokens' })],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
@@ -3947,8 +4133,14 @@ describe('LessonRecorder', () => {
   it('does not self-contradict duplicate positive without guidance', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Reuse cache without provenance checks' }),
-        [createLesson({ correctionApplied: 'Reuse cache without provenance checks' })],
+        createLesson({
+          correctionApplied: 'Reuse cache without provenance checks',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Reuse cache without provenance checks',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -3956,14 +4148,18 @@ describe('LessonRecorder', () => {
   it('splits newline-delimited directive clauses before assigning polarity', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not log PII\nLog debug metrics' }),
+        createLesson({
+          correctionApplied: 'Do not log PII\nLog debug metrics',
+        }),
         [createLesson({ correctionApplied: 'Log debug metrics' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
 
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not cache tokens, and rotate keys' }),
+        createLesson({
+          correctionApplied: 'Do not cache tokens, and rotate keys',
+        }),
         [createLesson({ correctionApplied: 'Rotate keys' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
@@ -4000,7 +4196,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Delete backups without approval' })],
+        [
+          createLesson({
+            correctionApplied: 'Delete backups without approval',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4008,15 +4208,25 @@ describe('LessonRecorder', () => {
   it('treats missing prerequisites as opposed guard outcomes', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Avoid cache reuse unless provenance checks pass' }),
-        [createLesson({ correctionApplied: 'Reuse cache when provenance checks are missing' })],
+        createLesson({
+          correctionApplied: 'Avoid cache reuse unless provenance checks pass',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Reuse cache when provenance checks are missing',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
 
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Deploy when approval is missing' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy when approval is missing',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4024,8 +4234,14 @@ describe('LessonRecorder', () => {
   it('recognizes bypass-style prohibitive directives as negative guidance', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Require authentication before API access' }),
-        [createLesson({ correctionApplied: 'Bypass authentication before API access' })],
+        createLesson({
+          correctionApplied: 'Require authentication before API access',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Bypass authentication before API access',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4034,7 +4250,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Run tests without network access' }),
-        [createLesson({ correctionApplied: 'Do not run tests with network access' })],
+        [
+          createLesson({
+            correctionApplied: 'Do not run tests with network access',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4061,7 +4281,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Allow requests with valid tokens' }),
-        [createLesson({ correctionApplied: 'Do not allow requests with invalid tokens' })],
+        [
+          createLesson({
+            correctionApplied: 'Do not allow requests with invalid tokens',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4069,7 +4293,9 @@ describe('LessonRecorder', () => {
   it('does not let unrelated valid qualifiers suppress invalid-object contradictions', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Allow invalid tokens with valid signature' }),
+        createLesson({
+          correctionApplied: 'Allow invalid tokens with valid signature',
+        }),
         [createLesson({ correctionApplied: 'Do not allow invalid tokens' })],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
@@ -4108,7 +4334,9 @@ describe('LessonRecorder', () => {
 
     expect(
       detectLessonContradictions(current, [
-        createLesson({ correctionApplied: 'Do not reuse cache without provenance checks' }),
+        createLesson({
+          correctionApplied: 'Do not reuse cache without provenance checks',
+        }),
       ]),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4157,7 +4385,9 @@ describe('LessonRecorder', () => {
   it('checks compatible siblings on prior compound lessons', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Cache user avatars after validation' }),
+        createLesson({
+          correctionApplied: 'Cache user avatars after validation',
+        }),
         [
           createLesson({
             correctionApplied:
@@ -4200,7 +4430,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Deploy if approval is not granted' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy if approval is not granted',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4208,7 +4442,9 @@ describe('LessonRecorder', () => {
   it('treats validated and unvalidated scopes as compatible qualifiers', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not cache unvalidated responses' }),
+        createLesson({
+          correctionApplied: 'Do not cache unvalidated responses',
+        }),
         [createLesson({ correctionApplied: 'Cache validated responses' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
@@ -4217,7 +4453,9 @@ describe('LessonRecorder', () => {
   it('keeps generic object terms available for qualifier checks', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not store error messages in DB' }),
+        createLesson({
+          correctionApplied: 'Do not store error messages in DB',
+        }),
         [createLesson({ correctionApplied: 'Store debug messages in DB' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
@@ -4226,8 +4464,14 @@ describe('LessonRecorder', () => {
   it('treats complementary success and failure guards as compatible', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not deploy when approval is missing' }),
-        [createLesson({ correctionApplied: 'Deploy when approval is granted' })],
+        createLesson({
+          correctionApplied: 'Do not deploy when approval is missing',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Deploy when approval is granted',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4250,10 +4494,13 @@ describe('LessonRecorder', () => {
   it('does not treat embedded negation as automatic compatibility for direct reversals', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Allow requests that do not validate tokens' }),
+        createLesson({
+          correctionApplied: 'Allow requests that do not validate tokens',
+        }),
         [
           createLesson({
-            correctionApplied: 'Do not allow requests that do not validate tokens',
+            correctionApplied:
+              'Do not allow requests that do not validate tokens',
           }),
         ],
       ),
@@ -4263,8 +4510,14 @@ describe('LessonRecorder', () => {
   it('classifies unverified guard allowances as failing outcomes', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not deploy unless provenance is verified' }),
-        [createLesson({ correctionApplied: 'Deploy with unverified provenance' })],
+        createLesson({
+          correctionApplied: 'Do not deploy unless provenance is verified',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Deploy with unverified provenance',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4287,7 +4540,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Deploy unless approval is missing' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy unless approval is missing',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4331,8 +4588,14 @@ describe('LessonRecorder', () => {
   it('detects unauthenticated access as conflicting with authentication requirements', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Require authentication before API access' }),
-        [createLesson({ correctionApplied: 'Allow unauthenticated API access' })],
+        createLesson({
+          correctionApplied: 'Require authentication before API access',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Allow unauthenticated API access',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4340,8 +4603,14 @@ describe('LessonRecorder', () => {
   it('preserves divergent auth scope qualifiers before flagging conflicts', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Require authentication before private API access' }),
-        [createLesson({ correctionApplied: 'Allow unauthenticated public API access' })],
+        createLesson({
+          correctionApplied: 'Require authentication before private API access',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Allow unauthenticated public API access',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4349,8 +4618,14 @@ describe('LessonRecorder', () => {
   it('treats after-validation allowances as compatible with unvalidated prohibitions', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not cache unvalidated responses' }),
-        [createLesson({ correctionApplied: 'Cache responses after validation' })],
+        createLesson({
+          correctionApplied: 'Do not cache unvalidated responses',
+        }),
+        [
+          createLesson({
+            correctionApplied: 'Cache responses after validation',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4368,7 +4643,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy when tests fail' }),
-        [createLesson({ correctionApplied: 'Deploy when approval is granted' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy when approval is granted',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
   });
@@ -4377,7 +4656,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Deploy unless approval is granted' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy unless approval is granted',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4406,7 +4689,11 @@ describe('LessonRecorder', () => {
     expect(
       detectLessonContradictions(
         createLesson({ correctionApplied: 'Do not deploy without approval' }),
-        [createLesson({ correctionApplied: 'Deploy when approval is missing' })],
+        [
+          createLesson({
+            correctionApplied: 'Deploy when approval is missing',
+          }),
+        ],
       ),
     ).toMatchObject({ status: 'contradiction_detected' });
   });
@@ -4423,7 +4710,9 @@ describe('LessonRecorder', () => {
   it('splits comma-and mixed directives before assigning polarity', () => {
     expect(
       detectLessonContradictions(
-        createLesson({ correctionApplied: 'Do not cache tokens, and rotate keys' }),
+        createLesson({
+          correctionApplied: 'Do not cache tokens, and rotate keys',
+        }),
         [createLesson({ correctionApplied: 'Rotate keys' })],
       ),
     ).toMatchObject({ status: 'clear', contradictions: [] });
@@ -4469,7 +4758,9 @@ describe('LessonRecorder', () => {
     expect(detectLessonContradictions(current, [prior])).toMatchObject({
       status: 'contradiction_detected',
     });
-    expect(detectLessonContradictions(prohibitCurrent, [permitPrior])).toMatchObject({
+    expect(
+      detectLessonContradictions(prohibitCurrent, [permitPrior]),
+    ).toMatchObject({
       status: 'contradiction_detected',
     });
   });
@@ -4495,7 +4786,9 @@ describe('LessonRecorder', () => {
     await recorder.record(result, 'lesson-task');
 
     expect(port.searchLessons).toHaveBeenCalledWith(
-      expect.stringContaining('Do not reuse cache responses without provenance checks'),
+      expect.stringContaining(
+        'Do not reuse cache responses without provenance checks',
+      ),
       10,
     );
   });
@@ -4547,14 +4840,18 @@ describe('LessonRecorder', () => {
             evaluatorName: 'factuality',
             message: 'Cache reuse lacked provenance checks',
             severity: 'critical',
-            suggestion: 'Do not reuse cache responses without provenance checks',
+            suggestion:
+              'Do not reuse cache responses without provenance checks',
           },
         ],
         suggestionsComplete: false,
       },
     });
 
-    const report = detectLessonContradictions(current, [reusePrior, allowPrior]);
+    const report = detectLessonContradictions(current, [
+      reusePrior,
+      allowPrior,
+    ]);
 
     expect(report.contradictions).toHaveLength(2);
     const ids = report.contradictions.map(
@@ -4566,7 +4863,8 @@ describe('LessonRecorder', () => {
 
   it('treats without as corrective negation when guidance otherwise overlaps strongly', () => {
     const current = createLesson({
-      correctionApplied: 'Require provenance checks before reusing cache responses',
+      correctionApplied:
+        'Require provenance checks before reusing cache responses',
     });
     const prior = createLesson({
       correctionApplied: 'Reuse cache responses without provenance checks',
@@ -4589,7 +4887,8 @@ describe('LessonRecorder', () => {
     });
     const prior = createLesson({
       failureDescription: 'Cache dependency metadata',
-      correctionApplied: 'Cache dependency metadata after checksum verification',
+      correctionApplied:
+        'Cache dependency metadata after checksum verification',
     });
 
     expect(detectLessonContradictions(current, [prior])).toMatchObject({
@@ -4601,7 +4900,8 @@ describe('LessonRecorder', () => {
   it('does not flag unrelated evaluators or non-overlapping lessons as contradictions', () => {
     const current = createLesson({
       evaluatorName: 'factuality',
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
     });
     const unrelated = createLesson({
       evaluatorName: 'security',

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -2538,6 +2538,90 @@ describe('LessonRecorder', () => {
     );
   });
 
+  it('does not infer arbitrary family prose as an explicit task family', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'style-reviewer', [
+          {
+            message:
+              'CSS font-family: Inter rule is missing fallback coverage in packages/franken-web',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'frontend-auth-201');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      taskFamily: 'frontend auth',
+      packageName: 'packages/franken-web',
+    });
+  });
+
+  it('does not route generic test-command mentions to Vitest clusters', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'handoff-reviewer', [
+          {
+            message:
+              'PM handoff omitted the required test command for packages/franken-critique',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'frontend-auth-202');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      taskFamily: 'frontend auth',
+      packageName: 'packages/franken-critique',
+      errorClass: 'critical:missing-contract',
+      rootCause: 'verification-evidence',
+    });
+    expect(recordedLesson.failureRecord?.toolName).toBeUndefined();
+  });
+
+  it('requires test context before classifying expected/received prose as a test failure', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'schema-reviewer', [
+          {
+            message:
+              'Expected PM handoff to include owner and evidence; received an incomplete summary',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'frontend-auth-203');
+
+    const recordedLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
+    expect(recordedLesson.failureRecord).toMatchObject({
+      errorClass: 'warning:review-finding',
+      rootCause: 'verification-evidence',
+    });
+  });
+
   it('records equivalent lessons again after the cooldown expires', async () => {
     const port = createMockMemoryPort();
     let now = new Date('2026-07-12T10:00:00.000Z');


### PR DESCRIPTION
## Summary
- Adds transcript-free failure record metadata to recovered critique lessons.
- Groups repeated failure signals by task family, package/tool, error class, and root cause.
- Surfaces failure-cluster reports and learning backlog items, including cooldown-suppressed repeats.

## Test Plan
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique

Closes #1762