### PR TITLE
test(orchestrator): bound issue scheduler liveness payloads

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -161,3 +161,7 @@ Before execution starts, `IssueRunner` emits `[issues] Scheduler fairness report
 - `warnings[]`: explicit edge cases, such as unprioritized issues that will run after prioritized work or approved issues missing triage results.
 
 Library callers can produce the same deterministic payload directly with `buildIssueSchedulerFairnessReport(issues, triageResults)`. Treat non-empty `warnings[]` as operator guidance: either add the missing labels/triage data before approving the run, or record why the fallback order is acceptable.
+
+### Large backlog liveness/refill scaling assumptions
+
+Issue scheduler liveness output is intended to stay bounded even when a refill run sees hundreds or thousands of issues/cards. `buildIssueSchedulerFairnessReport()` samples issue-number lists and warnings while keeping authoritative counts (`totalIssues`, bucket `count`, omitted counts, and `warningSummary`). Operators should rely on the counts and summaries for backlog health, then drill into GitHub/Kanban for the full list only when a specific bucket or warning class needs action. Callers that need a tighter UI payload can pass `maxIssueNumbersPerList` and `maxWarnings`; the defaults keep output concise without hiding blocker classes.

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -68,6 +68,7 @@ export type {
   IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
+  IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
   DuplicateWorkerCardProcessFinding,
 } from './issues/index.js';

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -30,6 +30,7 @@ export type {
   IssueDependencyStatus,
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
+  IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
   DuplicateWorkerCardProcessFinding,
 } from './issue-runner.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -190,15 +190,29 @@ export interface DuplicateWorkerCardProcessFinding {
 
 export interface IssueSchedulerFairnessBucket {
   readonly severity: 'critical' | 'high' | 'medium' | 'low' | 'unprioritized';
+  /** Sampled issue numbers for PM/liveness output; `count` is authoritative when this list is truncated. */
   readonly issueNumbers: readonly number[];
   readonly count: number;
+  readonly issueNumbersTruncated?: true | undefined;
+  readonly omittedIssueNumberCount?: number | undefined;
 }
 
 export interface IssueSchedulerFairnessReport {
   readonly totalIssues: number;
+  /** Sampled severity-ordered issue numbers for PM/liveness output; `totalIssues` is authoritative when truncated. */
   readonly scheduledIssueNumbers: readonly number[];
   readonly buckets: readonly IssueSchedulerFairnessBucket[];
   readonly warnings: readonly string[];
+  readonly scheduledIssueNumbersTruncated?: true | undefined;
+  readonly omittedScheduledIssueNumberCount?: number | undefined;
+  readonly warningsTruncated?: true | undefined;
+  readonly omittedWarningCount?: number | undefined;
+  readonly warningSummary?: readonly string[] | undefined;
+}
+
+export interface IssueSchedulerFairnessReportOptions {
+  readonly maxIssueNumbersPerList?: number | undefined;
+  readonly maxWarnings?: number | undefined;
 }
 
 export interface IssueRunnerConfig {
@@ -228,6 +242,8 @@ const NO_SEVERITY = 4;
 const TOKENS_PER_DOLLAR = 1_000_000;
 const ONE_SHOT_MAX_ITERATIONS = 50;
 const ONE_SHOT_STALE_MATE_LIMIT = 3;
+const DEFAULT_SCHEDULER_FAIRNESS_ISSUE_NUMBER_LIMIT = 50;
+const DEFAULT_SCHEDULER_FAIRNESS_WARNING_LIMIT = 50;
 
 function limitExceeded(value: number | undefined, limit: number | undefined): value is number {
   return limit !== undefined && value !== undefined && value > limit;
@@ -633,14 +649,43 @@ function sortBySeverity(issues: readonly GithubIssue[]): GithubIssue[] {
   return [...issues].sort((a, b) => extractSeverity(a.labels) - extractSeverity(b.labels));
 }
 
+function boundedPositiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const candidate: number = value;
+  return Number.isSafeInteger(candidate) && candidate > 0 ? candidate : fallback;
+}
+
+function sampleNumbers(values: readonly number[], limit: number): { sample: readonly number[]; omitted: number } {
+  if (values.length <= limit) return { sample: values, omitted: 0 };
+  return { sample: values.slice(0, limit), omitted: values.length - limit };
+}
+
+function sampleStrings(values: readonly string[], limit: number): { sample: readonly string[]; omitted: number } {
+  if (values.length <= limit) return { sample: values, omitted: 0 };
+  return { sample: values.slice(0, limit), omitted: values.length - limit };
+}
+
 export function buildIssueSchedulerFairnessReport(
   issues: readonly GithubIssue[],
   triageResults: readonly TriageResult[],
+  options: IssueSchedulerFairnessReportOptions = {},
 ): IssueSchedulerFairnessReport {
   const scheduled = sortBySeverity(issues);
   const triagedIssueNumbers = new Set(triageResults.map(triage => triage.issueNumber));
   const buckets = new Map<IssueSchedulerFairnessBucket['severity'], number[]>();
   const warnings: string[] = [];
+  const warningCounters = {
+    unprioritized: 0,
+    missingTriage: 0,
+  };
+  const issueNumberLimit = boundedPositiveInteger(
+    options.maxIssueNumbersPerList,
+    DEFAULT_SCHEDULER_FAIRNESS_ISSUE_NUMBER_LIMIT,
+  );
+  const warningLimit = boundedPositiveInteger(
+    options.maxWarnings,
+    DEFAULT_SCHEDULER_FAIRNESS_WARNING_LIMIT,
+  );
 
   for (const severity of ['critical', 'high', 'medium', 'low', 'unprioritized'] as const) {
     buckets.set(severity, []);
@@ -651,23 +696,58 @@ export function buildIssueSchedulerFairnessReport(
     buckets.get(severity)!.push(issue.number);
 
     if (severity === 'unprioritized') {
+      warningCounters.unprioritized += 1;
       warnings.push(`issue #${issue.number} has no recognized severity label and is scheduled after prioritized work`);
     }
 
     if (!triagedIssueNumbers.has(issue.number)) {
+      warningCounters.missingTriage += 1;
       warnings.push(`issue #${issue.number} has no triage result and will fail before execution if approved`);
     }
   }
 
