### PR TITLE
test(orchestrator): cover cancellation stability

### DIFF
--- a/docs/runbooks/cancellation-signal-handling.md
+++ b/docs/runbooks/cancellation-signal-handling.md
@@ -1,0 +1,16 @@
+# Cancellation and signal-handling semantics
+
+Frankenbeast worker loops treat cancellation as a retryable, non-successful terminal path. A cancelled worker must not claim a promise tag as completed, append final assistant output to the managed chunk session, or leave a provider child process running.
+
+## Cancellation points
+
+- Setup: if the `AbortSignal` is already aborted before the provider process is spawned, the loop rejects with the abort reason and does not start a child process.
+- Provider/tool execution: if cancellation arrives while a CLI provider is running, the loop sends `SIGTERM` to the child. If the process does not exit, the normal escalation path sends `SIGKILL` after the grace period.
+- Waits: retry, backoff, quota, or approval-style waits use abort-aware sleeps. Cancelling the signal rejects the wait instead of silently resuming or starting another provider attempt.
+- Log write/iteration callbacks: if cancellation is observed after an iteration callback, the loop exits with the abort reason before persisting assistant iteration output or marking a promise-tagged iteration complete.
+
+## State expectations
+
+Cancelled runs should be reported as cancelled/aborted by their caller and retried or cleaned up by the owning scheduler. Existing setup metadata may remain so operators can diagnose the attempted work, but final output/session state must not make the cancelled iteration look successful.
+
+Temporary process resources are cleaned best-effort: child processes receive `SIGTERM`, then `SIGKILL` if needed, and abort listeners are removed when sleeps or provider executions settle.

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -19,6 +19,10 @@ function abortReasonError(reason?: unknown): Error {
   return error;
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 // ── Iteration progress display ──
 
 export function formatIterationProgress(opts: {
@@ -403,6 +407,10 @@ export class CliSkillExecutor {
         });
         this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: 'budget-exceeded' });
         throw budgetError;
