### PR TITLE
docs(onboarding): add issue complexity rubric

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -142,6 +142,10 @@ Read the [agent role responsibility map](docs/onboarding/agent-role-responsibili
 
 Read the [coding-agent PR etiquette guide](docs/onboarding/coding-agent-pr-etiquette.md) before opening, updating, or merging agent-authored pull requests. It defines one-issue/one-PR scope, required PR body evidence, current-head CI/Codex expectations, negative cases that prevent duplicate work, and handoff fields for blocked PRs.
 
+## Issue complexity rubric
+
+Read the [issue complexity rubric](docs/onboarding/issue-complexity-rubric.md) before assigning, refilling, or taking an issue-worker card. It maps issue labels and acceptance criteria to six complexity/risk levels, allowed toolsets, model lanes, verification depth, and escalation triggers so low-risk fallback agents do not take high-risk implementation work.
+
 ## PM-swarm runtime glossary
 
 Read the [PM-swarm runtime glossary](docs/onboarding/pm-swarm-runtime-glossary.md) before interpreting PM-swarm Kanban comments, liveness reports, doctor treatment notes, or issue-worker handoffs. It defines the runtime vocabulary used to decode liveness, refill, Codex, approval-cop, and worker handoff terms without creating duplicate branches, worktrees, or PRs.

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -165,6 +165,7 @@ Most packages build with `tsc`; `franken-web` uses `tsc && vite build`.
 | `docs/PROGRESS.md` | PR-by-PR progress tracking, verified test counts, and Phase 8 CLI gap-closure work |
 | `docs/adr/` | ADRs covering monorepo structure, hex architecture, Hono, shared types, Beast Loop, circuit breakers, CLI execution, Approach C, pluggable CLI providers, multi-pass planning, chat dispatch, external comms, network operator control plane, tracked-agent init workflow, and ADR-036 sandboxed Beast execution |
 | `docs/guides/` | quickstart, run-dashboard-chat, deploy-beasts, add-llm-provider, wrap-external-agent, fix-github-issues |
+| `docs/onboarding/` | contributor onboarding, repository ownership, agent role map, issue complexity rubric, PM-swarm glossary, test-command decision tree |
 | `docs/plans/` | Design docs and implementation plans (MCP, beast-runner, approach-c, CLI E2E, pluggable providers, interview UX, etc.) |
 
 ## Secret Store

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -108,7 +108,7 @@ Resolves the GitHub `upstream` remote from the current fork checkout and uses th
 
 Before assigning or executing an issue, classify it with the [issue complexity rubric](../onboarding/issue-complexity-rubric.md). The rubric maps labels such as `docs`, `security`, `availability`, and priority tags to complexity/risk levels, allowed toolsets, recommended model lanes, verification depth, and escalation triggers.
 
-Use the rubric result in the review table and handoff so PMs can keep C0/C1 work in low-risk lanes while routing C3-C5 cross-package, security, disaster-recovery, or PM-swarm policy work to senior or PM-supervised lanes.
+Use the rubric result as separate PM handoff metadata or an issue comment alongside the CLI's existing review table. The current `frankenbeast issues` table still reports implementation complexity such as `one-shot` or `chunked`; the C0-C5 rubric is the assignment-risk overlay PMs use to keep C0/C1 work in low-risk lanes while routing C3-C5 cross-package, security, disaster-recovery, or PM-swarm policy work to senior or PM-supervised lanes.
 
 ## Review Flow
 

--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -104,6 +104,12 @@ Resolves the GitHub `upstream` remote from the current fork checkout and uses th
 | `--provider <name>` | CLI agent provider | claude |
 | `--providers <list>` | Fallback chain for rate limits | — |
 
+## Complexity routing
+
+Before assigning or executing an issue, classify it with the [issue complexity rubric](../onboarding/issue-complexity-rubric.md). The rubric maps labels such as `docs`, `security`, `availability`, and priority tags to complexity/risk levels, allowed toolsets, recommended model lanes, verification depth, and escalation triggers.
+
+Use the rubric result in the review table and handoff so PMs can keep C0/C1 work in low-risk lanes while routing C3-C5 cross-package, security, disaster-recovery, or PM-swarm policy work to senior or PM-supervised lanes.
+
 ## Review Flow
 
 After triage, you see a table:

--- a/docs/onboarding/issue-complexity-rubric.md
+++ b/docs/onboarding/issue-complexity-rubric.md
@@ -1,0 +1,71 @@
+# Issue complexity rubric for agent assignment
+
+Use this rubric when triaging GitHub issues, refilling PM-swarm lanes, or deciding whether a low-risk fallback agent may take a task. It complements the repository ownership manifest and agent role responsibility map: labels describe priority and topic, while this rubric describes execution risk, required tools, verification depth, and the agent/model lane that should own the work.
+
+## Fast assignment flow
+
+1. Read the issue title, labels, acceptance criteria, and linked files.
+2. Pick the highest matching complexity/risk level below. When two levels match, use the higher level.
+3. Match repository ownership entries for the likely touched paths.
+4. Assign only to a lane whose allowed toolsets and model capability cover the level.
+5. Include the chosen level, ownership entries, expected verification, and escalation triggers in the Kanban or PR handoff.
+
+## Complexity and risk levels
+
+| Level | Use when | Examples | Allowed toolsets | Recommended model lane | Verification depth | Escalate when |
+| --- | --- | --- | --- | --- | --- | --- |
+| C0 — Triage / no-code | The issue needs classification, duplicate checks, labeling, or a decision comment without repo mutations. | Duplicate issue closure; missing-acceptance-criteria triage; stale issue audit. | GitHub read-only, file read/search, Kanban comments. | Low-cost triage or fallback lane. | Live GitHub issue/PR search plus concise evidence comment. | Any code/doc change is needed, duplicate status is uncertain, or labels conflict with the body. |
+| C1 — Docs-only / low risk | The change is narrow prose, link, or onboarding guidance with no runtime behavior and deterministic doc verification. | Add a guide section; fix stale setup wording; update a README command. | File read/search/write, git, targeted docs tests, GitHub PR. | Low-risk docs lane; fallback agents are allowed if they can run checks and open PRs. | Targeted docs regression or markdown/content verifier; optional root docs test. | The doc describes future behavior not present in code, changes operator/security advice, or touches CI/workflow scripts. |
+| C2 — Localized implementation | The issue changes one package or one small workflow with clear acceptance criteria and bounded tests. | CLI flag validation; one route validation fix; a small UI state bug. | Repo file tools, package test/typecheck/build, GitHub PR, Codex gate. | Standard coding lane. | Failing/regression test first when practical, package-level test/typecheck/build. | More than one package boundary changes, public API shape changes, or package checks expose shared failures. |
+| C3 — Cross-package / integration | The issue spans multiple packages, shared schemas, runtime contracts, or a UI/backend flow. | Shared DTO migration; dashboard route plus orchestrator API; issue runner behavior plus docs. | Full repo search/edit, package and root tests, typecheck/build, CI review, GitHub PR/Codex. | Senior coding lane or PM-supervised issue worker. | Cross-package tests plus root or CI-equivalent checks that cover every owner surface. | Ownership is unclear, another active PR touches the same contract, or CI failure appears unrelated but blocks the PR. |
+| C4 — Security / data integrity / recovery | The issue can expose secrets, unsafe filesystem/process behavior, auth boundaries, durable state, backups, or disaster recovery paths. | Path containment, token redaction, approval/session integrity, backup encryption, restore rollback. | Security scan, targeted exploit/regression tests, package/root gates, GitHub PR/Codex, optional manual reviewer. | Security/high-capability lane only; fallback agents must not take implementation work. | Negative tests for abuse cases, typecheck/build, security-focused self-review, current-head Codex clean. | Secrets/PII could be exposed, destructive operations are possible, approval is denied, or a migration/rollback decision is needed. |
+| C5 — System / PM-swarm / release-critical | The issue affects orchestration policy, PM-swarm capacity, provider fallback, CI/release automation, migrations, or broad runtime availability. | Queue starvation, provider circuit breakers, release/deploy policy, multi-agent handoff quality, disaster-recovery workflows. | Full GitHub/Kanban state, repo-wide tests as feasible, CI/release checks, PM coordination, Codex gate, human approval for side effects. | Primary model / senior PM-supervised lane; split into child cards when separable. | Design note or structured handoff, broad verification plan, CI evidence, current-head Codex clean before merge. | Scope crosses unrelated owners, rollout could strand workers/users, provider limits block review, or human approval is required. |
+
+## Label-to-rubric mapping
+
+Labels are routing hints, not final authority. Always read the issue body and acceptance criteria before assignment.
+
+| Label signal | Default level | Routing note |
+| --- | --- | --- |
+| `docs`, `documentation`, `dx` | C1 | Promote to C2/C3 if the doc must be generated from code, alters scripts, or needs a new verifier. |
+| `test`, `ci` | C2 | Promote to C3/C5 when touching shared CI workflows, Turbo/root scripts, or release gates. |
+| `bug`, `fix` | C2 | Promote when the bug crosses packages, involves data loss, auth, process cleanup, or durable state. |
+| `feat` | C2 or C3 | Use C3+ when the feature adds a cross-package contract, UI/backend flow, or operator workflow. |
+| `security`, `vulnerability`, `auth`, `secrets` | C4 | Never route implementation to low-risk fallback lanes; require security-negative tests. |
+| `availability`, `stability`, `dr`, `memory`, `learning` | C3 by default | Promote to C4 for data integrity/recovery and to C5 for orchestration policy, PM-swarm, provider, or release-critical behavior. |
+| Priority labels (`P0`, `P1`, `P2`, etc.) | No direct level | Priority controls ordering; complexity controls lane assignment and verification depth. A P2 security issue can still be C4. |
+| `enriched` | No direct level | Treat it as a quality signal that acceptance criteria exist, not as a risk downgrade. |
+
+## Topic examples from the 2026-07-11 strategic issue set
+
+These examples show how to classify existing issues from each requested topic without broadening a worker beyond one issue.
+
+| Topic | Example issue | Suggested level | Why |
+| --- | --- | --- | --- |
+| Onboarding | #1733 — docs(onboarding): add issue complexity rubric for agent assignment | C1 | Documentation-only routing guide with a targeted docs verifier. |
+| Security | #1739 — Security: add per-lane network egress policy | C4 | Network policy can change safety boundaries and requires negative tests. |
+| Vulnerabilities | #1740 — Security: protect against regex denial-of-service in scanners and parsers | C4 | Abuse-case protection around parser/scanner behavior. |
+| Stability | #1745 — fix(stability): add heartbeat monotonicity checks | C3 | Runtime behavior and liveness semantics likely span worker/dispatcher state. |
+| Availability | #1750 — feat(availability): add partial dependency outage status in dashboard | C3 | Crosses runtime status and dashboard presentation. |
+| Disaster recovery | #1752 — feat(dr): add restore preview conflict detector | C4 | Restore planning touches durable state and must fail safely. |
+| Persistent memory for agents | #1758 — feat(memory): add project-scoped memory snapshots for worker handoff | C4 | Memory snapshots can carry sensitive or stale context and need ownership boundaries. |
+| Learning for agents | #1762 — feat(learning): add task-family clustering for repeated failures | C5 | Policy/learning behavior affects PM-swarm assignment and long-running automation. |
+
+## Fallback-lane guardrails
+
+- Low-risk fallback agents may take C0 and C1 work when the handoff includes exact files, checks, and PR/Codex expectations.
+- Low-risk fallback agents may plan C2 work but should not implement it unless a PM explicitly approves the lane and the package owner is clear.
+- Low-risk fallback agents must not implement C3–C5 work. They can only gather evidence, classify, or write a PM handoff.
+- If a fallback agent discovers that a task is higher than its lane, it should stop after a comment that names the evidence and recommended new level.
+
+## Handoff template
+
+```text
+Complexity level: C<0-5> — <name>
+Label basis: <labels inspected>
+Ownership entries: <repository ownership ids>
+Allowed lane: <fallback docs | standard coding | security | PM-supervised>
+Expected verification: <commands/checks>
+Escalation triggers: <specific triggers from the rubric>
+Duplicate-work guard: <issue/PR/worktree evidence>
+```

--- a/tests/docs-issue-1733.test.ts
+++ b/tests/docs-issue-1733.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readDoc(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+describe('issue #1733 issue complexity rubric docs', () => {
+  it('defines at least five routing levels with examples, toolsets, model lanes, and escalation triggers', () => {
+    const rubric = readDoc('docs/onboarding/issue-complexity-rubric.md');
+
+    const levelMatches = [...rubric.matchAll(/^\| C[0-5] — /gm)];
+    expect(levelMatches.length).toBeGreaterThanOrEqual(5);
+
+    expect(rubric).toContain('| Level | Use when | Examples | Allowed toolsets | Recommended model lane | Verification depth | Escalate when |');
+    expect(rubric).toContain('C0 — Triage / no-code');
+    expect(rubric).toContain('C5 — System / PM-swarm / release-critical');
+    expect(rubric).toContain('Low-risk fallback agents must not implement C3–C5 work.');
+  });
+
+  it('explains label mapping without treating priority as complexity', () => {
+    const rubric = readDoc('docs/onboarding/issue-complexity-rubric.md');
+
+    for (const label of ['docs', 'documentation', 'dx', 'security', 'availability', 'stability', 'dr', 'memory', 'learning']) {
+      expect(rubric).toContain(label);
+    }
+
+    expect(rubric).toContain('Priority labels (`P0`, `P1`, `P2`, etc.)');
+    expect(rubric).toContain('Priority controls ordering; complexity controls lane assignment and verification depth.');
+  });
+
+  it('classifies one existing issue from each strategic issue topic', () => {
+    const rubric = readDoc('docs/onboarding/issue-complexity-rubric.md');
+
+    for (const issue of ['#1733', '#1739', '#1740', '#1745', '#1750', '#1752', '#1758', '#1762']) {
+      expect(rubric).toContain(issue);
+    }
+
+    for (const topic of [
+      'Onboarding',
+      'Security',
+      'Vulnerabilities',
+      'Stability',
+      'Availability',
+      'Disaster recovery',
+      'Persistent memory for agents',
+      'Learning for agents',
+    ]) {
+      expect(rubric).toContain(`| ${topic} |`);
+    }
+  });
+
+  it('links the rubric from onboarding and issue workflow entrypoints', () => {
+    const onboarding = readDoc('ONBOARDING.md');
+    const rampUp = readDoc('docs/RAMP_UP.md');
+    const issueGuide = readDoc('docs/guides/fix-github-issues.md');
+
+    expect(onboarding).toContain('docs/onboarding/issue-complexity-rubric.md');
+    expect(rampUp).toContain('issue complexity rubric');
+    expect(issueGuide).toContain('../onboarding/issue-complexity-rubric.md');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `docs/onboarding/issue-complexity-rubric.md` with C0-C5 assignment levels, allowed toolsets, model lanes, verification depth, and escalation triggers.
- Maps issue labels and the 2026-07-11 strategic issue topics to routing levels, including onboarding, security, vulnerabilities, stability, availability, disaster recovery, persistent memory, and learning.
- Links the rubric from `ONBOARDING.md`, `docs/RAMP_UP.md`, and the GitHub issue workflow guide.

## Test Plan
- [x] `npm run test:root -- tests/docs-issue-1733.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint` (passes with existing warnings)

Closes #1733