+  const scheduledSample = sampleNumbers(scheduled.map(issue => issue.number), issueNumberLimit);
+  const warningSample = sampleStrings(warnings, warningLimit);
+  const warningSummary = [
+    warningCounters.unprioritized > 0
+      ? `${warningCounters.unprioritized} unprioritized issue(s) are scheduled after prioritized work`
+      : undefined,
+    warningCounters.missingTriage > 0
+      ? `${warningCounters.missingTriage} issue(s) are missing triage results and require labels/triage before safe execution`
+      : undefined,
+  ].filter((entry): entry is string => entry !== undefined);
+
   return {
     totalIssues: issues.length,
-    scheduledIssueNumbers: scheduled.map(issue => issue.number),
-    buckets: [...buckets.entries()].map(([severity, issueNumbers]) => ({
-      severity,
-      issueNumbers,
-      count: issueNumbers.length,
-    })),
-    warnings,
+    scheduledIssueNumbers: scheduledSample.sample,
+    ...(scheduledSample.omitted > 0
+      ? {
+          scheduledIssueNumbersTruncated: true as const,
+          omittedScheduledIssueNumberCount: scheduledSample.omitted,
+        }
+      : {}),
+    buckets: [...buckets.entries()].map(([severity, issueNumbers]) => {
+      const bucketSample = sampleNumbers(issueNumbers, issueNumberLimit);
+      return {
+        severity,
+        issueNumbers: bucketSample.sample,
+        count: issueNumbers.length,
+        ...(bucketSample.omitted > 0
+          ? {
+              issueNumbersTruncated: true as const,
+              omittedIssueNumberCount: bucketSample.omitted,
+            }
+          : {}),
+      };
+    }),
+    warnings: warningSample.sample,
+    ...(warningSample.omitted > 0
+      ? {
+          warningsTruncated: true as const,
+          omittedWarningCount: warningSample.omitted,
+          warningSummary,
+        }
+      : {}),
   };
 }
 

--- a/packages/franken-orchestrator/tests/unit/issues/fixtures/large-backlog-liveness-refill.json
+++ b/packages/franken-orchestrator/tests/unit/issues/fixtures/large-backlog-liveness-refill.json
@@ -1,0 +1,42 @@
+{
+  "description": "Large backlog liveness/refill fixture for bounded scheduler fairness output.",
+  "issueCount": 120,
+  "cardCount": 120,
+  "severitySplit": {
+    "high": 80,
+    "unprioritized": 40
+  },
+  "triage": {
+    "missingEvery": 3,
+    "expectedMissingCount": 40
+  },
+  "cardStates": {
+    "running": 60,
+    "blocked": 20,
+    "done": 20,
+    "ready": 20
+  },
+  "operationBounds": {
+    "maxIssueNumbersPerList": 5,
+    "maxWarnings": 6
+  },
+  "expectations": {
+    "scheduledIssueNumbers": [10000, 10001, 10002, 10003, 10004],
+    "omittedScheduledIssueNumberCount": 115,
+    "highBucket": {
+      "count": 80,
+      "issueNumbers": [10000, 10001, 10002, 10003, 10004],
+      "omittedIssueNumberCount": 75
+    },
+    "unprioritizedBucket": {
+      "count": 40,
+      "issueNumbers": [10080, 10081, 10082, 10083, 10084],
+      "omittedIssueNumberCount": 35
+    },
+    "omittedWarningCount": 74,
+    "warningSummary": [
+      "40 unprioritized issue(s) are scheduled after prioritized work",
+      "40 issue(s) are missing triage results and require labels/triage before safe execution"
+    ]
+  }
+}

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -78,6 +78,32 @@ interface FlakyLivenessReplayFixture {
   readonly edgeCases: readonly FlakyLivenessReplaySnapshot[];
 }
 