+      }
+      if (isAbortError(err)) {
+        this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: String(err) });
+        throw err;
       }
       this.observer.endSpan(chunkSpan, { status: 'error', errorMessage: String(err) });
       throw new Error(

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -13,9 +13,12 @@ function formatNumber(n: number): string {
 }
 
 function abortReasonError(reason?: unknown): Error {
-  if (reason instanceof Error) return reason;
-  const error = new Error(reason === undefined ? 'MartinLoop aborted' : String(reason));
+  if (reason instanceof Error && reason.name === 'AbortError') return reason;
+  const error = new Error(reason instanceof Error ? reason.message : reason === undefined ? 'MartinLoop aborted' : String(reason));
   error.name = 'AbortError';
+  if (reason instanceof Error) {
+    error.cause = reason;
+  }
   return error;
 }
 

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -12,6 +12,13 @@ function formatNumber(n: number): string {
   return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
+function abortReasonError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason;
+  const error = new Error(reason === undefined ? 'MartinLoop aborted' : String(reason));
+  error.name = 'AbortError';
+  return error;
+}
+
 // ── Iteration progress display ──
 
 export function formatIterationProgress(opts: {
@@ -701,6 +708,12 @@ export class CliSkillExecutor {
     );
     this.observer.endSpan(iterSpan, { status: 'completed' }, this.observer.loopDetector);
 
+    config.martin?.onIteration?.(iteration, result);
+
+    if (wrappedConfig.abortSignal?.aborted) {
+      throw abortReasonError(wrappedConfig.abortSignal.reason);
+    }
+
     const committed = this.git.autoCommit(chunkId, executionStage, iteration);
     if (committed && checkpoint && taskId) {
       const commitHash = this.git.getCurrentHead();
@@ -715,7 +728,6 @@ export class CliSkillExecutor {
       throw new BudgetExceededError(currentCost, budgetResult.limitUsd);
     }
 
-    config.martin?.onIteration?.(iteration, result);
   }
 
   private checkStaleMate(options: {

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -48,7 +48,7 @@ function extractPromiseTags(output: string): string[] {
 
 function abortError(reason?: unknown): Error {
   if (reason instanceof Error) return reason;
-  const error = new Error('MartinLoop sleep aborted');
+  const error = new Error(reason === undefined ? 'MartinLoop sleep aborted' : String(reason));
   error.name = 'AbortError';
   return error;
 }
@@ -474,7 +474,7 @@ export class MartinLoop {
         result = await spawnIteration(config, resolved, renderedPrompt, sessionContinue);
       } catch (error) {
         if (config.abortSignal?.aborted) {
-          throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+          throw abortError(config.abortSignal.reason);
         }
         if (isAbortError(error)) {
           throw error;
@@ -497,7 +497,7 @@ export class MartinLoop {
         const msg = error instanceof Error ? error.message : String(error);
         config.onSpawnError?.(activeProvider, msg);
         if (config.abortSignal?.aborted) {
-          throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+          throw abortError(config.abortSignal.reason);
         }
         if (failure.kind === 'spawn_error') {
           iteration--;
@@ -568,7 +568,7 @@ export class MartinLoop {
       }
 
       if (config.abortSignal?.aborted) {
-        throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+        throw abortError(config.abortSignal.reason);
       }
 
       const durationMs = wallClockNow() - startTime;
@@ -631,7 +631,7 @@ export class MartinLoop {
       config.onIteration?.(iteration, iterResult);
 
       if (config.abortSignal?.aborted) {
-        throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+        throw abortError(config.abortSignal.reason);
       }
 
       chunkSession = await this.persistIterationSession({
@@ -643,6 +643,10 @@ export class MartinLoop {
         resolved,
         config,
       });
+
+      if (config.abortSignal?.aborted) {
+        throw abortError(config.abortSignal.reason);
+      }
 
       // Rate limit: provider fallback chain
       if (rateLimited) {

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -47,9 +47,12 @@ function extractPromiseTags(output: string): string[] {
 }
 
 function abortError(reason?: unknown): Error {
-  if (reason instanceof Error) return reason;
-  const error = new Error(reason === undefined ? 'MartinLoop sleep aborted' : String(reason));
+  if (reason instanceof Error && reason.name === 'AbortError') return reason;
+  const error = new Error(reason instanceof Error ? reason.message : reason === undefined ? 'MartinLoop sleep aborted' : String(reason));
   error.name = 'AbortError';
+  if (reason instanceof Error) {
+    error.cause = reason;
+  }
   return error;
 }
 
@@ -750,15 +753,41 @@ export class MartinLoop {
       };
     }
 
-    if (
+    const shouldCompact = Boolean(
       config.contextUsage &&
       config.snapshotStore &&
       config.compactor &&
-      nextSession.contextWindow.usageRatio >= nextSession.contextWindow.compactThreshold
-    ) {
+      nextSession.contextWindow.usageRatio >= nextSession.contextWindow.compactThreshold,
+    );
+
+    if (shouldCompact && config.snapshotStore && config.compactor) {
+      const previousSession = config.sessionStore?.load(
+        nextSession.planName,
+        nextSession.chunkId,
+        nextSession.taskId,
+      );
+      const restorePreviousSession = (): void => {
+        if (!config.sessionStore) return;
+        if (previousSession) {
+          config.sessionStore.save(previousSession);
+          return;
+        }
+        config.sessionStore.delete(nextSession.planName, nextSession.chunkId, nextSession.taskId);
+      };
+
       config.snapshotStore.writeSnapshot(nextSession, 'pre-compaction');
-      nextSession = await config.compactor.compact(nextSession);
+      config.sessionStore?.save(nextSession);
+      try {
+        nextSession = await config.compactor.compact(nextSession);
+      } catch (error) {
+        if (config.abortSignal?.aborted || isAbortError(error)) {
+          restorePreviousSession();
+          throw config.abortSignal?.aborted ? abortError(config.abortSignal.reason) : error;
+        }
+        throw error;
+      }
       if (config.abortSignal?.aborted) {
+        restorePreviousSession();
         throw abortError(config.abortSignal.reason);
       }
     }

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -46,7 +46,8 @@ function extractPromiseTags(output: string): string[] {
     .filter((tag): tag is string => Boolean(tag && tag.length > 0));
 }
 
-function abortError(): Error {
+function abortError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason;
   const error = new Error('MartinLoop sleep aborted');
   error.name = 'AbortError';
   return error;
@@ -63,14 +64,14 @@ export function sleepWithAbort(
   signal?: AbortSignal,
 ): Promise<void> {
   if (!signal) return sleepFn(ms);
-  if (signal.aborted) return Promise.reject(abortError());
+  if (signal.aborted) return Promise.reject(abortError(signal.reason));
 
   if (sleepFn === defaultSleep) {
     return new Promise((resolve, reject) => {
       const onAbort = (): void => {
         clearTimeout(timer);
         signal.removeEventListener('abort', onAbort);
-        reject(abortError());
+        reject(abortError(signal.reason));
       };
 
       const timer = setTimeout(() => {
@@ -85,7 +86,7 @@ export function sleepWithAbort(
   return new Promise((resolve, reject) => {
     const onAbort = (): void => {
       signal.removeEventListener('abort', onAbort);
-      reject(abortError());
+      reject(abortError(signal.reason));
     };
 
     signal.addEventListener('abort', onAbort, { once: true });
@@ -273,7 +274,7 @@ function spawnIteration(
 ): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean; cleanStdout: string }> {
   return new Promise((resolve, reject) => {
     if (config.abortSignal?.aborted) {
-      reject(abortError());
+      reject(abortError(config.abortSignal.reason));
       return;
     }
 
@@ -313,7 +314,7 @@ function spawnIteration(
       settled = true;
       config.abortSignal?.removeEventListener('abort', onAbort);
       if (aborted) {
-        reject(abortError());
+        reject(abortError(config.abortSignal?.reason));
         return;
       }
       resolve(result);
@@ -628,6 +629,10 @@ export class MartinLoop {
       pendingSleepMs = 0;
 
       config.onIteration?.(iteration, iterResult);
+
+      if (config.abortSignal?.aborted) {
+        throw config.abortSignal.reason instanceof Error ? config.abortSignal.reason : abortError();
+      }
 
       chunkSession = await this.persistIterationSession({
         chunkSession,

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -750,8 +750,6 @@ export class MartinLoop {
       };
     }
 
-    config.sessionStore?.save(nextSession);
-
     if (
       config.contextUsage &&
       config.snapshotStore &&
@@ -760,8 +758,16 @@ export class MartinLoop {
     ) {
       config.snapshotStore.writeSnapshot(nextSession, 'pre-compaction');
       nextSession = await config.compactor.compact(nextSession);
-      config.sessionStore?.save(nextSession);
+      if (config.abortSignal?.aborted) {
+        throw abortError(config.abortSignal.reason);
+      }
     }
+
+    if (config.abortSignal?.aborted) {
+      throw abortError(config.abortSignal.reason);
+    }
+
+    config.sessionStore?.save(nextSession);
 
     return nextSession;
   }

--- a/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
+++ b/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
@@ -10,7 +10,10 @@ import {
   makeLogger,
 } from '../helpers/stubs.js';
 import type { ICheckpointStore, SkillInput, SkillResult } from '../../src/deps.js';
-import type { CliSkillExecutor } from '../../src/skills/cli-skill-executor.js';
+import type { CliSkillExecutor, ObserverDeps } from '../../src/skills/cli-skill-executor.js';
+import type { MartinLoop } from '../../src/skills/martin-loop.js';
+import type { CliSkillConfig, MartinLoopConfig } from '../../src/skills/cli-types.js';
+import type { GitBranchIsolator } from '../../src/skills/git-branch-isolator.js';
 
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
@@ -487,6 +490,13 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
       costCalc: { totalCost: vi.fn().mockReturnValue(0) },
       breaker: { check: vi.fn().mockReturnValue({ tripped: false, limitUsd: 10, spendUsd: 0 }) },
       loopDetector: { check: vi.fn().mockReturnValue({ detected: false }) },
+      estimateContextWindow: vi.fn().mockReturnValue({
+        usedTokens: 0,
+        maxTokens: 1000,
+        usageRatio: 0,
+        threshold: 0.85,
+        shouldCompact: false,
+      }),
       startSpan: vi.fn().mockImplementation(() => ({ id: `span-${spanCount++}` })),
       endSpan: vi.fn(),
       recordTokenUsage: vi.fn(),
@@ -495,6 +505,45 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
   }
 
   const mockedExecFileSync = vi.mocked(execFileSync);
+
+  it('does not auto-commit an iteration when a Martin onIteration hook cancels', async () => {
+    const ac = new AbortController();
+    const git = makeMockGit();
+    const martin = {
+      run: vi.fn(async (config: MartinLoopConfig) => {
+        config.onIteration?.(1, {
+          iteration: 1,
+          provider: 'claude',
+          stdout: 'done\n<promise>IMPL_t1_DONE</promise>',
+          stderr: '',
+          durationMs: 10,
+          exitCode: 0,
+          rateLimited: false,
+          promiseDetected: true,
+          emittedPromiseTags: ['IMPL_t1_DONE'],
+          tokensEstimated: 1,
+          sleepMs: 0,
+        });
+        return { completed: true, iterations: 1, output: 'done', tokensUsed: 1 };
+      }),
+    };
+    const { CliSkillExecutor } = await import('../../src/skills/cli-skill-executor.js');
+    const executor = new CliSkillExecutor(
+      martin as unknown as MartinLoop,
+      git as unknown as GitBranchIsolator,
+      makeMockObserver() as ObserverDeps,
+    );
+
+    await expect(executor.execute(
+      't1',
+      { objective: 'do it', sessionId: 'sess-1' } as SkillInput,
+      { martin: { abortSignal: ac.signal, onIteration: () => ac.abort('operator cancelled') } } as unknown as Partial<CliSkillConfig>,
+      makeCheckpoint(),
+      'impl:t1',
+    )).rejects.toThrow('operator cancelled');
+
+    expect(git.autoCommit).not.toHaveBeenCalled();
+  });
 
   function mockVerifyPass(): void {
     mockedExecFileSync.mockImplementation(() => 'ok');

--- a/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
+++ b/packages/franken-orchestrator/tests/unit/execution-checkpoint.test.ts
@@ -534,13 +534,14 @@ describe('CliSkillExecutor.recoverDirtyFiles', () => {
       makeMockObserver() as ObserverDeps,
     );
 
+    const abortReason = new Error('operator cancelled');
     await expect(executor.execute(
       't1',
       { objective: 'do it', sessionId: 'sess-1' } as SkillInput,
-      { martin: { abortSignal: ac.signal, onIteration: () => ac.abort('operator cancelled') } } as unknown as Partial<CliSkillConfig>,
+      { martin: { abortSignal: ac.signal, onIteration: () => ac.abort(abortReason) } } as unknown as Partial<CliSkillConfig>,
       makeCheckpoint(),
       'impl:t1',
-    )).rejects.toThrow('operator cancelled');
+    )).rejects.toMatchObject({ name: 'AbortError', message: 'operator cancelled' });
 
     expect(git.autoCommit).not.toHaveBeenCalled();
   });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -816,13 +816,12 @@ describe('MartinLoop', () => {
     it('does not return completed when cancellation arrives during async session persistence', async () => {
       const root = mkdtempSync(join(tmpdir(), 'martin-compact-cancel-'));
       tmpDirs.push(root);
-      const sessionStore = new FileChunkSessionStore(root);
-      const snapshotStore = new FileChunkSessionSnapshotStore(root);
+      const sessionStore = new FileChunkSessionStore(join(root, 'sessions'));
+      const snapshotStore = new FileChunkSessionSnapshotStore(join(root, 'snapshots'));
       const ac = new AbortController();
-
-      queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
-
+      queueMock({ stdout: 'done\n<promise>IMPL_COMPACT_DONE</promise>', exitCode: 0 });
       const loop = new MartinLoop();
+
       await expect(loop.run(baseConfig({
         abortSignal: ac.signal,
         planName: 'compact-cancel-plan',
@@ -836,7 +835,7 @@ describe('MartinLoop', () => {
             ac.abort('compaction cancelled');
             return session;
           },
-        },
+        } as unknown as ChunkSessionCompactor,
         contextUsage: () => ({
           usedTokens: 900,
           maxTokens: 1000,
@@ -849,6 +848,40 @@ describe('MartinLoop', () => {
       const stored = sessionStore.load('compact-cancel-plan', 'compact_cancel');
       expect(stored?.transcript).toHaveLength(1);
       expect(stored?.transcript[0]?.kind).toBe('objective');
+    });
+
+    it('keeps pre-compaction iteration output when non-abort compaction fails', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'martin-compact-fail-'));
+      tmpDirs.push(root);
+      const sessionStore = new FileChunkSessionStore(join(root, 'sessions'));
+      const snapshotStore = new FileChunkSessionSnapshotStore(join(root, 'snapshots'));
+      queueMock({ stdout: 'done\n<promise>IMPL_COMPACT_FAIL_DONE</promise>', exitCode: 0 });
+      const loop = new MartinLoop();
+
+      await expect(loop.run(baseConfig({
+        planName: 'compact-fail-plan',
+        taskId: 'impl:compact_fail',
+        chunkId: 'compact_fail',
+        sessionStore,
+        snapshotStore,
+        renderer: new ChunkSessionRenderer(),
+        compactor: {
+          compact: async () => {
+            throw new Error('summarizer unavailable');
+          },
+        } as unknown as ChunkSessionCompactor,
+        contextUsage: () => ({
+          usedTokens: 900,
+          maxTokens: 1000,
+          usageRatio: 0.9,
+          threshold: 0.85,
+          shouldCompact: true,
+        }),
+      }))).rejects.toThrow('summarizer unavailable');
+
+      const stored = sessionStore.load('compact-fail-plan', 'compact_fail');
+      expect(stored?.transcript.map((entry) => entry.kind)).toEqual(['objective', 'assistant']);
+      expect(stored?.transcript[1]?.content).toContain('IMPL_COMPACT_FAIL_DONE');
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -735,4 +735,82 @@ describe('MartinLoop', () => {
     expect(secondPrompt).toContain('Chunk: 01_demo');
     expect(secondPrompt).toContain('Promise tag: IMPL_X_DONE');
   });
+
+  describe('cancellation and signal-handling stability (issue #1746)', () => {
+    it('cancels during setup before spawning a provider process', async () => {
+      const ac = new AbortController();
+      ac.abort(new Error('setup cancelled'));
+
+      const loop = new MartinLoop();
+      await expect(loop.run(baseConfig({ abortSignal: ac.signal }))).rejects.toThrow('setup cancelled');
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('cancels during provider tool execution with SIGTERM cleanup', async () => {
+      const ac = new AbortController();
+      const hangingChild = mockChild({ hang: true });
+      const killFn = hangingChild.kill as ReturnType<typeof vi.fn>;
+      killFn.mockImplementation((signal: string) => {
+        if (signal === 'SIGTERM') {
+          process.nextTick(() => hangingChild.emit('close', null));
+        }
+        return true;
+      });
+      mockSpawn.mockImplementationOnce(() => hangingChild);
+
+      const loop = new MartinLoop();
+      const runPromise = loop.run(baseConfig({ abortSignal: ac.signal }));
+      ac.abort(new Error('tool execution cancelled'));
+
+      await expect(runPromise).rejects.toThrow('tool execution cancelled');
+      expect(killFn).toHaveBeenCalledWith('SIGTERM');
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels cleanly while blocked in a retry/approval-style wait', async () => {
+      const ac = new AbortController();
+      const onSleep = vi.fn(() => ac.abort(new Error('wait cancelled')));
+      const sleepFn = vi.fn(() => new Promise<void>(() => undefined));
+
+      queueMock({ stderr: 'rate limit exceeded retry-after: 60', exitCode: 1 });
+
+      const loop = new MartinLoop();
+      await expect(loop.run(baseConfig({
+        abortSignal: ac.signal,
+        providers: ['claude'],
+        maxIterations: 1,
+        onSleep,
+        _sleepFn: sleepFn,
+      }))).rejects.toThrow('wait cancelled');
+
+      expect(onSleep).toHaveBeenCalledWith(60_000, 'claude parseRetryAfter');
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not mark work complete or append session output when cancelled during log write', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'martin-log-cancel-'));
+      tmpDirs.push(root);
+      const sessionStore = new FileChunkSessionStore(root);
+      const ac = new AbortController();
+
+      queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+      const loop = new MartinLoop();
+      await expect(loop.run(baseConfig({
+        abortSignal: ac.signal,
+        planName: 'cancel-plan',
+        taskId: 'impl:cancel_demo',
+        chunkId: 'cancel_demo',
+        sessionStore,
+        renderer: new ChunkSessionRenderer(),
+        onIteration: () => ac.abort(new Error('log write cancelled')),
+      }))).rejects.toThrow('log write cancelled');
+
+      const stored = sessionStore.load('cancel-plan', 'cancel_demo');
+      expect(stored?.transcript).toHaveLength(1);
+      expect(stored?.transcript[0]?.kind).toBe('objective');
+      expect(stored?.transcript.some((entry) => entry.kind === 'assistant')).toBe(false);
+    });
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -845,6 +845,10 @@ describe('MartinLoop', () => {
           shouldCompact: true,
         }),
       }))).rejects.toThrow('compaction cancelled');
+
+      const stored = sessionStore.load('compact-cancel-plan', 'compact_cancel');
+      expect(stored?.transcript).toHaveLength(1);
+      expect(stored?.transcript[0]?.kind).toBe('objective');
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -739,7 +739,7 @@ describe('MartinLoop', () => {
   describe('cancellation and signal-handling stability (issue #1746)', () => {
     it('cancels during setup before spawning a provider process', async () => {
       const ac = new AbortController();
-      ac.abort(new Error('setup cancelled'));
+      ac.abort('setup cancelled');
 
       const loop = new MartinLoop();
       await expect(loop.run(baseConfig({ abortSignal: ac.signal }))).rejects.toThrow('setup cancelled');
@@ -811,6 +811,40 @@ describe('MartinLoop', () => {
       expect(stored?.transcript).toHaveLength(1);
       expect(stored?.transcript[0]?.kind).toBe('objective');
       expect(stored?.transcript.some((entry) => entry.kind === 'assistant')).toBe(false);
+    });
+
+    it('does not return completed when cancellation arrives during async session persistence', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'martin-compact-cancel-'));
+      tmpDirs.push(root);
+      const sessionStore = new FileChunkSessionStore(root);
+      const snapshotStore = new FileChunkSessionSnapshotStore(root);
+      const ac = new AbortController();
+
+      queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+      const loop = new MartinLoop();
+      await expect(loop.run(baseConfig({
+        abortSignal: ac.signal,
+        planName: 'compact-cancel-plan',
+        taskId: 'impl:compact_cancel',
+        chunkId: 'compact_cancel',
+        sessionStore,
+        snapshotStore,
+        renderer: new ChunkSessionRenderer(),
+        compactor: {
+          compact: async (session) => {
+            ac.abort('compaction cancelled');
+            return session;
+          },
+        },
+        contextUsage: () => ({
+          usedTokens: 900,
+          maxTokens: 1000,
+          usageRatio: 0.9,
+          threshold: 0.85,
+          shouldCompact: true,
+        }),
+      }))).rejects.toThrow('compaction cancelled');
     });
   });
 });

--- a/tasks/resolve-issue-1746-progress.md
+++ b/tasks/resolve-issue-1746-progress.md
@@ -1,0 +1,9 @@
+# Resolve issue #1746 progress
+
+- [x] Read issue #1746 and shared lessons.
+- [x] Create isolated worktree on `resolve/issue-1746-test-stability-add-cancellation-and-signal-handl`.
+- [x] Add focused cancellation/signal-handling regression coverage.
+- [x] Document cancellation semantics.
+- [ ] Run targeted tests and package checks.
+- [ ] Commit, push, open PR, run CI and Codex gate.
+- [ ] Merge when green/current-head clean, then close out card.

--- a/tasks/resolve-issue-1746-progress.md
+++ b/tasks/resolve-issue-1746-progress.md
@@ -4,6 +4,6 @@
 - [x] Create isolated worktree on `resolve/issue-1746-test-stability-add-cancellation-and-signal-handl`.
 - [x] Add focused cancellation/signal-handling regression coverage.
 - [x] Document cancellation semantics.
-- [ ] Run targeted tests and package checks.
+- [x] Run targeted tests and package checks.
 - [ ] Commit, push, open PR, run CI and Codex gate.
 - [ ] Merge when green/current-head clean, then close out card.


### PR DESCRIPTION
## Summary
- preserve abort reasons through MartinLoop cancellation paths
- stop persisting/completing iteration output when cancellation arrives during iteration logging
- add regressions for setup, provider execution, wait, and log-write cancellation points
- document cancellation and signal-handling semantics

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/skills/martin-loop.test.ts tests/unit/skills/martin-loop-abort-listeners.test.ts
- npm run build
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint

Closes #1746