### PR TITLE
fix(orchestrator): clean abandoned beast worktrees

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -6,6 +6,7 @@ import { ContainerBeastExecutor } from './execution/container-beast-executor.js'
 import { DEFAULT_SANDBOX_POLICY, nonRootUserForWorkspace } from './execution/sandbox-policy.js';
 import { ProcessBeastExecutor } from './execution/process-beast-executor.js';
 import { ProcessSupervisor } from './execution/process-supervisor.js';
+import { cleanupAbandonedBeastWorktrees } from './execution/git-worktree-isolation.js';
 import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './services/beast-catalog-service.js';
 import { BeastDispatchService } from './services/beast-dispatch-service.js';
@@ -44,6 +45,13 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const eventBus = new BeastEventBus();
   const ticketStore = new SseConnectionTicketStore();
   const capacityPolicy = createCapacityReservationPolicyFromEnv();
+
+  cleanupAbandonedBeastWorktrees({
+    agents: repository.listTrackedAgents(),
+    dryRun: false,
+    projectRoot,
+    runs: repository.listRuns(),
+  });
 
   // Deferred reference to break circular dep: executor → runService → executors → executor
   // eslint-disable-next-line prefer-const

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -6,7 +6,6 @@ import { ContainerBeastExecutor } from './execution/container-beast-executor.js'
 import { DEFAULT_SANDBOX_POLICY, nonRootUserForWorkspace } from './execution/sandbox-policy.js';
 import { ProcessBeastExecutor } from './execution/process-beast-executor.js';
 import { ProcessSupervisor } from './execution/process-supervisor.js';
-import { cleanupAbandonedBeastWorktrees } from './execution/git-worktree-isolation.js';
 import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './services/beast-catalog-service.js';
 import { BeastDispatchService } from './services/beast-dispatch-service.js';
@@ -45,13 +44,6 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const eventBus = new BeastEventBus();
   const ticketStore = new SseConnectionTicketStore();
   const capacityPolicy = createCapacityReservationPolicyFromEnv();
-
-  cleanupAbandonedBeastWorktrees({
-    agents: repository.listTrackedAgents(),
-    dryRun: false,
-    projectRoot,
-    runs: repository.listRuns(),
-  });
 
   // Deferred reference to break circular dep: executor → runService → executors → executor
   // eslint-disable-next-line prefer-const

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
+import type { TrackedAgent } from '../agent-types.js';
+import type { BeastRun } from '../types.js';
 
 export type GitRunner = (args: readonly string[], cwd: string) => string;
 
@@ -23,8 +25,41 @@ export interface BeastWorktreeAllocation {
   readonly worktreePath: string;
 }
 
+export interface GitWorktreeRecord {
+  readonly path: string;
+  readonly branch?: string | undefined;
+}
+
+export type BeastWorktreeCleanupReason = 'agent-deleted' | 'no-active-run' | 'orphaned-worktree';
+
+export interface BeastWorktreeCleanupCandidate {
+  readonly agentId: string;
+  readonly branchName: string;
+  readonly lastActivityAt?: string | undefined;
+  readonly linkedCard?: string | undefined;
+  readonly linkedPr?: string | undefined;
+  readonly owner?: string | undefined;
+  readonly path: string;
+  readonly reason: BeastWorktreeCleanupReason;
+}
+
+export interface BeastWorktreeCleanupPlanInput {
+  readonly agents: readonly TrackedAgent[];
+  readonly branchPrefix?: string | undefined;
+  readonly projectRoot: string;
+  readonly runs: readonly BeastRun[];
+  readonly worktrees: readonly GitWorktreeRecord[];
+  readonly worktreesDir?: string | undefined;
+}
+
+export interface BeastWorktreeCleanupInput extends Omit<BeastWorktreeCleanupPlanInput, 'worktrees'> {
+  readonly dryRun?: boolean | undefined;
+  readonly runGit?: GitRunner | undefined;
+}
+
 const DEFAULT_WORKTREES_DIR = join('.frankenbeast', '.worktrees');
 const DEFAULT_BRANCH_PREFIX = 'beast/';
