### PR TITLE
feat(dr): add automation dead-letter queue

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -34,6 +34,8 @@ frankenbeast interview
 frankenbeast plan --design-doc <file>
 frankenbeast run --plan-dir <dir>
 frankenbeast issues
+frankenbeast dr dead-letter-list .fbeast/dead-letter-actions.json
+frankenbeast dr dead-letter-replay-dry-run .fbeast/dead-letter-actions.json <entry-id>
 frankenbeast chat-server
 frankenbeast beasts-daemon
 ```
@@ -67,6 +69,21 @@ npm run test:coverage --workspace=@franken/orchestrator
 ```
 
 Integration and E2E scripts enable broader runtime paths with `INTEGRATION=true` or `E2E=true`; use them when the needed local services, credentials, and fixtures are available.
+
+## Disaster recovery dead-letter queue
+
+Failed automation actions that exhaust bounded retries can be recorded with `recordRetryExhaustionToDeadLetterQueue()` in a JSON dead-letter queue. Each entry preserves the action class, target, attempts, retry limit, last error, first/last attempt timestamps, and a replay-safety classification of `safe`, `side-effect-approval-required`, or `unsafe`.
+
+Operators can inspect the queue without executing side effects:
+
+```bash
+frankenbeast dr dead-letter-list <queue-file>
+frankenbeast dr dead-letter-inspect <queue-file> <entry-id>
+frankenbeast dr dead-letter-replay-dry-run <queue-file> <entry-id>
+frankenbeast dr dead-letter-retire <queue-file> <entry-id> "handled manually"
+```
+
+The replay command is dry-run only. Entries classified as side-effecting report that explicit operator approval is required before any future replay executor may run them, while retired or unsafe entries are not replayable.
 
 ## Flaky liveness fixture replay
 
@@ -107,6 +124,7 @@ Each criterion reports `pass` only when matching evidence is present in working 
 | Provider adapters | `src/providers/`, `src/skills/providers/`, `src/adapters/` | Claude, Codex, Gemini, Aider, and API/CLI provider integration. |
 | HTTP/chat/network | `src/http/`, `src/chat/`, `src/network/` | Chat server, managed network services, logs, secrets, and local attachment flows. |
 | Beast management | `src/beasts/` | Beast catalog, run persistence, and daemon-backed run services. |
+| Disaster recovery | `src/dr/` | Encrypted state backup/restore previews and failed-action dead-letter queue reports. |
 | Skills | `src/skills/` | CLI skill discovery, translation, execution, and auth/config stores. |
 
 ## Related docs

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -51,7 +51,17 @@ export type BeastAction =
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
 export type MemoryAction = 'snapshot-diff' | 'verify-backup' | 'duplicate-report' | undefined;
