### PR TITLE
feat(dashboard): surface dependency availability

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -67,6 +67,10 @@ import { loadRunConfigFromEnv, type RunConfig } from './run-config-loader.js';
 import { resolveProviderCatalogEntry, resolveProviderType, type ProviderConfig } from '../providers/provider-config.js';
 import type { ProviderRegistry as LlmProviderRegistry } from '../providers/provider-registry.js';
 import { redactLogData } from '../logging/redaction.js';
+import {
+  type DashboardAvailabilitySnapshot,
+  type DashboardProviderSnapshot,
+} from '../http/routes/dashboard-status.js';
 
 /**
  * Creates an InterviewIO backed by stdin/stdout.
@@ -617,7 +621,7 @@ export function buildDashboardProviderSnapshot(
   config: OrchestratorConfig,
   providerRegistry?: LlmProviderRegistry | undefined,
   extraProviderNames: readonly string[] = [],
-): Array<{ name: string; type: string; available: boolean; failoverOrder: number; model?: string }> {
+): DashboardProviderSnapshot[] {
   if (config.consolidatedProviders?.length) {
     return config.consolidatedProviders.map((provider, index) => ({
       name: provider.name,
@@ -1662,12 +1666,12 @@ export interface NetworkCommandSupervisorLike {
   up(options: {
     services: ResolvedNetworkService[];
     detached: boolean;
-    mode: 'secure' | 'insecure';
-    secureBackend: string;
-  }): Promise<{ services: { id: string; url?: string | undefined; status?: 'started' | 'already-running' | undefined }[] }>;
-  stopAll(state: Awaited<ReturnType<NetworkCommandSupervisorLike['up']>>): Promise<void>;
+    mode?: string;
+    secureBackend?: string;
+  }): Promise<{ services: Array<{ id: string; status?: string | undefined; url?: string | undefined }> }>;
   down(): Promise<void>;
-  status(): Promise<{ mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }> }>;
+  stopAll(state: Awaited<ReturnType<NetworkCommandSupervisorLike['up']>>): Promise<void>;
+  status(): Promise<{ mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }>; availability?: DashboardAvailabilitySnapshot }>;
   stop(target: string | 'all'): Promise<void>;
   logs(target: string | 'all'): Promise<string[]>;
 }
@@ -1739,7 +1743,7 @@ async function waitForTerminationSignal(root: string): Promise<void> {
   });
 }
 
-function formatStatus(status: { mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }> }): string[] {
+function formatStatus(status: { mode?: string; secureBackend?: string; services: Array<{ id: string; status: string }>; availability?: DashboardAvailabilitySnapshot }): string[] {
   const lines = [
     `Mode: ${status.mode ?? 'unknown'}`,
   ];
@@ -1750,6 +1754,19 @@ function formatStatus(status: { mode?: string; secureBackend?: string; services:
 
   for (const service of status.services) {
     lines.push(`${service.id}: ${service.status}`);
+  }
+
+  if (status.availability) {
+    lines.push(`Dependency availability: ${status.availability.status}`);
+    for (const dependency of status.availability.dependencies) {
+      lines.push(`dependency ${dependency.name} (${dependency.type}): ${dependency.status} — ${dependency.summary}`);
+      if (dependency.remediationHint) {
+        lines.push(`  remediation: ${dependency.remediationHint}`);
+      }
+      if (dependency.safeWork.length > 0) {
+        lines.push(`  safe work: ${dependency.safeWork.join(' ')}`);
+      }
+    }
   }
 
   return lines;

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -5,6 +5,11 @@ import type { SseConnectionTicketStore } from '../../beasts/events/sse-connectio
 import type { SkillManager } from '../../skills/skill-manager.js';
 import type { SecurityConfig } from '../../middleware/security-profiles.js';
 import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from '../operator-auth.js';
+import {
+  buildDashboardAvailabilitySnapshot,
+  type DashboardDependencySnapshot,
+  type DashboardProviderSnapshot,
+} from './dashboard-status.js';
 
 const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
 const DASHBOARD_HEARTBEAT_MS = 30_000;
@@ -13,7 +18,8 @@ const DASHBOARD_SSE_TICKET_SCOPE = 'dashboard';
 export interface DashboardRouteDeps {
   skillManager: SkillManager;
   getSecurityConfig: () => SecurityConfig;
-  getProviders: () => Array<{ name: string; type: string; available: boolean; failoverOrder: number; model?: string }>;
+  getProviders: () => DashboardProviderSnapshot[];
+  getDependencies?: (() => DashboardDependencySnapshot[]) | undefined;
   operatorToken?: string | undefined;
   ticketStore?: SseConnectionTicketStore | undefined;
 }
@@ -23,6 +29,7 @@ function buildSnapshot(deps: DashboardRouteDeps) {
   const enabledSkills = new Set(deps.skillManager.getEnabledSkills());
   const security = deps.getSecurityConfig();
   const providers = deps.getProviders();
+  const availability = buildDashboardAvailabilitySnapshot(providers, deps.getDependencies?.() ?? []);
 
   return {
     skills: skills.map((s) => ({
@@ -31,6 +38,7 @@ function buildSnapshot(deps: DashboardRouteDeps) {
     })),
     security,
     providers,
+    availability,
   };
 }
 

--- a/packages/franken-orchestrator/src/http/routes/dashboard-status.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-status.ts
@@ -1,0 +1,105 @@
+export type DashboardDependencyStatus = 'healthy' | 'degraded' | 'unavailable' | 'unknown';
+
+export interface DashboardProviderSnapshot {
+  name: string;
+  type: string;
+  available: boolean;
+  failoverOrder: number;
+  model?: string | undefined;
+}
+
+export interface DashboardDependencySnapshot {
+  name: string;
+  type: string;
+  status: DashboardDependencyStatus;
+  summary: string;
+  remediationHint: string;
+  safeWork: string[];
+}
+
+export interface DashboardAvailabilitySnapshot {
+  status: DashboardDependencyStatus;
+  dependencies: DashboardDependencySnapshot[];
+}
+
+const STATUS_RANK: Record<DashboardDependencyStatus, number> = {
+  healthy: 0,
+  degraded: 1,
+  unknown: 2,
+  unavailable: 3,
+};
+
+function normalizeDependency(dependency: DashboardDependencySnapshot): DashboardDependencySnapshot {
+  const safeWork = dependency.safeWork.length > 0
+    ? [...dependency.safeWork]
+    : ['Inspect this dependency before starting work that relies on it.'];
+
+  return {
+    ...dependency,
+    summary: dependency.summary.trim() || `${dependency.name} status is ${dependency.status}.`,
+    remediationHint: dependency.remediationHint.trim() || 'Inspect dependency configuration and upstream status.',
+    safeWork,
+  };
+}
+
+function providerToDependency(
+  provider: DashboardProviderSnapshot,
+  allProviders: readonly DashboardProviderSnapshot[],
+): DashboardDependencySnapshot {
+  const status: DashboardDependencyStatus = provider.available ? 'healthy' : 'unavailable';
+  const hasFailover = allProviders.some((candidate) => candidate.available && candidate.failoverOrder > provider.failoverOrder);
+  const modelSuffix = provider.model ? ` using ${provider.model}` : '';
+
+  return normalizeDependency({
+    name: provider.name,
+    type: `provider:${provider.type}`,
+    status,
+    summary: provider.available
+      ? `${provider.name}${modelSuffix} is available for failover slot #${provider.failoverOrder + 1}.`
+      : `${provider.name}${modelSuffix} is unavailable at failover slot #${provider.failoverOrder + 1}.`,
+    remediationHint: provider.available
+      ? 'No remediation needed.'
+      : `Check ${provider.name} credentials, CLI installation, or upstream provider status.`,
+    safeWork: provider.available
+      ? ['Provider-backed work can use this provider.']
+      : hasFailover
+        ? ['Route provider-backed work to the next available failover provider.', 'Continue work that does not require this provider.']
+        : ['Defer new provider-backed work until a provider is available.', 'Continue local-only review or documentation work.'],
+  });
+}
+
+function summarizeOverallStatus(
+  providers: readonly DashboardProviderSnapshot[],
+  dependencies: readonly DashboardDependencySnapshot[],
+): DashboardDependencyStatus {
+  if (dependencies.length === 0) return 'unknown';
+
+  const nonProviderDependencies = dependencies.filter((dependency) => !dependency.type.startsWith('provider:'));
+  const allProvidersUnavailable = providers.length > 0 && providers.every((provider) => !provider.available);
+  const anyNonProviderUnavailable = nonProviderDependencies.some((dependency) => dependency.status === 'unavailable');
+
+  if (allProvidersUnavailable || anyNonProviderUnavailable) return 'unavailable';
+
+  const worst = dependencies.reduce<DashboardDependencyStatus>((current, dependency) => (
+    STATUS_RANK[dependency.status] > STATUS_RANK[current] ? dependency.status : current
+  ), 'healthy');
+
+  if (worst === 'unavailable') return 'degraded';
+  return worst;
+}
+
+export function buildDashboardAvailabilitySnapshot(
+  providers: readonly DashboardProviderSnapshot[],
+  dependencies: readonly DashboardDependencySnapshot[] = [],
+): DashboardAvailabilitySnapshot {
+  const providerDependencies = [...providers]
+    .sort((a, b) => a.failoverOrder - b.failoverOrder)
+    .map((provider) => providerToDependency(provider, providers));
+  const normalizedDependencies = dependencies.map(normalizeDependency);
+  const combined = [...providerDependencies, ...normalizedDependencies];
+
+  return {
+    status: summarizeOverallStatus(providers, combined),
+    dependencies: combined,
+  };
+}

--- a/packages/franken-orchestrator/src/http/routes/dashboard-status.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-status.ts
@@ -47,7 +47,9 @@ function providerToDependency(
   allProviders: readonly DashboardProviderSnapshot[],
 ): DashboardDependencySnapshot {
   const status: DashboardDependencyStatus = provider.available ? 'healthy' : 'unavailable';
-  const hasFailover = allProviders.some((candidate) => candidate.available && candidate.failoverOrder > provider.failoverOrder);
+  const hasAvailableAlternateProvider = allProviders.some((candidate) => (
+    candidate.name !== provider.name && candidate.available
+  ));
   const modelSuffix = provider.model ? ` using ${provider.model}` : '';
 
   return normalizeDependency({
@@ -62,8 +64,8 @@ function providerToDependency(
       : `Check ${provider.name} credentials, CLI installation, or upstream provider status.`,
     safeWork: provider.available
       ? ['Provider-backed work can use this provider.']
-      : hasFailover
-        ? ['Route provider-backed work to the next available failover provider.', 'Continue work that does not require this provider.']
+      : hasAvailableAlternateProvider
+        ? ['Route provider-backed work to another available provider.', 'Continue work that does not require this provider.']
         : ['Defer new provider-backed work until a provider is available.', 'Continue local-only review or documentation work.'],
   });
 }

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -123,7 +123,7 @@ describe('dashboard routes', () => {
             type: 'provider:claude-cli',
             status: 'unavailable',
             remediationHint: 'Check claude credentials, CLI installation, or upstream provider status.',
-            safeWork: ['Route provider-backed work to the next available failover provider.', 'Continue work that does not require this provider.'],
+            safeWork: ['Route provider-backed work to another available provider.', 'Continue work that does not require this provider.'],
           },
           {
             name: 'codex',
@@ -137,6 +137,33 @@ describe('dashboard routes', () => {
             summary: 'GitHub API is rate limited for issue enrichment.',
             remediationHint: 'Wait for the API reset or reduce polling.',
             safeWork: ['Continue code review on already-fetched PRs.'],
+          },
+        ],
+      });
+    });
+
+    it('routes provider-backed work to a healthy primary when a later fallback is unavailable', async () => {
+      const deps = createMockDeps();
+      deps.getProviders = vi.fn().mockReturnValue([
+        { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0, model: 'sonnet' },
+        { name: 'codex', type: 'codex-cli', available: false, failoverOrder: 1, model: 'gpt-5.3-codex-spark' },
+      ]);
+      const app = createDashboardRoutes(deps);
+      const res = await app.request('/');
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.availability).toMatchObject({
+        status: 'degraded',
+        dependencies: [
+          {
+            name: 'claude',
+            status: 'healthy',
+          },
+          {
+            name: 'codex',
+            status: 'unavailable',
+            safeWork: ['Route provider-backed work to another available provider.', 'Continue work that does not require this provider.'],
           },
         ],
       });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -79,6 +79,67 @@ describe('dashboard routes', () => {
       expect(body.providers).toEqual([
         { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
       ]);
+      expect(body.availability).toEqual({
+        status: 'healthy',
+        dependencies: [
+          {
+            name: 'claude',
+            type: 'provider:claude-cli',
+            status: 'healthy',
+            summary: 'claude is available for failover slot #1.',
+            remediationHint: 'No remediation needed.',
+            safeWork: ['Provider-backed work can use this provider.'],
+          },
+        ],
+      });
+    });
+
+    it('reports partial dependency outages with remediation and safe-work guidance', async () => {
+      const deps = createMockDeps();
+      deps.getProviders = vi.fn().mockReturnValue([
+        { name: 'claude', type: 'claude-cli', available: false, failoverOrder: 0, model: 'sonnet' },
+        { name: 'codex', type: 'codex-cli', available: true, failoverOrder: 1, model: 'gpt-5.3-codex-spark' },
+      ]);
+      deps.getDependencies = vi.fn().mockReturnValue([
+        {
+          name: 'github-api',
+          type: 'github',
+          status: 'degraded',
+          summary: 'GitHub API is rate limited for issue enrichment.',
+          remediationHint: 'Wait for the API reset or reduce polling.',
+          safeWork: ['Continue code review on already-fetched PRs.'],
+        },
+      ]);
+      const app = createDashboardRoutes(deps);
+      const res = await app.request('/');
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.availability).toMatchObject({
+        status: 'degraded',
+        dependencies: [
+          {
+            name: 'claude',
+            type: 'provider:claude-cli',
+            status: 'unavailable',
+            remediationHint: 'Check claude credentials, CLI installation, or upstream provider status.',
+            safeWork: ['Route provider-backed work to the next available failover provider.', 'Continue work that does not require this provider.'],
+          },
+          {
+            name: 'codex',
+            type: 'provider:codex-cli',
+            status: 'healthy',
+          },
+          {
+            name: 'github-api',
+            type: 'github',
+            status: 'degraded',
+            summary: 'GitHub API is rate limited for issue enrichment.',
+            remediationHint: 'Wait for the API reset or reduce polling.',
+            safeWork: ['Continue code review on already-fetched PRs.'],
+          },
+        ],
+      });
     });
 
     it('merges enabled field from getEnabledSkills', async () => {

--- a/packages/franken-web/src/components/availability/availability-panel.tsx
+++ b/packages/franken-web/src/components/availability/availability-panel.tsx
@@ -1,0 +1,78 @@
+import type { DashboardAvailability, DashboardDependency, DashboardDependencyStatus } from '../../lib/dashboard-api';
+
+interface AvailabilityPanelProps {
+  availability?: DashboardAvailability | undefined;
+}
+
+const STATUS_LABELS: Record<DashboardDependencyStatus, string> = {
+  healthy: 'Healthy',
+  degraded: 'Degraded',
+  unavailable: 'Unavailable',
+  unknown: 'Unknown',
+};
+
+const STATUS_BADGES: Record<DashboardDependencyStatus, string> = {
+  healthy: '[ok]',
+  degraded: '[degraded]',
+  unavailable: '[unavailable]',
+  unknown: '[unknown]',
+};
+
+function priority(status: DashboardDependencyStatus): number {
+  if (status === 'unavailable') return 0;
+  if (status === 'degraded') return 1;
+  if (status === 'unknown') return 2;
+  return 3;
+}
+
+function visibleDependencies(availability?: DashboardAvailability): DashboardDependency[] {
+  return [...(availability?.dependencies ?? [])].sort((a, b) => {
+    const priorityDelta = priority(a.status) - priority(b.status);
+    if (priorityDelta !== 0) return priorityDelta;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function AvailabilityPanel({ availability }: AvailabilityPanelProps) {
+  const dependencies = visibleDependencies(availability);
+
+  return (
+    <section className="availability-panel rail-card" aria-label="Dependency availability">
+      <h3>Dependency availability</h3>
+      <p>
+        Overall status:{' '}
+        <strong>{STATUS_LABELS[availability?.status ?? 'unknown']}</strong>
+      </p>
+      {dependencies.length === 0 ? (
+        <p>No dependency status reported.</p>
+      ) : (
+        <ul className="availability-panel__list">
+          {dependencies.map((dependency) => (
+            <li key={`${dependency.type}:${dependency.name}`} className="availability-panel__item">
+              <div>
+                <span className="availability-panel__status">{STATUS_BADGES[dependency.status]}</span>
+                {' '}
+                <strong>{dependency.name}</strong>
+                {' '}
+                <span className="availability-panel__type">{dependency.type}</span>
+              </div>
+              <p>{dependency.summary}</p>
+              <p>
+                <strong>Remediation:</strong>
+                {' '}
+                {dependency.remediationHint}
+              </p>
+              {dependency.safeWork.length > 0 && (
+                <p>
+                  <strong>Safe work:</strong>
+                  {' '}
+                  {dependency.safeWork.join(' ')}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -23,10 +23,27 @@ export interface DashboardProvider {
   model?: string;
 }
 
+export type DashboardDependencyStatus = 'healthy' | 'degraded' | 'unavailable' | 'unknown';
+
+export interface DashboardDependency {
+  name: string;
+  type: string;
+  status: DashboardDependencyStatus;
+  summary: string;
+  remediationHint: string;
+  safeWork: string[];
+}
+
+export interface DashboardAvailability {
+  status: DashboardDependencyStatus;
+  dependencies: DashboardDependency[];
+}
+
 export interface DashboardSnapshot {
   skills: DashboardSkill[];
   security: DashboardSecurity;
   providers: DashboardProvider[];
+  availability?: DashboardAvailability;
 }
 
 export class DashboardApiClient {

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -17,6 +17,35 @@ const snapshot: DashboardSnapshot = {
   providers: [
     { name: 'openai', type: 'llm', available: true, failoverOrder: 1 },
   ],
+  availability: {
+    status: 'degraded',
+    dependencies: [
+      {
+        name: 'openai',
+        type: 'provider:llm',
+        status: 'healthy',
+        summary: 'openai is available for failover slot #2.',
+        remediationHint: 'No remediation needed.',
+        safeWork: ['Provider-backed work can use this provider.'],
+      },
+      {
+        name: 'github-api',
+        type: 'github',
+        status: 'degraded',
+        summary: 'GitHub API is rate limited for issue enrichment.',
+        remediationHint: 'Wait for the API reset or reduce polling.',
+        safeWork: ['Continue code review on already-fetched PRs.'],
+      },
+      {
+        name: 'discord-webhook',
+        type: 'comms',
+        status: 'unavailable',
+        summary: 'Discord webhook delivery is unavailable.',
+        remediationHint: 'Verify the webhook URL and downstream Discord status.',
+        safeWork: ['Continue local implementation and tests.'],
+      },
+    ],
+  },
 };
 
 function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiClient {
@@ -44,6 +73,22 @@ describe('DashboardPage', () => {
   afterEach(() => {
     cleanup();
     useDashboardStore.getState().reset();
+  });
+
+  it('renders partial dependency outages with remediation and safe work guidance', async () => {
+    const client = mockClient();
+
+    render(<DashboardPage client={client} />);
+
+    expect(await screen.findByLabelText('Dependency availability')).toBeTruthy();
+    expect(screen.getByText(/Overall status:/).textContent).toContain('Degraded');
+    expect(screen.getByText('discord-webhook')).toBeTruthy();
+    expect(screen.getByText('[unavailable]')).toBeTruthy();
+    expect(screen.getByText('Discord webhook delivery is unavailable.')).toBeTruthy();
+    expect(screen.getByText(/Verify the webhook URL and downstream Discord status/)).toBeTruthy();
+    expect(screen.getByText(/Continue local implementation and tests/)).toBeTruthy();
+    expect(screen.getByText('github-api')).toBeTruthy();
+    expect(screen.getByText('[degraded]')).toBeTruthy();
   });
 
   it('shows a load failure with a retry action instead of hiding it in the console', async () => {

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -3,6 +3,7 @@ import { useDashboardStore } from '../stores/dashboard-store';
 import { SkillCatalogBrowser } from '../components/skills/skill-catalog-browser';
 import { SecurityPanel } from '../components/security/security-panel';
 import { ProviderPanel } from '../components/providers/provider-panel';
+import { AvailabilityPanel } from '../components/availability/availability-panel';
 import type { DashboardApiClient, DashboardSecurity, DashboardSnapshot } from '../lib/dashboard-api';
 
 interface DashboardPageProps {
@@ -29,6 +30,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     skills,
     security,
     providers,
+    availability,
     loading,
     setSnapshot,
     setSkillEnabled,
@@ -98,6 +100,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         skills: currentSnapshot.skills,
         security: confirmedSecurity,
         providers: currentSnapshot.providers,
+        availability: currentSnapshot.availability ?? undefined,
       });
     }
   }, [setSnapshot]);
@@ -111,6 +114,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
       skills: currentSnapshot.skills.map((skill) => (skill.name === name ? confirmedSkill : skill)),
       security: currentSnapshot.security ?? confirmedSnapshot.security,
       providers: currentSnapshot.providers,
+      availability: currentSnapshot.availability ?? undefined,
     });
   }, [setSnapshot]);
 
@@ -122,6 +126,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
       skills: currentSnapshot.skills,
       security: confirmedSecurity,
       providers: currentSnapshot.providers,
+      availability: currentSnapshot.availability ?? undefined,
     });
   }, [setSnapshot]);
 
@@ -356,6 +361,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
           />
         )}
         <ProviderPanel providers={providers} />
+        <AvailabilityPanel availability={availability ?? undefined} />
       </div>
     </div>
   );

--- a/packages/franken-web/src/stores/dashboard-store.ts
+++ b/packages/franken-web/src/stores/dashboard-store.ts
@@ -1,14 +1,15 @@
 import { create } from 'zustand';
-import type { DashboardSkill, DashboardSecurity, DashboardProvider } from '../lib/dashboard-api';
+import type { DashboardSkill, DashboardSecurity, DashboardProvider, DashboardAvailability } from '../lib/dashboard-api';
 
 interface DashboardStore {
   skills: DashboardSkill[];
   security: DashboardSecurity | null;
   providers: DashboardProvider[];
+  availability: DashboardAvailability | null;
   loading: boolean;
   error: string | null;
 
-  setSnapshot: (snapshot: { skills: DashboardSkill[]; security: DashboardSecurity; providers: DashboardProvider[] }) => void;
+  setSnapshot: (snapshot: { skills: DashboardSkill[]; security: DashboardSecurity; providers: DashboardProvider[]; availability?: DashboardAvailability | undefined }) => void;
   toggleSkill: (name: string) => void;
   setSkillEnabled: (name: string, enabled: boolean) => void;
   setSecurityProfile: (profile: string) => void;
@@ -21,6 +22,7 @@ const initialState = {
   skills: [] as DashboardSkill[],
   security: null as DashboardSecurity | null,
   providers: [] as DashboardProvider[],
+  availability: null as DashboardAvailability | null,
   loading: true,
   error: null as string | null,
 };
@@ -33,6 +35,7 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
       skills: snapshot.skills,
       security: snapshot.security,
       providers: snapshot.providers,
+      availability: snapshot.availability ?? null,
       loading: false,
       error: null,
     }),


### PR DESCRIPTION
## Summary
- adds a structured dashboard availability snapshot with provider/dependency status, remediation hints, and safe-work guidance
- surfaces partial outages in the web dashboard via a dependency availability panel
- extends dashboard route and UI coverage for multiple simultaneous degraded/unavailable dependencies

## Test Plan
- npm ci
- npm run test --workspace @franken/orchestrator -- tests/unit/http/dashboard-routes.test.ts
- npm run test --workspace @franken/web -- src/pages/dashboard-page.test.tsx
- npx eslint packages/franken-orchestrator/src/http/routes/dashboard-status.ts packages/franken-orchestrator/src/http/routes/dashboard-routes.ts packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts packages/franken-web/src/components/availability/availability-panel.tsx packages/franken-web/src/pages/dashboard-page.tsx packages/franken-web/src/pages/dashboard-page.test.tsx packages/franken-web/src/lib/dashboard-api.ts packages/franken-web/src/stores/dashboard-store.ts (warnings only: pre-existing dashboard-api any / dashboard-page unused _cleared)

## Notes
- Full package typecheck currently fails on pre-existing missing workspace declarations such as @franken/types/@franken/observer; no errors were reported for the changed dashboard files after filtering.

Closes #1750