+const ACTIVE_RUN_STATUSES = new Set(['queued', 'interviewing', 'running', 'pending_approval']);
 
 function defaultRunGit(args: readonly string[], cwd: string): string {
   return execFileSync('git', [...args], {
@@ -41,6 +76,140 @@ function sanitizeAgentId(id: string): string {
 
 function branchExists(runGit: GitRunner, projectRoot: string, branchName: string): boolean {
   return runGit(['branch', '--list', branchName], projectRoot).length > 0;
+}
+
+function branchNameFromRef(ref: string): string {
+  return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+}
+
+export function parseGitWorktreePorcelain(output: string): GitWorktreeRecord[] {
+  const records: GitWorktreeRecord[] = [];
+  let current: { path?: string; branch?: string | undefined } = {};
+  const flush = () => {
+    if (current.path) {
+      records.push({ path: current.path, ...(current.branch ? { branch: current.branch } : {}) });
+    }
+    current = {};
+  };
+
+  for (const line of output.split(/\r?\n/)) {
+    if (line.length === 0) {
+      flush();
+      continue;
+    }
+    const [key, ...rest] = line.split(' ');
+    const value = rest.join(' ');
+    if (key === 'worktree') current.path = value;
+    if (key === 'branch') current.branch = branchNameFromRef(value);
+  }
+  flush();
+  return records;
+}
+
+function safeRelativePath(parent: string, child: string): string | undefined {
+  const relativePath = relative(resolve(parent), resolve(child));
+  return relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)
+    ? relativePath
+    : undefined;
+}
+
+function worktreeAgentId(worktreesRoot: string, worktreePath: string): string | undefined {
+  const relativePath = safeRelativePath(worktreesRoot, worktreePath);
+  if (!relativePath || relativePath.includes('/') || relativePath.includes('\\')) return undefined;
+  return relativePath;
+}
+
+function isActiveRun(run: BeastRun): boolean {
+  return ACTIVE_RUN_STATUSES.has(run.status);
+}
+
+function runActivityTime(run: BeastRun): string | undefined {
+  return run.lastHeartbeatAt ?? run.finishedAt ?? run.startedAt ?? run.createdAt;
+}
+
+function newestTime(values: readonly (string | undefined)[]): string | undefined {
+  return values.filter((value): value is string => value !== undefined).sort().at(-1);
+}
+
+function metadataString(metadata: Record<string, unknown> | undefined, keys: readonly string[]): string | undefined {
+  if (!metadata) return undefined;
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+export function planAbandonedBeastWorktreeCleanup(
+  input: BeastWorktreeCleanupPlanInput,
+): BeastWorktreeCleanupCandidate[] {
+  const branchPrefix = input.branchPrefix ?? DEFAULT_BRANCH_PREFIX;
+  const worktreesRoot = resolve(input.projectRoot, input.worktreesDir ?? DEFAULT_WORKTREES_DIR);
+  const agentsById = new Map(input.agents.map((agent) => [agent.id, agent]));
+  const runsByAgentId = new Map<string, BeastRun[]>();
+  for (const run of input.runs) {
+    if (!run.trackedAgentId) continue;
+    const runs = runsByAgentId.get(run.trackedAgentId) ?? [];
+    runs.push(run);
+    runsByAgentId.set(run.trackedAgentId, runs);
+  }
+  const activeRunAgentIds = new Set(
+    input.runs
+      .filter((run) => run.trackedAgentId && isActiveRun(run))
+      .map((run) => run.trackedAgentId as string),
+  );
+
+  return input.worktrees
+    .map((worktree): BeastWorktreeCleanupCandidate | undefined => {
+      if (!worktree.branch?.startsWith(branchPrefix)) return undefined;
+      const agentId = worktreeAgentId(worktreesRoot, worktree.path);
+      if (!agentId) return undefined;
+      const agent = agentsById.get(agentId);
+      const agentRuns = runsByAgentId.get(agentId) ?? [];
+      const lastActivityAt = newestTime(agentRuns.map(runActivityTime));
+      const latestRun = [...agentRuns].sort((left, right) => runActivityTime(right)?.localeCompare(runActivityTime(left) ?? '') ?? 0)[0];
+      const evidence = {
+        lastActivityAt,
+        linkedCard:
+          metadataString(latestRun?.configSnapshot, ['cardId', 'kanbanTaskId', 'taskId']) ??
+          metadataString(agent?.initConfig, ['cardId', 'kanbanTaskId', 'taskId']),
+        linkedPr:
+          metadataString(latestRun?.configSnapshot, ['pr', 'prNumber', 'pullRequest', 'pullRequestNumber']) ??
+          metadataString(agent?.initConfig, ['pr', 'prNumber', 'pullRequest', 'pullRequestNumber']),
+        owner: agent?.createdByUser ?? agentId,
+      };
+      if (!agent) {
+        return { agentId, branchName: worktree.branch, path: resolve(worktree.path), reason: 'orphaned-worktree', ...evidence };
+      }
+      if (agent.status === 'deleted') {
+        return { agentId, branchName: worktree.branch, path: resolve(worktree.path), reason: 'agent-deleted', ...evidence };
+      }
+      if (!activeRunAgentIds.has(agentId)) {
+        return { agentId, branchName: worktree.branch, path: resolve(worktree.path), reason: 'no-active-run', ...evidence };
+      }
+      return undefined;
+    })
+    .filter((candidate): candidate is BeastWorktreeCleanupCandidate => candidate !== undefined)
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function cleanupAbandonedBeastWorktrees(input: BeastWorktreeCleanupInput): BeastWorktreeCleanupCandidate[] {
+  const runGit = input.runGit ?? defaultRunGit;
+  if (!isGitRepository(runGit, input.projectRoot)) return [];
+  const worktrees = parseGitWorktreePorcelain(runGit(['worktree', 'list', '--porcelain'], input.projectRoot));
+  const plan = planAbandonedBeastWorktreeCleanup({ ...input, worktrees });
+
+  if (input.dryRun !== false) return plan;
+
+  for (const candidate of plan) {
+    runGit(['worktree', 'remove', '--force', candidate.path], input.projectRoot);
+    if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
+      runGit(['branch', '-D', candidate.branchName], input.projectRoot);
+    }
+  }
+
+  return plan;
 }
 
 function isGitRepository(runGit: GitRunner, projectRoot: string): boolean {

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -59,7 +59,6 @@ export interface BeastWorktreeCleanupInput extends Omit<BeastWorktreeCleanupPlan
 
 const DEFAULT_WORKTREES_DIR = join('.frankenbeast', '.worktrees');
 const DEFAULT_BRANCH_PREFIX = 'beast/';
-const ACTIVE_RUN_STATUSES = new Set(['queued', 'interviewing', 'running', 'pending_approval']);
 
 function defaultRunGit(args: readonly string[], cwd: string): string {
   return execFileSync('git', [...args], {
@@ -119,10 +118,6 @@ function worktreeAgentId(worktreesRoot: string, worktreePath: string): string | 
   return relativePath;
 }
 
-function isActiveRun(run: BeastRun): boolean {
-  return ACTIVE_RUN_STATUSES.has(run.status);
-}
-
 function runActivityTime(run: BeastRun): string | undefined {
   return run.lastHeartbeatAt ?? run.finishedAt ?? run.startedAt ?? run.createdAt;
 }
@@ -154,12 +149,6 @@ export function planAbandonedBeastWorktreeCleanup(
     runs.push(run);
     runsByAgentId.set(run.trackedAgentId, runs);
   }
-  const activeRunAgentIds = new Set(
-    input.runs
-      .filter((run) => run.trackedAgentId && isActiveRun(run))
-      .map((run) => run.trackedAgentId as string),
-  );
-
   return input.worktrees
     .map((worktree): BeastWorktreeCleanupCandidate | undefined => {
       if (!worktree.branch?.startsWith(branchPrefix)) return undefined;
@@ -184,9 +173,6 @@ export function planAbandonedBeastWorktreeCleanup(
       }
       if (agent.status === 'deleted') {
         return { agentId, branchName: worktree.branch, path: resolve(worktree.path), reason: 'agent-deleted', ...evidence };
-      }
-      if (!activeRunAgentIds.has(agentId)) {
-        return { agentId, branchName: worktree.branch, path: resolve(worktree.path), reason: 'no-active-run', ...evidence };
       }
       return undefined;
     })

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -59,6 +59,7 @@ export interface BeastWorktreeCleanupInput extends Omit<BeastWorktreeCleanupPlan
 
 const DEFAULT_WORKTREES_DIR = join('.frankenbeast', '.worktrees');
 const DEFAULT_BRANCH_PREFIX = 'beast/';
+const ACTIVE_RUN_STATUSES = new Set(['queued', 'interviewing', 'running', 'pending_approval']);
 
 function defaultRunGit(args: readonly string[], cwd: string): string {
   return execFileSync('git', [...args], {
@@ -118,6 +119,10 @@ function worktreeAgentId(worktreesRoot: string, worktreePath: string): string | 
   return relativePath;
 }
 
+function isActiveRun(run: BeastRun): boolean {
+  return ACTIVE_RUN_STATUSES.has(run.status);
+}
+
 function runActivityTime(run: BeastRun): string | undefined {
   return run.lastHeartbeatAt ?? run.finishedAt ?? run.startedAt ?? run.createdAt;
 }
@@ -149,12 +154,18 @@ export function planAbandonedBeastWorktreeCleanup(
     runs.push(run);
     runsByAgentId.set(run.trackedAgentId, runs);
   }
+  const activeRunAgentIds = new Set(
+    input.runs
+      .filter((run) => run.trackedAgentId && isActiveRun(run))
+      .map((run) => run.trackedAgentId as string),
+  );
   return input.worktrees
     .map((worktree): BeastWorktreeCleanupCandidate | undefined => {
       if (!worktree.branch?.startsWith(branchPrefix)) return undefined;
       const agentId = worktreeAgentId(worktreesRoot, worktree.path);
       if (!agentId) return undefined;
       const agent = agentsById.get(agentId);
+      if (activeRunAgentIds.has(agentId)) return undefined;
       const agentRuns = runsByAgentId.get(agentId) ?? [];
       const lastActivityAt = newestTime(agentRuns.map(runActivityTime));
       const latestRun = [...agentRuns].sort((left, right) => runActivityTime(right)?.localeCompare(runActivityTime(left) ?? '') ?? 0)[0];
@@ -188,14 +199,21 @@ export function cleanupAbandonedBeastWorktrees(input: BeastWorktreeCleanupInput)
 
   if (input.dryRun !== false) return plan;
 
+  const cleaned: BeastWorktreeCleanupCandidate[] = [];
   for (const candidate of plan) {
-    runGit(['worktree', 'remove', '--force', candidate.path], input.projectRoot);
-    if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
-      runGit(['branch', '-D', candidate.branchName], input.projectRoot);
+    try {
+      if (runGit(['status', '--porcelain'], candidate.path).length > 0) continue;
+      runGit(['worktree', 'remove', '--force', candidate.path], input.projectRoot);
+      if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
+        runGit(['branch', '-D', candidate.branchName], input.projectRoot);
+      }
+      cleaned.push(candidate);
+    } catch {
+      continue;
     }
   }
 
-  return plan;
+  return cleaned;
 }
 
 function isGitRepository(runGit: GitRunner, projectRoot: string): boolean {

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -26,6 +26,7 @@ export interface BeastWorktreeAllocation {
 }
 
 export interface GitWorktreeRecord {
+  readonly locked?: boolean | undefined;
   readonly path: string;
   readonly branch?: string | undefined;
 }
@@ -84,10 +85,14 @@ function branchNameFromRef(ref: string): string {
 
 export function parseGitWorktreePorcelain(output: string): GitWorktreeRecord[] {
   const records: GitWorktreeRecord[] = [];
-  let current: { path?: string; branch?: string | undefined } = {};
+  let current: { path?: string; branch?: string | undefined; locked?: boolean | undefined } = {};
   const flush = () => {
     if (current.path) {
-      records.push({ path: current.path, ...(current.branch ? { branch: current.branch } : {}) });
+      records.push({
+        path: current.path,
+        ...(current.branch ? { branch: current.branch } : {}),
+        ...(current.locked ? { locked: true } : {}),
+      });
     }
     current = {};
   };
@@ -101,6 +106,7 @@ export function parseGitWorktreePorcelain(output: string): GitWorktreeRecord[] {
     const value = rest.join(' ');
     if (key === 'worktree') current.path = value;
     if (key === 'branch') current.branch = branchNameFromRef(value);
+    if (key === 'locked') current.locked = true;
   }
   flush();
   return records;
@@ -162,8 +168,10 @@ export function planAbandonedBeastWorktreeCleanup(
   return input.worktrees
     .map((worktree): BeastWorktreeCleanupCandidate | undefined => {
       if (!worktree.branch?.startsWith(branchPrefix)) return undefined;
+      if (worktree.locked) return undefined;
       const agentId = worktreeAgentId(worktreesRoot, worktree.path);
       if (!agentId) return undefined;
+      if (worktree.branch !== `${branchPrefix}${agentId}`) return undefined;
       const agent = agentsById.get(agentId);
       if (activeRunAgentIds.has(agentId)) return undefined;
       const agentRuns = runsByAgentId.get(agentId) ?? [];
@@ -202,7 +210,7 @@ export function cleanupAbandonedBeastWorktrees(input: BeastWorktreeCleanupInput)
   const cleaned: BeastWorktreeCleanupCandidate[] = [];
   for (const candidate of plan) {
     try {
-      if (runGit(['status', '--porcelain'], candidate.path).length > 0) continue;
+      if (runGit(['status', '--porcelain', '--ignored'], candidate.path).length > 0) continue;
       runGit(['worktree', 'remove', '--force', candidate.path], input.projectRoot);
       if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
         runGit(['branch', '-D', candidate.branchName], input.projectRoot);

--- a/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/git-worktree-isolation.ts
@@ -210,10 +210,18 @@ export function cleanupAbandonedBeastWorktrees(input: BeastWorktreeCleanupInput)
   const cleaned: BeastWorktreeCleanupCandidate[] = [];
   for (const candidate of plan) {
     try {
-      if (runGit(['status', '--porcelain', '--ignored'], candidate.path).length > 0) continue;
-      runGit(['worktree', 'remove', '--force', candidate.path], input.projectRoot);
+      if (!existsSync(candidate.path)) {
+        runGit(['worktree', 'prune'], input.projectRoot);
+        if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
+          runGit(['branch', '-d', candidate.branchName], input.projectRoot);
+        }
+        cleaned.push(candidate);
+        continue;
+      }
+      if (runGit(['status', '--porcelain'], candidate.path).length > 0) continue;
+      runGit(['worktree', 'remove', candidate.path], input.projectRoot);
       if (branchExists(runGit, input.projectRoot, candidate.branchName)) {
-        runGit(['branch', '-D', candidate.branchName], input.projectRoot);
+        runGit(['branch', '-d', candidate.branchName], input.projectRoot);
       }
       cleaned.push(candidate);
     } catch {

--- a/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  cleanupAbandonedBeastWorktrees,
+  createBeastWorktree,
+  parseGitWorktreePorcelain,
+  planAbandonedBeastWorktreeCleanup,
+} from '../../../src/beasts/execution/git-worktree-isolation.js';
+import type { BeastRun } from '../../../src/beasts/types.js';
+import type { TrackedAgent } from '../../../src/beasts/agent-types.js';
+
+function trackedAgent(id: string, status: TrackedAgent['status'] = 'idle'): TrackedAgent {
+  return {
+    id,
+    definitionId: 'test-beast',
+    source: 'dashboard',
+    status,
+    createdByUser: 'pfk',
+    initAction: { kind: 'martin-loop', command: 'test', config: {} },
+    initConfig: {},
+    createdAt: '2026-03-10T00:00:00.000Z',
+    updatedAt: '2026-03-10T00:00:00.000Z',
+  };
+}
+
+function beastRun(input: Partial<BeastRun> & Pick<BeastRun, 'id' | 'status'>): BeastRun {
+  return {
+    definitionId: 'test-beast',
+    definitionVersion: 1,
+    executionMode: 'process',
+    configSnapshot: {},
+    dispatchedBy: 'dashboard',
+    dispatchedByUser: 'pfk',
+    createdAt: '2026-03-10T00:00:00.000Z',
+    attemptCount: 0,
+    ...input,
+  };
+}
+
+describe('git worktree isolation', () => {
+  it('creates an isolated worktree with a deterministic agent branch', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'franken-worktree-isolation-'));
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return projectRoot;
+      return '';
+    });
+
+    const allocation = createBeastWorktree({ enabled: true, projectRoot, runGit }, 'agent:one', projectRoot);
+
+    expect(allocation).toMatchObject({
+      agentId: 'agent-one',
+      branchName: 'beast/agent-one',
+      worktreePath: join(projectRoot, '.frankenbeast', '.worktrees', 'agent-one'),
+      created: true,
+      branchCreated: true,
+    });
+    expect(runGit).toHaveBeenCalledWith(
+      ['worktree', 'add', '-b', 'beast/agent-one', join(projectRoot, '.frankenbeast', '.worktrees', 'agent-one')],
+      projectRoot,
+    );
+  });
+
+  it('parses git worktree porcelain records with branch refs', () => {
+    expect(parseGitWorktreePorcelain([
+      'worktree /repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.frankenbeast/.worktrees/agent-a',
+      'HEAD def456',
+      'branch refs/heads/beast/agent-a',
+      '',
+      'worktree /repo/.frankenbeast/.worktrees/detached',
+      'detached',
+    ].join('\n'))).toEqual([
+      { path: '/repo', branch: 'main' },
+      { path: '/repo/.frankenbeast/.worktrees/agent-a', branch: 'beast/agent-a' },
+      { path: '/repo/.frankenbeast/.worktrees/detached' },
+    ]);
+  });
+
+  it('plans deterministic cleanup only for abandoned or orphaned beast worktrees', () => {
+    const projectRoot = '/repo';
+    const worktreesDir = '.frankenbeast/.worktrees';
+    const activeAgent = trackedAgent('agent-active', 'running');
+    const stoppedAgent = trackedAgent('agent-stopped', 'stopped');
+    const deletedAgent = trackedAgent('agent-deleted', 'deleted');
+    const runs = [
+      beastRun({ id: 'run-active', trackedAgentId: activeAgent.id, status: 'running' }),
+      beastRun({ id: 'run-stopped', trackedAgentId: stoppedAgent.id, status: 'stopped', finishedAt: '2026-03-10T00:01:00.000Z' }),
+      beastRun({ id: 'run-deleted', trackedAgentId: deletedAgent.id, status: 'failed', finishedAt: '2026-03-10T00:01:00.000Z' }),
+    ];
+    const worktrees = [
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', activeAgent.id), branch: `beast/${activeAgent.id}` },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', stoppedAgent.id), branch: `beast/${stoppedAgent.id}` },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', deletedAgent.id), branch: `beast/${deletedAgent.id}` },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', 'agent-orphan'), branch: 'beast/agent-orphan' },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', 'foreign'), branch: 'feature/foreign' },
+      { path: '/tmp/outside', branch: 'beast/outside' },
+    ];
+
+    const plan = planAbandonedBeastWorktreeCleanup({
+      agents: [activeAgent, stoppedAgent, deletedAgent],
+      branchPrefix: 'beast/',
+      projectRoot,
+      runs,
+      worktrees,
+      worktreesDir,
+    });
+
+    expect(plan.map((entry) => entry.agentId)).toEqual([deletedAgent.id, 'agent-orphan', stoppedAgent.id]);
+    expect(plan.map((entry) => entry.reason)).toEqual(['agent-deleted', 'orphaned-worktree', 'no-active-run']);
+    expect(plan.map((entry) => entry.branchName)).toEqual([
+      `beast/${deletedAgent.id}`,
+      'beast/agent-orphan',
+      `beast/${stoppedAgent.id}`,
+    ]);
+  });
+
+  it('keeps cleanup dry-run by default', () => {
+    const projectRoot = '/repo';
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return [
+          'worktree /repo/.frankenbeast/.worktrees/agent-z',
+          'HEAD abc',
+          'branch refs/heads/beast/agent-z',
+          '',
+        ].join('\n');
+      }
+      return '';
+    });
+
+    const cleaned = cleanupAbandonedBeastWorktrees({
+      agents: [],
+      branchPrefix: 'beast/',
+      projectRoot,
+      runGit,
+      runs: [],
+      worktreesDir: '.frankenbeast/.worktrees',
+    });
+
+    expect(cleaned).toHaveLength(1);
+    expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-z'], projectRoot);
+  });
+
+  it('executes the abandoned-worktree cleanup plan in sorted order and deletes owned branches', () => {
+    const projectRoot = '/repo';
+    const runGit = vi.fn((args: readonly string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return [
+          'worktree /repo/.frankenbeast/.worktrees/agent-z',
+          'branch refs/heads/beast/agent-z',
+          '',
+          'worktree /repo/.frankenbeast/.worktrees/agent-a',
+          'branch refs/heads/beast/agent-a',
+        ].join('\n');
+      }
+      if (args[0] === 'branch' && args[1] === '--list') return String(args[2] ?? '');
+      return '';
+    });
+
+    const result = cleanupAbandonedBeastWorktrees({
+      agents: [],
+      branchPrefix: 'beast/',
+      projectRoot,
+      runGit,
+      dryRun: false,
+      runs: [],
+      worktreesDir: '.frankenbeast/.worktrees',
+    });
+
+    expect(result.map((entry) => entry.agentId)).toEqual(['agent-a', 'agent-z']);
+    expect(runGit).toHaveBeenCalledWith(
+      ['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-a'],
+      projectRoot,
+    );
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-a'], projectRoot);
+    expect(runGit).toHaveBeenCalledWith(
+      ['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-z'],
+      projectRoot,
+    );
+    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-z'], projectRoot);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
@@ -111,13 +111,9 @@ describe('git worktree isolation', () => {
       worktreesDir,
     });
 
-    expect(plan.map((entry) => entry.agentId)).toEqual([deletedAgent.id, 'agent-orphan', stoppedAgent.id]);
-    expect(plan.map((entry) => entry.reason)).toEqual(['agent-deleted', 'orphaned-worktree', 'no-active-run']);
-    expect(plan.map((entry) => entry.branchName)).toEqual([
-      `beast/${deletedAgent.id}`,
-      'beast/agent-orphan',
-      `beast/${stoppedAgent.id}`,
-    ]);
+    expect(plan.map((entry) => entry.agentId)).toEqual([deletedAgent.id, 'agent-orphan']);
+    expect(plan.map((entry) => entry.reason)).toEqual(['agent-deleted', 'orphaned-worktree']);
+    expect(plan.map((entry) => entry.branchName)).toEqual([`beast/${deletedAgent.id}`, 'beast/agent-orphan']);
   });
 
   it('keeps cleanup dry-run by default', () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -176,25 +176,27 @@ describe('git worktree isolation', () => {
   });
 
   it('skips dirty or locked worktrees during destructive cleanup', () => {
-    const projectRoot = '/repo';
+    const projectRoot = mkdtempSync(join(tmpdir(), 'franken-cleanup-skip-'));
+    const dirtyPath = join(projectRoot, '.frankenbeast', '.worktrees', 'agent-dirty');
+    const lockedPath = join(projectRoot, '.frankenbeast', '.worktrees', 'agent-locked');
+    mkdirSync(dirtyPath, { recursive: true });
+    mkdirSync(lockedPath, { recursive: true });
     const runGit = vi.fn((args: readonly string[], cwd: string): string => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
       if (args[0] === 'worktree' && args[1] === 'list') {
         return [
-          'worktree /repo/.frankenbeast/.worktrees/agent-dirty',
+          `worktree ${dirtyPath}`,
           'HEAD abc',
           'branch refs/heads/beast/agent-dirty',
           '',
-          'worktree /repo/.frankenbeast/.worktrees/agent-locked',
+          `worktree ${lockedPath}`,
           'HEAD abc',
           'branch refs/heads/beast/agent-locked',
+          'locked because operator is inspecting it',
           '',
         ].join('\n');
       }
       if (args[0] === 'status') return cwd.endsWith('agent-dirty') ? ' M output.txt' : '';
-      if (args[0] === 'worktree' && args[1] === 'remove' && String(args[3]).endsWith('agent-locked')) {
-        throw new Error('locked');
-      }
       return '';
     });
 
@@ -214,15 +216,19 @@ describe('git worktree isolation', () => {
   });
 
   it('executes the abandoned-worktree cleanup plan in sorted order and deletes owned branches', () => {
-    const projectRoot = '/repo';
+    const projectRoot = mkdtempSync(join(tmpdir(), 'franken-cleanup-execute-'));
+    const agentAPath = join(projectRoot, '.frankenbeast', '.worktrees', 'agent-a');
+    const agentZPath = join(projectRoot, '.frankenbeast', '.worktrees', 'agent-z');
+    mkdirSync(agentAPath, { recursive: true });
+    mkdirSync(agentZPath, { recursive: true });
     const runGit = vi.fn((args: readonly string[]): string => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
       if (args[0] === 'worktree' && args[1] === 'list') {
         return [
-          'worktree /repo/.frankenbeast/.worktrees/agent-z',
+          `worktree ${agentZPath}`,
           'branch refs/heads/beast/agent-z',
           '',
-          'worktree /repo/.frankenbeast/.worktrees/agent-a',
+          `worktree ${agentAPath}`,
           'branch refs/heads/beast/agent-a',
         ].join('\n');
       }
@@ -241,15 +247,9 @@ describe('git worktree isolation', () => {
     });
 
     expect(result.map((entry) => entry.agentId)).toEqual(['agent-a', 'agent-z']);
-    expect(runGit).toHaveBeenCalledWith(
-      ['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-a'],
-      projectRoot,
-    );
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-a'], projectRoot);
-    expect(runGit).toHaveBeenCalledWith(
-      ['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-z'],
-      projectRoot,
-    );
-    expect(runGit).toHaveBeenCalledWith(['branch', '-D', 'beast/agent-z'], projectRoot);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', agentAPath], projectRoot);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-d', 'beast/agent-a'], projectRoot);
+    expect(runGit).toHaveBeenCalledWith(['worktree', 'remove', agentZPath], projectRoot);
+    expect(runGit).toHaveBeenCalledWith(['branch', '-d', 'beast/agent-z'], projectRoot);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
@@ -116,6 +116,29 @@ describe('git worktree isolation', () => {
     expect(plan.map((entry) => entry.branchName)).toEqual([`beast/${deletedAgent.id}`, 'beast/agent-orphan']);
   });
 
+  it('refuses deleted or missing-owner worktrees that still have active runs', () => {
+    const projectRoot = '/repo';
+    const worktreesDir = '/repo/.frankenbeast/.worktrees';
+    const deletedAgent = trackedAgent('agent-deleted', 'deleted');
+
+    const plan = planAbandonedBeastWorktreeCleanup({
+      agents: [deletedAgent],
+      branchPrefix: 'beast/',
+      projectRoot,
+      runs: [
+        beastRun({ id: 'run-deleted', status: 'running', trackedAgentId: deletedAgent.id }),
+        beastRun({ id: 'run-orphan', status: 'queued', trackedAgentId: 'agent-orphan' }),
+      ],
+      worktrees: [
+        { path: `${worktreesDir}/${deletedAgent.id}`, branch: `beast/${deletedAgent.id}` },
+        { path: `${worktreesDir}/agent-orphan`, branch: 'beast/agent-orphan' },
+      ],
+      worktreesDir,
+    });
+
+    expect(plan).toEqual([]);
+  });
+
   it('keeps cleanup dry-run by default', () => {
     const projectRoot = '/repo';
     const runGit = vi.fn((args: readonly string[]): string => {
@@ -142,6 +165,44 @@ describe('git worktree isolation', () => {
 
     expect(cleaned).toHaveLength(1);
     expect(runGit).not.toHaveBeenCalledWith(['worktree', 'remove', '--force', '/repo/.frankenbeast/.worktrees/agent-z'], projectRoot);
+  });
+
+  it('skips dirty or locked worktrees during destructive cleanup', () => {
+    const projectRoot = '/repo';
+    const runGit = vi.fn((args: readonly string[], cwd: string): string => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true';
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return [
+          'worktree /repo/.frankenbeast/.worktrees/agent-dirty',
+          'HEAD abc',
+          'branch refs/heads/beast/agent-dirty',
+          '',
+          'worktree /repo/.frankenbeast/.worktrees/agent-locked',
+          'HEAD abc',
+          'branch refs/heads/beast/agent-locked',
+          '',
+        ].join('\n');
+      }
+      if (args[0] === 'status') return cwd.endsWith('agent-dirty') ? ' M output.txt' : '';
+      if (args[0] === 'worktree' && args[1] === 'remove' && String(args[3]).endsWith('agent-locked')) {
+        throw new Error('locked');
+      }
+      return '';
+    });
+
+    const cleaned = cleanupAbandonedBeastWorktrees({
+      agents: [],
+      branchPrefix: 'beast/',
+      dryRun: false,
+      projectRoot,
+      runGit,
+      runs: [],
+      worktreesDir: '.frankenbeast/.worktrees',
+    });
+
+    expect(cleaned).toEqual([]);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', 'beast/agent-dirty'], projectRoot);
+    expect(runGit).not.toHaveBeenCalledWith(['branch', '-D', 'beast/agent-locked'], projectRoot);
   });
 
   it('executes the abandoned-worktree cleanup plan in sorted order and deletes owned branches', () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/git-worktree-isolation.test.ts
@@ -73,11 +73,17 @@ describe('git worktree isolation', () => {
       'HEAD def456',
       'branch refs/heads/beast/agent-a',
       '',
+      'worktree /repo/.frankenbeast/.worktrees/agent-locked',
+      'HEAD ghi789',
+      'branch refs/heads/beast/agent-locked',
+      'locked because operator is inspecting it',
+      '',
       'worktree /repo/.frankenbeast/.worktrees/detached',
       'detached',
     ].join('\n'))).toEqual([
       { path: '/repo', branch: 'main' },
       { path: '/repo/.frankenbeast/.worktrees/agent-a', branch: 'beast/agent-a' },
+      { path: '/repo/.frankenbeast/.worktrees/agent-locked', branch: 'beast/agent-locked', locked: true },
       { path: '/repo/.frankenbeast/.worktrees/detached' },
     ]);
   });
@@ -98,6 +104,8 @@ describe('git worktree isolation', () => {
       { path: join(projectRoot, '.frankenbeast', '.worktrees', stoppedAgent.id), branch: `beast/${stoppedAgent.id}` },
       { path: join(projectRoot, '.frankenbeast', '.worktrees', deletedAgent.id), branch: `beast/${deletedAgent.id}` },
       { path: join(projectRoot, '.frankenbeast', '.worktrees', 'agent-orphan'), branch: 'beast/agent-orphan' },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', 'agent-mismatch'), branch: 'beast/agent-other' },
+      { path: join(projectRoot, '.frankenbeast', '.worktrees', 'agent-locked'), branch: 'beast/agent-locked', locked: true },
       { path: join(projectRoot, '.frankenbeast', '.worktrees', 'foreign'), branch: 'feature/foreign' },
       { path: '/tmp/outside', branch: 'beast/outside' },
     ];

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -27,7 +27,7 @@
 - When verifying workspace package typechecks in a fresh worktree, build dependency packages (or run root `npm run build`) before package-local `tsc --noEmit`; otherwise unresolved workspace package declarations can look like feature regressions.
 
 ## 2026-07-15 — Beast process cleanup review fixes
-- For Beast worktree cleanup, scope candidates to the orchestrator-owned worktree root and branch prefix, then require no active queued/interviewing/running/pending-approval run before deletion; default scan APIs should be dry-run and return owner/activity/card/PR evidence for review.
+- For Beast worktree cleanup, scope candidates to the orchestrator-owned worktree root and branch prefix, then require a deleted tracked agent or missing agent owner before deletion; default scan APIs should be dry-run and return owner/activity/card/PR evidence for review.
 - For Beast cleanup paths, treat persisted process-group ownership as verified only when the stored start-time token matches the current `/proc` start time; missing or unreadable start times should fail closed to direct-PID signaling to avoid killing a PID-reused process group.
 - Keep cleanup ownership delegated through execution-mode wrappers: container executors must forward `cleanupPendingRun()` so queued container runs can be cancelled before an attempt exists.
 - CLI signal cleanup should register and unregister all handled signals symmetrically, and long-running `restart` commands should track the target run before awaiting restart so SIGINT/SIGHUP can clean up in-flight work.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -27,7 +27,7 @@
 - When verifying workspace package typechecks in a fresh worktree, build dependency packages (or run root `npm run build`) before package-local `tsc --noEmit`; otherwise unresolved workspace package declarations can look like feature regressions.
 
 ## 2026-07-15 — Beast process cleanup review fixes
-- For Beast worktree cleanup, scope candidates to the orchestrator-owned worktree root and branch prefix, then require a deleted tracked agent or missing agent owner before deletion; default scan APIs should be dry-run and return owner/activity/card/PR evidence for review.
+- For Beast worktree cleanup, scope candidates to the orchestrator-owned worktree root and branch prefix, then require a deleted tracked agent or missing agent owner before deletion; default scan APIs should be dry-run and return owner/activity/card/PR evidence for review. Even with explicit destructive cleanup, skip dirty, locked, or active-run worktrees rather than forcing data loss or aborting startup.
 - For Beast cleanup paths, treat persisted process-group ownership as verified only when the stored start-time token matches the current `/proc` start time; missing or unreadable start times should fail closed to direct-PID signaling to avoid killing a PID-reused process group.
 - Keep cleanup ownership delegated through execution-mode wrappers: container executors must forward `cleanupPendingRun()` so queued container runs can be cancelled before an attempt exists.
 - CLI signal cleanup should register and unregister all handled signals symmetrically, and long-running `restart` commands should track the target run before awaiting restart so SIGINT/SIGHUP can clean up in-flight work.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -27,6 +27,7 @@
 - When verifying workspace package typechecks in a fresh worktree, build dependency packages (or run root `npm run build`) before package-local `tsc --noEmit`; otherwise unresolved workspace package declarations can look like feature regressions.
 
 ## 2026-07-15 — Beast process cleanup review fixes
+- For Beast worktree cleanup, scope candidates to the orchestrator-owned worktree root and branch prefix, then require no active queued/interviewing/running/pending-approval run before deletion; default scan APIs should be dry-run and return owner/activity/card/PR evidence for review.
 - For Beast cleanup paths, treat persisted process-group ownership as verified only when the stored start-time token matches the current `/proc` start time; missing or unreadable start times should fail closed to direct-PID signaling to avoid killing a PID-reused process group.
 - Keep cleanup ownership delegated through execution-mode wrappers: container executors must forward `cleanupPendingRun()` so queued container runs can be cancelled before an attempt exists.
 - CLI signal cleanup should register and unregister all handled signals symmetrically, and long-running `restart` commands should track the target run before awaiting restart so SIGINT/SIGHUP can clean up in-flight work.


### PR DESCRIPTION
## Summary
- adds deterministic scanner/planner support for Beast-owned temporary worktrees
- protects active/ambiguous worktrees by requiring the orchestrator worktree root, Beast branch prefix, and absence of active runs before cleanup
- defaults cleanup API calls to dry-run while startup cleanup opts in explicitly and records owner/activity/card/PR evidence in candidates

## Test Plan
- npm --workspace @franken/orchestrator test -- tests/unit/beasts/git-worktree-isolation.test.ts
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/orchestrator test -- tests/unit/beasts/git-worktree-isolation.test.ts tests/unit/beasts/process-beast-executor.test.ts
- npm --workspace @franken/orchestrator run lint -- src/beasts/execution/git-worktree-isolation.ts src/beasts/create-beast-services.ts tests/unit/beasts/git-worktree-isolation.test.ts

Closes #1744