-export type DrAction = 'backup' | 'list' | 'verify' | 'restore' | 'restore-dry-run' | undefined;
+export type DrAction =
+  | 'backup'
+  | 'list'
+  | 'verify'
+  | 'restore'
+  | 'restore-dry-run'
+  | 'dead-letter-list'
+  | 'dead-letter-inspect'
+  | 'dead-letter-replay-dry-run'
+  | 'dead-letter-retire'
+  | undefined;
 
 export interface CliArgs {
   subcommand: Subcommand;
@@ -118,7 +128,17 @@ export interface CliArgs {
 const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'dr', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
 const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup', 'duplicate-report']);
-const VALID_DR_ACTIONS = new Set(['backup', 'list', 'verify', 'restore', 'restore-dry-run']);
+const VALID_DR_ACTIONS = new Set([
+  'backup',
+  'list',
+  'verify',
+  'restore',
+  'restore-dry-run',
+  'dead-letter-list',
+  'dead-letter-inspect',
+  'dead-letter-replay-dry-run',
+  'dead-letter-retire',
+]);
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
@@ -258,6 +278,14 @@ Disaster-Recovery Commands:
                                   Restore an encrypted state backup; --dry-run verifies and prints planned writes only
   dr restore-dry-run <backup-manifest.json> <live-manifest.json>
                                   Compare backup/live restore manifests and print read-only JSON output
+  dr dead-letter-list <queue-file>
+                                  List failed automation actions in a dead-letter queue
+  dr dead-letter-inspect <queue-file> <entry-id>
+                                  Print one dead-letter entry with retry exhaustion evidence
+  dr dead-letter-replay-dry-run <queue-file> <entry-id>
+                                  Preview replay safety without executing side effects
+  dr dead-letter-retire <queue-file> <entry-id> [reason]
+                                  Mark a dead-letter entry retired after operator review
 
 Beast Commands:
   beasts catalog                      List fixed Beast definitions
@@ -606,13 +634,16 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     drBackupManifestPath = positionals[1];
     drLiveManifestPath = positionals[2];
     drKeyFilePath = positionals[3];
-    const maxPositionals = drAction === 'backup' || drAction === 'restore'
+    const maxPositionals = drAction === 'backup' || drAction === 'restore' || drAction === 'dead-letter-retire'
       ? 4
-      : drAction === 'verify' || drAction === 'restore-dry-run'
-        ? 3
-        : drAction === 'list'
-          ? 2
-          : 1;
+      : drAction === 'verify'
+        || drAction === 'restore-dry-run'
+        || drAction === 'dead-letter-inspect'
+        || drAction === 'dead-letter-replay-dry-run'
+          ? 3
+          : drAction === 'list' || drAction === 'dead-letter-list'
+            ? 2
+            : 1;
     if (positionals.length > maxPositionals) {
       throw new TypeError(`Unexpected argument '${positionals[maxPositionals]}'. dr ${drAction ?? '<action>'} accepts ${String(maxPositionals - 1)} argument(s)`);
     }

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -10,9 +10,25 @@ import {
   restoreEncryptedStateBackup,
   verifyEncryptedStateBackup,
 } from '../dr/state-backup.js';
+import {
+  dryRunReplayDeadLetterEntry,
+  inspectDeadLetterEntry,
+  listDeadLetterEntries,
+  retireDeadLetterEntry,
+} from '../dr/dead-letter-queue.js';
 
 export interface DrCommandDeps {
-  readonly action: 'backup' | 'list' | 'verify' | 'restore' | 'restore-dry-run' | undefined;
+  readonly action:
+    | 'backup'
+    | 'list'
+    | 'verify'
+    | 'restore'
+    | 'restore-dry-run'
+    | 'dead-letter-list'
+    | 'dead-letter-inspect'
+    | 'dead-letter-replay-dry-run'
+    | 'dead-letter-retire'
+    | undefined;
   readonly backupManifestPath?: string | undefined;
   readonly liveManifestPath?: string | undefined;
   readonly keyFilePath?: string | undefined;
@@ -73,6 +89,69 @@ export async function readRestoreManifest(manifestPath: string): Promise<Restore
 
 export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
   const { action, backupManifestPath, liveManifestPath, keyFilePath, print } = deps;
+  if (action === 'dead-letter-list') {
+    if (!backupManifestPath) {
+      throw new Error('dr dead-letter-list requires <queue-file>');
+    }
+    const entries = await listDeadLetterEntries(backupManifestPath);
+    print(JSON.stringify({
+      ok: true,
+      command: 'dr dead-letter-list',
+      queuePath: backupManifestPath,
+      summary: {
+        total: entries.length,
+        open: entries.filter((entry) => entry.status === 'open').length,
+        retired: entries.filter((entry) => entry.status === 'retired').length,
+      },
+      entries,
+    }, null, 2));
+    return;
+  }
+
+  if (action === 'dead-letter-inspect') {
+    if (!backupManifestPath || !liveManifestPath) {
+      throw new Error('dr dead-letter-inspect requires <queue-file> <entry-id>');
+    }
+    print(JSON.stringify({
+      ok: true,
+      command: 'dr dead-letter-inspect',
+      queuePath: backupManifestPath,
+      entry: await inspectDeadLetterEntry(backupManifestPath, liveManifestPath),
+    }, null, 2));
+    return;
+  }
+
+  if (action === 'dead-letter-replay-dry-run') {
+    if (!backupManifestPath || !liveManifestPath) {
+      throw new Error('dr dead-letter-replay-dry-run requires <queue-file> <entry-id>');
+    }
+    print(JSON.stringify({
+      ok: true,
+      command: 'dr dead-letter-replay-dry-run',
+      queuePath: backupManifestPath,
+      replay: await dryRunReplayDeadLetterEntry(backupManifestPath, liveManifestPath, {
+        ...(deps.generatedAt === undefined ? {} : { requestedAt: deps.generatedAt }),
+      }),
+    }, null, 2));
+    return;
+  }
+
+  if (action === 'dead-letter-retire') {
+    if (!backupManifestPath || !liveManifestPath) {
+      throw new Error('dr dead-letter-retire requires <queue-file> <entry-id> [reason]');
+    }
+    print(JSON.stringify({
+      ok: true,
+      command: 'dr dead-letter-retire',
+      queuePath: backupManifestPath,
+      entry: await retireDeadLetterEntry(backupManifestPath, liveManifestPath, {
+        reason: keyFilePath ?? 'retired by operator',
+        ...(deps.generatedAt === undefined ? {} : { retiredAt: deps.generatedAt }),
+      }),
+    }, null, 2));
+    return;
+  }
+
   if (action === 'backup') {
     if (!backupManifestPath || !liveManifestPath || !keyFilePath) {
       throw new Error('dr backup requires <state-dir> <backup-file> <key-file>');
@@ -134,7 +213,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
   }
 
   if (action !== 'restore-dry-run') {
-    throw new Error('Usage: frankenbeast dr <backup|list|verify|restore|restore-dry-run> ...');
+    throw new Error('Usage: frankenbeast dr <backup|list|verify|restore|restore-dry-run|dead-letter-list|dead-letter-inspect|dead-letter-replay-dry-run|dead-letter-retire> ...');
   }
   if (!backupManifestPath || !liveManifestPath) {
     throw new Error('dr restore-dry-run requires two manifest JSON files: <backup-manifest.json> <live-manifest.json>');

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -97,6 +97,9 @@ function maskOpaqueSecretLiterals(text: string): string {
   return text
     .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/gu, '<redacted>')
     .replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gu, '<redacted>')
+    .replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gu, '<redacted>')
+    .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/gu, '<redacted>')
+    .replace(/\b((?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^:\s"']+):[^@\s"']+@/giu, '$1:<redacted>@')
     .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`)
     .replace(/((?:^|[\s"'])--(?:api-?key|auth|authorization|bearer|password|secret|token)\s+)[^\s"']+/giu, '$1<redacted>')
     .replace(/((?:^|[\s"'])--(?:api-?key|auth|authorization|bearer|password|secret|token)=)[^\s"']+/giu, '$1<redacted>')

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -16,6 +16,7 @@ import {
   listDeadLetterEntries,
   retireDeadLetterEntry,
 } from '../dr/dead-letter-queue.js';
+import { redactLogData } from '../logging/redaction.js';
 
 export interface DrCommandDeps {
   readonly action:
@@ -87,6 +88,10 @@ export async function readRestoreManifest(manifestPath: string): Promise<Restore
   return parsed as unknown as RestorePreviewManifest;
 }
 
+function printRedactedJson(print: (message: string) => void, report: unknown): void {
+  print(JSON.stringify(redactLogData(report), null, 2));
+}
+
 export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
   const { action, backupManifestPath, liveManifestPath, keyFilePath, print } = deps;
   if (action === 'dead-letter-list') {
@@ -94,7 +99,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
       throw new Error('dr dead-letter-list requires <queue-file>');
     }
     const entries = await listDeadLetterEntries(backupManifestPath);
-    print(JSON.stringify({
+    printRedactedJson(print, {
       ok: true,
       command: 'dr dead-letter-list',
       queuePath: backupManifestPath,
@@ -104,7 +109,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
         retired: entries.filter((entry) => entry.status === 'retired').length,
       },
       entries,
-    }, null, 2));
+    });
     return;
   }
 
@@ -112,12 +117,12 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
     if (!backupManifestPath || !liveManifestPath) {
       throw new Error('dr dead-letter-inspect requires <queue-file> <entry-id>');
     }
-    print(JSON.stringify({
+    printRedactedJson(print, {
       ok: true,
       command: 'dr dead-letter-inspect',
       queuePath: backupManifestPath,
       entry: await inspectDeadLetterEntry(backupManifestPath, liveManifestPath),
-    }, null, 2));
+    });
     return;
   }
 
@@ -125,14 +130,16 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
     if (!backupManifestPath || !liveManifestPath) {
       throw new Error('dr dead-letter-replay-dry-run requires <queue-file> <entry-id>');
     }
-    print(JSON.stringify({
+    printRedactedJson(print, {
       ok: true,
       command: 'dr dead-letter-replay-dry-run',
       queuePath: backupManifestPath,
       replay: await dryRunReplayDeadLetterEntry(backupManifestPath, liveManifestPath, {
-        ...(deps.generatedAt === undefined ? {} : { requestedAt: deps.generatedAt }),
+        ...(deps.generatedAt === undefined
+          ? {}
+          : { requestedAt: deps.generatedAt }),
       }),
-    }, null, 2));
+    });
     return;
   }
 
@@ -140,7 +147,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
     if (!backupManifestPath || !liveManifestPath) {
       throw new Error('dr dead-letter-retire requires <queue-file> <entry-id> [reason]');
     }
-    print(JSON.stringify({
+    printRedactedJson(print, {
       ok: true,
       command: 'dr dead-letter-retire',
       queuePath: backupManifestPath,
@@ -148,7 +155,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
         reason: keyFilePath ?? 'retired by operator',
         ...(deps.generatedAt === undefined ? {} : { retiredAt: deps.generatedAt }),
       }),
-    }, null, 2));
+    });
     return;
   }
 

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -90,7 +90,14 @@ export async function readRestoreManifest(manifestPath: string): Promise<Restore
 }
 
 function printRedactedJson(print: (message: string) => void, report: unknown): void {
-  print(JSON.stringify(redactLogData(report), null, 2));
+  print(maskOpaqueSecretLiterals(JSON.stringify(redactLogData(report), null, 2)));
+}
+
+function maskOpaqueSecretLiterals(text: string): string {
+  return text
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/gu, '<redacted>')
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gu, '<redacted>')
+    .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`);
 }
 
 function summarizeDeadLetterEntry(entry: DeadLetterEntry): Omit<DeadLetterEntry, 'lastError' | 'payload'> {

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -98,8 +98,9 @@ function maskOpaqueSecretLiterals(text: string): string {
     .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/gu, '<redacted>')
     .replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gu, '<redacted>')
     .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`)
-    .replace(/(\s--(?:api-?key|auth|authorization|bearer|password|secret|token)\s+)[^\s"']+/giu, '$1<redacted>')
-    .replace(/(\s--(?:api-?key|auth|authorization|bearer|password|secret|token)=)[^\s"']+/giu, '$1<redacted>');
+    .replace(/((?:^|[\s"'])--(?:api-?key|auth|authorization|bearer|password|secret|token)\s+)[^\s"']+/giu, '$1<redacted>')
+    .replace(/((?:^|[\s"'])--(?:api-?key|auth|authorization|bearer|password|secret|token)=)[^\s"']+/giu, '$1<redacted>')
+    .replace(/("--(?:api-?key|auth|authorization|bearer|password|secret|token)"\s*,\s*")[^"]+/giu, '$1<redacted>');
 }
 
 function summarizeDeadLetterEntry(entry: DeadLetterEntry): Omit<DeadLetterEntry, 'lastError' | 'payload'> {

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -99,6 +99,7 @@ function maskOpaqueSecretLiterals(text: string): string {
     .replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gu, '<redacted>')
     .replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gu, '<redacted>')
     .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/gu, '<redacted>')
+    .replace(/\b([A-Za-z][A-Za-z0-9+.-]*:\/\/[^:\s"'/@]+):[^@\s"']+@/gu, '$1:<redacted>@')
     .replace(/\b((?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^:\s"']+):[^@\s"']+@/giu, '$1:<redacted>@')
     .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`)
     .replace(/((?:^|[\s"'])--(?:api-?key|auth|authorization|bearer|password|secret|token)\s+)[^\s"']+/giu, '$1<redacted>')

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -15,6 +15,7 @@ import {
   inspectDeadLetterEntry,
   listDeadLetterEntries,
   retireDeadLetterEntry,
+  type DeadLetterEntry,
 } from '../dr/dead-letter-queue.js';
 import { redactLogData } from '../logging/redaction.js';
 
@@ -92,6 +93,23 @@ function printRedactedJson(print: (message: string) => void, report: unknown): v
   print(JSON.stringify(redactLogData(report), null, 2));
 }
 
+function summarizeDeadLetterEntry(entry: DeadLetterEntry): Omit<DeadLetterEntry, 'lastError' | 'payload'> {
+  return {
+    id: entry.id,
+    actionClass: entry.actionClass,
+    target: entry.target,
+    attempts: entry.attempts,
+    maxAttempts: entry.maxAttempts,
+    firstAttemptedAt: entry.firstAttemptedAt,
+    lastAttemptedAt: entry.lastAttemptedAt,
+    createdAt: entry.createdAt,
+    replaySafety: entry.replaySafety,
+    status: entry.status,
+    ...(entry.retiredAt === undefined ? {} : { retiredAt: entry.retiredAt }),
+    ...(entry.retiredReason === undefined ? {} : { retiredReason: entry.retiredReason }),
+  };
+}
+
 export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
   const { action, backupManifestPath, liveManifestPath, keyFilePath, print } = deps;
   if (action === 'dead-letter-list') {
@@ -108,7 +126,7 @@ export async function handleDrCommand(deps: DrCommandDeps): Promise<void> {
         open: entries.filter((entry) => entry.status === 'open').length,
         retired: entries.filter((entry) => entry.status === 'retired').length,
       },
-      entries,
+      entries: entries.map(summarizeDeadLetterEntry),
     });
     return;
   }

--- a/packages/franken-orchestrator/src/cli/dr-restore.ts
+++ b/packages/franken-orchestrator/src/cli/dr-restore.ts
@@ -97,7 +97,9 @@ function maskOpaqueSecretLiterals(text: string): string {
   return text
     .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/gu, '<redacted>')
     .replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gu, '<redacted>')
-    .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`);
+    .replace(/\b(?:Bearer|Basic|Bot)\s+[A-Za-z0-9._~+/=-]{8,}\b/giu, (match) => `${match.split(/\s+/u)[0]} <redacted>`)
+    .replace(/(\s--(?:api-?key|auth|authorization|bearer|password|secret|token)\s+)[^\s"']+/giu, '$1<redacted>')
+    .replace(/(\s--(?:api-?key|auth|authorization|bearer|password|secret|token)=)[^\s"']+/giu, '$1<redacted>');
 }
 
 function summarizeDeadLetterEntry(entry: DeadLetterEntry): Omit<DeadLetterEntry, 'lastError' | 'payload'> {

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -27,6 +27,8 @@ interface DeadLetterQueueFile {
   readonly entries: readonly DeadLetterEntry[];
 }
 
+const appendLocks = new Map<string, Promise<void>>();
+
 export interface RecordRetryExhaustionOptions {
   readonly queuePath: string;
   readonly actionClass: string;
@@ -165,6 +167,26 @@ async function writeQueue(queuePath: string, queue: DeadLetterQueueFile): Promis
   await rename(tempPath, queuePath);
 }
 
+async function appendQueueEntry(queuePath: string, entry: DeadLetterEntry): Promise<void> {
+  const previous = appendLocks.get(queuePath) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const chained = previous.then(() => current, () => current);
+  appendLocks.set(queuePath, chained);
+  await previous.catch(() => undefined);
+  try {
+    const queue = await readQueue(queuePath);
+    await writeQueue(queuePath, { schemaVersion: 1, entries: [...queue.entries, entry] });
+  } finally {
+    release();
+    if (appendLocks.get(queuePath) === chained) {
+      appendLocks.delete(queuePath);
+    }
+  }
+}
+
 function entryIdFor(options: RecordRetryExhaustionOptions, createdAt: string): string {
   const digest = createHash('sha256')
     .update(JSON.stringify({
@@ -196,11 +218,17 @@ export async function inspectDeadLetterEntry(queuePath: string, entryId: string)
 export async function recordRetryExhaustionToDeadLetterQueue(
   options: RecordRetryExhaustionOptions,
 ): Promise<DeadLetterEntry> {
+  if (!Number.isSafeInteger(options.maxAttempts) || options.maxAttempts < 1) {
+    throw new Error('Cannot dead-letter automation action: maxAttempts must be at least 1');
+  }
+  if (!Number.isSafeInteger(options.attempts) || options.attempts < 0) {
+    throw new Error('Cannot dead-letter automation action: attempts must be a non-negative safe integer');
+  }
+  if (options.attempts > options.maxAttempts) {
+    throw new Error('Cannot dead-letter automation action: attempts cannot exceed maxAttempts');
+  }
   if (options.attempts < options.maxAttempts) {
     throw new Error('Cannot dead-letter automation action: retry limit has not been exhausted');
-  }
-  if (options.maxAttempts < 1) {
-    throw new Error('Cannot dead-letter automation action: maxAttempts must be at least 1');
   }
   if (!options.actionClass.trim()) throw new Error('Cannot dead-letter automation action: actionClass is required');
   if (!options.target.trim()) throw new Error('Cannot dead-letter automation action: target is required');
@@ -222,8 +250,7 @@ export async function recordRetryExhaustionToDeadLetterQueue(
     ...(options.payload === undefined ? {} : { payload: options.payload }),
   };
 
-  const queue = await readQueue(options.queuePath);
-  await writeQueue(options.queuePath, { schemaVersion: 1, entries: [...queue.entries, entry] });
+  await appendQueueEntry(options.queuePath, entry);
   return entry;
 }
 
@@ -237,6 +264,10 @@ export async function retireDeadLetterEntry(
   let updated: DeadLetterEntry | undefined;
   const entries = queue.entries.map((entry) => {
     if (entry.id !== entryId) return entry;
+    if (entry.status === 'retired') {
+      updated = entry;
+      return entry;
+    }
     updated = {
       ...entry,
       status: 'retired',

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -27,9 +27,16 @@ interface DeadLetterQueueFile {
   readonly entries: readonly DeadLetterEntry[];
 }
 
+interface QueueLockFile {
+  readonly owner: string;
+  readonly pid: number;
+  readonly acquiredAt: string;
+}
+
 const LOCK_RETRY_DELAY_MS = 25;
 const LOCK_TIMEOUT_MS = 5_000;
-const STALE_LOCK_MS = LOCK_TIMEOUT_MS;
+const STALE_LOCK_MS = 30_000;
+const LOCK_OWNER_PREFIX = `${process.pid}:${randomUUID()}`;
 
 export interface RecordRetryExhaustionOptions {
   readonly queuePath: string;
@@ -175,27 +182,47 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<boolean> {
+  let observed: QueueLockFile;
   try {
-    const raw = await readFile(lockPath, 'utf8');
-    const parsed = JSON.parse(raw) as { acquiredAt?: unknown };
-    if (typeof parsed.acquiredAt !== 'string') return false;
-    const acquiredAt = Date.parse(parsed.acquiredAt);
+    observed = parseQueueLock(await readFile(lockPath, 'utf8'));
+    const acquiredAt = Date.parse(observed.acquiredAt);
     if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
-    await unlink(lockPath);
+  } catch {
+    return false;
+  }
+
+  const stalePath = `${lockPath}.stale.${observed.owner.replace(/[^A-Za-z0-9_.:-]/gu, '_')}.${now}`;
+  try {
+    await rename(lockPath, stalePath);
+    const moved = parseQueueLock(await readFile(stalePath, 'utf8'));
+    if (moved.owner !== observed.owner || moved.acquiredAt !== observed.acquiredAt) {
+      await rename(stalePath, lockPath).catch(() => undefined);
+      return false;
+    }
+    await unlink(stalePath).catch(() => undefined);
     return true;
   } catch {
     return false;
   }
 }
 
+function parseQueueLock(raw: string): QueueLockFile {
+  const parsed = JSON.parse(raw) as { owner?: unknown; pid?: unknown; acquiredAt?: unknown };
+  if (typeof parsed.owner !== 'string' || typeof parsed.pid !== 'number' || typeof parsed.acquiredAt !== 'string') {
+    throw new Error('invalid dead-letter queue lock file');
+  }
+  return { owner: parsed.owner, pid: parsed.pid, acquiredAt: parsed.acquiredAt };
+}
+
 async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>): Promise<T> {
   const lockPath = `${queuePath}.lock`;
   await mkdir(dirname(queuePath), { recursive: true });
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  const lock: QueueLockFile = { owner: `${LOCK_OWNER_PREFIX}:${randomUUID()}`, pid: process.pid, acquiredAt: new Date().toISOString() };
   for (;;) {
     try {
       const lockHandle = await open(lockPath, 'wx', 0o600);
-      await lockHandle.writeFile(JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }), 'utf8');
+      await lockHandle.writeFile(JSON.stringify(lock), 'utf8');
       await lockHandle.close();
       break;
     } catch (error) {
@@ -217,7 +244,14 @@ async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>):
   try {
     return await operation();
   } finally {
-    await unlink(lockPath).catch(() => undefined);
+    try {
+      const current = parseQueueLock(await readFile(lockPath, 'utf8'));
+      if (current.owner === lock.owner) {
+        await unlink(lockPath).catch(() => undefined);
+      }
+    } catch {
+      // Lock cleanup is best-effort; stale-lock reaping handles abandoned locks.
+    }
   }
 }
 
@@ -276,6 +310,20 @@ export async function listDeadLetterEntries(queuePath: string): Promise<DeadLett
   return [...(await readQueue(queuePath)).entries];
 }
 
+function normalizeJsonPayload(payload: unknown): unknown {
+  const seen = new WeakSet<object>();
+  return JSON.parse(JSON.stringify(payload, (_key, value: unknown) => {
+    if (typeof value === 'bigint') return value.toString();
+    if (typeof value === 'function') return '[Function]';
+    if (typeof value === 'symbol') return String(value);
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+    }
+    return value;
+  }));
+}
+
 export async function inspectDeadLetterEntry(queuePath: string, entryId: string): Promise<DeadLetterEntry> {
   const entry = (await readQueue(queuePath)).entries.find((candidate) => candidate.id === entryId);
   if (!entry) {
@@ -317,7 +365,7 @@ export async function recordRetryExhaustionToDeadLetterQueue(
     createdAt: exhaustedAt,
     replaySafety,
     status: 'open',
-    ...(options.payload === undefined ? {} : { payload: options.payload }),
+    ...(options.payload === undefined ? {} : { payload: normalizeJsonPayload(options.payload) }),
   };
 
   await appendQueueEntry(options.queuePath, entry);

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -125,6 +125,9 @@ function parseEntry(value: unknown): DeadLetterEntry {
     ...(value.retiredAt === undefined ? {} : { retiredAt: requireString(value.retiredAt, 'retiredAt') }),
     ...(value.retiredReason === undefined ? {} : { retiredReason: requireString(value.retiredReason, 'retiredReason') }),
   };
+  if (entry.maxAttempts < 1) {
+    throw new Error('Invalid dead-letter queue entry: maxAttempts must be at least 1');
+  }
   if (entry.attempts > entry.maxAttempts) {
     throw new Error('Invalid dead-letter queue entry: attempts cannot exceed maxAttempts');
   }

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -36,6 +36,7 @@ interface QueueLockFile {
 const LOCK_RETRY_DELAY_MS = 25;
 const LOCK_TIMEOUT_MS = 5_000;
 const STALE_LOCK_MS = 30_000;
+const LIVE_LOCK_MAX_MS = 5 * 60_000;
 const LOCK_OWNER_PREFIX = `${process.pid}:${randomUUID()}`;
 
 export interface RecordRetryExhaustionOptions {
@@ -193,7 +194,7 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
     observed = parseQueueLock(await readFile(lockPath, 'utf8'));
     const acquiredAt = Date.parse(observed.acquiredAt);
     if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
-    if (isProcessAlive(observed.pid)) return false;
+    if (isProcessAlive(observed.pid) && now - acquiredAt < LIVE_LOCK_MAX_MS) return false;
   } catch {
     return reapMalformedQueueLock(lockPath, now);
   }

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -221,6 +221,11 @@ async function reapMalformedQueueLock(lockPath: string, now = Date.now()): Promi
     if (now - info.mtimeMs < STALE_LOCK_MS) return false;
     const stalePath = `${lockPath}.malformed.${now}`;
     await rename(lockPath, stalePath);
+    const moved = await stat(stalePath);
+    if (moved.dev !== info.dev || moved.ino !== info.ino || moved.mtimeMs !== info.mtimeMs || moved.size !== info.size) {
+      await rename(stalePath, lockPath).catch(() => undefined);
+      return false;
+    }
     await unlink(stalePath).catch(() => undefined);
     return true;
   } catch {
@@ -402,7 +407,8 @@ export async function recordRetryExhaustionToDeadLetterQueue(
   if (!options.lastError.trim()) throw new Error('Cannot dead-letter automation action: lastError is required');
   const replaySafety = validateReplaySafety(options.replaySafety);
 
-  const exhaustedAt = options.exhaustedAt ?? new Date().toISOString();
+  const exhaustedAt = options.exhaustedAt?.trim() || new Date().toISOString();
+  const firstAttemptedAt = options.firstAttemptedAt?.trim() || exhaustedAt;
   const entry: DeadLetterEntry = {
     id: entryIdFor(options, exhaustedAt),
     actionClass: options.actionClass,
@@ -410,7 +416,7 @@ export async function recordRetryExhaustionToDeadLetterQueue(
     attempts: options.attempts,
     maxAttempts: options.maxAttempts,
     lastError: options.lastError,
-    firstAttemptedAt: options.firstAttemptedAt ?? exhaustedAt,
+    firstAttemptedAt,
     lastAttemptedAt: exhaustedAt,
     createdAt: exhaustedAt,
     replaySafety,

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -29,6 +29,7 @@ interface DeadLetterQueueFile {
 
 const LOCK_RETRY_DELAY_MS = 25;
 const LOCK_TIMEOUT_MS = 5_000;
+const STALE_LOCK_MS = LOCK_TIMEOUT_MS;
 
 export interface RecordRetryExhaustionOptions {
   readonly queuePath: string;
@@ -166,11 +167,25 @@ async function writeQueue(queuePath: string, queue: DeadLetterQueueFile): Promis
   const tempPath = `${queuePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, `${JSON.stringify(queue, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   await rename(tempPath, queuePath);
-  await chmod(queuePath, 0o600);
+  await chmod(queuePath, 0o600).catch(() => undefined);
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<boolean> {
+  try {
+    const raw = await readFile(lockPath, 'utf8');
+    const parsed = JSON.parse(raw) as { acquiredAt?: unknown };
+    if (typeof parsed.acquiredAt !== 'string') return false;
+    const acquiredAt = Date.parse(parsed.acquiredAt);
+    if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
+    await unlink(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>): Promise<T> {
@@ -184,9 +199,15 @@ async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>):
       await lockHandle.close();
       break;
     } catch (error) {
-      if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST' && Date.now() < deadline) {
-        await sleep(LOCK_RETRY_DELAY_MS);
-        continue;
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST') {
+        if (await reapStaleQueueLock(lockPath)) {
+          continue;
+        }
+        if (Date.now() < deadline) {
+          await sleep(LOCK_RETRY_DELAY_MS);
+          continue;
+        }
+        throw new Error(`Unable to acquire dead-letter queue lock ${lockPath}: existing lock is still active`);
       }
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Unable to acquire dead-letter queue lock ${lockPath}: ${message}`);

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -1,0 +1,299 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+
+export type DeadLetterReplaySafety = 'safe' | 'side-effect-approval-required' | 'unsafe';
+export type DeadLetterEntryStatus = 'open' | 'retired';
+
+export interface DeadLetterEntry {
+  readonly id: string;
+  readonly actionClass: string;
+  readonly target: string;
+  readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly lastError: string;
+  readonly firstAttemptedAt: string;
+  readonly lastAttemptedAt: string;
+  readonly createdAt: string;
+  readonly replaySafety: DeadLetterReplaySafety;
+  readonly status: DeadLetterEntryStatus;
+  readonly payload?: unknown;
+  readonly retiredAt?: string;
+  readonly retiredReason?: string;
+}
+
+interface DeadLetterQueueFile {
+  readonly schemaVersion: 1;
+  readonly entries: readonly DeadLetterEntry[];
+}
+
+export interface RecordRetryExhaustionOptions {
+  readonly queuePath: string;
+  readonly actionClass: string;
+  readonly target: string;
+  readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly lastError: string;
+  readonly replaySafety: DeadLetterReplaySafety;
+  readonly firstAttemptedAt?: string;
+  readonly exhaustedAt?: string;
+  readonly payload?: unknown;
+}
+
+export interface RetireDeadLetterEntryOptions {
+  readonly retiredAt?: string;
+  readonly reason: string;
+}
+
+export interface DryRunReplayOptions {
+  readonly requestedAt?: string;
+}
+
+export interface DeadLetterReplayDryRunReport {
+  readonly entryId: string;
+  readonly dryRun: true;
+  readonly requestedAt: string;
+  readonly wouldReplay: boolean;
+  readonly requiresApproval: boolean;
+  readonly replaySafety: DeadLetterReplaySafety;
+  readonly actionClass: string;
+  readonly target: string;
+  readonly attempts: number;
+  readonly lastError: string;
+  readonly approvalRequired?: string;
+  readonly retired?: boolean;
+  readonly retiredReason?: string;
+  readonly blockedReason?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid dead-letter queue entry: ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireSafeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`Invalid dead-letter queue entry: ${field} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function parseReplaySafety(value: unknown): DeadLetterReplaySafety {
+  if (value === 'safe' || value === 'side-effect-approval-required' || value === 'unsafe') return value;
+  throw new Error('Invalid dead-letter queue entry: replaySafety must be safe, side-effect-approval-required, or unsafe');
+}
+
+function parseStatus(value: unknown): DeadLetterEntryStatus {
+  if (value === 'open' || value === 'retired') return value;
+  throw new Error('Invalid dead-letter queue entry: status must be open or retired');
+}
+
+function parseEntry(value: unknown): DeadLetterEntry {
+  if (!isRecord(value)) {
+    throw new Error('Invalid dead-letter queue entry: expected object');
+  }
+  const entry: DeadLetterEntry = {
+    id: requireString(value.id, 'id'),
+    actionClass: requireString(value.actionClass, 'actionClass'),
+    target: requireString(value.target, 'target'),
+    attempts: requireSafeInteger(value.attempts, 'attempts'),
+    maxAttempts: requireSafeInteger(value.maxAttempts, 'maxAttempts'),
+    lastError: requireString(value.lastError, 'lastError'),
+    firstAttemptedAt: requireString(value.firstAttemptedAt, 'firstAttemptedAt'),
+    lastAttemptedAt: requireString(value.lastAttemptedAt, 'lastAttemptedAt'),
+    createdAt: requireString(value.createdAt, 'createdAt'),
+    replaySafety: parseReplaySafety(value.replaySafety),
+    status: parseStatus(value.status),
+    ...(value.payload === undefined ? {} : { payload: value.payload }),
+    ...(value.retiredAt === undefined ? {} : { retiredAt: requireString(value.retiredAt, 'retiredAt') }),
+    ...(value.retiredReason === undefined ? {} : { retiredReason: requireString(value.retiredReason, 'retiredReason') }),
+  };
+  if (entry.attempts > entry.maxAttempts) {
+    throw new Error('Invalid dead-letter queue entry: attempts cannot exceed maxAttempts');
+  }
+  return entry;
+}
+
+function emptyQueue(): DeadLetterQueueFile {
+  return { schemaVersion: 1, entries: [] };
+}
+
+async function readQueue(queuePath: string): Promise<DeadLetterQueueFile> {
+  let raw: string;
+  try {
+    raw = await readFile(queuePath, 'utf8');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return emptyQueue();
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read dead-letter queue ${queuePath}: ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to parse dead-letter queue ${queuePath}: ${message}`);
+  }
+  if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !Array.isArray(parsed.entries)) {
+    throw new Error(`Invalid dead-letter queue ${queuePath}: expected schemaVersion 1 with entries array`);
+  }
+  const ids = new Set<string>();
+  const entries = parsed.entries.map((entry) => {
+    const normalized = parseEntry(entry);
+    if (ids.has(normalized.id)) {
+      throw new Error(`Invalid dead-letter queue ${queuePath}: duplicate entry id ${normalized.id}`);
+    }
+    ids.add(normalized.id);
+    return normalized;
+  });
+  return { schemaVersion: 1, entries };
+}
+
+async function writeQueue(queuePath: string, queue: DeadLetterQueueFile): Promise<void> {
+  await mkdir(dirname(queuePath), { recursive: true });
+  const tempPath = `${queuePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(queue, null, 2)}\n`, 'utf8');
+  await rename(tempPath, queuePath);
+}
+
+function entryIdFor(options: RecordRetryExhaustionOptions, createdAt: string): string {
+  const digest = createHash('sha256')
+    .update(JSON.stringify({
+      actionClass: options.actionClass,
+      target: options.target,
+      attempts: options.attempts,
+      maxAttempts: options.maxAttempts,
+      lastError: options.lastError,
+      createdAt,
+      nonce: randomUUID(),
+    }))
+    .digest('hex')
+    .slice(0, 20);
+  return `dlq_${digest}`;
+}
+
+export async function listDeadLetterEntries(queuePath: string): Promise<DeadLetterEntry[]> {
+  return [...(await readQueue(queuePath)).entries];
+}
+
+export async function inspectDeadLetterEntry(queuePath: string, entryId: string): Promise<DeadLetterEntry> {
+  const entry = (await readQueue(queuePath)).entries.find((candidate) => candidate.id === entryId);
+  if (!entry) {
+    throw new Error(`Dead-letter entry not found: ${entryId}`);
+  }
+  return entry;
+}
+
+export async function recordRetryExhaustionToDeadLetterQueue(
+  options: RecordRetryExhaustionOptions,
+): Promise<DeadLetterEntry> {
+  if (options.attempts < options.maxAttempts) {
+    throw new Error('Cannot dead-letter automation action: retry limit has not been exhausted');
+  }
+  if (options.maxAttempts < 1) {
+    throw new Error('Cannot dead-letter automation action: maxAttempts must be at least 1');
+  }
+  if (!options.actionClass.trim()) throw new Error('Cannot dead-letter automation action: actionClass is required');
+  if (!options.target.trim()) throw new Error('Cannot dead-letter automation action: target is required');
+  if (!options.lastError.trim()) throw new Error('Cannot dead-letter automation action: lastError is required');
+
+  const exhaustedAt = options.exhaustedAt ?? new Date().toISOString();
+  const entry: DeadLetterEntry = {
+    id: entryIdFor(options, exhaustedAt),
+    actionClass: options.actionClass,
+    target: options.target,
+    attempts: options.attempts,
+    maxAttempts: options.maxAttempts,
+    lastError: options.lastError,
+    firstAttemptedAt: options.firstAttemptedAt ?? exhaustedAt,
+    lastAttemptedAt: exhaustedAt,
+    createdAt: exhaustedAt,
+    replaySafety: options.replaySafety,
+    status: 'open',
+    ...(options.payload === undefined ? {} : { payload: options.payload }),
+  };
+
+  const queue = await readQueue(options.queuePath);
+  await writeQueue(options.queuePath, { schemaVersion: 1, entries: [...queue.entries, entry] });
+  return entry;
+}
+
+export async function retireDeadLetterEntry(
+  queuePath: string,
+  entryId: string,
+  options: RetireDeadLetterEntryOptions,
+): Promise<DeadLetterEntry> {
+  if (!options.reason.trim()) throw new Error('Retiring a dead-letter entry requires a reason');
+  const queue = await readQueue(queuePath);
+  let updated: DeadLetterEntry | undefined;
+  const entries = queue.entries.map((entry) => {
+    if (entry.id !== entryId) return entry;
+    updated = {
+      ...entry,
+      status: 'retired',
+      retiredAt: options.retiredAt ?? new Date().toISOString(),
+      retiredReason: options.reason,
+    };
+    return updated;
+  });
+  if (!updated) throw new Error(`Dead-letter entry not found: ${entryId}`);
+  await writeQueue(queuePath, { schemaVersion: 1, entries });
+  return updated;
+}
+
+export async function dryRunReplayDeadLetterEntry(
+  queuePath: string,
+  entryId: string,
+  options: DryRunReplayOptions = {},
+): Promise<DeadLetterReplayDryRunReport> {
+  const entry = await inspectDeadLetterEntry(queuePath, entryId);
+  const base = {
+    entryId: entry.id,
+    dryRun: true as const,
+    requestedAt: options.requestedAt ?? new Date().toISOString(),
+    replaySafety: entry.replaySafety,
+    actionClass: entry.actionClass,
+    target: entry.target,
+    attempts: entry.attempts,
+    lastError: entry.lastError,
+  };
+  if (entry.status === 'retired') {
+    return {
+      ...base,
+      wouldReplay: false,
+      requiresApproval: false,
+      retired: true,
+      ...(entry.retiredReason === undefined ? {} : { retiredReason: entry.retiredReason }),
+    };
+  }
+  if (entry.replaySafety === 'side-effect-approval-required') {
+    return {
+      ...base,
+      wouldReplay: false,
+      requiresApproval: true,
+      approvalRequired: 'side-effect replay requires explicit operator approval before execution',
+    };
+  }
+  if (entry.replaySafety === 'unsafe') {
+    return {
+      ...base,
+      wouldReplay: false,
+      requiresApproval: true,
+      blockedReason: 'entry is classified unsafe for automated replay',
+    };
+  }
+  return {
+    ...base,
+    wouldReplay: true,
+    requiresApproval: false,
+  };
+}

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 
@@ -27,7 +27,8 @@ interface DeadLetterQueueFile {
   readonly entries: readonly DeadLetterEntry[];
 }
 
