### PR TITLE
feat(learning): scope cross-agent lesson sharing

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -63,6 +63,11 @@ export type {
   LessonCritiqueChecklistItem,
   LessonCritiqueAgentFinding,
   LessonMultiAgentCritique,
+  LessonInjectionContext,
+  LessonScopeAuditEntry,
+  LessonScopeKind,
+  LessonScopeMetadata,
+  LessonScopeProvenance,
   CritiqueLesson,
   TokenSpend,
   EscalationRequest,
@@ -108,6 +113,7 @@ export {
   detectLessonContradictions,
   critiqueProposedLesson,
   isLessonApplicable,
+  updateLessonScope,
   quarantineLesson,
   quarantineLessonForRepeatedFailures,
   unquarantineLesson,
@@ -122,6 +128,7 @@ export type {
   RepeatedFailureQuarantineRequest,
   LessonUnquarantineRequest,
   LessonHumanFeedbackRequest,
+  LessonScopeReviewRequest,
 } from './memory/lesson-recorder.js';
 
 // Evaluators

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -450,20 +450,17 @@ export function updateLessonScope(
     toScope: scope,
     reason,
   };
+  const allowedRepos = request.allowedRepos ?? lesson.lessonScope?.allowedRepos;
+  const allowedRoles = request.allowedRoles ?? lesson.lessonScope?.allowedRoles;
+  const allowedProfiles =
+    request.allowedProfiles ?? lesson.lessonScope?.allowedProfiles;
+  const allowedTasks = request.allowedTasks ?? lesson.lessonScope?.allowedTasks;
   const lessonScope = createLessonScopeMetadata({
     scope,
-    ...(request.allowedRepos !== undefined
-      ? { allowedRepos: request.allowedRepos }
-      : {}),
-    ...(request.allowedRoles !== undefined
-      ? { allowedRoles: request.allowedRoles }
-      : {}),
-    ...(request.allowedProfiles !== undefined
-      ? { allowedProfiles: request.allowedProfiles }
-      : {}),
-    ...(request.allowedTasks !== undefined
-      ? { allowedTasks: request.allowedTasks }
-      : {}),
+    ...(allowedRepos !== undefined ? { allowedRepos } : {}),
+    ...(allowedRoles !== undefined ? { allowedRoles } : {}),
+    ...(allowedProfiles !== undefined ? { allowedProfiles } : {}),
+    ...(allowedTasks !== undefined ? { allowedTasks } : {}),
     provenance: request.provenance ??
       lesson.lessonScope?.provenance ?? {
         source: 'human-review',
@@ -1205,9 +1202,12 @@ export class LessonRecorder {
         createLessonSearchQuery(lesson),
         10,
       );
+      const applicablePriorLessons = priorLessons.filter((priorLesson) =>
+        isLessonApplicable(priorLesson, { taskId: lesson.taskId }),
+      );
       return {
-        report: detectLessonContradictions(lesson, priorLessons),
-        priorLessons,
+        report: detectLessonContradictions(lesson, applicablePriorLessons),
+        priorLessons: applicablePriorLessons,
       };
     } catch {
       return {
@@ -1263,6 +1263,7 @@ export class LessonRecorder {
         const cooldownBaseMs = Date.parse(recordedAt);
         this.pruneExpiredCooldowns(cooldownBaseMs);
         const cooldownKey = createCooldownKey(
+          taskId,
           evalResult.evaluatorName,
           findingMessages,
         );
@@ -1851,9 +1852,15 @@ function isLessonScopeAllowed(
   if (isEmptyLessonInjectionContext(context)) {
     return false;
   }
-  const nowMs = Date.parse(context.now ?? new Date().toISOString());
-  if (scope.expiresAt !== undefined && Date.parse(scope.expiresAt) <= nowMs) {
+  const nowMs = parseScopeTimestamp(context.now ?? new Date().toISOString());
+  if (nowMs === undefined) {
     return false;
+  }
+  if (scope.expiresAt !== undefined) {
+    const expiresAtMs = parseScopeTimestamp(scope.expiresAt);
+    if (expiresAtMs === undefined || expiresAtMs <= nowMs) {
+      return false;
+    }
   }
   if (!matchesOptionalAllowlist(scope.allowedRepos, context.repo)) {
     return false;
@@ -1862,6 +1869,9 @@ function isLessonScopeAllowed(
     return false;
   }
   if (!matchesOptionalAllowlist(scope.allowedProfiles, context.profile)) {
+    return false;
+  }
+  if (!matchesOptionalAllowlist(scope.allowedTasks, context.taskId)) {
     return false;
   }
   if (scope.scope === 'global') {
@@ -1877,6 +1887,11 @@ function isLessonScopeAllowed(
     return matchesRequiredAllowlist(scope.allowedProfiles, context.profile);
   }
   return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
+}
+
+function parseScopeTimestamp(timestamp: string): number | undefined {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function isEmptyLessonInjectionContext(
@@ -2824,15 +2839,18 @@ function createLessonId(
 }
 
 function createCooldownKey(
+  taskId: TaskId,
   evaluatorName: string,
   findingMessages: readonly string[],
 ): string {
   const normalizedFindings = JSON.stringify({
+    taskId,
     evaluatorName,
     findings: findingMessages.map((message) => message.trim()).sort(),
   });
   return [
     'critique-lesson',
+    sanitizeLessonIdPart(taskId),
     sanitizeLessonIdPart(evaluatorName),
     stableHash(normalizedFindings),
   ].join(':');

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1979,13 +1979,24 @@ function hasValidScopeAuditTrail(
   scope: LessonScopeMetadata,
   currentScope: LessonScopeKind,
 ): boolean {
-  return scope.auditTrail.some(
-    (entry) =>
-      parseScopeTimestamp(entry.changedAt) !== undefined &&
-      entry.toScope === currentScope &&
-      entry.actor.trim().length > 0 &&
-      entry.reason.trim().length > 0,
-  );
+  if (!Array.isArray(scope.auditTrail)) {
+    return false;
+  }
+  return scope.auditTrail.some((entry) => {
+    if (entry === null || typeof entry !== 'object') {
+      return false;
+    }
+    const candidate = entry as Partial<LessonScopeAuditEntry>;
+    return (
+      typeof candidate.changedAt === 'string' &&
+      parseScopeTimestamp(candidate.changedAt) !== undefined &&
+      candidate.toScope === currentScope &&
+      typeof candidate.actor === 'string' &&
+      candidate.actor.trim().length > 0 &&
+      typeof candidate.reason === 'string' &&
+      candidate.reason.trim().length > 0
+    );
+  });
 }
 
 function parseScopeTimestamp(timestamp: string): number | undefined {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -25,6 +25,11 @@ import type {
   LessonMultiAgentCritique,
   FailureRecordMetadata,
   FailureCluster,
+  LessonInjectionContext,
+  LessonScopeAuditEntry,
+  LessonScopeKind,
+  LessonScopeMetadata,
+  LessonScopeProvenance,
 } from '../types/contracts.js';
 import type { CritiqueLoopResult, CritiqueIteration } from '../types/loop.js';
 import type { TaskId } from '../types/common.js';
@@ -84,6 +89,8 @@ const LESSON_CRITIQUE_NEEDS_EDIT_GUIDANCE =
   'Lesson candidate needs edits or additional evidence before promotion; keep it out of durable guidance until the findings are addressed.';
 const LESSON_CRITIQUE_REJECT_GUIDANCE =
   'Lesson candidate was rejected by critique and should not be promoted to durable guidance.';
+const LESSON_SCOPE_REVIEW_GUIDANCE =
+  'Reviewers may promote or demote lesson scope only with an audit entry; injection must deny lessons whose scope does not match the current repo, role, profile, task, or expiry.';
 
 interface InternalLessonPrivacyRedaction extends LessonPrivacyRedaction {
   readonly original: string;
@@ -413,6 +420,67 @@ export interface LessonHumanFeedbackRequest {
   readonly revisedCorrectionApplied?: string;
 }
 
+export interface LessonScopeReviewRequest {
+  readonly scope: LessonScopeKind;
+  readonly allowedRepos?: readonly string[];
+  readonly allowedRoles?: readonly string[];
+  readonly allowedProfiles?: readonly string[];
+  readonly allowedTasks?: readonly TaskId[];
+  readonly provenance?: LessonScopeProvenance;
+  readonly expiresAt?: string;
+  readonly actor: string;
+  readonly reason: string;
+  readonly changedAt: string;
+}
+
+export function updateLessonScope(
+  lesson: CritiqueLesson,
+  request: LessonScopeReviewRequest,
+): CritiqueLesson {
+  const changedAt = normalizeTimestamp(request.changedAt);
+  const actor = requireNonEmptyString(request.actor, 'scope reviewer actor');
+  const reason = requireNonEmptyString(request.reason, 'scope review reason');
+  const scope = normalizeLessonScopeKind(request.scope);
+  const auditEntry: LessonScopeAuditEntry = {
+    changedAt,
+    actor,
+    ...(lesson.lessonScope?.scope !== undefined
+      ? { fromScope: lesson.lessonScope.scope }
+      : {}),
+    toScope: scope,
+    reason,
+  };
+  const lessonScope = createLessonScopeMetadata({
+    scope,
+    ...(request.allowedRepos !== undefined
+      ? { allowedRepos: request.allowedRepos }
+      : {}),
+    ...(request.allowedRoles !== undefined
+      ? { allowedRoles: request.allowedRoles }
+      : {}),
+    ...(request.allowedProfiles !== undefined
+      ? { allowedProfiles: request.allowedProfiles }
+      : {}),
+    ...(request.allowedTasks !== undefined
+      ? { allowedTasks: request.allowedTasks }
+      : {}),
+    provenance: request.provenance ??
+      lesson.lessonScope?.provenance ?? {
+        source: 'human-review',
+        taskId: lesson.taskId,
+        note: LESSON_SCOPE_REVIEW_GUIDANCE,
+      },
+    ...(request.expiresAt !== undefined
+      ? { expiresAt: request.expiresAt }
+      : {}),
+    auditTrail: [...(lesson.lessonScope?.auditTrail ?? []), auditEntry],
+  });
+  return {
+    ...lesson,
+    lessonScope,
+  };
+}
+
 export function applyHumanFeedbackToLesson(
   lesson: CritiqueLesson,
   request: LessonHumanFeedbackRequest,
@@ -570,16 +638,23 @@ function isManualReviewResolvableCritiqueFinding(
   );
 }
 
-export function isLessonApplicable(lesson: CritiqueLesson): boolean {
+export function isLessonApplicable(
+  lesson: CritiqueLesson,
+  context: LessonInjectionContext = {},
+): boolean {
   if (lesson.quarantine !== undefined) {
     return false;
   }
   if (lesson.experimentSandbox?.promotionBlocked === true) {
     return false;
   }
-  return (
-    lesson.lifecycleStatus === undefined || lesson.lifecycleStatus === 'active'
-  );
+  if (
+    lesson.lifecycleStatus !== undefined &&
+    lesson.lifecycleStatus !== 'active'
+  ) {
+    return false;
+  }
+  return isLessonScopeAllowed(lesson.lessonScope, context);
 }
 
 function isLessonComparableForDuplicate(lesson: CritiqueLesson): boolean {
@@ -613,8 +688,12 @@ export function critiqueProposedLesson(
       severity: 'critical',
       message:
         'Privacy filter rejected this lesson candidate before durable promotion.',
-      evidenceRefs: addEvidenceRef(evidenceRefs, `privacy:${privacyFilter.originalHash}`),
-      suggestion: 'Discard the candidate or rewrite it without transient/private data.',
+      evidenceRefs: addEvidenceRef(
+        evidenceRefs,
+        `privacy:${privacyFilter.originalHash}`,
+      ),
+      suggestion:
+        'Discard the candidate or rewrite it without transient/private data.',
     });
   }
 
@@ -636,9 +715,14 @@ export function critiqueProposedLesson(
       checklistItem: 'scope',
       verdict: 'needs-edit',
       severity: 'warning',
-      message: 'Reviewer feedback does not include suggestions for every finding.',
-      evidenceRefs: addEvidenceRef(evidenceRefs, 'reviewer-feedback:missing-suggestions'),
-      suggestion: 'Add remediation guidance so the lesson is scoped and actionable.',
+      message:
+        'Reviewer feedback does not include suggestions for every finding.',
+      evidenceRefs: addEvidenceRef(
+        evidenceRefs,
+        'reviewer-feedback:missing-suggestions',
+      ),
+      suggestion:
+        'Add remediation guidance so the lesson is scoped and actionable.',
     });
   }
 
@@ -650,8 +734,12 @@ export function critiqueProposedLesson(
       severity: 'warning',
       message:
         'Lesson candidate contains redacted sensitive signals and requires manual review even though only stable evidence refs are exposed.',
-      evidenceRefs: addEvidenceRef(evidenceRefs, `privacy:${lesson.privacyFilter.originalHash}`),
-      suggestion: 'Have a human reviewer inspect the redacted candidate before promotion.',
+      evidenceRefs: addEvidenceRef(
+        evidenceRefs,
+        `privacy:${lesson.privacyFilter.originalHash}`,
+      ),
+      suggestion:
+        'Have a human reviewer inspect the redacted candidate before promotion.',
     });
   }
 
@@ -668,7 +756,8 @@ export function critiqueProposedLesson(
       message:
         'High-risk critique signal requires manual review before promotion.',
       evidenceRefs: addEvidenceRef(evidenceRefs, 'risk:critical-finding'),
-      suggestion: 'Confirm the lesson is safe, scoped, and not overgeneralized.',
+      suggestion:
+        'Confirm the lesson is safe, scoped, and not overgeneralized.',
     });
   }
 
@@ -691,7 +780,8 @@ export function critiqueProposedLesson(
       message:
         'Historical duplicate lessons were not checked, so promotion needs manual review.',
       evidenceRefs: addEvidenceRef(evidenceRefs, 'duplicate:not_checked'),
-      suggestion: 'Run lesson search or have a reviewer confirm no matching prior guidance exists.',
+      suggestion:
+        'Run lesson search or have a reviewer confirm no matching prior guidance exists.',
     });
   } else if (duplicate) {
     findings.push({
@@ -701,8 +791,12 @@ export function critiqueProposedLesson(
       severity: 'warning',
       message:
         'A comparable prior lesson already covers the same failure description.',
-      evidenceRefs: addEvidenceRef(evidenceRefs, `duplicate:${getLessonId(duplicate)}`),
-      suggestion: 'Update or link the existing lesson instead of promoting a duplicate.',
+      evidenceRefs: addEvidenceRef(
+        evidenceRefs,
+        `duplicate:${getLessonId(duplicate)}`,
+      ),
+      suggestion:
+        'Update or link the existing lesson instead of promoting a duplicate.',
     });
   }
 
@@ -720,7 +814,8 @@ export function critiqueProposedLesson(
       message:
         'Historical lesson conflicts were not checked, so promotion needs manual review.',
       evidenceRefs: addEvidenceRef(evidenceRefs, 'contradiction:not_checked'),
-      suggestion: 'Run lesson search or have a reviewer confirm no conflicting prior guidance exists.',
+      suggestion:
+        'Run lesson search or have a reviewer confirm no conflicting prior guidance exists.',
     });
   }
   if (contradictionReport.status === 'contradiction_detected') {
@@ -731,10 +826,16 @@ export function critiqueProposedLesson(
       severity: 'critical',
       message:
         'Potential contradiction with existing lesson guidance blocks promotion until reconciled.',
-      evidenceRefs: contradictionReport.contradictions.map((contradiction) =>
-        addEvidenceRef(evidenceRefs, `conflict:${contradiction.conflictingLessonId}`),
-      ).flat(),
-      suggestion: 'Resolve or supersede the conflicting lesson before promotion.',
+      evidenceRefs: contradictionReport.contradictions
+        .map((contradiction) =>
+          addEvidenceRef(
+            evidenceRefs,
+            `conflict:${contradiction.conflictingLessonId}`,
+          ),
+        )
+        .flat(),
+      suggestion:
+        'Resolve or supersede the conflicting lesson before promotion.',
     });
   }
 
@@ -1045,7 +1146,9 @@ export class LessonRecorder {
           ...lesson,
           contradictionReport: contradictionContext.report,
         };
-        const admittedBaseLesson = this.withAdmissionTimestamp(lessonWithContradiction);
+        const admittedBaseLesson = this.withDefaultLessonScope(
+          this.withAdmissionTimestamp(lessonWithContradiction),
+        );
         const admittedLesson = {
           ...admittedBaseLesson,
           proposedLessonCritique: critiqueProposedLesson(
@@ -1571,6 +1674,33 @@ export class LessonRecorder {
     }
   }
 
+  private withDefaultLessonScope(lesson: CritiqueLesson): CritiqueLesson {
+    if (lesson.lessonScope !== undefined) {
+      return lesson;
+    }
+    return {
+      ...lesson,
+      lessonScope: createLessonScopeMetadata({
+        scope: 'task',
+        allowedTasks: [lesson.taskId],
+        provenance: {
+          source: 'critique-loop',
+          taskId: lesson.taskId,
+          note: 'Newly recorded critique lessons default to one-task scope until reviewed for broader sharing.',
+        },
+        auditTrail: [
+          {
+            changedAt: lesson.timestamp,
+            actor: 'lesson-recorder',
+            toScope: 'task',
+            reason:
+              'Default one-task scope prevents cross-agent sharing before review.',
+          },
+        ],
+      }),
+    };
+  }
+
   private withAdmissionTimestamp(lesson: CritiqueLesson): CritiqueLesson {
     if (!lesson.cooldown) {
       return lesson;
@@ -1599,6 +1729,177 @@ export class LessonRecorder {
       },
     };
   }
+}
+
+interface LessonScopeMetadataInput {
+  readonly scope: LessonScopeKind;
+  readonly allowedRepos?: readonly string[];
+  readonly allowedRoles?: readonly string[];
+  readonly allowedProfiles?: readonly string[];
+  readonly allowedTasks?: readonly TaskId[];
+  readonly provenance: LessonScopeProvenance;
+  readonly expiresAt?: string;
+  readonly auditTrail: readonly LessonScopeAuditEntry[];
+}
+
+function createLessonScopeMetadata(
+  input: LessonScopeMetadataInput,
+): LessonScopeMetadata {
+  const scope = normalizeLessonScopeKind(input.scope);
+  const metadata: LessonScopeMetadata = {
+    schemaVersion: 'lesson-scope-v1',
+    scope,
+    ...(input.allowedRepos !== undefined
+      ? { allowedRepos: normalizeScopeList(input.allowedRepos, 'allowedRepos') }
+      : {}),
+    ...(input.allowedRoles !== undefined
+      ? { allowedRoles: normalizeScopeList(input.allowedRoles, 'allowedRoles') }
+      : {}),
+    ...(input.allowedProfiles !== undefined
+      ? {
+          allowedProfiles: normalizeScopeList(
+            input.allowedProfiles,
+            'allowedProfiles',
+          ),
+        }
+      : {}),
+    ...(input.allowedTasks !== undefined
+      ? {
+          allowedTasks: normalizeScopeList(
+            input.allowedTasks,
+            'allowedTasks',
+          ) as TaskId[],
+        }
+      : {}),
+    provenance: input.provenance,
+    ...(input.expiresAt !== undefined
+      ? { expiresAt: normalizeTimestamp(input.expiresAt) }
+      : {}),
+    auditTrail: input.auditTrail.map((entry) => ({
+      ...entry,
+      changedAt: normalizeTimestamp(entry.changedAt),
+      actor: requireNonEmptyString(entry.actor, 'scope audit actor'),
+      reason: requireNonEmptyString(entry.reason, 'scope audit reason'),
+      toScope: normalizeLessonScopeKind(entry.toScope),
+      ...(entry.fromScope !== undefined
+        ? { fromScope: normalizeLessonScopeKind(entry.fromScope) }
+        : {}),
+    })),
+  };
+  assertScopeHasRequiredAllowlist(metadata);
+  return metadata;
+}
+
+function normalizeLessonScopeKind(scope: LessonScopeKind): LessonScopeKind {
+  if (
+    scope !== 'global' &&
+    scope !== 'repo' &&
+    scope !== 'role' &&
+    scope !== 'profile' &&
+    scope !== 'task'
+  ) {
+    throw new RangeError(`Unsupported lesson scope: ${String(scope)}`);
+  }
+  return scope;
+}
+
+function normalizeScopeList(
+  values: readonly string[],
+  label: string,
+): readonly string[] {
+  const normalized = values.map((value) =>
+    requireNonEmptyString(value, label).trim(),
+  );
+  if (normalized.length === 0) {
+    throw new RangeError(
+      `${label} must contain at least one value when provided.`,
+    );
+  }
+  return Array.from(new Set(normalized)).sort();
+}
+
+function assertScopeHasRequiredAllowlist(scope: LessonScopeMetadata): void {
+  if (scope.scope === 'repo' && (scope.allowedRepos?.length ?? 0) === 0) {
+    throw new RangeError(
+      'Repo-scoped lessons require at least one allowed repo.',
+    );
+  }
+  if (scope.scope === 'role' && (scope.allowedRoles?.length ?? 0) === 0) {
+    throw new RangeError(
+      'Role-scoped lessons require at least one allowed role.',
+    );
+  }
+  if (scope.scope === 'profile' && (scope.allowedProfiles?.length ?? 0) === 0) {
+    throw new RangeError(
+      'Profile-scoped lessons require at least one allowed profile.',
+    );
+  }
+  if (scope.scope === 'task' && (scope.allowedTasks?.length ?? 0) === 0) {
+    throw new RangeError(
+      'Task-scoped lessons require at least one allowed task.',
+    );
+  }
+}
+
+function isLessonScopeAllowed(
+  scope: LessonScopeMetadata | undefined,
+  context: LessonInjectionContext,
+): boolean {
+  if (scope === undefined || isEmptyLessonInjectionContext(context)) {
+    return true;
+  }
+  const nowMs = Date.parse(context.now ?? new Date().toISOString());
+  if (scope.expiresAt !== undefined && Date.parse(scope.expiresAt) <= nowMs) {
+    return false;
+  }
+  if (!matchesOptionalAllowlist(scope.allowedRepos, context.repo)) {
+    return false;
+  }
+  if (!matchesOptionalAllowlist(scope.allowedRoles, context.role)) {
+    return false;
+  }
+  if (!matchesOptionalAllowlist(scope.allowedProfiles, context.profile)) {
+    return false;
+  }
+  if (scope.scope === 'global') {
+    return true;
+  }
+  if (scope.scope === 'repo') {
+    return matchesRequiredAllowlist(scope.allowedRepos, context.repo);
+  }
+  if (scope.scope === 'role') {
+    return matchesRequiredAllowlist(scope.allowedRoles, context.role);
+  }
+  if (scope.scope === 'profile') {
+    return matchesRequiredAllowlist(scope.allowedProfiles, context.profile);
+  }
+  return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
+}
+
+function isEmptyLessonInjectionContext(
+  context: LessonInjectionContext,
+): boolean {
+  return (
+    context.repo === undefined &&
+    context.role === undefined &&
+    context.profile === undefined &&
+    context.taskId === undefined &&
+    context.now === undefined
+  );
+}
+
+function matchesOptionalAllowlist(
+  allowed: readonly string[] | undefined,
+  actual: string | undefined,
+): boolean {
+  return allowed === undefined || matchesRequiredAllowlist(allowed, actual);
+}
+
+function matchesRequiredAllowlist(
+  allowed: readonly string[] | undefined,
+  actual: string | undefined,
+): boolean {
+  return actual !== undefined && allowed?.includes(actual) === true;
 }
 
 export function detectLessonContradictions(

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -450,11 +450,19 @@ export function updateLessonScope(
     toScope: scope,
     reason,
   };
-  const allowedRepos = request.allowedRepos ?? lesson.lessonScope?.allowedRepos;
-  const allowedRoles = request.allowedRoles ?? lesson.lessonScope?.allowedRoles;
+  const allowedRepos =
+    request.allowedRepos ??
+    (scope !== 'global' ? lesson.lessonScope?.allowedRepos : undefined);
+  const allowedRoles =
+    request.allowedRoles ??
+    (scope === 'role' ? lesson.lessonScope?.allowedRoles : undefined);
   const allowedProfiles =
-    request.allowedProfiles ?? lesson.lessonScope?.allowedProfiles;
-  const allowedTasks = request.allowedTasks ?? lesson.lessonScope?.allowedTasks;
+    request.allowedProfiles ??
+    (scope === 'profile' ? lesson.lessonScope?.allowedProfiles : undefined);
+  const allowedTasks =
+    request.allowedTasks ??
+    (scope === 'task' ? lesson.lessonScope?.allowedTasks : undefined);
+  const expiresAt = request.expiresAt ?? lesson.lessonScope?.expiresAt;
   const lessonScope = createLessonScopeMetadata({
     scope,
     ...(allowedRepos !== undefined ? { allowedRepos } : {}),
@@ -467,9 +475,7 @@ export function updateLessonScope(
         taskId: lesson.taskId,
         note: LESSON_SCOPE_REVIEW_GUIDANCE,
       },
-    ...(request.expiresAt !== undefined
-      ? { expiresAt: request.expiresAt }
-      : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
     auditTrail: [...(lesson.lessonScope?.auditTrail ?? []), auditEntry],
   });
   return {
@@ -1203,7 +1209,9 @@ export class LessonRecorder {
         10,
       );
       const applicablePriorLessons = priorLessons.filter((priorLesson) =>
-        isLessonApplicable(priorLesson, { taskId: lesson.taskId }),
+        isLessonApplicableForKnownContext(priorLesson, {
+          taskId: lesson.taskId,
+        }),
       );
       return {
         report: detectLessonContradictions(lesson, applicablePriorLessons),
@@ -1886,7 +1894,35 @@ function isLessonScopeAllowed(
   if (scope.scope === 'profile') {
     return matchesRequiredAllowlist(scope.allowedProfiles, context.profile);
   }
-  return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
+  if (scope.scope === 'task') {
+    return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
+  }
+  return false;
+}
+
+function isLessonApplicableForKnownContext(
+  lesson: CritiqueLesson,
+  context: LessonInjectionContext,
+): boolean {
+  if (
+    lesson.lifecycleStatus === 'quarantined' ||
+    lesson.lifecycleStatus === 'retired'
+  ) {
+    return false;
+  }
+  const scope = lesson.lessonScope;
+  if (scope === undefined) {
+    return true;
+  }
+  if (scope.scope === 'task' && context.taskId !== undefined) {
+    return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
+  }
+  return (
+    scope.scope === 'global' ||
+    scope.scope === 'repo' ||
+    scope.scope === 'role' ||
+    scope.scope === 'profile'
+  );
 }
 
 function parseScopeTimestamp(timestamp: string): number | undefined {
@@ -2843,14 +2879,13 @@ function createCooldownKey(
   evaluatorName: string,
   findingMessages: readonly string[],
 ): string {
+  void taskId;
   const normalizedFindings = JSON.stringify({
-    taskId,
     evaluatorName,
     findings: findingMessages.map((message) => message.trim()).sort(),
   });
   return [
     'critique-lesson',
-    sanitizeLessonIdPart(taskId),
     sanitizeLessonIdPart(evaluatorName),
     stableHash(normalizedFindings),
   ].join(':');

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -455,7 +455,7 @@ export function updateLessonScope(
   const isSameScope = lesson.lessonScope?.scope === scope;
   const allowedRepos =
     request.allowedRepos ??
-    (isSameScope || scope !== 'global'
+    (isSameScope || scope === 'repo'
       ? lesson.lessonScope?.allowedRepos
       : undefined);
   const allowedRoles =
@@ -1221,10 +1221,13 @@ export class LessonRecorder {
         createLessonSearchQuery(lesson),
         10,
       );
+      const lessonInjectionContext = {
+        ...this.lessonInjectionContext,
+        taskId: lesson.taskId,
+        now: this.now(),
+      };
       const applicablePriorLessons = priorLessons.filter((priorLesson) =>
-        isLessonApplicableForKnownContext(priorLesson, {
-          taskId: lesson.taskId,
-        }),
+        isLessonApplicableForKnownContext(priorLesson, lessonInjectionContext),
       );
       return {
         report: detectLessonContradictions(lesson, applicablePriorLessons),
@@ -1896,7 +1899,7 @@ function isLessonScopeAllowed(
     return false;
   }
   if (scope.scope === 'global') {
-    return true;
+    return hasValidScopeAuditTrail(scope);
   }
   if (scope.scope === 'repo') {
     return matchesRequiredAllowlist(scope.allowedRepos, context.repo);
@@ -1928,6 +1931,15 @@ function isLessonApplicableForKnownContext(
     return true;
   }
   return isLessonScopeAllowed(scope, context);
+}
+
+function hasValidScopeAuditTrail(scope: LessonScopeMetadata): boolean {
+  return scope.auditTrail.some(
+    (entry) =>
+      parseScopeTimestamp(entry.changedAt) !== undefined &&
+      entry.actor.trim().length > 0 &&
+      entry.reason.trim().length > 0,
+  );
 }
 
 function parseScopeTimestamp(timestamp: string): number | undefined {

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -422,12 +422,17 @@ export interface LessonHumanFeedbackRequest {
   readonly revisedCorrectionApplied?: string;
 }
 
+export type LessonScopeAllowlistDimension =
+  'repos' | 'roles' | 'profiles' | 'tasks';
+
 export interface LessonScopeReviewRequest {
   readonly scope: LessonScopeKind;
   readonly allowedRepos?: readonly string[];
   readonly allowedRoles?: readonly string[];
   readonly allowedProfiles?: readonly string[];
   readonly allowedTasks?: readonly TaskId[];
+  /** Explicit allowlist dimensions to drop during review; omitted dimensions preserve existing narrowers. */
+  readonly clearAllowlists?: readonly LessonScopeAllowlistDimension[];
   readonly provenance?: LessonScopeProvenance;
   readonly expiresAt?: string;
   readonly actor: string;
@@ -452,27 +457,27 @@ export function updateLessonScope(
     toScope: scope,
     reason,
   };
-  const isSameScope = lesson.lessonScope?.scope === scope;
-  const allowedRepos =
-    request.allowedRepos ??
-    (isSameScope || scope === 'repo'
-      ? lesson.lessonScope?.allowedRepos
-      : undefined);
-  const allowedRoles =
-    request.allowedRoles ??
-    (isSameScope || scope === 'role'
-      ? lesson.lessonScope?.allowedRoles
-      : undefined);
-  const allowedProfiles =
-    request.allowedProfiles ??
-    (isSameScope || scope === 'profile'
-      ? lesson.lessonScope?.allowedProfiles
-      : undefined);
-  const allowedTasks =
-    request.allowedTasks ??
-    (isSameScope || scope === 'task'
-      ? lesson.lessonScope?.allowedTasks
-      : undefined);
+  const clearedAllowlists = new Set(request.clearAllowlists ?? []);
+  const allowedRepos = resolveReviewedAllowlist(
+    request.allowedRepos,
+    lesson.lessonScope?.allowedRepos,
+    clearedAllowlists.has('repos'),
+  );
+  const allowedRoles = resolveReviewedAllowlist(
+    request.allowedRoles,
+    lesson.lessonScope?.allowedRoles,
+    clearedAllowlists.has('roles'),
+  );
+  const allowedProfiles = resolveReviewedAllowlist(
+    request.allowedProfiles,
+    lesson.lessonScope?.allowedProfiles,
+    clearedAllowlists.has('profiles'),
+  );
+  const allowedTasks = resolveReviewedAllowlist(
+    request.allowedTasks,
+    lesson.lessonScope?.allowedTasks,
+    clearedAllowlists.has('tasks'),
+  );
   const expiresAt = request.expiresAt ?? lesson.lessonScope?.expiresAt;
   const lessonScope = createLessonScopeMetadata({
     scope,
@@ -1068,6 +1073,7 @@ export class LessonRecorder {
   async record(
     result: CritiqueLoopResult,
     taskId: TaskId,
+    lessonInjectionContext?: LessonInjectionContext,
   ): Promise<LessonRecordingResult> {
     const recordingResult = createMutableLessonRecordingResult(this.now());
 
@@ -1091,7 +1097,11 @@ export class LessonRecorder {
         recordingResult,
       );
       for (const extractedLesson of lessons) {
-        await this.recordExtractedLesson(extractedLesson, recordingResult);
+        await this.recordExtractedLesson(
+          extractedLesson,
+          recordingResult,
+          lessonInjectionContext,
+        );
       }
     }
 
@@ -1101,6 +1111,7 @@ export class LessonRecorder {
   private async recordExtractedLesson(
     extractedLesson: CritiqueLesson,
     recordingResult: MutableLessonRecordingResult,
+    recordLessonInjectionContext: LessonInjectionContext | undefined,
   ): Promise<void> {
     await this.withBlockerPatternAdmissionLock(extractedLesson, async () => {
       let lesson = this.withCurrentBlockerPatterns(extractedLesson);
@@ -1156,8 +1167,10 @@ export class LessonRecorder {
       }
 
       try {
-        const contradictionContext =
-          await this.createContradictionContext(lesson);
+        const contradictionContext = await this.createContradictionContext(
+          lesson,
+          recordLessonInjectionContext,
+        );
         const lessonWithContradiction = {
           ...lesson,
           contradictionReport: contradictionContext.report,
@@ -1209,6 +1222,7 @@ export class LessonRecorder {
 
   private async createContradictionContext(
     lesson: CritiqueLesson,
+    recordLessonInjectionContext: LessonInjectionContext | undefined,
   ): Promise<LessonContradictionContext> {
     if (!this.memory.searchLessons) {
       return {
@@ -1223,8 +1237,9 @@ export class LessonRecorder {
       );
       const lessonInjectionContext = {
         ...this.lessonInjectionContext,
+        ...recordLessonInjectionContext,
         taskId: lesson.taskId,
-        now: this.now(),
+        now: recordLessonInjectionContext?.now ?? this.now(),
       };
       const applicablePriorLessons = priorLessons.filter((priorLesson) =>
         isLessonApplicableForKnownContext(priorLesson, lessonInjectionContext),
@@ -1756,6 +1771,17 @@ export class LessonRecorder {
   }
 }
 
+function resolveReviewedAllowlist<T extends string>(
+  requested: readonly T[] | undefined,
+  existing: readonly T[] | undefined,
+  clear: boolean,
+): readonly T[] | undefined {
+  if (requested !== undefined) {
+    return requested;
+  }
+  return clear ? undefined : existing;
+}
+
 interface LessonScopeMetadataInput {
   readonly scope: LessonScopeKind;
   readonly allowedRepos?: readonly string[];
@@ -1898,8 +1924,11 @@ function isLessonScopeAllowed(
   if (!matchesOptionalAllowlist(scope.allowedTasks, context.taskId)) {
     return false;
   }
+  if (!hasValidScopeAuditTrail(scope)) {
+    return false;
+  }
   if (scope.scope === 'global') {
-    return hasValidScopeAuditTrail(scope);
+    return true;
   }
   if (scope.scope === 'repo') {
     return matchesRequiredAllowlist(scope.allowedRepos, context.repo);

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -266,6 +266,8 @@ export interface LessonRecorderOptions {
   readonly blockerPatternStore?: Map<string, BlockerPatternState>;
   /** Shared failure-cluster state for grouping repeated failures across recorder instances. */
   readonly failureClusterStore?: Map<string, FailureClusterState>;
+  /** Optional scope context used when filtering prior lessons returned by memory search. */
+  readonly lessonInjectionContext?: LessonInjectionContext;
   /** Optional per-agent identifier used to attach deterministic improvement scorecards to learned lessons. */
   readonly agentId?: string;
 }
@@ -450,18 +452,27 @@ export function updateLessonScope(
     toScope: scope,
     reason,
   };
+  const isSameScope = lesson.lessonScope?.scope === scope;
   const allowedRepos =
     request.allowedRepos ??
-    (scope !== 'global' ? lesson.lessonScope?.allowedRepos : undefined);
+    (isSameScope || scope !== 'global'
+      ? lesson.lessonScope?.allowedRepos
+      : undefined);
   const allowedRoles =
     request.allowedRoles ??
-    (scope === 'role' ? lesson.lessonScope?.allowedRoles : undefined);
+    (isSameScope || scope === 'role'
+      ? lesson.lessonScope?.allowedRoles
+      : undefined);
   const allowedProfiles =
     request.allowedProfiles ??
-    (scope === 'profile' ? lesson.lessonScope?.allowedProfiles : undefined);
+    (isSameScope || scope === 'profile'
+      ? lesson.lessonScope?.allowedProfiles
+      : undefined);
   const allowedTasks =
     request.allowedTasks ??
-    (scope === 'task' ? lesson.lessonScope?.allowedTasks : undefined);
+    (isSameScope || scope === 'task'
+      ? lesson.lessonScope?.allowedTasks
+      : undefined);
   const expiresAt = request.expiresAt ?? lesson.lessonScope?.expiresAt;
   const lessonScope = createLessonScopeMetadata({
     scope,
@@ -999,6 +1010,7 @@ export class LessonRecorder {
   private readonly blockerPatterns: Map<string, BlockerPatternState>;
   private readonly pendingBlockerAdmissions: Map<string, Promise<void>>;
   private readonly failureClusters: Map<string, FailureClusterState>;
+  private readonly lessonInjectionContext: LessonInjectionContext | undefined;
   private readonly agentId?: string;
   private readonly pendingBlockerObservations = new WeakMap<
     CritiqueLesson,
@@ -1035,6 +1047,7 @@ export class LessonRecorder {
       this.blockerPatterns,
     );
     this.failureClusters = options.failureClusterStore ?? new Map();
+    this.lessonInjectionContext = options.lessonInjectionContext;
     if (options.agentId !== undefined) {
       const agentId = options.agentId.trim();
       if (!agentId) {
@@ -1914,15 +1927,7 @@ function isLessonApplicableForKnownContext(
   if (scope === undefined) {
     return true;
   }
-  if (scope.scope === 'task' && context.taskId !== undefined) {
-    return matchesRequiredAllowlist(scope.allowedTasks, context.taskId);
-  }
-  return (
-    scope.scope === 'global' ||
-    scope.scope === 'repo' ||
-    scope.scope === 'role' ||
-    scope.scope === 'profile'
-  );
+  return isLessonScopeAllowed(scope, context);
 }
 
 function parseScopeTimestamp(timestamp: string): number | undefined {
@@ -2879,13 +2884,14 @@ function createCooldownKey(
   evaluatorName: string,
   findingMessages: readonly string[],
 ): string {
-  void taskId;
   const normalizedFindings = JSON.stringify({
+    taskId,
     evaluatorName,
     findings: findingMessages.map((message) => message.trim()).sort(),
   });
   return [
     'critique-lesson',
+    sanitizeLessonIdPart(taskId),
     sanitizeLessonIdPart(evaluatorName),
     stableHash(normalizedFindings),
   ].join(':');

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -43,6 +43,8 @@ const LESSON_CONTRADICTION_VERIFICATION_COMMAND =
 
 const DEFAULT_LESSON_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const MAX_LESSON_COOLDOWN_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+const PRIOR_LESSON_SCOPE_FILTER_FETCH_LIMIT = 50;
+const PRIOR_LESSON_CONTRADICTION_LIMIT = 10;
 const PENDING_ADMISSIONS_BY_COOLDOWN_STORE = new WeakMap<
   Map<string, number>,
   Map<string, Promise<boolean>>
@@ -1233,17 +1235,25 @@ export class LessonRecorder {
     try {
       const priorLessons = await this.memory.searchLessons(
         createLessonSearchQuery(lesson),
-        10,
+        PRIOR_LESSON_SCOPE_FILTER_FETCH_LIMIT,
       );
       const lessonInjectionContext = {
         ...this.lessonInjectionContext,
         ...recordLessonInjectionContext,
         taskId: lesson.taskId,
-        now: recordLessonInjectionContext?.now ?? this.now(),
+        now:
+          recordLessonInjectionContext?.now ??
+          this.lessonInjectionContext?.now ??
+          this.now(),
       };
-      const applicablePriorLessons = priorLessons.filter((priorLesson) =>
-        isLessonApplicableForKnownContext(priorLesson, lessonInjectionContext),
-      );
+      const applicablePriorLessons = priorLessons
+        .filter((priorLesson) =>
+          isLessonApplicableForKnownContext(
+            priorLesson,
+            lessonInjectionContext,
+          ),
+        )
+        .slice(0, PRIOR_LESSON_CONTRADICTION_LIMIT);
       return {
         report: detectLessonContradictions(lesson, applicablePriorLessons),
         priorLessons: applicablePriorLessons,
@@ -1899,6 +1909,9 @@ function isLessonScopeAllowed(
   if (scope === undefined) {
     return true;
   }
+  if (scope.schemaVersion !== 'lesson-scope-v1') {
+    return false;
+  }
   if (isEmptyLessonInjectionContext(context)) {
     return false;
   }
@@ -1924,7 +1937,7 @@ function isLessonScopeAllowed(
   if (!matchesOptionalAllowlist(scope.allowedTasks, context.taskId)) {
     return false;
   }
-  if (!hasValidScopeAuditTrail(scope)) {
+  if (!hasValidScopeAuditTrail(scope, scope.scope)) {
     return false;
   }
   if (scope.scope === 'global') {
@@ -1962,10 +1975,14 @@ function isLessonApplicableForKnownContext(
   return isLessonScopeAllowed(scope, context);
 }
 
-function hasValidScopeAuditTrail(scope: LessonScopeMetadata): boolean {
+function hasValidScopeAuditTrail(
+  scope: LessonScopeMetadata,
+  currentScope: LessonScopeKind,
+): boolean {
   return scope.auditTrail.some(
     (entry) =>
       parseScopeTimestamp(entry.changedAt) !== undefined &&
+      entry.toScope === currentScope &&
       entry.actor.trim().length > 0 &&
       entry.reason.trim().length > 0,
   );

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1845,8 +1845,11 @@ function isLessonScopeAllowed(
   scope: LessonScopeMetadata | undefined,
   context: LessonInjectionContext,
 ): boolean {
-  if (scope === undefined || isEmptyLessonInjectionContext(context)) {
+  if (scope === undefined) {
     return true;
+  }
+  if (isEmptyLessonInjectionContext(context)) {
+    return false;
   }
   const nowMs = Date.parse(context.now ?? new Date().toISOString());
   if (scope.expiresAt !== undefined && Date.parse(scope.expiresAt) <= nowMs) {

--- a/packages/franken-critique/src/reviewer.ts
+++ b/packages/franken-critique/src/reviewer.ts
@@ -1,4 +1,9 @@
-import type { GuardrailsPort, MemoryPort, ObservabilityPort } from './types/contracts.js';
+import type {
+  GuardrailsPort,
+  LessonInjectionContext,
+  MemoryPort,
+  ObservabilityPort,
+} from './types/contracts.js';
 import type { EvaluationInput } from './types/evaluation.js';
 import type { LoopConfig, CritiqueLoopResult } from './types/loop.js';
 import { CritiquePipeline } from './pipeline/critique-pipeline.js';
@@ -24,7 +29,50 @@ export interface ReviewerConfig {
 }
 
 export interface Reviewer {
-  review(input: EvaluationInput, loopConfig: LoopConfig): Promise<CritiqueLoopResult>;
+  review(
+    input: EvaluationInput,
+    loopConfig: LoopConfig,
+  ): Promise<CritiqueLoopResult>;
+}
+
+function readMetadataString(
+  metadata: Readonly<Record<string, unknown>>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function createLessonInjectionContextFromInput(
+  input: EvaluationInput,
+): LessonInjectionContext {
+  const context: {
+    repo?: string;
+    role?: string;
+    profile?: string;
+  } = {};
+  const repo = readMetadataString(input.metadata, ['repo', 'repository']);
+  if (repo !== undefined) {
+    context.repo = repo;
+  }
+  const role = readMetadataString(input.metadata, [
+    'role',
+    'reviewerRole',
+    'agentRole',
+  ]);
+  if (role !== undefined) {
+    context.role = role;
+  }
+  const profile = readMetadataString(input.metadata, ['profile', 'profileId']);
+  if (profile !== undefined) {
+    context.profile = profile;
+  }
+  return context;
 }
 
 export function createReviewer(config: ReviewerConfig): Reviewer {
@@ -51,9 +99,16 @@ export function createReviewer(config: ReviewerConfig): Reviewer {
   const recorder = new LessonRecorder(config.memory);
 
   return {
-    async review(input: EvaluationInput, loopConfig: LoopConfig): Promise<CritiqueLoopResult> {
+    async review(
+      input: EvaluationInput,
+      loopConfig: LoopConfig,
+    ): Promise<CritiqueLoopResult> {
       const result = await loop.run(input, loopConfig);
-      await recorder.record(result, loopConfig.taskId);
+      await recorder.record(
+        result,
+        loopConfig.taskId,
+        createLessonInjectionContextFromInput(input),
+      );
       return result;
     },
   };

--- a/packages/franken-critique/src/reviewer.ts
+++ b/packages/franken-critique/src/reviewer.ts
@@ -48,6 +48,27 @@ function readMetadataString(
   return undefined;
 }
 
+function readNestedContextMetadata(
+  metadata: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+  const context = metadata.context;
+  return context !== null &&
+    typeof context === 'object' &&
+    !Array.isArray(context)
+    ? (context as Readonly<Record<string, unknown>>)
+    : {};
+}
+
+function readReviewContextString(
+  metadata: Readonly<Record<string, unknown>>,
+  keys: readonly string[],
+): string | undefined {
+  return (
+    readMetadataString(metadata, keys) ??
+    readMetadataString(readNestedContextMetadata(metadata), keys)
+  );
+}
+
 function createLessonInjectionContextFromInput(
   input: EvaluationInput,
 ): LessonInjectionContext {
@@ -56,11 +77,11 @@ function createLessonInjectionContextFromInput(
     role?: string;
     profile?: string;
   } = {};
-  const repo = readMetadataString(input.metadata, ['repo', 'repository']);
+  const repo = readReviewContextString(input.metadata, ['repo', 'repository']);
   if (repo !== undefined) {
     context.repo = repo;
   }
-  const role = readMetadataString(input.metadata, [
+  const role = readReviewContextString(input.metadata, [
     'role',
     'reviewerRole',
     'agentRole',
@@ -68,7 +89,10 @@ function createLessonInjectionContextFromInput(
   if (role !== undefined) {
     context.role = role;
   }
-  const profile = readMetadataString(input.metadata, ['profile', 'profileId']);
+  const profile = readReviewContextString(input.metadata, [
+    'profile',
+    'profileId',
+  ]);
   if (profile !== undefined) {
     context.profile = profile;
   }

--- a/packages/franken-critique/src/types/contracts.ts
+++ b/packages/franken-critique/src/types/contracts.ts
@@ -242,12 +242,7 @@ export interface FailedTestSkillCandidate {
 export type LessonCritiqueVerdict = 'accepted' | 'needs-edit' | 'rejected';
 
 export type LessonCritiqueChecklistItem =
-  | 'correctness'
-  | 'scope'
-  | 'privacy'
-  | 'security'
-  | 'duplication'
-  | 'conflict';
+  'correctness' | 'scope' | 'privacy' | 'security' | 'duplication' | 'conflict';
 
 export interface LessonCritiqueAgentFinding {
   /** Deterministic agent/reviewer persona that produced this finding. */
@@ -323,6 +318,55 @@ export interface LessonPrivacyFilterDecision {
   readonly redactions: readonly LessonPrivacyRedaction[];
   readonly originalHash: string;
   readonly reason: string;
+}
+
+/** Deliberate visibility boundary for cross-agent lesson sharing. */
+export type LessonScopeKind = 'global' | 'repo' | 'role' | 'profile' | 'task';
+
+/** Provenance explaining why a lesson exists and who/what may promote it. */
+export interface LessonScopeProvenance {
+  readonly source:
+    'critique-loop' | 'post-pr-extraction' | 'human-review' | 'import';
+  readonly taskId?: TaskId;
+  readonly issueNumber?: number;
+  readonly prUrl?: string;
+  readonly note?: string;
+}
+
+/** Audit entry emitted whenever a reviewer changes lesson scope. */
+export interface LessonScopeAuditEntry {
+  readonly changedAt: string;
+  readonly actor: string;
+  readonly fromScope?: LessonScopeKind;
+  readonly toScope: LessonScopeKind;
+  readonly reason: string;
+}
+
+/** Scope controls used before injecting or sharing a lesson with another agent. */
+export interface LessonScopeMetadata {
+  readonly schemaVersion: 'lesson-scope-v1';
+  readonly scope: LessonScopeKind;
+  /** Repos allowed to receive the lesson. Required for repo scope; optional narrowing otherwise. */
+  readonly allowedRepos?: readonly string[];
+  /** Agent roles allowed to receive the lesson. Required for role scope; optional narrowing otherwise. */
+  readonly allowedRoles?: readonly string[];
+  /** Hermes profiles allowed to receive the lesson. Required for profile scope; optional narrowing otherwise. */
+  readonly allowedProfiles?: readonly string[];
+  /** Task ids allowed to receive one-task notes. Required for task scope. */
+  readonly allowedTasks?: readonly TaskId[];
+  readonly provenance: LessonScopeProvenance;
+  /** ISO timestamp after which injection must deny the lesson. */
+  readonly expiresAt?: string;
+  readonly auditTrail: readonly LessonScopeAuditEntry[];
+}
+
+/** Runtime context used to decide whether a scoped lesson may be injected. */
+export interface LessonInjectionContext {
+  readonly repo?: string;
+  readonly role?: string;
+  readonly profile?: string;
+  readonly taskId?: TaskId;
+  readonly now?: string;
 }
 
 /** Cooldown metadata attached to a recorded lesson so PM/liveness tooling can prevent churn. */
@@ -549,6 +593,8 @@ export interface CritiqueLesson {
   readonly privacyFilter?: LessonPrivacyFilterDecision;
   /** Human/inferred feedback weighting used for promotion, demotion, retirement, and quarantine decisions. */
   readonly feedbackWeighting?: LessonFeedbackWeighting;
+  /** Scope controls checked before sharing or injecting this lesson into another agent context. */
+  readonly lessonScope?: LessonScopeMetadata;
   /** Multi-agent critique of the proposed lesson before promotion. */
   readonly proposedLessonCritique?: LessonMultiAgentCritique;
 }

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1679,10 +1679,18 @@ describe('LessonRecorder', () => {
       false,
     );
     expect(
-      isLessonApplicable(globalForOneTask, {
-        taskId: 'task-a',
-        now: 'not-a-date',
-      }),
+      isLessonApplicable(
+        {
+          ...baseLesson,
+          lessonScope: {
+            scope: 'future-scope',
+            allowedTasks: ['task-a'],
+            provenance: { source: 'recorded', taskId: 'scope-task' },
+            auditTrail: [],
+          } as unknown as CritiqueLesson['lessonScope'],
+        },
+        { taskId: 'task-a' },
+      ),
     ).toBe(false);
 
     const expired = updateLessonScope(baseLesson, {
@@ -1751,6 +1759,28 @@ describe('LessonRecorder', () => {
         toScope: 'role',
       }),
     ]);
+
+    const taskScoped = updateLessonScope(baseLesson, {
+      scope: 'task',
+      allowedTasks: ['scope-task'],
+      actor: 'pm-reviewer',
+      reason: 'Start as task-local until review.',
+      changedAt: '2026-07-13T03:00:00.000Z',
+      expiresAt: '2026-07-20T00:00:00.000Z',
+    });
+    const promoted = updateLessonScope(taskScoped, {
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      actor: 'pm-reviewer',
+      reason: 'Promote after review without carrying the task allowlist.',
+      changedAt: '2026-07-13T04:00:00.000Z',
+    });
+    expect(promoted.lessonScope).toMatchObject({
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      expiresAt: '2026-07-20T00:00:00.000Z',
+    });
+    expect(promoted.lessonScope?.allowedTasks).toBeUndefined();
   });
 
   it('ignores scoped-out prior lessons during promotion critique', async () => {
@@ -2767,7 +2797,7 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(lesson.cooldown).toEqual({
-      key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
+      key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
       windowMs: 60_000,
       recordedAt: '2026-07-12T10:00:00.000Z',
       suppressUntil: '2026-07-12T10:01:00.000Z',
@@ -2805,7 +2835,7 @@ describe('LessonRecorder', () => {
     expect(suppressed.recorded).toBe(0);
     expect(suppressed.suppressedByCooldown).toEqual([
       {
-        key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
+        key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
         taskId: 'first-task',
         evaluatorName: 'learning-reviewer',
         suppressedAt: '2026-07-12T10:00:30.000Z',
@@ -2817,7 +2847,7 @@ describe('LessonRecorder', () => {
     ]);
   });
 
-  it('does not suppress equivalent task-scoped lessons across different tasks', async () => {
+  it('suppresses equivalent lessons across different tasks', async () => {
     const port = createMockMemoryPort();
     let now = new Date('2026-07-12T10:00:00.000Z');
     const recorder = new LessonRecorder(port, {
@@ -2841,9 +2871,9 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:30.000Z');
     const second = await recorder.record(result, 'second-task');
 
-    expect(port.recordLesson).toHaveBeenCalledTimes(2);
-    expect(second.recorded).toBe(1);
-    expect(second.suppressedByCooldown).toEqual([]);
+    expect(port.recordLesson).toHaveBeenCalledTimes(1);
+    expect(second.recorded).toBe(0);
+    expect(second.suppressedByCooldown).toHaveLength(1);
   });
 
   it('clusters repeated failures by task family, package, tool, and root cause without retaining raw transcripts', async () => {
@@ -2899,8 +2929,8 @@ describe('LessonRecorder', () => {
         occurrences: 1,
       }),
     ]);
-    expect(secondSummary.recorded).toBe(1);
-    expect(secondSummary.suppressedByCooldown).toEqual([]);
+    expect(secondSummary.recorded).toBe(0);
+    expect(secondSummary.suppressedByCooldown).toHaveLength(1);
     expect(secondSummary.failureClusterReport.clusters).toEqual([
       expect.objectContaining({
         taskFamily: 'frontend auth',
@@ -3436,7 +3466,7 @@ describe('LessonRecorder', () => {
       thirdRecord,
     ]);
 
-    expect(port.recordLesson).toHaveBeenCalledTimes(3);
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
     expect(firstSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [],
@@ -3448,8 +3478,13 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(thirdSummary).toMatchObject({
-      recorded: 1,
-      suppressedByCooldown: [],
+      recorded: 0,
+      suppressedByCooldown: [
+        expect.objectContaining({
+          taskId: 'third-task',
+          evaluatorName: 'learning-reviewer',
+        }),
+      ],
       minedBlockerPatterns: [],
     });
   });
@@ -3642,32 +3677,25 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:10.000Z');
     const secondSummary = await recorder.record(result, 'task-b');
     now = new Date('2026-07-12T10:00:20.000Z');
-    const thirdSummary = await recorder.record(result, 'task-b');
-    now = new Date('2026-07-12T10:00:30.000Z');
-    const fourthSummary = await recorder.record(result, 'task-c');
-    const fourthLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[2]![0];
+    const thirdSummary = await recorder.record(result, 'task-c');
+    const thirdLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0];
 
     expect(secondSummary).toMatchObject({
-      recorded: 1,
-      suppressedByCooldown: [],
-      minedBlockerPatterns: [],
-    });
-    expect(thirdSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [expect.objectContaining({ taskId: 'task-b' })],
       minedBlockerPatterns: [],
     });
-    expect(fourthSummary.recorded).toBe(1);
-    expect(fourthSummary.suppressedByCooldown).toEqual([]);
-    expect(fourthSummary.minedBlockerPatterns).toEqual([
+    expect(thirdSummary.recorded).toBe(1);
+    expect(thirdSummary.suppressedByCooldown).toEqual([]);
+    expect(thirdSummary.minedBlockerPatterns).toEqual([
       expect.objectContaining({
         occurrences: 3,
         taskIds: ['task-a', 'task-b', 'task-c'],
       }),
     ]);
-    expect(fourthLesson.blockerPatterns).toEqual(
-      fourthSummary.minedBlockerPatterns,
+    expect(thirdLesson.blockerPatterns).toEqual(
+      thirdSummary.minedBlockerPatterns,
     );
   });
 

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1732,6 +1732,37 @@ describe('LessonRecorder', () => {
       }),
     ).toBe(false);
 
+    const importedRepoWithMalformedAudit = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+        auditTrail: [{ changedAt: reviewedAt, actor: 42, toScope: 'repo' }],
+      } as unknown as CritiqueLesson['lessonScope'],
+    };
+    expect(
+      isLessonApplicable(importedRepoWithMalformedAudit, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
+    const importedRepoWithMissingAudit = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+      } as unknown as CritiqueLesson['lessonScope'],
+    };
+    expect(
+      isLessonApplicable(importedRepoWithMissingAudit, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const unknownSchemaRepoScope = {
       ...repoScoped,
       lessonScope: {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -2797,7 +2797,7 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(lesson.cooldown).toEqual({
-      key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
+      key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
       windowMs: 60_000,
       recordedAt: '2026-07-12T10:00:00.000Z',
       suppressUntil: '2026-07-12T10:01:00.000Z',
@@ -2835,7 +2835,7 @@ describe('LessonRecorder', () => {
     expect(suppressed.recorded).toBe(0);
     expect(suppressed.suppressedByCooldown).toEqual([
       {
-        key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
+        key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
         taskId: 'first-task',
         evaluatorName: 'learning-reviewer',
         suppressedAt: '2026-07-12T10:00:30.000Z',
@@ -2847,7 +2847,7 @@ describe('LessonRecorder', () => {
     ]);
   });
 
-  it('suppresses equivalent lessons across different tasks', async () => {
+  it('does not suppress equivalent task-scoped lessons across different tasks', async () => {
     const port = createMockMemoryPort();
     let now = new Date('2026-07-12T10:00:00.000Z');
     const recorder = new LessonRecorder(port, {
@@ -2871,9 +2871,9 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:30.000Z');
     const second = await recorder.record(result, 'second-task');
 
-    expect(port.recordLesson).toHaveBeenCalledTimes(1);
-    expect(second.recorded).toBe(0);
-    expect(second.suppressedByCooldown).toHaveLength(1);
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(second.recorded).toBe(1);
+    expect(second.suppressedByCooldown).toEqual([]);
   });
 
   it('clusters repeated failures by task family, package, tool, and root cause without retaining raw transcripts', async () => {
@@ -2929,8 +2929,8 @@ describe('LessonRecorder', () => {
         occurrences: 1,
       }),
     ]);
-    expect(secondSummary.recorded).toBe(0);
-    expect(secondSummary.suppressedByCooldown).toHaveLength(1);
+    expect(secondSummary.recorded).toBe(1);
+    expect(secondSummary.suppressedByCooldown).toEqual([]);
     expect(secondSummary.failureClusterReport.clusters).toEqual([
       expect.objectContaining({
         taskFamily: 'frontend auth',
@@ -3466,7 +3466,7 @@ describe('LessonRecorder', () => {
       thirdRecord,
     ]);
 
-    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(port.recordLesson).toHaveBeenCalledTimes(3);
     expect(firstSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [],
@@ -3478,13 +3478,8 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(thirdSummary).toMatchObject({
-      recorded: 0,
-      suppressedByCooldown: [
-        expect.objectContaining({
-          taskId: 'third-task',
-          evaluatorName: 'learning-reviewer',
-        }),
-      ],
+      recorded: 1,
+      suppressedByCooldown: [],
       minedBlockerPatterns: [],
     });
   });
@@ -3677,25 +3672,32 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:10.000Z');
     const secondSummary = await recorder.record(result, 'task-b');
     now = new Date('2026-07-12T10:00:20.000Z');
-    const thirdSummary = await recorder.record(result, 'task-c');
-    const thirdLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[1]![0];
+    const thirdSummary = await recorder.record(result, 'task-b');
+    now = new Date('2026-07-12T10:00:30.000Z');
+    const fourthSummary = await recorder.record(result, 'task-c');
+    const fourthLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[2]![0];
 
     expect(secondSummary).toMatchObject({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
+    expect(thirdSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [expect.objectContaining({ taskId: 'task-b' })],
       minedBlockerPatterns: [],
     });
-    expect(thirdSummary.recorded).toBe(1);
-    expect(thirdSummary.suppressedByCooldown).toEqual([]);
-    expect(thirdSummary.minedBlockerPatterns).toEqual([
+    expect(fourthSummary.recorded).toBe(1);
+    expect(fourthSummary.suppressedByCooldown).toEqual([]);
+    expect(fourthSummary.minedBlockerPatterns).toEqual([
       expect.objectContaining({
         occurrences: 3,
         taskIds: ['task-a', 'task-b', 'task-c'],
       }),
     ]);
-    expect(thirdLesson.blockerPatterns).toEqual(
-      thirdSummary.minedBlockerPatterns,
+    expect(fourthLesson.blockerPatterns).toEqual(
+      fourthSummary.minedBlockerPatterns,
     );
   });
 

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1693,6 +1693,22 @@ describe('LessonRecorder', () => {
       ),
     ).toBe(false);
 
+    const importedRepoWithoutAudit = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+        auditTrail: [],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithoutAudit, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const expired = updateLessonScope(baseLesson, {
       scope: 'role',
       allowedRoles: ['worker'],
@@ -1738,6 +1754,7 @@ describe('LessonRecorder', () => {
     const roleScoped = updateLessonScope(repoScoped, {
       scope: 'role',
       allowedRoles: ['reviewer'],
+      clearAllowlists: ['repos'],
       actor: 'senior-reviewer',
       reason: 'Demote to reviewer-only scope after privacy review.',
       changedAt: '2026-07-13T02:00:00.000Z',
@@ -1771,6 +1788,7 @@ describe('LessonRecorder', () => {
     const promoted = updateLessonScope(taskScoped, {
       scope: 'repo',
       allowedRepos: ['djm204/frankenbeast'],
+      clearAllowlists: ['tasks'],
       actor: 'pm-reviewer',
       reason: 'Promote after review without carrying the task allowlist.',
       changedAt: '2026-07-13T04:00:00.000Z',
@@ -1797,9 +1815,44 @@ describe('LessonRecorder', () => {
     });
     expect(metadataOnlyReview.lessonScope?.allowedRoles).toEqual(['reviewer']);
 
+    const repoScopedReviewerOnly = updateLessonScope(narrowedGlobal, {
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      actor: 'pm-reviewer',
+      reason: 'Narrow global reviewer-only guidance to one repository.',
+      changedAt: '2026-07-13T06:30:00.000Z',
+    });
+    expect(repoScopedReviewerOnly.lessonScope).toMatchObject({
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      allowedRoles: ['reviewer'],
+    });
+    expect(
+      isLessonApplicable(repoScopedReviewerOnly, {
+        repo: 'djm204/frankenbeast',
+        role: 'reviewer',
+      }),
+    ).toBe(true);
+    expect(
+      isLessonApplicable(repoScopedReviewerOnly, {
+        repo: 'djm204/frankenbeast',
+        role: 'worker',
+      }),
+    ).toBe(false);
+
+    const clearedRoleNarrowing = updateLessonScope(repoScopedReviewerOnly, {
+      scope: 'repo',
+      clearAllowlists: ['roles'],
+      actor: 'pm-reviewer',
+      reason: 'Explicitly clear role narrowing after review.',
+      changedAt: '2026-07-13T06:45:00.000Z',
+    });
+    expect(clearedRoleNarrowing.lessonScope?.allowedRoles).toBeUndefined();
+
     const demoted = updateLessonScope(promoted, {
       scope: 'task',
       allowedTasks: ['scope-task'],
+      clearAllowlists: ['repos'],
       actor: 'pm-reviewer',
       reason: 'Demote back to task-local.',
       changedAt: '2026-07-13T07:00:00.000Z',
@@ -1865,6 +1918,59 @@ describe('LessonRecorder', () => {
         ),
       ),
     ).toBe(false);
+  });
+
+  it('uses per-review lesson injection context before filtering prior lessons', async () => {
+    const scopedPrior = updateLessonScope(
+      createLesson({
+        failureDescription: 'Cache guidance allowed unaudited stale responses',
+        correctionApplied: 'Require cache verification before reuse',
+        taskId: 'prior-task',
+        lifecycleStatus: 'active',
+      }),
+      {
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        actor: 'pm-reviewer',
+        reason: 'Prior lesson is repo-local.',
+        changedAt: '2026-07-13T01:00:00.000Z',
+      },
+    );
+    const port = {
+      ...createMockMemoryPort(),
+      searchLessons: vi.fn().mockResolvedValue([scopedPrior]),
+    };
+    const recorder = new LessonRecorder(port, {
+      now: (): Date => new Date('2026-07-13T03:00:00.000Z'),
+    });
+
+    await recorder.record(
+      {
+        verdict: 'pass',
+        iterations: [
+          createIteration(0, 'fail', 'factuality', [
+            {
+              message: 'Cache guidance allowed unaudited stale responses',
+              severity: 'warning',
+              suggestion: 'Require cache verification before reuse',
+            },
+          ]),
+          createIteration(1, 'pass'),
+        ],
+      },
+      'current-task',
+      { repo: 'djm204/frankenbeast' },
+    );
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as CritiqueLesson;
+    expect(
+      lesson.proposedLessonCritique?.findings.some(
+        (finding) =>
+          finding.checklistItem === 'duplication' &&
+          finding.verdict === 'needs-edit',
+      ),
+    ).toBe(true);
   });
 
   it('weights explicit human feedback higher than inferred lesson signals', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1592,6 +1592,7 @@ describe('LessonRecorder', () => {
         },
       ],
     });
+    expect(isLessonApplicable(approved)).toBe(false);
     expect(isLessonApplicable(approved, { taskId: 'scope-task' })).toBe(true);
   });
 
@@ -1945,7 +1946,9 @@ describe('LessonRecorder', () => {
         },
       ],
     });
-    expect(isLessonApplicable(directlyApproved)).toBe(true);
+    expect(
+      isLessonApplicable(directlyApproved, { taskId: 'feedback-weight-task' }),
+    ).toBe(true);
 
     const approvedLegacySandboxed = applyHumanFeedbackToLesson(
       { ...approvalReadyLesson, lifecycleStatus: 'active' },
@@ -1964,7 +1967,11 @@ describe('LessonRecorder', () => {
     );
     expect(approvedLegacySandboxed.lifecycleStatus).toBe('active');
     expect(approvedLegacySandboxed.experimentSandbox).toBeUndefined();
-    expect(isLessonApplicable(approvedLegacySandboxed)).toBe(true);
+    expect(
+      isLessonApplicable(approvedLegacySandboxed, {
+        taskId: 'feedback-weight-task',
+      }),
+    ).toBe(true);
 
     const approvedAfterCorrection = applyHumanFeedbackToLesson(corrected, {
       source: 'explicit-user-approval',
@@ -2057,7 +2064,9 @@ describe('LessonRecorder', () => {
     expect(approvedLegacy.unquarantine?.evidenceUrl).toBe(
       'https://github.com/djm204/frankenbeast/issues/1763#legacy',
     );
-    expect(isLessonApplicable(approvedLegacy)).toBe(true);
+    expect(
+      isLessonApplicable(approvedLegacy, { taskId: 'feedback-weight-task' }),
+    ).toBe(true);
 
     const legacySandboxedActiveQuarantine = quarantineLesson(
       {
@@ -2102,7 +2111,11 @@ describe('LessonRecorder', () => {
     expect(approvedLegacySandboxedQuarantine.lifecycleStatus).toBe('active');
     expect(approvedLegacySandboxedQuarantine.quarantine).toBeUndefined();
     expect(approvedLegacySandboxedQuarantine.experimentSandbox).toBeUndefined();
-    expect(isLessonApplicable(approvedLegacySandboxedQuarantine)).toBe(true);
+    expect(
+      isLessonApplicable(approvedLegacySandboxedQuarantine, {
+        taskId: 'feedback-weight-task',
+      }),
+    ).toBe(true);
 
     const approvedRetired = applyHumanFeedbackToLesson(
       {
@@ -2590,7 +2603,9 @@ describe('LessonRecorder', () => {
       evidenceUrl: 'https://github.com/djm204/frankenbeast/pull/3',
       reason: 'Replacement guidance has regression coverage.',
     });
-    expect(isLessonApplicable(unquarantined)).toBe(true);
+    expect(
+      isLessonApplicable(unquarantined, { taskId: 'lifecycle-task' }),
+    ).toBe(true);
   });
 
   it('does not attach rollback workflow guidance when no actionable lesson is recorded', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1745,9 +1745,9 @@ describe('LessonRecorder', () => {
 
     expect(roleScoped.lessonScope).toMatchObject({
       scope: 'role',
-      allowedRepos: ['djm204/frankenbeast'],
       allowedRoles: ['reviewer'],
     });
+    expect(roleScoped.lessonScope?.allowedRepos).toBeUndefined();
     expect(roleScoped.lessonScope?.auditTrail).toEqual([
       expect.objectContaining({
         actor: 'pm-reviewer',
@@ -1781,6 +1781,34 @@ describe('LessonRecorder', () => {
       expiresAt: '2026-07-20T00:00:00.000Z',
     });
     expect(promoted.lessonScope?.allowedTasks).toBeUndefined();
+
+    const narrowedGlobal = updateLessonScope(baseLesson, {
+      scope: 'global',
+      allowedRoles: ['reviewer'],
+      actor: 'pm-reviewer',
+      reason: 'Global reviewer-only guidance.',
+      changedAt: '2026-07-13T05:00:00.000Z',
+    });
+    const metadataOnlyReview = updateLessonScope(narrowedGlobal, {
+      scope: 'global',
+      actor: 'pm-reviewer',
+      reason: 'Refresh audit metadata without widening.',
+      changedAt: '2026-07-13T06:00:00.000Z',
+    });
+    expect(metadataOnlyReview.lessonScope?.allowedRoles).toEqual(['reviewer']);
+
+    const demoted = updateLessonScope(promoted, {
+      scope: 'task',
+      allowedTasks: ['scope-task'],
+      actor: 'pm-reviewer',
+      reason: 'Demote back to task-local.',
+      changedAt: '2026-07-13T07:00:00.000Z',
+    });
+    expect(demoted.lessonScope).toMatchObject({
+      scope: 'task',
+      allowedTasks: ['scope-task'],
+    });
+    expect(demoted.lessonScope?.allowedRepos).toBeUndefined();
   });
 
   it('ignores scoped-out prior lessons during promotion critique', async () => {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -8,6 +8,7 @@ import {
   quarantineLesson,
   quarantineLessonForRepeatedFailures,
   unquarantineLesson,
+  updateLessonScope,
 } from '../../../src/memory/lesson-recorder.js';
 import { EVALUATOR_EXCEPTION_LOCATION } from '../../../src/types/evaluation.js';
 import type {
@@ -1534,6 +1535,174 @@ describe('LessonRecorder', () => {
     });
   });
 
+  it('records critique lessons with one-task scope until a reviewer promotes sharing', async () => {
+    const port = createMockMemoryPort();
+    const recorder = new LessonRecorder(port, {
+      now: (): Date => new Date('2026-07-13T00:00:00.000Z'),
+    });
+
+    await recorder.record(
+      {
+        verdict: 'pass',
+        iterations: [
+          createIteration(0, 'fail', 'scope-reviewer', [
+            {
+              message:
+                'Repo-specific build lesson should not be injected into unrelated repos.',
+              severity: 'warning',
+              suggestion:
+                'Keep the lesson one-task scoped until a reviewer approves broader sharing.',
+            },
+          ]),
+          createIteration(1, 'pass'),
+        ],
+      },
+      'scope-task',
+    );
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as CritiqueLesson;
+    expect(lesson.lessonScope).toMatchObject({
+      schemaVersion: 'lesson-scope-v1',
+      scope: 'task',
+      allowedTasks: ['scope-task'],
+      provenance: {
+        source: 'critique-loop',
+        taskId: 'scope-task',
+      },
+      auditTrail: [
+        expect.objectContaining({
+          actor: 'lesson-recorder',
+          toScope: 'task',
+          reason:
+            'Default one-task scope prevents cross-agent sharing before review.',
+        }),
+      ],
+    });
+    expect(isLessonApplicable(lesson, { taskId: 'scope-task' })).toBe(false);
+    const approved = applyHumanFeedbackToLesson(lesson, {
+      source: 'explicit-user-approval',
+      reason: 'Traceability and scope reviewed for repo-local reuse.',
+      observedAt: '2026-07-13T00:10:00.000Z',
+      evidence: [
+        {
+          kind: 'operator-report',
+          reference:
+            'https://github.com/djm204/frankenbeast/issues/1731#scope-review',
+        },
+      ],
+    });
+    expect(isLessonApplicable(approved, { taskId: 'scope-task' })).toBe(true);
+  });
+
+  it('filters scoped lessons by repo role profile task and expiry', () => {
+    const baseLesson = createLesson({ lifecycleStatus: 'active' });
+    const reviewedAt = '2026-07-13T01:00:00.000Z';
+
+    const globalForReviewer = updateLessonScope(baseLesson, {
+      scope: 'global',
+      allowedRoles: ['reviewer'],
+      actor: 'pm-reviewer',
+      reason: 'Safe global workflow lesson only for reviewer agents.',
+      changedAt: reviewedAt,
+      provenance: { source: 'human-review', taskId: 'scope-task' },
+    });
+    expect(isLessonApplicable(globalForReviewer, { role: 'reviewer' })).toBe(
+      true,
+    );
+    expect(isLessonApplicable(globalForReviewer, { role: 'worker' })).toBe(
+      false,
+    );
+
+    const repoScoped = updateLessonScope(baseLesson, {
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      actor: 'pm-reviewer',
+      reason: 'Repo-specific convention must stay in this repository.',
+      changedAt: reviewedAt,
+      provenance: { source: 'human-review', taskId: 'scope-task' },
+    });
+    expect(
+      isLessonApplicable(repoScoped, { repo: 'djm204/frankenbeast' }),
+    ).toBe(true);
+    expect(isLessonApplicable(repoScoped, { repo: 'other/repo' })).toBe(false);
+
+    const profileScoped = updateLessonScope(baseLesson, {
+      scope: 'profile',
+      allowedProfiles: ['default'],
+      actor: 'pm-reviewer',
+      reason: 'Profile-local fact must not leak to other Hermes profiles.',
+      changedAt: reviewedAt,
+      provenance: { source: 'human-review', taskId: 'scope-task' },
+    });
+    expect(isLessonApplicable(profileScoped, { profile: 'default' })).toBe(
+      true,
+    );
+    expect(isLessonApplicable(profileScoped, { profile: 'other' })).toBe(false);
+
+    const expired = updateLessonScope(baseLesson, {
+      scope: 'role',
+      allowedRoles: ['worker'],
+      actor: 'pm-reviewer',
+      reason: 'Temporary role lesson should expire after the migration.',
+      changedAt: reviewedAt,
+      expiresAt: '2026-07-13T02:00:00.000Z',
+      provenance: { source: 'human-review', taskId: 'scope-task' },
+    });
+    expect(
+      isLessonApplicable(expired, {
+        role: 'worker',
+        now: '2026-07-13T01:30:00.000Z',
+      }),
+    ).toBe(true);
+    expect(
+      isLessonApplicable(expired, {
+        role: 'worker',
+        now: '2026-07-13T02:00:00.000Z',
+      }),
+    ).toBe(false);
+  });
+
+  it('requires scope-specific allowlists and appends review audit entries', () => {
+    const baseLesson = createLesson({ lifecycleStatus: 'active' });
+
+    expect(() =>
+      updateLessonScope(baseLesson, {
+        scope: 'repo',
+        actor: 'pm-reviewer',
+        reason: 'Missing repo allowlist should fail closed.',
+        changedAt: '2026-07-13T01:00:00.000Z',
+      }),
+    ).toThrow('Repo-scoped lessons require at least one allowed repo.');
+
+    const repoScoped = updateLessonScope(baseLesson, {
+      scope: 'repo',
+      allowedRepos: ['djm204/frankenbeast'],
+      actor: 'pm-reviewer',
+      reason: 'Promote to repo scope after review.',
+      changedAt: '2026-07-13T01:00:00.000Z',
+    });
+    const roleScoped = updateLessonScope(repoScoped, {
+      scope: 'role',
+      allowedRoles: ['reviewer'],
+      actor: 'senior-reviewer',
+      reason: 'Demote to reviewer-only scope after privacy review.',
+      changedAt: '2026-07-13T02:00:00.000Z',
+    });
+
+    expect(roleScoped.lessonScope?.auditTrail).toEqual([
+      expect.objectContaining({
+        actor: 'pm-reviewer',
+        toScope: 'repo',
+      }),
+      expect.objectContaining({
+        actor: 'senior-reviewer',
+        fromScope: 'repo',
+        toScope: 'role',
+      }),
+    ]);
+  });
+
   it('weights explicit human feedback higher than inferred lesson signals', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port, {
@@ -1700,7 +1869,8 @@ describe('LessonRecorder', () => {
           evidence: [
             {
               kind: 'operator-report',
-              reference: 'https://github.com/djm204/frankenbeast/issues/1763#critique',
+              reference:
+                'https://github.com/djm204/frankenbeast/issues/1763#critique',
             },
           ],
         },
@@ -1745,8 +1915,10 @@ describe('LessonRecorder', () => {
     expect(manualReviewApproved.lifecycleStatus).toBe('active');
     expect(manualReviewApproved.experimentSandbox).toBeUndefined();
 
-    const { proposedLessonCritique: ignoredPromotionCritique, ...approvalReadyLesson } =
-      lesson;
+    const {
+      proposedLessonCritique: ignoredPromotionCritique,
+      ...approvalReadyLesson
+    } = lesson;
     void ignoredPromotionCritique;
 
     const directlyApproved = applyHumanFeedbackToLesson(approvalReadyLesson, {
@@ -1933,7 +2105,11 @@ describe('LessonRecorder', () => {
     expect(isLessonApplicable(approvedLegacySandboxedQuarantine)).toBe(true);
 
     const approvedRetired = applyHumanFeedbackToLesson(
-      { ...approvalReadyLesson, lifecycleStatus: 'retired', experimentSandbox: undefined },
+      {
+        ...approvalReadyLesson,
+        lifecycleStatus: 'retired',
+        experimentSandbox: undefined,
+      },
       {
         source: 'explicit-user-approval',
         reason: 'User acknowledged retired guidance for audit history only.',
@@ -3700,7 +3876,8 @@ describe('LessonRecorder', () => {
       },
       contradictionReport: {
         status: 'clear',
-        guidance: 'No deterministic lesson contradiction was detected among comparable prior lessons.',
+        guidance:
+          'No deterministic lesson contradiction was detected among comparable prior lessons.',
         verificationCommand: 'npm run test --workspace @franken/critique',
         contradictions: [],
       },
@@ -3719,21 +3896,34 @@ describe('LessonRecorder', () => {
       },
     });
 
-    const critique = critiqueProposedLesson(lesson, [], '2026-07-12T00:00:00.000Z');
+    const critique = critiqueProposedLesson(
+      lesson,
+      [],
+      '2026-07-12T00:00:00.000Z',
+    );
 
     expect(critique).toMatchObject({
       schemaVersion: 'lesson-multi-agent-critique-v1',
       verdict: 'accepted',
       highRisk: false,
       manualReviewRequired: false,
-      checklist: ['correctness', 'scope', 'privacy', 'security', 'duplication', 'conflict'],
+      checklist: [
+        'correctness',
+        'scope',
+        'privacy',
+        'security',
+        'duplication',
+        'conflict',
+      ],
       criticAgents: [
         'correctness-scope-critic',
         'privacy-security-critic',
         'duplication-conflict-critic',
       ],
     });
-    expect(critique.findings.every((finding) => finding.verdict === 'pass')).toBe(true);
+    expect(
+      critique.findings.every((finding) => finding.verdict === 'pass'),
+    ).toBe(true);
     expect(critique.evidenceRefs).toEqual(
       expect.arrayContaining([
         'traceability:lesson-task:factuality:iteration-0',
@@ -3753,7 +3943,13 @@ describe('LessonRecorder', () => {
           sensitive: true,
           approvalRequired: false,
           flags: ['task-state'],
-          redactions: [{ kind: 'secret', label: 'github-token', replacement: '[REDACTED_GITHUB_TOKEN]' }],
+          redactions: [
+            {
+              kind: 'secret',
+              label: 'github-token',
+              replacement: '[REDACTED_GITHUB_TOKEN]',
+            },
+          ],
           originalHash: 'secret-hash',
           reason: 'rejected before durable learning',
         },
@@ -3795,8 +3991,14 @@ describe('LessonRecorder', () => {
       verdict: 'needs-edit',
       manualReviewRequired: true,
       findings: expect.arrayContaining([
-        expect.objectContaining({ checklistItem: 'duplication', verdict: 'needs-edit' }),
-        expect.objectContaining({ checklistItem: 'conflict', verdict: 'needs-edit' }),
+        expect.objectContaining({
+          checklistItem: 'duplication',
+          verdict: 'needs-edit',
+        }),
+        expect.objectContaining({
+          checklistItem: 'conflict',
+          verdict: 'needs-edit',
+        }),
       ]),
     });
     expect(critiqueProposedLesson(lesson, [])).toMatchObject({
@@ -3849,7 +4051,8 @@ describe('LessonRecorder', () => {
       ],
       contradictionReport: {
         status: 'clear',
-        guidance: 'No deterministic lesson contradiction was detected among comparable prior lessons.',
+        guidance:
+          'No deterministic lesson contradiction was detected among comparable prior lessons.',
         verificationCommand: 'npm run test --workspace @franken/critique',
         contradictions: [],
       },
@@ -3875,13 +4078,17 @@ describe('LessonRecorder', () => {
       },
     });
 
-    const critique = critiqueProposedLesson(lesson, [deserializedSelf, quarantinedPrior]);
+    const critique = critiqueProposedLesson(lesson, [
+      deserializedSelf,
+      quarantinedPrior,
+    ]);
 
     expect(critique.verdict).toBe('accepted');
     expect(
       critique.findings.some(
         (finding) =>
-          finding.checklistItem === 'duplication' && finding.verdict === 'needs-edit',
+          finding.checklistItem === 'duplication' &&
+          finding.verdict === 'needs-edit',
       ),
     ).toBe(false);
   });
@@ -3902,7 +4109,8 @@ describe('LessonRecorder', () => {
       ],
       contradictionReport: {
         status: 'clear',
-        guidance: 'No deterministic lesson contradiction was detected among comparable prior lessons.',
+        guidance:
+          'No deterministic lesson contradiction was detected among comparable prior lessons.',
         verificationCommand: 'npm run test --workspace @franken/critique',
         contradictions: [],
       },
@@ -3934,14 +4142,18 @@ describe('LessonRecorder', () => {
     expect(critiqueProposedLesson(lesson, [sandboxedPrior])).toMatchObject({
       verdict: 'needs-edit',
       findings: expect.arrayContaining([
-        expect.objectContaining({ checklistItem: 'duplication', verdict: 'needs-edit' }),
+        expect.objectContaining({
+          checklistItem: 'duplication',
+          verdict: 'needs-edit',
+        }),
       ]),
     });
   });
 
   it('marks high-risk or conflicting proposed lessons as needs-edit/manual-review', () => {
     const current = createLesson({
-      correctionApplied: 'Do not reuse cache responses without provenance checks',
+      correctionApplied:
+        'Do not reuse cache responses without provenance checks',
       testTraceability: [
         {
           lessonId: 'current-cache-lesson',
@@ -3949,7 +4161,9 @@ describe('LessonRecorder', () => {
           evaluatorName: 'factuality',
           failingIteration: 0,
           resolvedIteration: 1,
-          sourceFindingMessages: ['Cache guidance allowed unaudited stale responses'],
+          sourceFindingMessages: [
+            'Cache guidance allowed unaudited stale responses',
+          ],
           testId: 'current-cache-lesson:regression',
           verificationCommand: 'npm run test --workspace @franken/critique',
         },
@@ -3961,7 +4175,13 @@ describe('LessonRecorder', () => {
         sensitive: true,
         approvalRequired: true,
         flags: ['secret'],
-        redactions: [{ kind: 'secret', label: 'bearer-token', replacement: 'Bearer [REDACTED_TOKEN]' }],
+        redactions: [
+          {
+            kind: 'secret',
+            label: 'bearer-token',
+            replacement: 'Bearer [REDACTED_TOKEN]',
+          },
+        ],
         originalHash: 'redacted-hash',
         reason: 'sensitive candidate was redacted before durable learning',
       },
@@ -3974,7 +4194,9 @@ describe('LessonRecorder', () => {
           evaluatorName: 'factuality',
           failingIteration: 0,
           resolvedIteration: 1,
-          sourceFindingMessages: ['Cache guidance allowed unaudited stale responses'],
+          sourceFindingMessages: [
+            'Cache guidance allowed unaudited stale responses',
+          ],
           testId: 'prior-cache-lesson:regression',
           verificationCommand: 'npm run test --workspace @franken/critique',
         },
@@ -3990,8 +4212,14 @@ describe('LessonRecorder', () => {
     expect(critique.findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ checklistItem: 'privacy', verdict: 'pass' }),
-        expect.objectContaining({ checklistItem: 'conflict', verdict: 'needs-edit' }),
-        expect.objectContaining({ checklistItem: 'duplication', verdict: 'needs-edit' }),
+        expect.objectContaining({
+          checklistItem: 'conflict',
+          verdict: 'needs-edit',
+        }),
+        expect.objectContaining({
+          checklistItem: 'duplication',
+          verdict: 'needs-edit',
+        }),
       ]),
     );
     expect(JSON.stringify(critique)).not.toContain('Bearer token');
@@ -4089,7 +4317,8 @@ describe('LessonRecorder', () => {
     port.searchLessons = vi.fn().mockResolvedValue([
       createLesson({
         failureDescription: 'Cache guidance allowed unaudited stale responses',
-        correctionApplied: 'Require cache verification and provenance review before reuse',
+        correctionApplied:
+          'Require cache verification and provenance review before reuse',
       }),
     ]);
     const recorder = new LessonRecorder(port);
@@ -4099,7 +4328,10 @@ describe('LessonRecorder', () => {
         verdict: 'pass',
         iterations: [
           createIteration(0, 'fail', 'factuality', [
-            { message: 'Cache guidance allowed unaudited stale responses', severity: 'warning' },
+            {
+              message: 'Cache guidance allowed unaudited stale responses',
+              severity: 'warning',
+            },
           ]),
           createIteration(1, 'pass'),
         ],
@@ -4107,7 +4339,8 @@ describe('LessonRecorder', () => {
       'lesson-task',
     );
 
-    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0];
     expect(lesson.proposedLessonCritique).toMatchObject({
       verdict: 'needs-edit',
       findings: expect.arrayContaining([
@@ -4135,7 +4368,8 @@ describe('LessonRecorder', () => {
       ],
       contradictionReport: {
         status: 'clear',
-        guidance: 'No deterministic lesson contradiction was detected among comparable prior lessons.',
+        guidance:
+          'No deterministic lesson contradiction was detected among comparable prior lessons.',
         verificationCommand: 'npm run test --workspace @franken/critique',
         contradictions: [],
       },

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1639,7 +1639,51 @@ describe('LessonRecorder', () => {
     expect(isLessonApplicable(profileScoped, { profile: 'default' })).toBe(
       true,
     );
-    expect(isLessonApplicable(profileScoped, { profile: 'other' })).toBe(false);
+    const globalForOneTask = updateLessonScope(baseLesson, {
+      scope: 'global',
+      allowedTasks: ['task-a'],
+      actor: 'pm-reviewer',
+      reason: 'Globally reusable only for one migration task.',
+      changedAt: reviewedAt,
+      provenance: { source: 'human-review', taskId: 'scope-task' },
+    });
+    expect(isLessonApplicable(globalForOneTask, { taskId: 'task-a' })).toBe(
+      true,
+    );
+    expect(isLessonApplicable(globalForOneTask, { taskId: 'task-b' })).toBe(
+      false,
+    );
+
+    const malformedExpiry = {
+      ...updateLessonScope(baseLesson, {
+        scope: 'task',
+        allowedTasks: ['task-a'],
+        actor: 'pm-reviewer',
+        reason: 'Persisted malformed expiry must fail closed.',
+        changedAt: reviewedAt,
+        provenance: { source: 'human-review', taskId: 'scope-task' },
+      }),
+      lessonScope: {
+        ...updateLessonScope(baseLesson, {
+          scope: 'task',
+          allowedTasks: ['task-a'],
+          actor: 'pm-reviewer',
+          reason: 'Persisted malformed expiry must fail closed.',
+          changedAt: reviewedAt,
+          provenance: { source: 'human-review', taskId: 'scope-task' },
+        }).lessonScope!,
+        expiresAt: 'not-a-date',
+      },
+    };
+    expect(isLessonApplicable(malformedExpiry, { taskId: 'task-a' })).toBe(
+      false,
+    );
+    expect(
+      isLessonApplicable(globalForOneTask, {
+        taskId: 'task-a',
+        now: 'not-a-date',
+      }),
+    ).toBe(false);
 
     const expired = updateLessonScope(baseLesson, {
       scope: 'role',
@@ -1691,6 +1735,11 @@ describe('LessonRecorder', () => {
       changedAt: '2026-07-13T02:00:00.000Z',
     });
 
+    expect(roleScoped.lessonScope).toMatchObject({
+      scope: 'role',
+      allowedRepos: ['djm204/frankenbeast'],
+      allowedRoles: ['reviewer'],
+    });
     expect(roleScoped.lessonScope?.auditTrail).toEqual([
       expect.objectContaining({
         actor: 'pm-reviewer',
@@ -1702,6 +1751,62 @@ describe('LessonRecorder', () => {
         toScope: 'role',
       }),
     ]);
+  });
+
+  it('ignores scoped-out prior lessons during promotion critique', async () => {
+    const scopedOutPrior = updateLessonScope(
+      createLesson({
+        failureDescription: 'Cache guidance allowed unaudited stale responses',
+        correctionApplied: 'Require cache verification before reuse',
+        taskId: 'prior-task',
+        lifecycleStatus: 'active',
+      }),
+      {
+        scope: 'task',
+        allowedTasks: ['prior-task'],
+        actor: 'pm-reviewer',
+        reason: 'Prior lesson is task-local only.',
+        changedAt: '2026-07-13T01:00:00.000Z',
+      },
+    );
+    const port = {
+      ...createMockMemoryPort(),
+      searchLessons: vi.fn().mockResolvedValue([scopedOutPrior]),
+    };
+    const recorder = new LessonRecorder(port, {
+      now: (): Date => new Date('2026-07-13T03:00:00.000Z'),
+    });
+
+    await recorder.record(
+      {
+        verdict: 'pass',
+        iterations: [
+          createIteration(0, 'fail', 'factuality', [
+            {
+              message: 'Cache guidance allowed unaudited stale responses',
+              severity: 'warning',
+              suggestion: 'Require cache verification before reuse',
+            },
+          ]),
+          createIteration(1, 'pass'),
+        ],
+      },
+      'current-task',
+    );
+
+    const lesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as CritiqueLesson;
+    expect(lesson.contradictionReport?.status).not.toBe(
+      'contradiction_detected',
+    );
+    expect(
+      lesson.proposedLessonCritique?.findings.some((finding) =>
+        finding.evidenceRefs.some(
+          (ref) =>
+            ref !== 'duplicate:not_checked' && ref.startsWith('duplicate:'),
+        ),
+      ),
+    ).toBe(false);
   });
 
   it('weights explicit human feedback higher than inferred lesson signals', async () => {
@@ -2162,14 +2267,14 @@ describe('LessonRecorder', () => {
 
     await recorder.record(result, 'first-task');
     now = new Date('2026-07-12T10:00:30.000Z');
-    const suppressed = await recorder.record(result, 'second-task');
+    const suppressed = await recorder.record(result, 'first-task');
 
     expect(suppressed.learningBacklogPrioritizationReport.items).toEqual([
       expect.objectContaining({
         source: 'cooldown-suppression',
         priority: 'low',
         score: 20,
-        taskId: 'second-task',
+        taskId: 'first-task',
         evaluatorName: 'learning-reviewer',
         recommendedAction:
           'Reuse the existing in-cooldown lesson until suppression expires; do not create a duplicate backlog item.',
@@ -2662,7 +2767,7 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(lesson.cooldown).toEqual({
-      key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
+      key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
       windowMs: 60_000,
       recordedAt: '2026-07-12T10:00:00.000Z',
       suppressUntil: '2026-07-12T10:01:00.000Z',
@@ -2694,14 +2799,14 @@ describe('LessonRecorder', () => {
 
     await recorder.record(result, 'first-task');
     now = new Date('2026-07-12T10:00:30.000Z');
-    const suppressed = await recorder.record(result, 'second-task');
+    const suppressed = await recorder.record(result, 'first-task');
 
     expect(port.recordLesson).toHaveBeenCalledTimes(1);
     expect(suppressed.recorded).toBe(0);
     expect(suppressed.suppressedByCooldown).toEqual([
       {
-        key: expect.stringMatching(/^critique-lesson:learning-reviewer:/),
-        taskId: 'second-task',
+        key: expect.stringMatching(/^critique-lesson:[^:]+:learning-reviewer:/),
+        taskId: 'first-task',
         evaluatorName: 'learning-reviewer',
         suppressedAt: '2026-07-12T10:00:30.000Z',
         suppressUntil: '2026-07-12T10:01:00.000Z',
@@ -2710,6 +2815,35 @@ describe('LessonRecorder', () => {
           'Equivalent critique lesson is still inside the learning cooldown window; reuse the existing lesson metadata instead of recording another copy.',
       },
     ]);
+  });
+
+  it('does not suppress equivalent task-scoped lessons across different tasks', async () => {
+    const port = createMockMemoryPort();
+    let now = new Date('2026-07-12T10:00:00.000Z');
+    const recorder = new LessonRecorder(port, {
+      cooldownMs: 60_000,
+      now: (): Date => now,
+    });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'learning-reviewer', [
+          {
+            message: 'Repeated PM handoff lesson caused churn',
+            severity: 'warning',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await recorder.record(result, 'first-task');
+    now = new Date('2026-07-12T10:00:30.000Z');
+    const second = await recorder.record(result, 'second-task');
+
+    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(second.recorded).toBe(1);
+    expect(second.suppressedByCooldown).toEqual([]);
   });
 
   it('clusters repeated failures by task family, package, tool, and root cause without retaining raw transcripts', async () => {
@@ -2765,8 +2899,8 @@ describe('LessonRecorder', () => {
         occurrences: 1,
       }),
     ]);
-    expect(secondSummary.recorded).toBe(0);
-    expect(secondSummary.suppressedByCooldown).toHaveLength(1);
+    expect(secondSummary.recorded).toBe(1);
+    expect(secondSummary.suppressedByCooldown).toEqual([]);
     expect(secondSummary.failureClusterReport.clusters).toEqual([
       expect.objectContaining({
         taskFamily: 'frontend auth',
@@ -3037,14 +3171,14 @@ describe('LessonRecorder', () => {
     };
 
     await firstRecorder.record(result, 'first-task');
-    const suppressed = await secondRecorder.record(result, 'second-task');
+    const suppressed = await secondRecorder.record(result, 'first-task');
 
     expect(port.recordLesson).toHaveBeenCalledTimes(1);
     expect(suppressed).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [
         expect.objectContaining({
-          taskId: 'second-task',
+          taskId: 'first-task',
           remainingMs: 30_000,
         }),
       ],
@@ -3091,7 +3225,7 @@ describe('LessonRecorder', () => {
 
     const firstRecord = firstRecorder.record(result, 'first-task');
     await persistenceStarted;
-    const secondRecord = secondRecorder.record(result, 'second-task');
+    const secondRecord = secondRecorder.record(result, 'first-task');
     releasePersistence();
     const [firstSummary, secondSummary] = await Promise.all([
       firstRecord,
@@ -3106,9 +3240,7 @@ describe('LessonRecorder', () => {
     });
     expect(secondSummary).toMatchObject({
       recorded: 0,
-      suppressedByCooldown: [
-        expect.objectContaining({ taskId: 'second-task' }),
-      ],
+      suppressedByCooldown: [expect.objectContaining({ taskId: 'first-task' })],
       minedBlockerPatterns: [],
     });
   });
@@ -3189,7 +3321,7 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:02.000Z');
     releasePersistence();
     await firstRecord;
-    const secondSummary = await recorder.record(result, 'second-task');
+    const secondSummary = await recorder.record(result, 'first-task');
     const firstLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
       .calls[0]![0] as {
       cooldown: { recordedAt: string; suppressUntil: string };
@@ -3236,7 +3368,7 @@ describe('LessonRecorder', () => {
 
     const firstRecord = recorder.record(result, 'first-task');
     await persistenceStarted;
-    const secondRecord = recorder.record(result, 'second-task');
+    const secondRecord = recorder.record(result, 'first-task');
     releasePersistence();
     const [firstSummary, secondSummary] = await Promise.all([
       firstRecord,
@@ -3253,7 +3385,7 @@ describe('LessonRecorder', () => {
       recorded: 0,
       suppressedByCooldown: [
         expect.objectContaining({
-          taskId: 'second-task',
+          taskId: 'first-task',
           evaluatorName: 'learning-reviewer',
           remainingMs: 60_000,
         }),
@@ -3295,7 +3427,7 @@ describe('LessonRecorder', () => {
 
     const firstRecord = recorder.record(result, 'first-task');
     await firstPersistenceStarted;
-    const secondRecord = recorder.record(result, 'second-task');
+    const secondRecord = recorder.record(result, 'first-task');
     const thirdRecord = recorder.record(result, 'third-task');
     rejectFirstPersistence(new Error('transient store failure'));
     const [firstSummary, secondSummary, thirdSummary] = await Promise.all([
@@ -3304,7 +3436,7 @@ describe('LessonRecorder', () => {
       thirdRecord,
     ]);
 
-    expect(port.recordLesson).toHaveBeenCalledTimes(2);
+    expect(port.recordLesson).toHaveBeenCalledTimes(3);
     expect(firstSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [],
@@ -3316,13 +3448,8 @@ describe('LessonRecorder', () => {
       minedBlockerPatterns: [],
     });
     expect(thirdSummary).toMatchObject({
-      recorded: 0,
-      suppressedByCooldown: [
-        expect.objectContaining({
-          taskId: 'third-task',
-          evaluatorName: 'learning-reviewer',
-        }),
-      ],
+      recorded: 1,
+      suppressedByCooldown: [],
       minedBlockerPatterns: [],
     });
   });
@@ -3515,25 +3642,32 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:10.000Z');
     const secondSummary = await recorder.record(result, 'task-b');
     now = new Date('2026-07-12T10:00:20.000Z');
-    const thirdSummary = await recorder.record(result, 'task-c');
-    const thirdLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
-      .calls[1]![0];
+    const thirdSummary = await recorder.record(result, 'task-b');
+    now = new Date('2026-07-12T10:00:30.000Z');
+    const fourthSummary = await recorder.record(result, 'task-c');
+    const fourthLesson = (port.recordLesson as ReturnType<typeof vi.fn>).mock
+      .calls[2]![0];
 
     expect(secondSummary).toMatchObject({
+      recorded: 1,
+      suppressedByCooldown: [],
+      minedBlockerPatterns: [],
+    });
+    expect(thirdSummary).toMatchObject({
       recorded: 0,
       suppressedByCooldown: [expect.objectContaining({ taskId: 'task-b' })],
       minedBlockerPatterns: [],
     });
-    expect(thirdSummary.recorded).toBe(1);
-    expect(thirdSummary.suppressedByCooldown).toEqual([]);
-    expect(thirdSummary.minedBlockerPatterns).toEqual([
+    expect(fourthSummary.recorded).toBe(1);
+    expect(fourthSummary.suppressedByCooldown).toEqual([]);
+    expect(fourthSummary.minedBlockerPatterns).toEqual([
       expect.objectContaining({
         occurrences: 3,
         taskIds: ['task-a', 'task-b', 'task-c'],
       }),
     ]);
-    expect(thirdLesson.blockerPatterns).toEqual(
-      thirdSummary.minedBlockerPatterns,
+    expect(fourthLesson.blockerPatterns).toEqual(
+      fourthSummary.minedBlockerPatterns,
     );
   });
 
@@ -3727,14 +3861,14 @@ describe('LessonRecorder', () => {
     now = new Date('2026-07-12T10:00:10.000Z');
     const secondSummary = await recorder.record(result, 'task-b');
     now = new Date('2026-07-12T10:00:20.000Z');
-    const thirdSummary = await recorder.record(result, 'task-c');
+    const thirdSummary = await recorder.record(result, 'task-b');
 
     expect(secondSummary.recorded).toBe(1);
     expect(secondSummary.minedBlockerPatterns).toHaveLength(1);
     expect(port.recordLesson).toHaveBeenCalledTimes(2);
     expect(thirdSummary).toMatchObject({
       recorded: 0,
-      suppressedByCooldown: [expect.objectContaining({ taskId: 'task-c' })],
+      suppressedByCooldown: [expect.objectContaining({ taskId: 'task-b' })],
       minedBlockerPatterns: [],
     });
   });
@@ -3764,7 +3898,7 @@ describe('LessonRecorder', () => {
     };
 
     const failedSummary = await recorder.record(result, 'task-a');
-    const secondSummary = await recorder.record(result, 'task-b');
+    const secondSummary = await recorder.record(result, 'task-a');
 
     expect(failedSummary).toMatchObject({
       recorded: 0,
@@ -3825,7 +3959,7 @@ describe('LessonRecorder', () => {
     };
 
     await recorder.record(result, 'task-a');
-    const secondSummary = await recorder.record(result, 'task-b');
+    const secondSummary = await recorder.record(result, 'task-a');
 
     expect(secondSummary.minedBlockerPatterns).toEqual([]);
   });

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1709,6 +1709,42 @@ describe('LessonRecorder', () => {
       }),
     ).toBe(false);
 
+    const importedRepoWithWrongAuditScope = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+        auditTrail: [
+          {
+            changedAt: reviewedAt,
+            actor: 'pm-reviewer',
+            toScope: 'task',
+            reason: 'Only attested a task-local scope.',
+          },
+        ],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithWrongAuditScope, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
+    const unknownSchemaRepoScope = {
+      ...repoScoped,
+      lessonScope: {
+        ...repoScoped.lessonScope!,
+        schemaVersion: 'lesson-scope-v2',
+      } as unknown as CritiqueLesson['lessonScope'],
+    };
+    expect(
+      isLessonApplicable(unknownSchemaRepoScope, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const expired = updateLessonScope(baseLesson, {
       scope: 'role',
       allowedRoles: ['worker'],
@@ -1936,9 +1972,28 @@ describe('LessonRecorder', () => {
         changedAt: '2026-07-13T01:00:00.000Z',
       },
     );
+    const scopedOutPriors = Array.from({ length: 10 }, (_, index) =>
+      updateLessonScope(
+        createLesson({
+          failureDescription: `Scoped-out duplicate ${index}`,
+          correctionApplied: 'Require cache verification before reuse',
+          taskId: `scoped-out-${index}`,
+          lifecycleStatus: 'active',
+        }),
+        {
+          scope: 'task',
+          allowedTasks: [`scoped-out-${index}`],
+          actor: 'pm-reviewer',
+          reason: 'Scoped to another task.',
+          changedAt: '2026-07-13T01:00:00.000Z',
+        },
+      ),
+    );
     const port = {
       ...createMockMemoryPort(),
-      searchLessons: vi.fn().mockResolvedValue([scopedPrior]),
+      searchLessons: vi
+        .fn()
+        .mockResolvedValue([...scopedOutPriors, scopedPrior]),
     };
     const recorder = new LessonRecorder(port, {
       now: (): Date => new Date('2026-07-13T03:00:00.000Z'),
@@ -4613,7 +4668,7 @@ describe('LessonRecorder', () => {
       expect.stringContaining(
         'Cache guidance allowed unaudited stale responses',
       ),
-      10,
+      50,
     );
     expect(lesson.contradictionReport).toEqual({
       status: 'clear',
@@ -5988,7 +6043,7 @@ describe('LessonRecorder', () => {
       expect.stringContaining(
         'Do not reuse cache responses without provenance checks',
       ),
-      10,
+      50,
     );
   });
 


### PR DESCRIPTION
## Summary
- Adds explicit lesson scope metadata for global/repo/role/profile/task sharing gates.
- Defaults newly recorded critique lessons to task-local scope until reviewed.
- Adds scoped applicability checks, review audit trails, expiry handling, and unit coverage.

## Test Plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run typecheck --workspace @franken/critique
- npm run build --workspace @franken/critique
- npm run lint --workspace @franken/critique

Note: npm run format:check --workspace @franken/critique currently fails on pre-existing formatting drift outside this PR's touched files.

Closes #1731