### PR TITLE
fix(orchestrator): add heartbeat monotonicity diagnostics

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -45,6 +45,7 @@ interface UpdateRunPatch {
   currentAttemptId?: string | null | undefined;
   attemptCount?: number | undefined;
   lastHeartbeatAt?: string | undefined;
+  heartbeatSource?: string | undefined;
   stopReason?: string | null | undefined;
   latestExitCode?: number | null | undefined;
 }
@@ -114,6 +115,7 @@ type BeastRunRow = {
   current_attempt_id: string | null;
   attempt_count: number;
   last_heartbeat_at: string | null;
+  last_heartbeat_sequence: number;
   stop_reason: string | null;
   latest_exit_code: number | null;
 };
@@ -297,6 +299,9 @@ export class SQLiteBeastRepository {
 
   updateRun(runId: string, patch: UpdateRunPatch): BeastRun {
     const current = this.getRunOrThrow(runId);
+    const heartbeatUpdated = patch.lastHeartbeatAt !== undefined;
+    const nextHeartbeatSequence = heartbeatUpdated ? (current.lastHeartbeatSequence ?? 0) + 1 : current.lastHeartbeatSequence;
+    const priorHeartbeatAt = current.lastHeartbeatAt;
     const next: BeastRun = {
       ...current,
       ...(patch.status !== undefined ? { status: patch.status } : {}),
@@ -317,7 +322,7 @@ export class SQLiteBeastRepository {
           : { currentAttemptId: patch.currentAttemptId }
         : {}),
       ...(patch.attemptCount !== undefined ? { attemptCount: patch.attemptCount } : {}),
-      ...(patch.lastHeartbeatAt !== undefined ? { lastHeartbeatAt: patch.lastHeartbeatAt } : {}),
+      ...(heartbeatUpdated ? { lastHeartbeatAt: patch.lastHeartbeatAt, lastHeartbeatSequence: nextHeartbeatSequence } : {}),
       ...(patch.stopReason !== undefined
         ? patch.stopReason === null
           ? { stopReason: undefined }
@@ -339,6 +344,7 @@ export class SQLiteBeastRepository {
              current_attempt_id = ?,
              attempt_count = ?,
              last_heartbeat_at = ?,
+             last_heartbeat_sequence = ?,
              stop_reason = ?,
              latest_exit_code = ?
        WHERE id = ?`,
@@ -350,10 +356,32 @@ export class SQLiteBeastRepository {
       next.currentAttemptId ?? null,
       next.attemptCount,
       next.lastHeartbeatAt ?? null,
+      next.lastHeartbeatSequence ?? 0,
       next.stopReason ?? null,
       next.latestExitCode ?? null,
       runId,
     );
+
+    if (patch.lastHeartbeatAt !== undefined && priorHeartbeatAt !== undefined) {
+      const newHeartbeatAt = patch.lastHeartbeatAt;
+      const priorMs = Date.parse(priorHeartbeatAt);
+      const nextMs = Date.parse(newHeartbeatAt);
+      if (Number.isFinite(priorMs) && Number.isFinite(nextMs) && nextMs <= priorMs) {
+        this.insertEvent(runId, {
+          type: 'run.heartbeat.anomaly',
+          payload: {
+            code: nextMs < priorMs ? 'regressive-heartbeat' : 'duplicate-heartbeat',
+            workerId: runId,
+            source: patch.heartbeatSource ?? 'unknown-source',
+            priorSequence: current.lastHeartbeatSequence ?? 0,
+            newSequence: next.lastHeartbeatSequence ?? 0,
+            priorHeartbeatAt,
+            newHeartbeatAt: patch.lastHeartbeatAt,
+          },
+          createdAt: patch.lastHeartbeatAt,
+        });
+      }
+    }
 
     return next;
   }
@@ -396,6 +424,10 @@ export class SQLiteBeastRepository {
   }
 
   appendEvent(runId: string, input: AppendEventInput): BeastRunEvent {
+    return this.insertEvent(runId, input);
+  }
+
+  private insertEvent(runId: string, input: AppendEventInput): BeastRunEvent {
     const sequence = nextEventSequence(this.db, runId);
     const event: BeastRunEvent = {
       id: prefixedId('event'),
@@ -666,6 +698,7 @@ export class SQLiteBeastRepository {
 
   private migrateLegacySchema(): void {
     this.ensureColumnExists('beast_runs', 'tracked_agent_id', 'ALTER TABLE beast_runs ADD COLUMN tracked_agent_id TEXT');
+    this.ensureColumnExists('beast_runs', 'last_heartbeat_sequence', 'ALTER TABLE beast_runs ADD COLUMN last_heartbeat_sequence INTEGER NOT NULL DEFAULT 0');
     this.ensureColumnExists('tracked_agents', 'module_config', 'ALTER TABLE tracked_agents ADD COLUMN module_config TEXT');
     this.ensureColumnExists('tracked_agents', 'execution_mode', 'ALTER TABLE tracked_agents ADD COLUMN execution_mode TEXT');
   }
@@ -779,6 +812,7 @@ function mapRun(row: BeastRunRow): BeastRun {
     ...(row.current_attempt_id ? { currentAttemptId: row.current_attempt_id } : {}),
     attemptCount: row.attempt_count,
     ...(row.last_heartbeat_at ? { lastHeartbeatAt: row.last_heartbeat_at } : {}),
+    ...(row.last_heartbeat_sequence > 0 ? { lastHeartbeatSequence: row.last_heartbeat_sequence } : {}),
     ...(row.stop_reason ? { stopReason: row.stop_reason } : {}),
     ...(row.latest_exit_code !== null ? { latestExitCode: row.latest_exit_code } : {}),
   };

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -15,6 +15,7 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     current_attempt_id TEXT,
     attempt_count INTEGER NOT NULL DEFAULT 0,
     last_heartbeat_at TEXT,
+    last_heartbeat_sequence INTEGER NOT NULL DEFAULT 0,
     stop_reason TEXT,
     latest_exit_code INTEGER,
     FOREIGN KEY (tracked_agent_id) REFERENCES tracked_agents(id)

--- a/packages/franken-orchestrator/src/beasts/types.ts
+++ b/packages/franken-orchestrator/src/beasts/types.ts
@@ -64,6 +64,7 @@ export interface BeastRun {
   readonly currentAttemptId?: string | undefined;
   readonly attemptCount: number;
   readonly lastHeartbeatAt?: string | undefined;
+  readonly lastHeartbeatSequence?: number | undefined;
   readonly stopReason?: string | undefined;
   readonly latestExitCode?: number | undefined;
 }

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -70,6 +70,7 @@ export type {
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
+  WorkerHeartbeatMonotonicityFinding,
   DuplicateWorkerCardProcessFinding,
 } from './issues/index.js';
 

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -32,6 +32,7 @@ export type {
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
+  WorkerHeartbeatMonotonicityFinding,
   DuplicateWorkerCardProcessFinding,
 } from './issue-runner.js';
 export { IssueReview } from './issue-review.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -624,13 +624,14 @@ function timestampDidNotAdvance(
 export function detectWorkerHeartbeatMonotonicityAnomalies(
   snapshots: readonly IssueWorkerCardProcessSnapshot[],
 ): WorkerHeartbeatMonotonicityFinding[] {
-  const priorByCard = new Map<string, IssueWorkerCardProcessSnapshot>();
+  const highWaterByRun = new Map<string, IssueWorkerCardProcessSnapshot>();
   const findings: WorkerHeartbeatMonotonicityFinding[] = [];
 
   for (const snapshot of snapshots) {
     if (!activeWorkerCardProcess(snapshot)) continue;
     const cardId = snapshot.cardId.trim();
-    const prior = priorByCard.get(cardId);
+    const baselineKey = `${cardId}\0${snapshot.runId ?? 'unknown-run'}`;
+    const prior = highWaterByRun.get(baselineKey);
     if (prior) {
       const priorHeartbeatAt = isoTimestamp(prior.lastHeartbeatAt);
       const newHeartbeatAt = isoTimestamp(snapshot.lastHeartbeatAt);
@@ -654,9 +655,10 @@ export function detectWorkerHeartbeatMonotonicityAnomalies(
           ...(newHeartbeatAt ? { newHeartbeatAt } : {}),
           message: `Worker card ${cardId} heartbeat ${code === 'regressive-heartbeat' ? 'regressed' : 'did not advance'}: prior sequence ${prior.heartbeatSequence ?? 'unknown'} at ${priorHeartbeatAt ?? 'unknown'}, new sequence ${snapshot.heartbeatSequence ?? 'unknown'} at ${newHeartbeatAt ?? 'unknown'} from ${source}`,
         });
+        continue;
       }
     }
-    priorByCard.set(cardId, snapshot);
+    highWaterByRun.set(baselineKey, snapshot);
   }
 
   return findings;

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -171,6 +171,23 @@ export interface IssueWorkerCardProcessSnapshot {
   readonly alive?: boolean | undefined;
   readonly startedAt?: string | number | Date | undefined;
   readonly lastHeartbeatAt?: string | number | Date | undefined;
+  /** Monotonic heartbeat sequence recorded by the heartbeat writer. */
+  readonly heartbeatSequence?: number | undefined;
+  /** Writer/reader source for diagnostics when heartbeat state is stale or regressive. */
+  readonly source?: string | undefined;
+}
+
+export interface WorkerHeartbeatMonotonicityFinding {
+  readonly cardId: string;
+  readonly runId?: string | undefined;
+  readonly source: string;
+  readonly severity: 'warning';
+  readonly code: 'duplicate-heartbeat' | 'regressive-heartbeat';
+  readonly priorSequence?: number | undefined;
+  readonly newSequence?: number | undefined;
+  readonly priorHeartbeatAt?: string | undefined;
+  readonly newHeartbeatAt?: string | undefined;
+  readonly message: string;
 }
 
 export interface DuplicateWorkerCardProcessFinding {
@@ -579,6 +596,70 @@ function maxIsoTimestamp(values: Iterable<string | number | Date | undefined>): 
     }
   }
   return maxIso;
+}
+
+function heartbeatSource(snapshot: IssueWorkerCardProcessSnapshot): string {
+  return snapshot.source?.trim() || snapshot.owner?.trim() || 'unknown-source';
+}
+
+function sequenceDidNotAdvance(
+  prior: number | undefined,
+  next: number | undefined,
+): boolean {
+  return prior !== undefined
+    && next !== undefined
+    && Number.isSafeInteger(prior)
+    && Number.isSafeInteger(next)
+    && next <= prior;
+}
+
+function timestampDidNotAdvance(
+  prior: string | undefined,
+  next: string | undefined,
+): boolean {
+  if (!prior || !next) return false;
+  return new Date(next).getTime() <= new Date(prior).getTime();
+}
+
+export function detectWorkerHeartbeatMonotonicityAnomalies(
+  snapshots: readonly IssueWorkerCardProcessSnapshot[],
+): WorkerHeartbeatMonotonicityFinding[] {
+  const priorByCard = new Map<string, IssueWorkerCardProcessSnapshot>();
+  const findings: WorkerHeartbeatMonotonicityFinding[] = [];
+
+  for (const snapshot of snapshots) {
+    if (!activeWorkerCardProcess(snapshot)) continue;
+    const cardId = snapshot.cardId.trim();
+    const prior = priorByCard.get(cardId);
+    if (prior) {
+      const priorHeartbeatAt = isoTimestamp(prior.lastHeartbeatAt);
+      const newHeartbeatAt = isoTimestamp(snapshot.lastHeartbeatAt);
+      const sequenceStale = sequenceDidNotAdvance(prior.heartbeatSequence, snapshot.heartbeatSequence);
+      const timestampStale = timestampDidNotAdvance(priorHeartbeatAt, newHeartbeatAt);
+
+      if (sequenceStale || timestampStale) {
+        const regressed = (snapshot.heartbeatSequence !== undefined && prior.heartbeatSequence !== undefined && snapshot.heartbeatSequence < prior.heartbeatSequence)
+          || (priorHeartbeatAt !== undefined && newHeartbeatAt !== undefined && new Date(newHeartbeatAt).getTime() < new Date(priorHeartbeatAt).getTime());
+        const code: WorkerHeartbeatMonotonicityFinding['code'] = regressed ? 'regressive-heartbeat' : 'duplicate-heartbeat';
+        const source = heartbeatSource(snapshot);
+        findings.push({
+          cardId,
+          ...(snapshot.runId ? { runId: snapshot.runId } : prior.runId ? { runId: prior.runId } : {}),
+          source,
+          severity: 'warning',
+          code,
+          ...(prior.heartbeatSequence !== undefined ? { priorSequence: prior.heartbeatSequence } : {}),
+          ...(snapshot.heartbeatSequence !== undefined ? { newSequence: snapshot.heartbeatSequence } : {}),
+          ...(priorHeartbeatAt ? { priorHeartbeatAt } : {}),
+          ...(newHeartbeatAt ? { newHeartbeatAt } : {}),
+          message: `Worker card ${cardId} heartbeat ${code === 'regressive-heartbeat' ? 'regressed' : 'did not advance'}: prior sequence ${prior.heartbeatSequence ?? 'unknown'} at ${priorHeartbeatAt ?? 'unknown'}, new sequence ${snapshot.heartbeatSequence ?? 'unknown'} at ${newHeartbeatAt ?? 'unknown'} from ${source}`,
+        });
+      }
+    }
+    priorByCard.set(cardId, snapshot);
+  }
+
+  return findings;
 }
 
 export function detectDuplicateWorkerCardProcesses(

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -217,6 +217,67 @@ describe('SQLiteBeastRepository', () => {
     expect(storedRun).not.toHaveProperty('currentAttemptId');
   });
 
+  it('increments heartbeat sequence and logs duplicate or regressive heartbeat writes', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const run = repo.createRun({
+      definitionId: 'heartbeat-worker',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { workerId: 't_worker_1' },
+      dispatchedBy: 'cli',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    const first = repo.updateRun(run.id, {
+      lastHeartbeatAt: '2026-03-10T00:01:00.000Z',
+      heartbeatSource: 'kanban-heartbeat-writer',
+    });
+    const duplicate = repo.updateRun(run.id, {
+      lastHeartbeatAt: '2026-03-10T00:01:00.000Z',
+      heartbeatSource: 'kanban-heartbeat-writer',
+    });
+    const regressive = repo.updateRun(run.id, {
+      lastHeartbeatAt: '2026-03-10T00:00:59.000Z',
+      heartbeatSource: 'kanban-heartbeat-writer',
+    });
+
+    expect(first.lastHeartbeatSequence).toBe(1);
+    expect(duplicate.lastHeartbeatSequence).toBe(2);
+    expect(regressive.lastHeartbeatSequence).toBe(3);
+    expect(repo.getRun(run.id)).toMatchObject({
+      lastHeartbeatAt: '2026-03-10T00:00:59.000Z',
+      lastHeartbeatSequence: 3,
+    });
+    expect(repo.listEvents(run.id).map(event => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: 'run.heartbeat.anomaly',
+        payload: {
+          code: 'duplicate-heartbeat',
+          workerId: run.id,
+          source: 'kanban-heartbeat-writer',
+          priorSequence: 1,
+          newSequence: 2,
+          priorHeartbeatAt: '2026-03-10T00:01:00.000Z',
+          newHeartbeatAt: '2026-03-10T00:01:00.000Z',
+        },
+      },
+      {
+        type: 'run.heartbeat.anomaly',
+        payload: {
+          code: 'regressive-heartbeat',
+          workerId: run.id,
+          source: 'kanban-heartbeat-writer',
+          priorSequence: 2,
+          newSequence: 3,
+          priorHeartbeatAt: '2026-03-10T00:01:00.000Z',
+          newHeartbeatAt: '2026-03-10T00:00:59.000Z',
+        },
+      },
+    ]);
+  });
+
   it('appends ordered run events and updates terminal status', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -321,6 +321,22 @@ describe('duplicate worker-card process detector', () => {
         lastHeartbeatAt: '2026-07-15T09:09:59.000Z',
       },
       {
+        cardId: 't_worker_1',
+        pid: 4201,
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 1,
+        lastHeartbeatAt: '2026-07-15T09:10:00.000Z',
+      },
+      {
+        cardId: 't_worker_1',
+        pid: 4202,
+        runId: 'run-12',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 1,
+        lastHeartbeatAt: '2026-07-15T09:10:01.000Z',
+      },
+      {
         cardId: 't_worker_2',
         pid: 4300,
         runId: 'run-11',
@@ -362,6 +378,18 @@ describe('duplicate worker-card process detector', () => {
         priorHeartbeatAt: '2026-07-15T09:10:00.000Z',
         newHeartbeatAt: '2026-07-15T09:09:59.000Z',
         message: 'Worker card t_worker_1 heartbeat regressed: prior sequence 1 at 2026-07-15T09:10:00.000Z, new sequence 0 at 2026-07-15T09:09:59.000Z from kanban-heartbeat-writer',
+      },
+      {
+        cardId: 't_worker_1',
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        severity: 'warning',
+        code: 'duplicate-heartbeat',
+        priorSequence: 1,
+        newSequence: 1,
+        priorHeartbeatAt: '2026-07-15T09:10:00.000Z',
+        newHeartbeatAt: '2026-07-15T09:10:00.000Z',
+        message: 'Worker card t_worker_1 heartbeat did not advance: prior sequence 1 at 2026-07-15T09:10:00.000Z, new sequence 1 at 2026-07-15T09:10:00.000Z from kanban-heartbeat-writer',
       },
     ]);
   });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -294,6 +294,78 @@ function makeIssueRuntimeSupport(): IssueRuntimeSupport {
 
 
 describe('duplicate worker-card process detector', () => {
+  it('detects duplicate and regressive heartbeat writes with worker diagnostics', () => {
+    const findings = detectWorkerHeartbeatMonotonicityAnomalies([
+      {
+        cardId: 't_worker_1',
+        pid: 4201,
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 1,
+        lastHeartbeatAt: '2026-07-15T09:10:00.000Z',
+      },
+      {
+        cardId: 't_worker_1',
+        pid: 4201,
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 1,
+        lastHeartbeatAt: '2026-07-15T09:10:00.000Z',
+      },
+      {
+        cardId: 't_worker_1',
+        pid: 4201,
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 0,
+        lastHeartbeatAt: '2026-07-15T09:09:59.000Z',
+      },
+      {
+        cardId: 't_worker_2',
+        pid: 4300,
+        runId: 'run-11',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 1,
+        lastHeartbeatAt: '2026-07-15T09:10:00.000Z',
+      },
+      {
+        cardId: 't_worker_2',
+        pid: 4300,
+        runId: 'run-11',
+        source: 'kanban-heartbeat-writer',
+        heartbeatSequence: 2,
+        lastHeartbeatAt: '2026-07-15T09:11:00.000Z',
+      },
+    ]);
+
+    expect(findings).toEqual([
+      {
+        cardId: 't_worker_1',
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        severity: 'warning',
+        code: 'duplicate-heartbeat',
+        priorSequence: 1,
+        newSequence: 1,
+        priorHeartbeatAt: '2026-07-15T09:10:00.000Z',
+        newHeartbeatAt: '2026-07-15T09:10:00.000Z',
+        message: 'Worker card t_worker_1 heartbeat did not advance: prior sequence 1 at 2026-07-15T09:10:00.000Z, new sequence 1 at 2026-07-15T09:10:00.000Z from kanban-heartbeat-writer',
+      },
+      {
+        cardId: 't_worker_1',
+        runId: 'run-10',
+        source: 'kanban-heartbeat-writer',
+        severity: 'warning',
+        code: 'regressive-heartbeat',
+        priorSequence: 1,
+        newSequence: 0,
+        priorHeartbeatAt: '2026-07-15T09:10:00.000Z',
+        newHeartbeatAt: '2026-07-15T09:09:59.000Z',
+        message: 'Worker card t_worker_1 heartbeat regressed: prior sequence 1 at 2026-07-15T09:10:00.000Z, new sequence 0 at 2026-07-15T09:09:59.000Z from kanban-heartbeat-writer',
+      },
+    ]);
+  });
+
   it('reports duplicate live process ownership for the same worker card with structured guidance', () => {
     const findings = detectDuplicateWorkerCardProcesses([
       {


### PR DESCRIPTION
## Summary
- add heartbeat sequence persistence to beast runs
- log duplicate/regressive heartbeat writes with prior/new sequence and source diagnostics
- add worker heartbeat monotonicity detection helper and focused tests

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts tests/unit/beasts/sqlite-beast-repository.test.ts
- npx eslint packages/franken-orchestrator/src/beasts/types.ts packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts packages/franken-orchestrator/src/issues/issue-runner.ts packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts

## Known verification note
- npm run typecheck --workspace @franken/orchestrator is blocked by existing unresolved @franken/* workspace package type declarations; no new sqlite-beast-repository.ts type errors remain after the fix.

Closes #1745