### PR TITLE
feat(orchestrator): add DR process cleanup plan

### DIFF
--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -4,6 +4,10 @@ export type ProcessCleanupFindingCode =
   | 'live-matching-worker'
   | 'wrong-command'
   | 'wrong-cwd'
+  | 'wrong-uid'
+  | 'wrong-args'
+  | 'wrong-start-time'
+  | 'duplicate-recorded-pid'
   | 'orphan-duplicate-process';
 
 export type ProcessCleanupSeverity = 'info' | 'warning' | 'blocker';
@@ -19,6 +23,7 @@ export interface ProcessCleanupAttemptSnapshot {
   readonly expectedArgs?: readonly string[] | undefined;
   readonly expectedCwd?: string | undefined;
   readonly expectedUid?: number | undefined;
+  readonly expectedStartTimeTicks?: string | undefined;
 }
 
 export interface ProcessTableEntry {
@@ -97,6 +102,11 @@ function argsMatch(attempt: ProcessCleanupAttemptSnapshot, processEntry: Process
   return attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
 }
 
+function startTimeMatches(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
+  return attempt.expectedStartTimeTicks === undefined
+    || attempt.expectedStartTimeTicks === processEntry.startTimeTicks;
+}
+
 function isLiveMatchingWorker(
   attempt: ProcessCleanupAttemptSnapshot,
   processEntry: ProcessTableEntry,
@@ -105,7 +115,8 @@ function isLiveMatchingWorker(
   return commandMatches(attempt, processEntry)
     && cwdMatches(attempt, processEntry)
     && uidMatches(attempt, processEntry, currentUid)
-    && argsMatch(attempt, processEntry);
+    && argsMatch(attempt, processEntry)
+    && startTimeMatches(attempt, processEntry);
 }
 
 function finding(input: ProcessCleanupFinding): ProcessCleanupFinding {
@@ -121,9 +132,16 @@ function statusForFindings(findings: readonly ProcessCleanupFinding[]): ProcessC
 function summarize(report: Pick<ProcessCleanupPlanReport, 'status' | 'findings' | 'actions'>): string {
   const staleCount = report.findings.filter((item) => item.code === 'stale-pid').length;
   const orphanCount = report.findings.filter((item) => item.code === 'orphan-duplicate-process').length;
-  const guardedSkips = report.findings.filter((item) => item.code === 'wrong-command' || item.code === 'wrong-cwd').length;
+  const guardedSkips = report.findings.filter((item) => [
+    'wrong-command',
+    'wrong-cwd',
+    'wrong-uid',
+    'wrong-args',
+    'wrong-start-time',
+    'duplicate-recorded-pid',
+  ].includes(item.code)).length;
   const planned = report.actions.filter((action) => action.action !== 'none').length;
-  const evidenceRule = 'No orphan duplicate termination is planned without matching uid, cwd, and command evidence.';
+  const evidenceRule = 'No orphan duplicate termination is planned without matching uid, cwd, command, args, and process-start evidence.';
 
   if (report.status === 'clean') {
     return `Process cleanup plan is clean; all inspected live attempts match their recorded PID, command, cwd, and owner. ${evidenceRule}`;
@@ -136,6 +154,12 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
   const findings: ProcessCleanupFinding[] = [];
   const actions: ProcessCleanupAction[] = [];
   const processByPid = new Map(options.processes.map((entry) => [entry.pid, entry] as const));
+  const recordedPidCounts = new Map<number, number>();
+  for (const attempt of options.attempts) {
+    if (typeof attempt.pid === 'number' && attempt.pid > 0) {
+      recordedPidCounts.set(attempt.pid, (recordedPidCounts.get(attempt.pid) ?? 0) + 1);
+    }
+  }
   const claimedPids = new Set<number>();
 
   for (const attempt of options.attempts) {
@@ -179,6 +203,31 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
         requiresApproval: false,
         wouldExecute: false,
         reason: 'Dry-run would clear the stale attempt PID/run liveness pointer; no process signal is needed.',
+      });
+      continue;
+    }
+
+    if ((recordedPidCounts.get(attempt.pid) ?? 0) > 1) {
+      findings.push(finding({
+        code: 'duplicate-recorded-pid',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is recorded by more than one live attempt snapshot.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Duplicate PID ownership requires operator review to choose the surviving run/attempt before cleanup.',
       });
       continue;
     }
@@ -229,6 +278,81 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
         requiresApproval: true,
         wouldExecute: false,
         reason: 'Wrong-cwd PID may be a sibling or unrelated process; skip termination and require manual investigation.',
+      });
+      continue;
+    }
+
+    if (!uidMatches(attempt, liveProcess, options.currentUid)) {
+      findings.push(finding({
+        code: 'wrong-uid',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is live with expected command/cwd but a different owner uid.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Wrong-uid PID may be reused by another user; skip termination and require manual investigation.',
+      });
+      continue;
+    }
+
+    if (!argsMatch(attempt, liveProcess)) {
+      findings.push(finding({
+        code: 'wrong-args',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is live with expected command/cwd/uid but different launch arguments.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Wrong-args PID may be a different worker-looking process; skip termination and require manual investigation.',
+      });
+      continue;
+    }
+
+    if (!startTimeMatches(attempt, liveProcess)) {
+      findings.push(finding({
+        code: 'wrong-start-time',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is live but the process start token does not match the recorded attempt.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Wrong-start-time PID may be PID reuse; skip termination and require manual investigation.',
       });
       continue;
     }

--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -95,16 +95,16 @@ function uidMatches(
 }
 
 function argsMatch(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
-  if (!attempt.expectedArgs || attempt.expectedArgs.length === 0) {
-    return true;
-  }
+  if (!attempt.expectedArgs) return false;
   const actualArgs = processEntry.args ?? [];
-  return attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
+  return actualArgs.length === attempt.expectedArgs.length
+    && attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
 }
 
 function startTimeMatches(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
-  return attempt.expectedStartTimeTicks === undefined
-    || attempt.expectedStartTimeTicks === processEntry.startTimeTicks;
+  return typeof attempt.expectedStartTimeTicks === 'string'
+    && attempt.expectedStartTimeTicks.length > 0
+    && attempt.expectedStartTimeTicks === processEntry.startTimeTicks;
 }
 
 function isLiveMatchingWorker(
@@ -383,6 +383,7 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
   const orphanPids = new Set<number>();
   for (const attempt of options.attempts) {
     if (!attempt.expectedCommand || !attempt.expectedCwd) continue;
+    if (typeof attempt.pid === 'number' && (recordedPidCounts.get(attempt.pid) ?? 0) > 1) continue;
     const recordedProcess = typeof attempt.pid === 'number' ? processByPid.get(attempt.pid) : undefined;
     if (!recordedProcess || !isLiveMatchingWorker(attempt, recordedProcess, options.currentUid)) continue;
     for (const processEntry of options.processes) {

--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -95,10 +95,10 @@ function uidMatches(
 }
 
 function argsMatch(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
-  if (!attempt.expectedArgs || !processEntry.args) return false;
-  const actualArgs = processEntry.args;
-  return actualArgs.length === attempt.expectedArgs.length
-    && attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
+  if (!attempt.expectedArgs) return false;
+  if (!processEntry.args) return false;
+  return processEntry.args.length === attempt.expectedArgs.length
+    && attempt.expectedArgs.every((arg, index) => processEntry.args?.[index] === arg);
 }
 
 function startTimeMatches(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
@@ -127,7 +127,9 @@ function isMatchingOrphanCandidate(
   return commandMatches(attempt, processEntry)
     && cwdMatches(attempt, processEntry)
     && uidMatches(attempt, processEntry, currentUid)
-    && argsMatch(attempt, processEntry);
+    && argsMatch(attempt, processEntry)
+    && typeof processEntry.startTimeTicks === 'string'
+    && processEntry.startTimeTicks.length > 0;
 }
 
 function finding(input: ProcessCleanupFinding): ProcessCleanupFinding {

--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -95,8 +95,8 @@ function uidMatches(
 }
 
 function argsMatch(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
-  if (!attempt.expectedArgs) return false;
-  const actualArgs = processEntry.args ?? [];
+  if (!attempt.expectedArgs || !processEntry.args) return false;
+  const actualArgs = processEntry.args;
   return actualArgs.length === attempt.expectedArgs.length
     && attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
 }
@@ -117,6 +117,17 @@ function isLiveMatchingWorker(
     && uidMatches(attempt, processEntry, currentUid)
     && argsMatch(attempt, processEntry)
     && startTimeMatches(attempt, processEntry);
+}
+
+function isMatchingOrphanCandidate(
+  attempt: ProcessCleanupAttemptSnapshot,
+  processEntry: ProcessTableEntry,
+  currentUid: number | undefined,
+): boolean {
+  return commandMatches(attempt, processEntry)
+    && cwdMatches(attempt, processEntry)
+    && uidMatches(attempt, processEntry, currentUid)
+    && argsMatch(attempt, processEntry);
 }
 
 function finding(input: ProcessCleanupFinding): ProcessCleanupFinding {
@@ -388,7 +399,7 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
     if (!recordedProcess || !isLiveMatchingWorker(attempt, recordedProcess, options.currentUid)) continue;
     for (const processEntry of options.processes) {
       if (claimedPids.has(processEntry.pid) || orphanPids.has(processEntry.pid)) continue;
-      if (!isLiveMatchingWorker(attempt, processEntry, options.currentUid)) continue;
+      if (!isMatchingOrphanCandidate(attempt, processEntry, options.currentUid)) continue;
       orphanPids.add(processEntry.pid);
       findings.push(finding({
         code: 'orphan-duplicate-process',

--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -53,6 +53,7 @@ export interface ProcessCleanupAction {
   readonly runId: string;
   readonly attemptId: string;
   readonly pid?: number | undefined;
+  readonly startTimeTicks?: string | undefined;
   readonly requiresApproval: boolean;
   readonly wouldExecute: boolean;
   readonly reason: string;
@@ -132,6 +133,20 @@ function isMatchingOrphanCandidate(
     && processEntry.startTimeTicks.length > 0;
 }
 
+const TERMINAL_ATTEMPT_STATUSES = new Set([
+  'completed',
+  'complete',
+  'failed',
+  'stopped',
+  'cancelled',
+  'canceled',
+  'crashed',
+]);
+
+function isTerminalAttempt(attempt: ProcessCleanupAttemptSnapshot): boolean {
+  return TERMINAL_ATTEMPT_STATUSES.has(attempt.status.toLowerCase());
+}
+
 function finding(input: ProcessCleanupFinding): ProcessCleanupFinding {
   return input;
 }
@@ -167,16 +182,19 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
   const findings: ProcessCleanupFinding[] = [];
   const actions: ProcessCleanupAction[] = [];
   const processByPid = new Map(options.processes.map((entry) => [entry.pid, entry] as const));
+  const activeAttempts = options.attempts.filter((attempt) => !isTerminalAttempt(attempt));
   const recordedPidCounts = new Map<number, number>();
-  for (const attempt of options.attempts) {
+  for (const attempt of activeAttempts) {
     if (typeof attempt.pid === 'number' && attempt.pid > 0) {
       recordedPidCounts.set(attempt.pid, (recordedPidCounts.get(attempt.pid) ?? 0) + 1);
     }
   }
   const claimedPids = new Set<number>();
+  const missingPidAttempts: ProcessCleanupAttemptSnapshot[] = [];
 
-  for (const attempt of options.attempts) {
+  for (const attempt of activeAttempts) {
     if (typeof attempt.pid !== 'number' || attempt.pid <= 0) {
+      missingPidAttempts.push(attempt);
       findings.push(finding({
         code: 'missing-pid',
         severity: 'warning',
@@ -394,7 +412,7 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
   }
 
   const orphanPids = new Set<number>();
-  for (const attempt of options.attempts) {
+  for (const attempt of activeAttempts) {
     if (!attempt.expectedCommand || !attempt.expectedCwd) continue;
     if (typeof attempt.pid === 'number' && (recordedPidCounts.get(attempt.pid) ?? 0) > 1) continue;
     const recordedProcess = typeof attempt.pid === 'number' ? processByPid.get(attempt.pid) : undefined;
@@ -402,6 +420,9 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
     for (const processEntry of options.processes) {
       if (claimedPids.has(processEntry.pid) || orphanPids.has(processEntry.pid)) continue;
       if (!isMatchingOrphanCandidate(attempt, processEntry, options.currentUid)) continue;
+      if (missingPidAttempts.some((missingAttempt) => isMatchingOrphanCandidate(missingAttempt, processEntry, options.currentUid))) {
+        continue;
+      }
       orphanPids.add(processEntry.pid);
       findings.push(finding({
         code: 'orphan-duplicate-process',
@@ -420,9 +441,10 @@ export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): Pro
         runId: attempt.runId,
         attemptId: attempt.attemptId,
         pid: processEntry.pid,
+        startTimeTicks: processEntry.startTimeTicks,
         requiresApproval: true,
         wouldExecute: !dryRun && options.approveTermination === true,
-        reason: 'Duplicate orphan termination requires matching uid, cwd, and command evidence plus explicit operator approval.',
+        reason: 'Duplicate orphan termination requires matching uid, cwd, command, args, and process-start evidence plus explicit operator approval.',
       });
     }
   }
@@ -461,7 +483,8 @@ export function renderProcessCleanupDryRunPlan(report: ProcessCleanupPlanReport)
         const pid = action.pid === undefined ? 'none' : String(action.pid);
         const approval = action.requiresApproval ? 'required' : 'not-required';
         const mode = action.wouldExecute ? 'execute' : 'dry-run';
-        return `- ${action.action} pid=${pid} approval=${approval} ${mode} run=${action.runId} attempt=${action.attemptId}: ${action.reason}`;
+        const start = action.startTimeTicks ? ` startTimeTicks=${action.startTimeTicks}` : '';
+        return `- ${action.action} pid=${pid}${start} approval=${approval} ${mode} run=${action.runId} attempt=${action.attemptId}: ${action.reason}`;
       }),
   ];
   if (report.actions.every((action) => action.action === 'none')) {

--- a/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
+++ b/packages/franken-orchestrator/src/dr/process-cleanup-plan.ts
@@ -1,0 +1,333 @@
+export type ProcessCleanupFindingCode =
+  | 'missing-pid'
+  | 'stale-pid'
+  | 'live-matching-worker'
+  | 'wrong-command'
+  | 'wrong-cwd'
+  | 'orphan-duplicate-process';
+
+export type ProcessCleanupSeverity = 'info' | 'warning' | 'blocker';
+export type ProcessCleanupStatus = 'clean' | 'review-required' | 'blocked';
+export type ProcessCleanupActionKind = 'none' | 'clear-stale-pid' | 'terminate-orphan';
+
+export interface ProcessCleanupAttemptSnapshot {
+  readonly runId: string;
+  readonly attemptId: string;
+  readonly status: string;
+  readonly pid?: number | undefined;
+  readonly expectedCommand?: string | undefined;
+  readonly expectedArgs?: readonly string[] | undefined;
+  readonly expectedCwd?: string | undefined;
+  readonly expectedUid?: number | undefined;
+}
+
+export interface ProcessTableEntry {
+  readonly pid: number;
+  readonly command: string;
+  readonly args?: readonly string[] | undefined;
+  readonly cwd?: string | undefined;
+  readonly uid?: number | undefined;
+  readonly startTimeTicks?: string | undefined;
+}
+
+export interface ProcessCleanupFinding {
+  readonly code: ProcessCleanupFindingCode;
+  readonly severity: ProcessCleanupSeverity;
+  readonly runId: string;
+  readonly attemptId: string;
+  readonly pid?: number | undefined;
+  readonly expectedCommand?: string | undefined;
+  readonly actualCommand?: string | undefined;
+  readonly expectedCwd?: string | undefined;
+  readonly actualCwd?: string | undefined;
+  readonly message: string;
+}
+
+export interface ProcessCleanupAction {
+  readonly action: ProcessCleanupActionKind;
+  readonly runId: string;
+  readonly attemptId: string;
+  readonly pid?: number | undefined;
+  readonly requiresApproval: boolean;
+  readonly wouldExecute: boolean;
+  readonly reason: string;
+}
+
+export interface ProcessCleanupPlanOptions {
+  readonly checkedAt: string;
+  readonly dryRun?: boolean | undefined;
+  readonly currentUid?: number | undefined;
+  readonly approveTermination?: boolean | undefined;
+  readonly attempts: readonly ProcessCleanupAttemptSnapshot[];
+  readonly processes: readonly ProcessTableEntry[];
+}
+
+export interface ProcessCleanupPlanReport {
+  readonly checkedAt: string;
+  readonly wouldWrite: false;
+  readonly status: ProcessCleanupStatus;
+  readonly dryRun: boolean;
+  readonly findings: readonly ProcessCleanupFinding[];
+  readonly actions: readonly ProcessCleanupAction[];
+  readonly operatorSummary: string;
+}
+
+function commandMatches(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
+  return typeof attempt.expectedCommand === 'string' && attempt.expectedCommand === processEntry.command;
+}
+
+function cwdMatches(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
+  return typeof attempt.expectedCwd === 'string' && attempt.expectedCwd === processEntry.cwd;
+}
+
+function uidMatches(
+  attempt: ProcessCleanupAttemptSnapshot,
+  processEntry: ProcessTableEntry,
+  currentUid: number | undefined,
+): boolean {
+  const expectedUid = attempt.expectedUid ?? currentUid;
+  return typeof expectedUid === 'number' && processEntry.uid === expectedUid;
+}
+
+function argsMatch(attempt: ProcessCleanupAttemptSnapshot, processEntry: ProcessTableEntry): boolean {
+  if (!attempt.expectedArgs || attempt.expectedArgs.length === 0) {
+    return true;
+  }
+  const actualArgs = processEntry.args ?? [];
+  return attempt.expectedArgs.every((arg, index) => actualArgs[index] === arg);
+}
+
+function isLiveMatchingWorker(
+  attempt: ProcessCleanupAttemptSnapshot,
+  processEntry: ProcessTableEntry,
+  currentUid: number | undefined,
+): boolean {
+  return commandMatches(attempt, processEntry)
+    && cwdMatches(attempt, processEntry)
+    && uidMatches(attempt, processEntry, currentUid)
+    && argsMatch(attempt, processEntry);
+}
+
+function finding(input: ProcessCleanupFinding): ProcessCleanupFinding {
+  return input;
+}
+
+function statusForFindings(findings: readonly ProcessCleanupFinding[]): ProcessCleanupStatus {
+  if (findings.some((item) => item.severity === 'blocker')) return 'blocked';
+  if (findings.some((item) => item.code !== 'live-matching-worker')) return 'review-required';
+  return 'clean';
+}
+
+function summarize(report: Pick<ProcessCleanupPlanReport, 'status' | 'findings' | 'actions'>): string {
+  const staleCount = report.findings.filter((item) => item.code === 'stale-pid').length;
+  const orphanCount = report.findings.filter((item) => item.code === 'orphan-duplicate-process').length;
+  const guardedSkips = report.findings.filter((item) => item.code === 'wrong-command' || item.code === 'wrong-cwd').length;
+  const planned = report.actions.filter((action) => action.action !== 'none').length;
+  const evidenceRule = 'No orphan duplicate termination is planned without matching uid, cwd, and command evidence.';
+
+  if (report.status === 'clean') {
+    return `Process cleanup plan is clean; all inspected live attempts match their recorded PID, command, cwd, and owner. ${evidenceRule}`;
+  }
+  return `Process cleanup plan is ${report.status}: ${staleCount} stale PID(s), ${orphanCount} orphan duplicate(s), ${guardedSkips} guarded skip(s), ${planned} planned cleanup action(s). ${evidenceRule}`;
+}
+
+export function buildProcessCleanupPlan(options: ProcessCleanupPlanOptions): ProcessCleanupPlanReport {
+  const dryRun = options.dryRun ?? true;
+  const findings: ProcessCleanupFinding[] = [];
+  const actions: ProcessCleanupAction[] = [];
+  const processByPid = new Map(options.processes.map((entry) => [entry.pid, entry] as const));
+  const claimedPids = new Set<number>();
+
+  for (const attempt of options.attempts) {
+    if (typeof attempt.pid !== 'number' || attempt.pid <= 0) {
+      findings.push(finding({
+        code: 'missing-pid',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        message: `Attempt ${attempt.attemptId} is ${attempt.status} but has no positive PID recorded.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        requiresApproval: false,
+        wouldExecute: false,
+        reason: 'Missing PID requires run-state reconciliation rather than process signaling.',
+      });
+      continue;
+    }
+
+    claimedPids.add(attempt.pid);
+    const liveProcess = processByPid.get(attempt.pid);
+    if (!liveProcess) {
+      findings.push(finding({
+        code: 'stale-pid',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        expectedCwd: attempt.expectedCwd,
+        message: `Recorded PID ${attempt.pid} is not present in the process table.`,
+      }));
+      actions.push({
+        action: 'clear-stale-pid',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: false,
+        wouldExecute: false,
+        reason: 'Dry-run would clear the stale attempt PID/run liveness pointer; no process signal is needed.',
+      });
+      continue;
+    }
+
+    if (!commandMatches(attempt, liveProcess)) {
+      findings.push(finding({
+        code: 'wrong-command',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is live but command does not match the recorded Beast attempt.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Wrong-command PID may be reused by an unrelated user process; skip termination and require manual investigation.',
+      });
+      continue;
+    }
+
+    if (!cwdMatches(attempt, liveProcess)) {
+      findings.push(finding({
+        code: 'wrong-cwd',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: liveProcess.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: liveProcess.cwd,
+        message: `PID ${attempt.pid} is live with the expected command but a different cwd.`,
+      }));
+      actions.push({
+        action: 'none',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: attempt.pid,
+        requiresApproval: true,
+        wouldExecute: false,
+        reason: 'Wrong-cwd PID may be a sibling or unrelated process; skip termination and require manual investigation.',
+      });
+      continue;
+    }
+
+    findings.push(finding({
+      code: 'live-matching-worker',
+      severity: 'info',
+      runId: attempt.runId,
+      attemptId: attempt.attemptId,
+      pid: attempt.pid,
+      expectedCommand: attempt.expectedCommand,
+      actualCommand: liveProcess.command,
+      expectedCwd: attempt.expectedCwd,
+      actualCwd: liveProcess.cwd,
+      message: `PID ${attempt.pid} matches the recorded Beast worker command, cwd, and owner evidence.`,
+    }));
+    actions.push({
+      action: 'none',
+      runId: attempt.runId,
+      attemptId: attempt.attemptId,
+      pid: attempt.pid,
+      requiresApproval: false,
+      wouldExecute: false,
+      reason: 'Worker appears live and owned; no cleanup planned.',
+    });
+  }
+
+  const orphanPids = new Set<number>();
+  for (const attempt of options.attempts) {
+    if (!attempt.expectedCommand || !attempt.expectedCwd) continue;
+    const recordedProcess = typeof attempt.pid === 'number' ? processByPid.get(attempt.pid) : undefined;
+    if (!recordedProcess || !isLiveMatchingWorker(attempt, recordedProcess, options.currentUid)) continue;
+    for (const processEntry of options.processes) {
+      if (claimedPids.has(processEntry.pid) || orphanPids.has(processEntry.pid)) continue;
+      if (!isLiveMatchingWorker(attempt, processEntry, options.currentUid)) continue;
+      orphanPids.add(processEntry.pid);
+      findings.push(finding({
+        code: 'orphan-duplicate-process',
+        severity: 'warning',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: processEntry.pid,
+        expectedCommand: attempt.expectedCommand,
+        actualCommand: processEntry.command,
+        expectedCwd: attempt.expectedCwd,
+        actualCwd: processEntry.cwd,
+        message: `PID ${processEntry.pid} matches Beast command/cwd/owner evidence but is not the recorded attempt PID.`,
+      }));
+      actions.push({
+        action: 'terminate-orphan',
+        runId: attempt.runId,
+        attemptId: attempt.attemptId,
+        pid: processEntry.pid,
+        requiresApproval: true,
+        wouldExecute: !dryRun && options.approveTermination === true,
+        reason: 'Duplicate orphan termination requires matching uid, cwd, and command evidence plus explicit operator approval.',
+      });
+    }
+  }
+
+  const status = statusForFindings(findings);
+  const partialReport = { status, findings, actions };
+  return {
+    checkedAt: options.checkedAt,
+    wouldWrite: false,
+    dryRun,
+    status,
+    findings,
+    actions,
+    operatorSummary: summarize(partialReport),
+  };
+}
+
+export function renderProcessCleanupDryRunPlan(report: ProcessCleanupPlanReport): string {
+  const lines = [
+    `DR process cleanup dry-run: ${report.status}`,
+    `checkedAt=${report.checkedAt} wouldWrite=${String(report.wouldWrite)} dryRun=${String(report.dryRun)}`,
+    report.operatorSummary,
+    'findings:',
+    ...report.findings.map((item) => {
+      const pid = item.pid === undefined ? 'none' : String(item.pid);
+      const expected = item.expectedCommand ? ` expected=${item.expectedCommand}` : '';
+      const actual = item.actualCommand ? ` actual=${item.actualCommand}` : '';
+      const cwd = item.expectedCwd ? ` cwd=${item.expectedCwd}` : '';
+      const actualCwd = item.actualCwd ? ` actualCwd=${item.actualCwd}` : '';
+      return `- ${item.code} run=${item.runId} attempt=${item.attemptId} pid=${pid}${expected}${actual}${cwd}${actualCwd}: ${item.message}`;
+    }),
+    'planned actions:',
+    ...report.actions
+      .filter((action) => action.action !== 'none')
+      .map((action) => {
+        const pid = action.pid === undefined ? 'none' : String(action.pid);
+        const approval = action.requiresApproval ? 'required' : 'not-required';
+        const mode = action.wouldExecute ? 'execute' : 'dry-run';
+        return `- ${action.action} pid=${pid} approval=${approval} ${mode} run=${action.runId} attempt=${action.attemptId}: ${action.reason}`;
+      }),
+  ];
+  if (report.actions.every((action) => action.action === 'none')) {
+    lines.push('- none');
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -291,6 +291,10 @@ export {
   buildRestoreDryRunReport,
   detectRestorePreviewConflicts,
 } from './dr/restore-preview.js';
+export {
+  buildProcessCleanupPlan,
+  renderProcessCleanupDryRunPlan,
+} from './dr/process-cleanup-plan.js';
 export type {
   ApprovalLedgerRecordSummary,
   ApprovalLedgerRecoveryFinding,
@@ -337,6 +341,18 @@ export type {
   RestorePreviewResult,
   RestorePreviewSeverity,
 } from './dr/restore-preview.js';
+export type {
+  ProcessCleanupAction,
+  ProcessCleanupActionKind,
+  ProcessCleanupAttemptSnapshot,
+  ProcessCleanupFinding,
+  ProcessCleanupFindingCode,
+  ProcessCleanupPlanOptions,
+  ProcessCleanupPlanReport,
+  ProcessCleanupSeverity,
+  ProcessCleanupStatus,
+  ProcessTableEntry,
+} from './dr/process-cleanup-plan.js';
 
 // CLI — file writer
 export { writeDesignDoc, readDesignDoc } from './cli/file-writer.js';

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -34,6 +34,7 @@ describe('process cleanup plan', () => {
           expectedCommand: '/usr/bin/node',
           expectedArgs: ['dist/cli/run.js', 'beast'],
           expectedCwd: '/repo',
+          expectedStartTimeTicks: '102-start',
         },
         {
           runId: 'run-wrong-command',
@@ -53,10 +54,10 @@ describe('process cleanup plan', () => {
         },
       ],
       processes: [
-        { pid: 102, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000 },
+        { pid: 102, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '102-start' },
         { pid: 103, command: '/bin/bash', args: ['-lc', 'sleep 60'], cwd: '/repo', uid: 1000 },
         { pid: 104, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/tmp/other', uid: 1000 },
-        { pid: 202, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000 },
+        { pid: 202, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '102-start' },
       ],
     });
 
@@ -186,5 +187,101 @@ describe('process cleanup plan', () => {
     expect(report.findings).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ code: 'live-matching-worker' }),
     ]));
+  });
+
+  it('does not treat a process with trailing args as a matching worker', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-extra-args',
+          attemptId: 'attempt-extra-args',
+          status: 'running',
+          pid: 501,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '501-start',
+        },
+      ],
+      processes: [
+        { pid: 501, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast', '--other-card'], cwd: '/repo', uid: 1000, startTimeTicks: '501-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual(['wrong-args']);
+    expect(report.actions).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'terminate-orphan' }),
+    ]));
+  });
+
+  it('requires process-start evidence before matching workers or planning orphan cleanup', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-no-start-token',
+          attemptId: 'attempt-no-start-token',
+          status: 'running',
+          pid: 601,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+        },
+      ],
+      processes: [
+        { pid: 601, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '601-start' },
+        { pid: 602, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '602-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual(['wrong-start-time']);
+    expect(report.actions).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'terminate-orphan' }),
+    ]));
+  });
+
+  it('skips orphan cleanup when recorded PID ownership is duplicated', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-duplicate-a',
+          attemptId: 'attempt-duplicate-a',
+          status: 'running',
+          pid: 701,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '701-start',
+        },
+        {
+          runId: 'run-duplicate-b',
+          attemptId: 'attempt-duplicate-b',
+          status: 'running',
+          pid: 701,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '701-start',
+        },
+      ],
+      processes: [
+        { pid: 701, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '701-start' },
+        { pid: 702, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '701-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual([
+      'duplicate-recorded-pid',
+      'duplicate-recorded-pid',
+    ]);
+    expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -83,7 +83,7 @@ describe('process cleanup plan', () => {
     const dryRun = renderProcessCleanupDryRunPlan(report);
     expect(dryRun).toContain('DR process cleanup dry-run: review-required');
     expect(dryRun).toContain('clear-stale-pid pid=101');
-    expect(dryRun).toContain('terminate-orphan pid=202 approval=required dry-run');
+    expect(dryRun).toContain('terminate-orphan pid=202 startTimeTicks=202-start approval=required dry-run');
     expect(dryRun).toContain('wrong-command');
     expect(dryRun).toContain('wrong-cwd');
   });
@@ -338,5 +338,115 @@ describe('process cleanup plan', () => {
 
     expect(report.findings.map((finding) => finding.code)).toEqual(['wrong-args']);
     expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
+  });
+
+  it('filters terminal attempts before planning cleanup', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-completed',
+          attemptId: 'attempt-completed',
+          status: 'completed',
+          pid: 901,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '901-start',
+        },
+        {
+          runId: 'run-live',
+          attemptId: 'attempt-live',
+          status: 'running',
+          pid: 902,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '902-start',
+        },
+      ],
+      processes: [
+        { pid: 902, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '902-start' },
+      ],
+    });
+
+    expect(report.status).toBe('clean');
+    expect(report.findings.map((finding) => finding.attemptId)).toEqual(['attempt-live']);
+    expect(report.actions).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ attemptId: 'attempt-completed' }),
+    ]));
+  });
+
+  it('excludes missing-PID matching owners from orphan cleanup', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: false,
+      approveTermination: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-recorded',
+          attemptId: 'attempt-recorded',
+          status: 'running',
+          pid: 1001,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '1001-start',
+        },
+        {
+          runId: 'run-missing',
+          attemptId: 'attempt-missing',
+          status: 'running',
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+        },
+      ],
+      processes: [
+        { pid: 1001, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '1001-start' },
+        { pid: 1002, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '1002-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual(['live-matching-worker', 'missing-pid']);
+    expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
+  });
+
+  it('carries process-start evidence on orphan termination actions', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: false,
+      approveTermination: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-live',
+          attemptId: 'attempt-live',
+          status: 'running',
+          pid: 1101,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '1101-start',
+        },
+      ],
+      processes: [
+        { pid: 1101, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '1101-start' },
+        { pid: 1102, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '1102-start' },
+      ],
+    });
+
+    expect(report.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'terminate-orphan',
+        pid: 1102,
+        startTimeTicks: '1102-start',
+        wouldExecute: true,
+      }),
+    ]));
+    expect(renderProcessCleanupDryRunPlan(report)).toContain('terminate-orphan pid=1102 startTimeTicks=1102-start approval=required execute');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -57,7 +57,7 @@ describe('process cleanup plan', () => {
         { pid: 102, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '102-start' },
         { pid: 103, command: '/bin/bash', args: ['-lc', 'sleep 60'], cwd: '/repo', uid: 1000 },
         { pid: 104, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/tmp/other', uid: 1000 },
-        { pid: 202, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '102-start' },
+        { pid: 202, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '202-start' },
       ],
     });
 
@@ -208,6 +208,35 @@ describe('process cleanup plan', () => {
       ],
       processes: [
         { pid: 501, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast', '--other-card'], cwd: '/repo', uid: 1000, startTimeTicks: '501-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual(['wrong-args']);
+    expect(report.actions).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'terminate-orphan' }),
+    ]));
+  });
+
+  it('fails closed when process args could not be captured', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-missing-argv',
+          attemptId: 'attempt-missing-argv',
+          status: 'running',
+          pid: 551,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: [],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '551-start',
+        },
+      ],
+      processes: [
+        { pid: 551, command: '/usr/bin/node', cwd: '/repo', uid: 1000, startTimeTicks: '551-start' },
+        { pid: 552, command: '/usr/bin/node', cwd: '/repo', uid: 1000, startTimeTicks: '552-start' },
       ],
     });
 

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -303,7 +303,7 @@ describe('process cleanup plan', () => {
       ],
       processes: [
         { pid: 701, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '701-start' },
-        { pid: 702, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '701-start' },
+        { pid: 702, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '702-start' },
       ],
     });
 
@@ -311,6 +311,32 @@ describe('process cleanup plan', () => {
       'duplicate-recorded-pid',
       'duplicate-recorded-pid',
     ]);
+    expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
+  });
+
+  it('fails closed when process args could not be captured', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-missing-args',
+          attemptId: 'attempt-missing-args',
+          status: 'running',
+          pid: 801,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: [],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '801-start',
+        },
+      ],
+      processes: [
+        { pid: 801, command: '/usr/bin/node', cwd: '/repo', uid: 1000, startTimeTicks: '801-start' },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toEqual(['wrong-args']);
     expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -113,6 +113,78 @@ describe('process cleanup plan', () => {
 
     expect(report.findings.filter((finding) => finding.code === 'orphan-duplicate-process')).toHaveLength(0);
     expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
-    expect(report.operatorSummary).toContain('No orphan duplicate termination is planned without matching uid, cwd, and command evidence');
+    expect(report.operatorSummary).toContain('No orphan duplicate termination is planned without matching uid, cwd, command, args, and process-start evidence');
+  });
+
+  it('requires full recorded process evidence before marking a PID clean', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-duplicate-a',
+          attemptId: 'attempt-duplicate-a',
+          status: 'running',
+          pid: 401,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-duplicate-b',
+          attemptId: 'attempt-duplicate-b',
+          status: 'running',
+          pid: 401,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-wrong-uid',
+          attemptId: 'attempt-wrong-uid',
+          status: 'running',
+          pid: 402,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+          expectedUid: 1000,
+        },
+        {
+          runId: 'run-wrong-args',
+          attemptId: 'attempt-wrong-args',
+          status: 'running',
+          pid: 403,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-wrong-start',
+          attemptId: 'attempt-wrong-start',
+          status: 'running',
+          pid: 404,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+          expectedStartTimeTicks: '100',
+        },
+      ],
+      processes: [
+        { pid: 401, command: '/usr/bin/node', args: [], cwd: '/repo', uid: 1000 },
+        { pid: 402, command: '/usr/bin/node', args: [], cwd: '/repo', uid: 2000 },
+        { pid: 403, command: '/usr/bin/node', args: ['dist/cli/run.js', 'other'], cwd: '/repo', uid: 1000 },
+        { pid: 404, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000, startTimeTicks: '200' },
+      ],
+    });
+
+    expect(report.status).toBe('review-required');
+    expect(report.findings.map((finding) => finding.code)).toEqual([
+      'duplicate-recorded-pid',
+      'duplicate-recorded-pid',
+      'wrong-uid',
+      'wrong-args',
+      'wrong-start-time',
+    ]);
+    expect(report.findings).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'live-matching-worker' }),
+    ]));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/process-cleanup-plan.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProcessCleanupPlan,
+  renderProcessCleanupDryRunPlan,
+} from '../../../src/dr/process-cleanup-plan.js';
+
+describe('process cleanup plan', () => {
+  it('distinguishes missing, stale, live, wrong-command, wrong-cwd, and orphan duplicate process states', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-missing-pid',
+          attemptId: 'attempt-missing-pid',
+          status: 'running',
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-stale-pid',
+          attemptId: 'attempt-stale-pid',
+          status: 'running',
+          pid: 101,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-live',
+          attemptId: 'attempt-live',
+          status: 'running',
+          pid: 102,
+          expectedCommand: '/usr/bin/node',
+          expectedArgs: ['dist/cli/run.js', 'beast'],
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-wrong-command',
+          attemptId: 'attempt-wrong-command',
+          status: 'running',
+          pid: 103,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+        {
+          runId: 'run-wrong-cwd',
+          attemptId: 'attempt-wrong-cwd',
+          status: 'running',
+          pid: 104,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+      ],
+      processes: [
+        { pid: 102, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000 },
+        { pid: 103, command: '/bin/bash', args: ['-lc', 'sleep 60'], cwd: '/repo', uid: 1000 },
+        { pid: 104, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/tmp/other', uid: 1000 },
+        { pid: 202, command: '/usr/bin/node', args: ['dist/cli/run.js', 'beast'], cwd: '/repo', uid: 1000 },
+      ],
+    });
+
+    expect(report.wouldWrite).toBe(false);
+    expect(report.status).toBe('review-required');
+    expect(report.findings.map((finding) => finding.code)).toEqual([
+      'missing-pid',
+      'stale-pid',
+      'live-matching-worker',
+      'wrong-command',
+      'wrong-cwd',
+      'orphan-duplicate-process',
+    ]);
+    expect(report.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'clear-stale-pid', pid: 101, requiresApproval: false }),
+      expect.objectContaining({ action: 'terminate-orphan', pid: 202, requiresApproval: true, wouldExecute: false }),
+    ]));
+    expect(report.actions).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ pid: 103, action: 'terminate-orphan' }),
+      expect.objectContaining({ pid: 104, action: 'terminate-orphan' }),
+    ]));
+
+    const dryRun = renderProcessCleanupDryRunPlan(report);
+    expect(dryRun).toContain('DR process cleanup dry-run: review-required');
+    expect(dryRun).toContain('clear-stale-pid pid=101');
+    expect(dryRun).toContain('terminate-orphan pid=202 approval=required dry-run');
+    expect(dryRun).toContain('wrong-command');
+    expect(dryRun).toContain('wrong-cwd');
+  });
+
+  it('requires uid, cwd, and command evidence before planning orphan termination', () => {
+    const report = buildProcessCleanupPlan({
+      checkedAt: '2026-07-16T12:00:00.000Z',
+      dryRun: true,
+      currentUid: 1000,
+      attempts: [
+        {
+          runId: 'run-live',
+          attemptId: 'attempt-live',
+          status: 'running',
+          pid: 301,
+          expectedCommand: '/usr/bin/node',
+          expectedCwd: '/repo',
+        },
+      ],
+      processes: [
+        { pid: 301, command: '/usr/bin/node', args: [], cwd: '/repo', uid: 1000 },
+        { pid: 302, command: '/usr/bin/node', args: [], cwd: '/repo', uid: 2000 },
+        { pid: 303, command: '/usr/bin/node', args: [], cwd: undefined, uid: 1000 },
+        { pid: 304, command: '/usr/bin/node', args: [], cwd: '/other', uid: 1000 },
+        { pid: 305, command: '/bin/bash', args: [], cwd: '/repo', uid: 1000 },
+      ],
+    });
+
+    expect(report.findings.filter((finding) => finding.code === 'orphan-duplicate-process')).toHaveLength(0);
+    expect(report.actions.filter((action) => action.action === 'terminate-orphan')).toHaveLength(0);
+    expect(report.operatorSummary).toContain('No orphan duplicate termination is planned without matching uid, cwd, and command evidence');
+  });
+});

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -272,3 +272,6 @@
 - For JSON cache stores, validate both schemaVersion and the runtime shape (`content` type) before returning entries, otherwise stale/malformed files can be reused as cache hits.
 - Add regression tests that write an explicitly mismatched schema version and a wrong-shaped payload to prove stale cache entries are rejected.
 - Keep Codex review follow-ups separate from CI: CI green + no fresh Codex findings is not sufficient when Codex usage-limited responses occur; treat limits as blocked merge gates and retry only after credits reset.
+
+## 2026-07-16 — DR process cleanup closeout
+- DR process cleanup planners should ignore terminal attempts before PID counting and orphan scans, treat missing-PID live attempts as possible owners of matching processes, and include process-start tokens on executable orphan actions so signal-time consumers can revalidate PID identity before termination.


### PR DESCRIPTION
## Summary
- adds a DR process cleanup planner for missing/stale PIDs, live matching workers, command/cwd mismatches, and duplicate orphan worker processes
- renders dry-run cleanup summaries with approval-gated orphan termination actions
- exports the cleanup planner API and adds regression coverage

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/dr/restore-preview.test.ts tests/unit/dr/process-cleanup-plan.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint
- npm run build

Closes #1723