+interface LargeBacklogLivenessRefillFixture {
+  readonly description: string;
+  readonly issueCount: number;
+  readonly cardCount: number;
+  readonly severitySplit: { readonly high: number; readonly unprioritized: number };
+  readonly triage: { readonly missingEvery: number; readonly expectedMissingCount: number };
+  readonly cardStates: Readonly<Record<string, number>>;
+  readonly operationBounds: { readonly maxIssueNumbersPerList: number; readonly maxWarnings: number };
+  readonly expectations: {
+    readonly scheduledIssueNumbers: readonly number[];
+    readonly omittedScheduledIssueNumberCount: number;
+    readonly highBucket: {
+      readonly count: number;
+      readonly issueNumbers: readonly number[];
+      readonly omittedIssueNumberCount: number;
+    };
+    readonly unprioritizedBucket: {
+      readonly count: number;
+      readonly issueNumbers: readonly number[];
+      readonly omittedIssueNumberCount: number;
+    };
+    readonly omittedWarningCount: number;
+    readonly warningSummary: readonly string[];
+  };
+}
+
 function readBurstDispatchLoadFixture(): BurstDispatchLoadFixture {
   return JSON.parse(
     readFileSync(join(__dirname, 'fixtures', 'burst-dispatch-load.json'), 'utf8'),
@@ -88,6 +114,12 @@ function readFlakyLivenessReplayFixture(): FlakyLivenessReplayFixture {
   return JSON.parse(
     readFileSync(join(__dirname, 'fixtures', 'flaky-liveness-replay.json'), 'utf8'),
   ) as FlakyLivenessReplayFixture;
+}
+
+function readLargeBacklogLivenessRefillFixture(): LargeBacklogLivenessRefillFixture {
+  return JSON.parse(
+    readFileSync(join(__dirname, 'fixtures', 'large-backlog-liveness-refill.json'), 'utf8'),
+  ) as LargeBacklogLivenessRefillFixture;
 }
 
 vi.mock('../../../src/beast-loop.js', () => {
@@ -506,6 +538,39 @@ describe('IssueRunner', () => {
       expect(report.warnings).toEqual([
         'issue #41 has no triage result and will fail before execution if approved',
       ]);
+    });
+
+    it('bounds scheduler liveness payloads under large refill queues while preserving authoritative counts', () => {
+      const fixture = readLargeBacklogLivenessRefillFixture();
+      const issues = Array.from({ length: fixture.issueCount }, (_, index) => makeIssue({
+        number: 10_000 + index,
+        labels: index < fixture.severitySplit.high ? ['high'] : [],
+      }));
+      const triages = issues
+        .filter((_, index) => index % fixture.triage.missingEvery !== 0)
+        .map(issue => makeTriage(issue.number));
+
+      const report = buildIssueSchedulerFairnessReport(issues, triages, fixture.operationBounds);
+
+      expect(fixture.description).toContain('Large backlog liveness/refill fixture');
+      expect(Object.values(fixture.cardStates).reduce((total, count) => total + count, 0)).toBe(fixture.cardCount);
+      expect(report.totalIssues).toBe(fixture.issueCount);
+      expect(report.scheduledIssueNumbers).toEqual(fixture.expectations.scheduledIssueNumbers);
+      expect(report.scheduledIssueNumbers.length).toBeLessThanOrEqual(fixture.operationBounds.maxIssueNumbersPerList);
+      expect(report.scheduledIssueNumbersTruncated).toBe(true);
+      expect(report.omittedScheduledIssueNumberCount).toBe(fixture.expectations.omittedScheduledIssueNumberCount);
+      expect(report.buckets.find(bucket => bucket.severity === 'high')).toMatchObject({
+        ...fixture.expectations.highBucket,
+        issueNumbersTruncated: true,
+      });
+      expect(report.buckets.find(bucket => bucket.severity === 'unprioritized')).toMatchObject({
+        ...fixture.expectations.unprioritizedBucket,
+        issueNumbersTruncated: true,
+      });
+      expect(report.warnings).toHaveLength(fixture.operationBounds.maxWarnings);
+      expect(report.warningsTruncated).toBe(true);
+      expect(report.omittedWarningCount).toBe(fixture.expectations.omittedWarningCount);
+      expect(report.warningSummary).toEqual(fixture.expectations.warningSummary);
     });
 
     it('logs the scheduler fairness report before executing approved issues', async () => {


### PR DESCRIPTION
## Summary
- add a large-backlog liveness/refill fixture with mixed issue/card states
- bound scheduler fairness issue-number and warning payloads while preserving authoritative counts and summaries
- document large-backlog scaling assumptions for issue scheduler liveness/refill output

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer --workspace @franken/brain --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm run test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)
- npm run build --workspace @franken/orchestrator

Closes #1751