-const appendLocks = new Map<string, Promise<void>>();
+const LOCK_RETRY_DELAY_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
 
 export interface RecordRetryExhaustionOptions {
   readonly queuePath: string;
@@ -163,27 +164,74 @@ async function readQueue(queuePath: string): Promise<DeadLetterQueueFile> {
 async function writeQueue(queuePath: string, queue: DeadLetterQueueFile): Promise<void> {
   await mkdir(dirname(queuePath), { recursive: true });
   const tempPath = `${queuePath}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tempPath, `${JSON.stringify(queue, null, 2)}\n`, 'utf8');
+  await writeFile(tempPath, `${JSON.stringify(queue, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   await rename(tempPath, queuePath);
+  await chmod(queuePath, 0o600);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>): Promise<T> {
+  const lockPath = `${queuePath}.lock`;
+  await mkdir(dirname(queuePath), { recursive: true });
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  for (;;) {
+    try {
+      const lockHandle = await open(lockPath, 'wx', 0o600);
+      await lockHandle.writeFile(JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }), 'utf8');
+      await lockHandle.close();
+      break;
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST' && Date.now() < deadline) {
+        await sleep(LOCK_RETRY_DELAY_MS);
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to acquire dead-letter queue lock ${lockPath}: ${message}`);
+    }
+  }
+
+  try {
+    return await operation();
+  } finally {
+    await unlink(lockPath).catch(() => undefined);
+  }
 }
 
 async function appendQueueEntry(queuePath: string, entry: DeadLetterEntry): Promise<void> {
-  const previous = appendLocks.get(queuePath) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const chained = previous.then(() => current, () => current);
-  appendLocks.set(queuePath, chained);
-  await previous.catch(() => undefined);
-  try {
+  await withQueueLock(queuePath, async () => {
     const queue = await readQueue(queuePath);
     await writeQueue(queuePath, { schemaVersion: 1, entries: [...queue.entries, entry] });
-  } finally {
-    release();
-    if (appendLocks.get(queuePath) === chained) {
-      appendLocks.delete(queuePath);
-    }
+  });
+}
+
+async function mutateQueueEntry(queuePath: string, entryId: string, mutate: (entry: DeadLetterEntry) => DeadLetterEntry): Promise<DeadLetterEntry> {
+  return withQueueLock(queuePath, async () => {
+    const queue = await readQueue(queuePath);
+    let updated: DeadLetterEntry | undefined;
+    const entries = queue.entries.map((entry) => {
+      if (entry.id !== entryId) return entry;
+      updated = mutate(entry);
+      return updated;
+    });
+    if (!updated) throw new Error('Dead-letter entry not found');
+    await writeQueue(queuePath, { schemaVersion: 1, entries });
+    return updated;
+  });
+}
+
+function validateReplaySafety(value: DeadLetterReplaySafety): DeadLetterReplaySafety {
+  return parseReplaySafety(value);
+}
+
+/* c8 ignore next 7 */
+async function assertQueueFileMode(queuePath: string): Promise<void> {
+  try {
+    await chmod(queuePath, 0o600);
+  } catch {
+    // Best-effort hardening for platforms/filesystems that do not support chmod.
   }
 }
 
@@ -233,6 +281,7 @@ export async function recordRetryExhaustionToDeadLetterQueue(
   if (!options.actionClass.trim()) throw new Error('Cannot dead-letter automation action: actionClass is required');
   if (!options.target.trim()) throw new Error('Cannot dead-letter automation action: target is required');
   if (!options.lastError.trim()) throw new Error('Cannot dead-letter automation action: lastError is required');
+  const replaySafety = validateReplaySafety(options.replaySafety);
 
   const exhaustedAt = options.exhaustedAt ?? new Date().toISOString();
   const entry: DeadLetterEntry = {
@@ -245,12 +294,13 @@ export async function recordRetryExhaustionToDeadLetterQueue(
     firstAttemptedAt: options.firstAttemptedAt ?? exhaustedAt,
     lastAttemptedAt: exhaustedAt,
     createdAt: exhaustedAt,
-    replaySafety: options.replaySafety,
+    replaySafety,
     status: 'open',
     ...(options.payload === undefined ? {} : { payload: options.payload }),
   };
 
   await appendQueueEntry(options.queuePath, entry);
+  await assertQueueFileMode(options.queuePath);
   return entry;
 }
 
@@ -260,25 +310,26 @@ export async function retireDeadLetterEntry(
   options: RetireDeadLetterEntryOptions,
 ): Promise<DeadLetterEntry> {
   if (!options.reason.trim()) throw new Error('Retiring a dead-letter entry requires a reason');
-  const queue = await readQueue(queuePath);
-  let updated: DeadLetterEntry | undefined;
-  const entries = queue.entries.map((entry) => {
-    if (entry.id !== entryId) return entry;
-    if (entry.status === 'retired') {
-      updated = entry;
-      return entry;
-    }
-    updated = {
-      ...entry,
-      status: 'retired',
-      retiredAt: options.retiredAt ?? new Date().toISOString(),
-      retiredReason: options.reason,
-    };
+  try {
+    const updated = await mutateQueueEntry(queuePath, entryId, (entry) => {
+      if (entry.status === 'retired') {
+        return entry;
+      }
+      return {
+        ...entry,
+        status: 'retired',
+        retiredAt: options.retiredAt ?? new Date().toISOString(),
+        retiredReason: options.reason,
+      };
+    });
+    await assertQueueFileMode(queuePath);
     return updated;
-  });
-  if (!updated) throw new Error(`Dead-letter entry not found: ${entryId}`);
-  await writeQueue(queuePath, { schemaVersion: 1, entries });
-  return updated;
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Dead-letter entry not found') {
+      throw new Error(`Dead-letter entry not found: ${entryId}`);
+    }
+    throw error;
+  }
 }
 
 export async function dryRunReplayDeadLetterEntry(

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 
@@ -128,6 +128,9 @@ function parseEntry(value: unknown): DeadLetterEntry {
   if (entry.attempts > entry.maxAttempts) {
     throw new Error('Invalid dead-letter queue entry: attempts cannot exceed maxAttempts');
   }
+  if (entry.attempts < entry.maxAttempts) {
+    throw new Error('Invalid dead-letter queue entry: retry limit has not been exhausted');
+  }
   return entry;
 }
 
@@ -189,7 +192,7 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
     if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
     if (isProcessAlive(observed.pid)) return false;
   } catch {
-    return false;
+    return reapMalformedQueueLock(lockPath, now);
   }
 
   const stalePath = `${lockPath}.stale.${observed.owner.replace(/[^A-Za-z0-9_.:-]/gu, '_')}.${now}`;
@@ -200,6 +203,19 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
       await rename(stalePath, lockPath).catch(() => undefined);
       return false;
     }
+    await unlink(stalePath).catch(() => undefined);
+    return true;
+  } catch {
+    return reapMalformedQueueLock(lockPath, now);
+  }
+}
+
+async function reapMalformedQueueLock(lockPath: string, now = Date.now()): Promise<boolean> {
+  try {
+    const info = await stat(lockPath);
+    if (now - info.mtimeMs < STALE_LOCK_MS) return false;
+    const stalePath = `${lockPath}.malformed.${now}`;
+    await rename(lockPath, stalePath);
     await unlink(stalePath).catch(() => undefined);
     return true;
   } catch {
@@ -322,16 +338,35 @@ export async function listDeadLetterEntries(queuePath: string): Promise<DeadLett
 
 function normalizeJsonPayload(payload: unknown): unknown {
   const seen = new WeakSet<object>();
-  return JSON.parse(JSON.stringify(payload, (_key, value: unknown) => {
+  const normalize = (value: unknown): unknown => {
     if (typeof value === 'bigint') return value.toString();
     if (typeof value === 'function') return '[Function]';
     if (typeof value === 'symbol') return String(value);
     if (typeof value === 'object' && value !== null) {
       if (seen.has(value)) return '[Circular]';
       seen.add(value);
+      if (Array.isArray(value)) {
+        return value.map((item) => normalize(item));
+      }
+      const normalized: Record<string, unknown> = {};
+      let keys: string[];
+      try {
+        keys = Object.keys(value);
+      } catch {
+        return '[Unserializable Object]';
+      }
+      for (const key of keys) {
+        try {
+          normalized[key] = normalize((value as Record<string, unknown>)[key]);
+        } catch {
+          normalized[key] = '[Unserializable Property]';
+        }
+      }
+      return normalized;
     }
     return value;
-  }));
+  };
+  return normalize(payload);
 }
 
 export async function inspectDeadLetterEntry(queuePath: string, entryId: string): Promise<DeadLetterEntry> {

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -187,6 +187,7 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
     observed = parseQueueLock(await readFile(lockPath, 'utf8'));
     const acquiredAt = Date.parse(observed.acquiredAt);
     if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
+    if (isProcessAlive(observed.pid)) return false;
   } catch {
     return false;
   }
@@ -200,6 +201,15 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
       return false;
     }
     await unlink(stalePath).catch(() => undefined);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
+++ b/packages/franken-orchestrator/src/dr/dead-letter-queue.ts
@@ -193,7 +193,8 @@ async function reapStaleQueueLock(lockPath: string, now = Date.now()): Promise<b
   try {
     observed = parseQueueLock(await readFile(lockPath, 'utf8'));
     const acquiredAt = Date.parse(observed.acquiredAt);
-    if (!Number.isFinite(acquiredAt) || now - acquiredAt < STALE_LOCK_MS) return false;
+    if (!Number.isFinite(acquiredAt)) return reapMalformedQueueLock(lockPath, now);
+    if (now - acquiredAt < STALE_LOCK_MS) return false;
     if (isProcessAlive(observed.pid) && now - acquiredAt < LIVE_LOCK_MAX_MS) return false;
   } catch {
     return reapMalformedQueueLock(lockPath, now);

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -165,6 +165,22 @@ export { LlmPlanner } from './skills/llm-planner.js';
 export { quoteUntrustedPayload, wrapUntrustedContent } from './prompt/untrusted-content.js';
 export type { UntrustedContentSource } from './prompt/untrusted-content.js';
 export { buildProjectMemorySnapshot } from './memory/project-memory-snapshot.js';
+export {
+  dryRunReplayDeadLetterEntry,
+  inspectDeadLetterEntry,
+  listDeadLetterEntries,
+  recordRetryExhaustionToDeadLetterQueue,
+  retireDeadLetterEntry,
+} from './dr/dead-letter-queue.js';
+export type {
+  DeadLetterEntry,
+  DeadLetterEntryStatus,
+  DeadLetterReplayDryRunReport,
+  DeadLetterReplaySafety,
+  DryRunReplayOptions,
+  RecordRetryExhaustionOptions,
+  RetireDeadLetterEntryOptions,
+} from './dr/dead-letter-queue.js';
 export type {
   BuildProjectMemorySnapshotInput,
   ProjectMemoryRecord,

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -103,7 +103,7 @@ describe('dr restore-dry-run CLI', () => {
         summary: { open: 1 },
         entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'pr-2342' }],
       });
-      expect(listOutput).not.toContain('ghp_secretvalue1234567890');
+      expect(listOutput).not.toContain('ghp_testtoken1234567890');
       expect(listOutput).not.toContain('abcd1234secret5678');
       expect(listOutput).not.toContain('GH_TOKEN');
       expect(listOutput).not.toContain('lastError');
@@ -119,7 +119,7 @@ describe('dr restore-dry-run CLI', () => {
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });
       const replayOutput = output.pop() ?? '';
       expect(JSON.parse(replayOutput)).toMatchObject({ command: 'dr dead-letter-replay-dry-run', replay: { dryRun: true, wouldReplay: false, requiresApproval: true } });
-      expect(replayOutput).not.toContain('secret-value');
+      expect(replayOutput).not.toContain('ghp_testtoken1234567890');
 
       await handleDrCommand({ action: 'dead-letter-retire', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', keyFilePath: 'handled manually', generatedAt: '2026-07-16T08:07:00.000Z', print: (message) => output.push(message) });
       expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-retire', entry: { id: 'dlq_test', status: 'retired', retiredReason: 'handled manually' } });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -92,7 +92,10 @@ describe('dr restore-dry-run CLI', () => {
           createdAt: '2026-07-16T08:05:00.000Z',
           replaySafety: 'side-effect-approval-required',
           status: 'open',
-          payload: { command: 'curl --password notasecret -H "Authorization: Bearer abcdef...3456" https://api.github.com/repos/djm204/frankenbeast' },
+          payload: {
+            command: 'curl --password notasecret -H "Authorization: Bearer ***" https://api.github.com/repos/djm204/frankenbeast',
+            argv: ['gh', 'api', '--token', 'abcdefghijklmnopqrstuvwxyz123456', '--password=abcd1234secret5678'],
+          },
         }],
       }), 'utf8');
 

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -83,10 +83,10 @@ describe('dr restore-dry-run CLI', () => {
         entries: [{
           id: 'dlq_test',
           actionClass: 'codex-review-trigger',
-          target: 'pr-2342',
+          target: 'postgres://beast:databaseSecret123@db.example/franken',
           attempts: 5,
           maxAttempts: 5,
-          lastError: 'HTTP 403 for token ghp_deadlettersecretdeadlettersecret',
+          lastError: 'provider failures: sk-proj-abcdefghijklmnopqrstuvwxyz123456 and xoxb-123456789012-abcdefabcdef',
           firstAttemptedAt: '2026-07-16T08:00:00.000Z',
           lastAttemptedAt: '2026-07-16T08:05:00.000Z',
           createdAt: '2026-07-16T08:05:00.000Z',
@@ -95,6 +95,7 @@ describe('dr restore-dry-run CLI', () => {
           payload: {
             command: 'curl --password notasecret -H "Authorization: Bearer ***" https://api.github.com/repos/djm204/frankenbeast',
             argv: ['gh', 'api', '--token', 'abcdefghijklmnopqrstuvwxyz123456', '--password=abcd1234secret5678'],
+            databaseUrl: 'postgres://beast:anotherSecret456@db.example/franken',
           },
         }],
       }), 'utf8');
@@ -104,9 +105,9 @@ describe('dr restore-dry-run CLI', () => {
       expect(JSON.parse(listOutput)).toMatchObject({
         command: 'dr dead-letter-list',
         summary: { open: 1 },
-        entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'pr-2342' }],
+        entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'postgres://beast:<redacted>@db.example/franken' }],
       });
-      expect(listOutput).not.toContain('ghp_testtoken1234567890');
+      expect(listOutput).not.toContain('databaseSecret123');
       expect(listOutput).not.toContain('abcd1234secret5678');
       expect(listOutput).not.toContain('GH_TOKEN');
       expect(listOutput).not.toContain('lastError');
@@ -115,9 +116,11 @@ describe('dr restore-dry-run CLI', () => {
       await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
       const inspectOutput = output.pop() ?? '';
       expect(JSON.parse(inspectOutput)).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
-      expect(inspectOutput).not.toContain('ghp_deadlettersecretdeadlettersecret');
+      expect(inspectOutput).not.toContain('databaseSecret123');
       expect(inspectOutput).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
       expect(inspectOutput).not.toContain('notasecret');
+      expect(inspectOutput).not.toContain('xoxb-123456789012-abcdefabcdef');
+      expect(inspectOutput).not.toContain('anotherSecret456');
       expect(inspectOutput).toContain('<redacted>');
 
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -86,13 +86,13 @@ describe('dr restore-dry-run CLI', () => {
           target: 'pr-2342',
           attempts: 5,
           maxAttempts: 5,
-          lastError: 'HTTP 403 for token ghp_secretvalue1234567890',
+          lastError: 'HTTP 403 for token ghp_deadlettersecretdeadlettersecret',
           firstAttemptedAt: '2026-07-16T08:00:00.000Z',
           lastAttemptedAt: '2026-07-16T08:05:00.000Z',
           createdAt: '2026-07-16T08:05:00.000Z',
           replaySafety: 'side-effect-approval-required',
           status: 'open',
-          payload: { command: 'curl -H "Authorization: Bearer abcd1234secret5678" https://api.github.com/repos/djm204/frankenbeast' },
+          payload: { command: 'curl -H "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456" https://api.github.com/repos/djm204/frankenbeast' },
         }],
       }), 'utf8');
 
@@ -112,8 +112,8 @@ describe('dr restore-dry-run CLI', () => {
       await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
       const inspectOutput = output.pop() ?? '';
       expect(JSON.parse(inspectOutput)).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
-      expect(inspectOutput).not.toContain('ghp_secretvalue1234567890');
-      expect(inspectOutput).not.toContain('abcd1234secret5678');
+      expect(inspectOutput).not.toContain('ghp_deadlettersecretdeadlettersecret');
+      expect(inspectOutput).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
       expect(inspectOutput).toContain('<redacted>');
 
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -92,7 +92,7 @@ describe('dr restore-dry-run CLI', () => {
           createdAt: '2026-07-16T08:05:00.000Z',
           replaySafety: 'side-effect-approval-required',
           status: 'open',
-          payload: { command: 'curl -H "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456" https://api.github.com/repos/djm204/frankenbeast' },
+          payload: { command: 'curl --password notasecret -H "Authorization: Bearer abcdef...3456" https://api.github.com/repos/djm204/frankenbeast' },
         }],
       }), 'utf8');
 
@@ -114,6 +114,7 @@ describe('dr restore-dry-run CLI', () => {
       expect(JSON.parse(inspectOutput)).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
       expect(inspectOutput).not.toContain('ghp_deadlettersecretdeadlettersecret');
       expect(inspectOutput).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+      expect(inspectOutput).not.toContain('notasecret');
       expect(inspectOutput).toContain('<redacted>');
 
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -86,23 +86,31 @@ describe('dr restore-dry-run CLI', () => {
           target: 'pr-2342',
           attempts: 5,
           maxAttempts: 5,
-          lastError: 'usage limit',
+          lastError: 'usage limit for GH_TOKEN=secret-value',
           firstAttemptedAt: '2026-07-16T08:00:00.000Z',
           lastAttemptedAt: '2026-07-16T08:05:00.000Z',
           createdAt: '2026-07-16T08:05:00.000Z',
           replaySafety: 'side-effect-approval-required',
           status: 'open',
+          payload: { command: 'GH_TOKEN=secret-value gh pr comment 2342 --body @codex review' },
         }],
       }), 'utf8');
 
       await handleDrCommand({ action: 'dead-letter-list', backupManifestPath: queuePath, print: (message) => output.push(message) });
-      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-list', summary: { open: 1 } });
+      const listOutput = output.pop() ?? '';
+      expect(JSON.parse(listOutput)).toMatchObject({ command: 'dr dead-letter-list', summary: { open: 1 } });
+      expect(listOutput).not.toContain('secret-value');
+      expect(listOutput).toContain('<redacted>');
 
       await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
-      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
+      const inspectOutput = output.pop() ?? '';
+      expect(JSON.parse(inspectOutput)).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
+      expect(inspectOutput).not.toContain('secret-value');
 
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });
-      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-replay-dry-run', replay: { dryRun: true, wouldReplay: false, requiresApproval: true } });
+      const replayOutput = output.pop() ?? '';
+      expect(JSON.parse(replayOutput)).toMatchObject({ command: 'dr dead-letter-replay-dry-run', replay: { dryRun: true, wouldReplay: false, requiresApproval: true } });
+      expect(replayOutput).not.toContain('secret-value');
 
       await handleDrCommand({ action: 'dead-letter-retire', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', keyFilePath: 'handled manually', generatedAt: '2026-07-16T08:07:00.000Z', print: (message) => output.push(message) });
       expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-retire', entry: { id: 'dlq_test', status: 'retired', retiredReason: 'handled manually' } });

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -83,10 +83,10 @@ describe('dr restore-dry-run CLI', () => {
         entries: [{
           id: 'dlq_test',
           actionClass: 'codex-review-trigger',
-          target: 'postgres://beast:databaseSecret123@db.example/franken',
+          target: 'https://operator:targetSecret123@example.com/franken',
           attempts: 5,
           maxAttempts: 5,
-          lastError: 'provider failures: sk-proj-abcdefghijklmnopqrstuvwxyz123456 and xoxb-123456789012-abcdefabcdef',
+          lastError: 'provider failures: «redacted:sk-…» and «redacted:xox…»',
           firstAttemptedAt: '2026-07-16T08:00:00.000Z',
           lastAttemptedAt: '2026-07-16T08:05:00.000Z',
           createdAt: '2026-07-16T08:05:00.000Z',
@@ -105,8 +105,9 @@ describe('dr restore-dry-run CLI', () => {
       expect(JSON.parse(listOutput)).toMatchObject({
         command: 'dr dead-letter-list',
         summary: { open: 1 },
-        entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'postgres://beast:<redacted>@db.example/franken' }],
+        entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'https://operator:<redacted>@example.com/franken' }],
       });
+      expect(listOutput).not.toContain('targetSecret123');
       expect(listOutput).not.toContain('databaseSecret123');
       expect(listOutput).not.toContain('abcd1234secret5678');
       expect(listOutput).not.toContain('GH_TOKEN');

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -17,7 +17,7 @@ describe('dr restore-dry-run CLI', () => {
     expect(args.drLiveManifestPath).toBe('/live/manifest.json');
   });
 
-  it('parses encrypted backup, verify, list, and restore commands', () => {
+  it('parses encrypted backup, verify, list, restore, and dead-letter commands', () => {
     expect(parseArgs(['dr', 'backup', '/state', '/backup.enc.json', '/key']).drKeyFilePath).toBe('/key');
     expect(parseArgs(['dr', 'list', '/backup.enc.json']).drAction).toBe('list');
     expect(parseArgs(['dr', 'verify', '/backup.enc.json', '/key']).drLiveManifestPath).toBe('/key');
@@ -27,6 +27,14 @@ describe('dr restore-dry-run CLI', () => {
     expect(restore.drLiveManifestPath).toBe('/restore');
     expect(restore.drKeyFilePath).toBe('/key');
     expect(restore.dryRun).toBe(true);
+
+    const inspect = parseArgs(['dr', 'dead-letter-inspect', '/queue.json', 'dlq_123']);
+    expect(inspect.drAction).toBe('dead-letter-inspect');
+    expect(inspect.drBackupManifestPath).toBe('/queue.json');
+    expect(inspect.drLiveManifestPath).toBe('dlq_123');
+    const retire = parseArgs(['dr', 'dead-letter-retire', '/queue.json', 'dlq_123', 'operator resolved manually']);
+    expect(retire.drAction).toBe('dead-letter-retire');
+    expect(retire.drKeyFilePath).toBe('operator resolved manually');
   });
 
   it('prints a small backup summary and marks list output unverified', async () => {
@@ -59,6 +67,45 @@ describe('dr restore-dry-run CLI', () => {
       expect(listReport.command).toBe('dr list');
       expect(listReport.verified).toBe(false);
       expect(listReport.verificationRequired).toContain('dr verify');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints dead-letter list, inspect, dry-run replay, and retire JSON', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dr-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const output: string[] = [];
+
+    try {
+      await writeFile(queuePath, JSON.stringify({
+        schemaVersion: 1,
+        entries: [{
+          id: 'dlq_test',
+          actionClass: 'codex-review-trigger',
+          target: 'pr-2342',
+          attempts: 5,
+          maxAttempts: 5,
+          lastError: 'usage limit',
+          firstAttemptedAt: '2026-07-16T08:00:00.000Z',
+          lastAttemptedAt: '2026-07-16T08:05:00.000Z',
+          createdAt: '2026-07-16T08:05:00.000Z',
+          replaySafety: 'side-effect-approval-required',
+          status: 'open',
+        }],
+      }), 'utf8');
+
+      await handleDrCommand({ action: 'dead-letter-list', backupManifestPath: queuePath, print: (message) => output.push(message) });
+      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-list', summary: { open: 1 } });
+
+      await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
+      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
+
+      await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });
+      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-replay-dry-run', replay: { dryRun: true, wouldReplay: false, requiresApproval: true } });
+
+      await handleDrCommand({ action: 'dead-letter-retire', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', keyFilePath: 'handled manually', generatedAt: '2026-07-16T08:07:00.000Z', print: (message) => output.push(message) });
+      expect(JSON.parse(output.pop() ?? '')).toMatchObject({ command: 'dr dead-letter-retire', entry: { id: 'dlq_test', status: 'retired', retiredReason: 'handled manually' } });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -98,9 +98,15 @@ describe('dr restore-dry-run CLI', () => {
 
       await handleDrCommand({ action: 'dead-letter-list', backupManifestPath: queuePath, print: (message) => output.push(message) });
       const listOutput = output.pop() ?? '';
-      expect(JSON.parse(listOutput)).toMatchObject({ command: 'dr dead-letter-list', summary: { open: 1 } });
+      expect(JSON.parse(listOutput)).toMatchObject({
+        command: 'dr dead-letter-list',
+        summary: { open: 1 },
+        entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'pr-2342' }],
+      });
       expect(listOutput).not.toContain('secret-value');
-      expect(listOutput).toContain('<redacted>');
+      expect(listOutput).not.toContain('GH_TOKEN');
+      expect(listOutput).not.toContain('lastError');
+      expect(listOutput).not.toContain('payload');
 
       await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
       const inspectOutput = output.pop() ?? '';

--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -86,13 +86,13 @@ describe('dr restore-dry-run CLI', () => {
           target: 'pr-2342',
           attempts: 5,
           maxAttempts: 5,
-          lastError: 'usage limit for GH_TOKEN=secret-value',
+          lastError: 'HTTP 403 for token ghp_secretvalue1234567890',
           firstAttemptedAt: '2026-07-16T08:00:00.000Z',
           lastAttemptedAt: '2026-07-16T08:05:00.000Z',
           createdAt: '2026-07-16T08:05:00.000Z',
           replaySafety: 'side-effect-approval-required',
           status: 'open',
-          payload: { command: 'GH_TOKEN=secret-value gh pr comment 2342 --body @codex review' },
+          payload: { command: 'curl -H "Authorization: Bearer abcd1234secret5678" https://api.github.com/repos/djm204/frankenbeast' },
         }],
       }), 'utf8');
 
@@ -103,7 +103,8 @@ describe('dr restore-dry-run CLI', () => {
         summary: { open: 1 },
         entries: [{ id: 'dlq_test', actionClass: 'codex-review-trigger', target: 'pr-2342' }],
       });
-      expect(listOutput).not.toContain('secret-value');
+      expect(listOutput).not.toContain('ghp_secretvalue1234567890');
+      expect(listOutput).not.toContain('abcd1234secret5678');
       expect(listOutput).not.toContain('GH_TOKEN');
       expect(listOutput).not.toContain('lastError');
       expect(listOutput).not.toContain('payload');
@@ -111,7 +112,9 @@ describe('dr restore-dry-run CLI', () => {
       await handleDrCommand({ action: 'dead-letter-inspect', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', print: (message) => output.push(message) });
       const inspectOutput = output.pop() ?? '';
       expect(JSON.parse(inspectOutput)).toMatchObject({ command: 'dr dead-letter-inspect', entry: { id: 'dlq_test' } });
-      expect(inspectOutput).not.toContain('secret-value');
+      expect(inspectOutput).not.toContain('ghp_secretvalue1234567890');
+      expect(inspectOutput).not.toContain('abcd1234secret5678');
+      expect(inspectOutput).toContain('<redacted>');
 
       await handleDrCommand({ action: 'dead-letter-replay-dry-run', backupManifestPath: queuePath, liveManifestPath: 'dlq_test', generatedAt: '2026-07-16T08:06:00.000Z', print: (message) => output.push(message) });
       const replayOutput = output.pop() ?? '';

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -165,6 +165,34 @@ describe('dead-letter queue for failed automation actions', () => {
     }
   });
 
+  it('reaps very old locks even if the recorded pid is live to avoid pid-reuse wedges', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const lockPath = `${queuePath}.lock`;
+
+    try {
+      await writeFile(lockPath, JSON.stringify({
+        owner: 'reused-pid-lock',
+        pid: process.pid,
+        acquiredAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      }), 'utf8');
+
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'pid-reused lock should not strand the queue',
+        replaySafety: 'safe',
+      });
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('reaps stale malformed lock files left by crashed writers', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
     const queuePath = join(dir, 'dead-letter.json');

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -219,6 +219,32 @@ describe('dead-letter queue for failed automation actions', () => {
     }
   });
 
+  it('reaps stale lock files with invalid timestamps', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const lockPath = `${queuePath}.lock`;
+
+    try {
+      await writeFile(lockPath, JSON.stringify({ owner: 'bad-time-lock', pid: 999_999, acquiredAt: 'not-a-date' }), 'utf8');
+      const old = new Date(Date.now() - 60_000);
+      await utimes(lockPath, old, old);
+
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'invalid timestamp lock should not strand the queue',
+        replaySafety: 'safe',
+      });
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects queue entries parsed from disk before retry exhaustion', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
     const queuePath = join(dir, 'dead-letter.json');

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -116,6 +116,32 @@ describe('dead-letter queue for failed automation actions', () => {
     }
   });
 
+  it('normalizes blank retry exhaustion timestamps before writing entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'blank timestamp from caller',
+        replaySafety: 'safe',
+        firstAttemptedAt: ' ',
+        exhaustedAt: '',
+      });
+
+      expect(entry.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(entry.lastAttemptedAt).toBe(entry.createdAt);
+      expect(entry.firstAttemptedAt).toBe(entry.createdAt);
+      expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('serializes concurrent dead-letter appends to preserve every exhausted action', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
     const queuePath = join(dir, 'dead-letter.json');

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -73,6 +73,52 @@ describe('dead-letter queue for failed automation actions', () => {
     }
   });
 
+  it('rejects over-limit attempt counts before writing unreadable entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      await expect(recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 4,
+        maxAttempts: 3,
+        lastError: 'loop incremented past cap',
+        replaySafety: 'side-effect-approval-required',
+      })).rejects.toThrow(/attempts cannot exceed maxAttempts/);
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent dead-letter appends to preserve every exhausted action', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      const writes = Array.from({ length: 8 }, (_, index) => recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: `pr-${index}`,
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: `failure ${index}`,
+        replaySafety: 'safe',
+        exhaustedAt: `2026-07-16T08:0${index}:00.000Z`,
+      }));
+
+      const recorded = await Promise.all(writes);
+      const listed = await listDeadLetterEntries(queuePath);
+      expect(listed).toHaveLength(recorded.length);
+      expect(new Set(listed.map((entry) => entry.target))).toEqual(new Set(recorded.map((entry) => entry.target)));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('inspects, retires, and dry-runs replay without executing side effects', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
     const queuePath = join(dir, 'dead-letter.json');
@@ -118,6 +164,17 @@ describe('dead-letter queue for failed automation actions', () => {
         dryRun: true,
         wouldReplay: false,
         retired: true,
+      });
+
+      const stillRetired = await retireDeadLetterEntry(queuePath, entry.id, {
+        reason: 'second retry should not overwrite audit evidence',
+        retiredAt: '2026-07-16T08:30:00.000Z',
+      });
+      expect(stillRetired).toMatchObject({
+        id: entry.id,
+        status: 'retired',
+        retiredReason: 'operator chose to abandon stale retry',
+        retiredAt: '2026-07-16T08:20:00.000Z',
       });
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -214,6 +214,25 @@ describe('dead-letter queue for failed automation actions', () => {
       }), 'utf8');
 
       await expect(listDeadLetterEntries(queuePath)).rejects.toThrow(/retry limit has not been exhausted/);
+
+      await writeFile(queuePath, JSON.stringify({
+        schemaVersion: 1,
+        entries: [{
+          id: 'dlq_zero_limit',
+          actionClass: 'codex-review-trigger',
+          target: 'pr-2342',
+          attempts: 0,
+          maxAttempts: 0,
+          lastError: 'invalid retry limit',
+          firstAttemptedAt: '2026-07-16T08:00:00.000Z',
+          lastAttemptedAt: '2026-07-16T08:01:00.000Z',
+          createdAt: '2026-07-16T08:01:00.000Z',
+          replaySafety: 'safe',
+          status: 'open',
+        }],
+      }), 'utf8');
+
+      await expect(listDeadLetterEntries(queuePath)).rejects.toThrow(/maxAttempts must be at least 1/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -136,6 +136,30 @@ describe('dead-letter queue for failed automation actions', () => {
       const listed = await listDeadLetterEntries(queuePath);
       expect(listed).toHaveLength(recorded.length);
       expect(new Set(listed.map((entry) => entry.target))).toEqual(new Set(recorded.map((entry) => entry.target)));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reaps stale dead-letter lock files before recording exhausted actions', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const lockPath = `${queuePath}.lock`;
+
+    try {
+      await writeFile(lockPath, JSON.stringify({ pid: 1, acquiredAt: '2000-01-01T00:00:00.000Z' }), 'utf8');
+
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'stale lock should not strand the queue',
+        replaySafety: 'safe',
+      });
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -165,11 +165,71 @@ describe('dead-letter queue for failed automation actions', () => {
     }
   });
 
+  it('reaps stale malformed lock files left by crashed writers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const lockPath = `${queuePath}.lock`;
+
+    try {
+      await writeFile(lockPath, '{not-json', 'utf8');
+      const old = new Date(Date.now() - 60_000);
+      await utimes(lockPath, old, old);
+
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'malformed lock should not strand the queue',
+        replaySafety: 'safe',
+      });
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects queue entries parsed from disk before retry exhaustion', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      await writeFile(queuePath, JSON.stringify({
+        schemaVersion: 1,
+        entries: [{
+          id: 'dlq_under_limit',
+          actionClass: 'codex-review-trigger',
+          target: 'pr-2342',
+          attempts: 2,
+          maxAttempts: 3,
+          lastError: 'still retryable',
+          firstAttemptedAt: '2026-07-16T08:00:00.000Z',
+          lastAttemptedAt: '2026-07-16T08:01:00.000Z',
+          createdAt: '2026-07-16T08:01:00.000Z',
+          replaySafety: 'safe',
+          status: 'open',
+        }],
+      }), 'utf8');
+
+      await expect(listDeadLetterEntries(queuePath)).rejects.toThrow(/retry limit has not been exhausted/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes non-JSON payloads so retry evidence is still recorded', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
     const queuePath = join(dir, 'dead-letter.json');
-    const payload: { id: bigint; self?: unknown } = { id: 123n };
+    const payload: { id: bigint; self?: unknown; broken?: unknown } = { id: 123n };
     payload.self = payload;
+    Object.defineProperty(payload, 'broken', {
+      enumerable: true,
+      get() {
+        throw new Error('diagnostic getter failed');
+      },
+    });
 
     try {
       const entry = await recordRetryExhaustionToDeadLetterQueue({
@@ -183,7 +243,7 @@ describe('dead-letter queue for failed automation actions', () => {
         payload,
       });
 
-      expect(entry.payload).toEqual({ id: '123', self: '[Circular]' });
+      expect(entry.payload).toEqual({ id: '123', self: '[Circular]', broken: '[Unserializable Property]' });
       await expect(listDeadLetterEntries(queuePath)).resolves.toHaveLength(1);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -47,6 +47,7 @@ describe('dead-letter queue for failed automation actions', () => {
       const listed = await listDeadLetterEntries(queuePath);
       expect(listed).toHaveLength(1);
       expect(listed[0]).toEqual(entry);
+      expect((await stat(queuePath)).mode & 0o777).toBe(0o600);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -87,6 +88,27 @@ describe('dead-letter queue for failed automation actions', () => {
         lastError: 'loop incremented past cap',
         replaySafety: 'side-effect-approval-required',
       })).rejects.toThrow(/attempts cannot exceed maxAttempts/);
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid replay safety before writing unreadable entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      await expect(recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'bad replay safety',
+        replaySafety: 'bogus' as 'safe',
+      })).rejects.toThrow(/replaySafety/);
 
       expect(await listDeadLetterEntries(queuePath)).toEqual([]);
     } finally {

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  dryRunReplayDeadLetterEntry,
+  inspectDeadLetterEntry,
+  listDeadLetterEntries,
+  recordRetryExhaustionToDeadLetterQueue,
+  retireDeadLetterEntry,
+} from '../../../src/dr/dead-letter-queue.js';
+
+describe('dead-letter queue for failed automation actions', () => {
+  it('records retry exhaustion evidence with replay safety classification', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'approval command failed after provider timeout',
+        replaySafety: 'side-effect-approval-required',
+        firstAttemptedAt: '2026-07-16T08:00:00.000Z',
+        exhaustedAt: '2026-07-16T08:05:00.000Z',
+        payload: { command: 'gh pr comment 2342 --body @codex review' },
+      });
+
+      expect(entry).toMatchObject({
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'approval command failed after provider timeout',
+        replaySafety: 'side-effect-approval-required',
+        firstAttemptedAt: '2026-07-16T08:00:00.000Z',
+        lastAttemptedAt: '2026-07-16T08:05:00.000Z',
+        status: 'open',
+      });
+      expect(entry.id).toMatch(/^dlq_/);
+
+      const listed = await listDeadLetterEntries(queuePath);
+      expect(listed).toHaveLength(1);
+      expect(listed[0]).toEqual(entry);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not enqueue actions before the bounded retry limit is exhausted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      await expect(recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 2,
+        maxAttempts: 3,
+        lastError: 'still retryable',
+        replaySafety: 'safe',
+      })).rejects.toThrow(/retry limit has not been exhausted/);
+
+      expect(await listDeadLetterEntries(queuePath)).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('inspects, retires, and dry-runs replay without executing side effects', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+
+    try {
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'codex-review-trigger',
+        target: 'pr-2342',
+        attempts: 5,
+        maxAttempts: 5,
+        lastError: 'connector usage limit',
+        replaySafety: 'side-effect-approval-required',
+        exhaustedAt: '2026-07-16T08:10:00.000Z',
+      });
+
+      await expect(inspectDeadLetterEntry(queuePath, entry.id)).resolves.toEqual(entry);
+      await expect(dryRunReplayDeadLetterEntry(queuePath, entry.id, {
+        requestedAt: '2026-07-16T08:12:00.000Z',
+      })).resolves.toMatchObject({
+        entryId: entry.id,
+        dryRun: true,
+        wouldReplay: false,
+        requiresApproval: true,
+        approvalRequired: 'side-effect replay requires explicit operator approval before execution',
+      });
+
+      const retired = await retireDeadLetterEntry(queuePath, entry.id, {
+        reason: 'operator chose to abandon stale retry',
+        retiredAt: '2026-07-16T08:20:00.000Z',
+      });
+      expect(retired).toMatchObject({
+        id: entry.id,
+        status: 'retired',
+        retiredReason: 'operator chose to abandon stale retry',
+        retiredAt: '2026-07-16T08:20:00.000Z',
+      });
+
+      await expect(dryRunReplayDeadLetterEntry(queuePath, entry.id, {
+        requestedAt: '2026-07-16T08:25:00.000Z',
+      })).resolves.toMatchObject({
+        entryId: entry.id,
+        dryRun: true,
+        wouldReplay: false,
+        retired: true,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -147,7 +147,7 @@ describe('dead-letter queue for failed automation actions', () => {
     const lockPath = `${queuePath}.lock`;
 
     try {
-      await writeFile(lockPath, JSON.stringify({ pid: 1, acquiredAt: '2000-01-01T00:00:00.000Z' }), 'utf8');
+      await writeFile(lockPath, JSON.stringify({ owner: 'crashed-worker', pid: 1, acquiredAt: '2000-01-01T00:00:00.000Z' }), 'utf8');
 
       const entry = await recordRetryExhaustionToDeadLetterQueue({
         queuePath,
@@ -160,6 +160,31 @@ describe('dead-letter queue for failed automation actions', () => {
       });
 
       expect(await listDeadLetterEntries(queuePath)).toEqual([entry]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes non-JSON payloads so retry evidence is still recorded', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-dlq-'));
+    const queuePath = join(dir, 'dead-letter.json');
+    const payload: { id: bigint; self?: unknown } = { id: 123n };
+    payload.self = payload;
+
+    try {
+      const entry = await recordRetryExhaustionToDeadLetterQueue({
+        queuePath,
+        actionClass: 'approval-cop-command',
+        target: 'pr-2342',
+        attempts: 3,
+        maxAttempts: 3,
+        lastError: 'payload had rich retry context',
+        replaySafety: 'safe',
+        payload,
+      });
+
+      expect(entry.payload).toEqual({ id: '123', self: '[Circular]' });
+      await expect(listDeadLetterEntries(queuePath)).resolves.toHaveLength(1);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/dead-letter-queue.test.ts
@@ -147,7 +147,7 @@ describe('dead-letter queue for failed automation actions', () => {
     const lockPath = `${queuePath}.lock`;
 
     try {
-      await writeFile(lockPath, JSON.stringify({ owner: 'crashed-worker', pid: 1, acquiredAt: '2000-01-01T00:00:00.000Z' }), 'utf8');
+      await writeFile(lockPath, JSON.stringify({ owner: 'stale-test-lock', pid: 999_999, acquiredAt: '2000-01-01T00:00:00.000Z' }), 'utf8');
 
       const entry = await recordRetryExhaustionToDeadLetterQueue({
         queuePath,

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -3,6 +3,7 @@
 ## 2026-07-16 — Dead-letter queue Codex closeout
 - DLQ/DR restore output redaction must cover provider token literals (for example `sk-*`, `xox*`) and credentialed database URLs even when they appear inside free-text fields such as `target`, `lastError`, or nested payload strings; test fixtures should prove output does not leak the original secret substrings.
 - For DLQ file locks, treat unparseable lock timestamps as malformed stale-lock candidates and fall back to mtime-based reaping; otherwise a syntactically valid lock JSON with `acquiredAt: not-a-date` can wedge writers forever.
+- When reaping malformed DLQ locks, revalidate the moved file identity after `rename` before unlinking so a stale-lock race cannot delete a fresh active lock; when persisting retry exhaustion, normalize blank caller timestamps before writing so later queue reads do not reject the whole DLQ.
 
 ## 2026-07-15 — Webhook DNS pinning review fixes
 - For outbound webhook SSRF hardening, validate object-form allowlist origins for credentials too; URL normalization can otherwise hide deceptive `userinfo@host` entries.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-16 — Dead-letter queue Codex closeout
+- DLQ/DR restore output redaction must cover provider token literals (for example `sk-*`, `xox*`) and credentialed database URLs even when they appear inside free-text fields such as `target`, `lastError`, or nested payload strings; test fixtures should prove output does not leak the original secret substrings.
+- For DLQ file locks, treat unparseable lock timestamps as malformed stale-lock candidates and fall back to mtime-based reaping; otherwise a syntactically valid lock JSON with `acquiredAt: not-a-date` can wedge writers forever.
+
 ## 2026-07-15 — Webhook DNS pinning review fixes
 - For outbound webhook SSRF hardening, validate object-form allowlist origins for credentials too; URL normalization can otherwise hide deceptive `userinfo@host` entries.
 - When a webhook hostname is DNS-validated before delivery, the actual transport must consume the validated address: custom fetches should receive an IP-pinned URL plus original Host header, default HTTPS should try later validated addresses after network failures, and pinned HTTPS error bodies need async-iterable response coverage.


### PR DESCRIPTION
## Summary
- add a DR dead-letter queue module for failed automation actions after bounded retry exhaustion
- expose CLI commands to list, inspect, dry-run replay, and retire dead-letter entries
- document the operator workflow and export the new helper APIs

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/dr/dead-letter-queue.test.ts tests/unit/cli/dr-restore.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1754