### PR TITLE
feat(beasts): add maintenance dispatch guardrails

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -88,7 +88,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     executors,
   });
 
-  runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy });
+  runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy, maintenance });
 
   return {
     agents: new AgentService(repository, undefined, { capacityPolicy }),

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -15,6 +15,7 @@ import { BeastInterviewService } from './services/beast-interview-service.js';
 import { AgentService } from './services/agent-service.js';
 import { CapacityReservationPolicy, type CapacityReservationRule } from './services/capacity-reservation-policy.js';
 import { BeastRunService } from './services/beast-run-service.js';
+import { MaintenanceModeService } from './services/maintenance-mode-service.js';
 import { PrometheusBeastMetrics } from './telemetry/prometheus-beast-metrics.js';
 
 export interface BeastServicePaths {
@@ -30,6 +31,7 @@ export interface BeastServiceBundle {
   runs: BeastRunService;
   interviews: BeastInterviewService;
   metrics: PrometheusBeastMetrics;
+  maintenance: MaintenanceModeService;
   eventBus: BeastEventBus;
   ticketStore: SseConnectionTicketStore;
   dispose(): void;
@@ -45,6 +47,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const eventBus = new BeastEventBus();
   const ticketStore = new SseConnectionTicketStore();
   const capacityPolicy = createCapacityReservationPolicyFromEnv();
+  const maintenance = MaintenanceModeService.forProjectRoot(projectRoot);
 
   cleanupAbandonedBeastWorktrees({
     agents: repository.listTrackedAgents(),
@@ -90,10 +93,11 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   return {
     agents: new AgentService(repository, undefined, { capacityPolicy }),
     catalog,
-    dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy }),
+    dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy, maintenance }),
     runs: runService,
     interviews: new BeastInterviewService(repository, catalog),
     metrics,
+    maintenance,
     eventBus,
     ticketStore,
     dispose: () => {

--- a/packages/franken-orchestrator/src/beasts/services/agent-init-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-init-service.ts
@@ -1,6 +1,7 @@
 import type { TrackedAgent, TrackedAgentInitActionKind, BeastExecutionMode, BeastRun } from '../types.js';
 import type { BeastDispatchService } from './beast-dispatch-service.js';
 import { AgentService } from './agent-service.js';
+import { MaintenanceModeError } from './maintenance-mode-service.js';
 import { isoNow } from '@franken/types';
 
 export interface CreateChatInitAgentRequest {
@@ -78,14 +79,27 @@ export class AgentInitService {
       },
     });
 
-    return this.dispatch.createRun({
-      definitionId: request.definitionId,
-      config: request.config,
-      dispatchedBy: 'chat',
-      dispatchedByUser: `chat-session:${request.chatSessionId}`,
-      trackedAgentId: agentId,
-      startNow: true,
-      ...(request.executionMode ? { executionMode: request.executionMode } : {}),
-    });
+    try {
+      return await this.dispatch.createRun({
+        definitionId: request.definitionId,
+        config: request.config,
+        dispatchedBy: 'chat',
+        dispatchedByUser: `chat-session:${request.chatSessionId}`,
+        trackedAgentId: agentId,
+        startNow: true,
+        ...(request.executionMode ? { executionMode: request.executionMode } : {}),
+      });
+    } catch (error) {
+      if (error instanceof MaintenanceModeError) {
+        this.agents.updateAgent(agentId, { status: 'stopped' });
+        this.agents.appendEvent(agentId, {
+          level: 'warning',
+          type: 'agent.dispatch.paused',
+          message: error.message,
+          payload: { maintenance: error.state },
+        });
+      }
+      throw error;
+    }
   }
 }

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -14,10 +14,12 @@ import {
   type CapacityReservationWorkItem,
   capacityItemFromConfig,
 } from './capacity-reservation-policy.js';
+import type { MaintenanceModeService } from './maintenance-mode-service.js';
 
 export interface BeastDispatchServiceOptions {
   eventBus?: BeastEventBus;
   capacityPolicy?: CapacityReservationPolicy | undefined;
+  maintenance?: MaintenanceModeService | undefined;
 }
 
 export interface BeastExecutors {
@@ -148,6 +150,7 @@ export class BeastDispatchService {
   ) {}
 
   async createRun(request: CreateBeastRunRequest): Promise<BeastRun> {
+    this.options.maintenance?.assertDispatchAllowed();
     const definition = this.getDefinitionOrThrow(request.definitionId);
     // Try parsing as-is first. If it fails with unrecognized_keys (strict schema
     // rejecting extra fields from agent init config), strip to only known keys.

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -12,10 +12,12 @@ import {
   type CapacityReservationWorkItem,
   capacityItemFromConfig,
 } from './capacity-reservation-policy.js';
+import type { MaintenanceModeService } from './maintenance-mode-service.js';
 
 export interface BeastRunServiceOptions {
   eventBus?: BeastEventBus;
   capacityPolicy?: CapacityReservationPolicy | undefined;
+  maintenance?: MaintenanceModeService | undefined;
 }
 
 export class UnknownBeastRunError extends Error {
@@ -67,6 +69,7 @@ export class BeastRunService {
   }
 
   async start(runId: string, _actor: string): Promise<BeastRun> {
+    this.serviceOptions.maintenance?.assertDispatchAllowed();
     const run = this.reserveTrackedAgentCapacityForStart(this.requireRun(runId));
     const definition = this.getDefinitionOrThrow(run.definitionId);
     const priorAttemptId = run.currentAttemptId;
@@ -280,6 +283,7 @@ export class BeastRunService {
   }
 
   async restart(runId: string, actor: string): Promise<BeastRun> {
+    this.serviceOptions.maintenance?.assertDispatchAllowed();
     const run = this.requireRun(runId);
     if (run.status === 'running') {
       this.assertTrackedAgentCapacity(run);

--- a/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
@@ -87,13 +87,20 @@ export class MaintenanceModeService {
       const parsed = JSON.parse(readFileSync(this.stateFile, 'utf8')) as unknown;
       return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
         ? parsed as Record<string, unknown>
-        : undefined;
+        : this.unreadableState();
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code === 'ENOENT') {
         return undefined;
       }
-      return undefined;
+      return this.unreadableState();
     }
+  }
+
+  private unreadableState(): Record<string, unknown> {
+    return {
+      enabled: true,
+      reason: `Maintenance state is unreadable; dispatch is paused until ${this.stateFile} is repaired or removed.`,
+    };
   }
 }

--- a/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
@@ -40,8 +40,11 @@ export class MaintenanceModeService {
 
   getState(): MaintenanceModeState {
     const parsed = this.readStateFile();
-    if (!parsed?.enabled) {
+    if (!parsed) {
       return this.disabledState();
+    }
+    if (parsed.enabled !== true) {
+      return parsed.enabled === false ? this.disabledState() : this.unreadableState();
     }
     return {
       enabled: true,
@@ -97,10 +100,11 @@ export class MaintenanceModeService {
     }
   }
 
-  private unreadableState(): Record<string, unknown> {
+  private unreadableState(): Record<string, unknown> & MaintenanceModeState {
     return {
       enabled: true,
       reason: `Maintenance state is unreadable; dispatch is paused until ${this.stateFile} is repaired or removed.`,
+      allowedCommands: DEFAULT_ALLOWED_COMMANDS,
     };
   }
 }

--- a/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/maintenance-mode-service.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { wallClockNow } from '@franken/types';
+
+export interface MaintenanceModeState {
+  readonly enabled: boolean;
+  readonly reason?: string | undefined;
+  readonly startedAt?: string | undefined;
+  readonly allowedCommands: readonly string[];
+}
+
+export interface MaintenanceModeActivation {
+  readonly reason?: string | undefined;
+  readonly startedAt?: string | undefined;
+}
+
+const DEFAULT_ALLOWED_COMMANDS = [
+  'beasts list',
+  'beasts status <run-id>',
+  'beasts logs <run-id>',
+  'beasts stop <run-id>',
+  'beasts kill <run-id>',
+  'beasts maintenance off',
+] as const;
+
+export class MaintenanceModeError extends Error {
+  constructor(readonly state: MaintenanceModeState) {
+    const reason = state.reason ? ` Reason: ${state.reason}` : '';
+    super(`Maintenance mode is active; new Beast dispatch is paused.${reason}`);
+    this.name = 'MaintenanceModeError';
+  }
+}
+
+export class MaintenanceModeService {
+  constructor(private readonly stateFile: string) {}
+
+  static forProjectRoot(projectRoot: string): MaintenanceModeService {
+    return new MaintenanceModeService(join(projectRoot, '.fbeast', 'maintenance-mode.json'));
+  }
+
+  getState(): MaintenanceModeState {
+    const parsed = this.readStateFile();
+    if (!parsed?.enabled) {
+      return this.disabledState();
+    }
+    return {
+      enabled: true,
+      ...(typeof parsed.reason === 'string' && parsed.reason.trim().length > 0 ? { reason: parsed.reason } : {}),
+      ...(typeof parsed.startedAt === 'string' && parsed.startedAt.trim().length > 0 ? { startedAt: parsed.startedAt } : {}),
+      allowedCommands: DEFAULT_ALLOWED_COMMANDS,
+    };
+  }
+
+  activate(input: MaintenanceModeActivation = {}): MaintenanceModeState {
+    const state: MaintenanceModeState = {
+      enabled: true,
+      ...(input.reason && input.reason.trim().length > 0 ? { reason: input.reason.trim() } : {}),
+      startedAt: input.startedAt ?? new Date(wallClockNow()).toISOString(),
+      allowedCommands: DEFAULT_ALLOWED_COMMANDS,
+    };
+    mkdirSync(dirname(this.stateFile), { recursive: true });
+    writeFileSync(this.stateFile, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+    return state;
+  }
+
+  deactivate(): MaintenanceModeState {
+    rmSync(this.stateFile, { force: true });
+    return this.disabledState();
+  }
+
+  assertDispatchAllowed(): void {
+    const state = this.getState();
+    if (state.enabled) {
+      throw new MaintenanceModeError(state);
+    }
+  }
+
+  private disabledState(): MaintenanceModeState {
+    return {
+      enabled: false,
+      allowedCommands: DEFAULT_ALLOWED_COMMANDS,
+    };
+  }
+
+  private readStateFile(): Record<string, unknown> | undefined {
+    try {
+      const parsed = JSON.parse(readFileSync(this.stateFile, 'utf8')) as unknown;
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : undefined;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return undefined;
+      }
+      return undefined;
+    }
+  }
+}

--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -134,13 +134,26 @@ export class BeastDaemonDispatchAdapter {
       };
     }
 
-    const run = await this.createRun({
-      definitionId,
-      config: progress.config,
-      sessionId,
-      ...(context.agentId ? { trackedAgentId: context.agentId } : {}),
-      ...(context.executionMode ? { executionMode: context.executionMode } : {}),
-    });
+    let run;
+    try {
+      run = await this.createRun({
+        definitionId,
+        config: progress.config,
+        sessionId,
+        ...(context.agentId ? { trackedAgentId: context.agentId } : {}),
+        ...(context.executionMode ? { executionMode: context.executionMode } : {}),
+      });
+    } catch (error) {
+      if (error instanceof BeastDaemonRequestError && error.status === 423 && error.code === 'MAINTENANCE_MODE_ACTIVE') {
+        return {
+          kind: 'dispatch',
+          definitionId,
+          assistantMessage: formatMaintenanceDaemonMessage(error),
+          beastContext: context,
+        };
+      }
+      throw error;
+    }
 
     return {
       kind: 'dispatch',
@@ -278,6 +291,23 @@ export class BeastDaemonDispatchAdapter {
     }
     return `${label} interview: ${prompt} Options: ${options.join(', ')}`;
   }
+}
+
+function formatMaintenanceDaemonMessage(error: BeastDaemonRequestError): string {
+  const maintenance = error.details && typeof error.details === 'object'
+    ? (error.details as Record<string, unknown>).maintenance
+    : undefined;
+  const state = maintenance && typeof maintenance === 'object'
+    ? maintenance as Record<string, unknown>
+    : undefined;
+  const reason = typeof state?.reason === 'string' && state.reason.trim().length > 0
+    ? ` Reason: ${state.reason}`
+    : '';
+  const allowedCommands = Array.isArray(state?.allowedCommands)
+    ? state.allowedCommands.filter((command): command is string => typeof command === 'string')
+    : [];
+  const allowed = allowedCommands.length > 0 ? ` Allowed commands: ${allowedCommands.join(', ')}.` : '';
+  return `Maintenance mode is active; new Beast dispatch is paused.${reason}${allowed}`;
 }
 
 export type BeastDispatchPort = {

--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -149,7 +149,7 @@ export class BeastDaemonDispatchAdapter {
           kind: 'dispatch',
           definitionId,
           assistantMessage: formatMaintenanceDaemonMessage(error),
-          beastContext: context,
+          beastContext: null,
         };
       }
       throw error;

--- a/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
@@ -130,7 +130,7 @@ export class ChatBeastDispatchAdapter {
           kind: 'dispatch',
           definitionId,
           assistantMessage: `${error.message} Allowed commands: ${error.state.allowedCommands.join(', ')}.`,
-          beastContext: context,
+          beastContext: null,
         };
       }
       throw error;

--- a/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
@@ -2,6 +2,7 @@ import type { BeastCatalogService } from '../beasts/services/beast-catalog-servi
 import type { BeastDispatchService } from '../beasts/services/beast-dispatch-service.js';
 import type { BeastInterviewService, BeastInterviewProgress } from '../beasts/services/beast-interview-service.js';
 import type { AgentInitService } from '../beasts/services/agent-init-service.js';
+import { MaintenanceModeError } from '../beasts/services/maintenance-mode-service.js';
 import type { BeastExecutionMode } from '../beasts/types.js';
 import type { ChatBeastContext, TranscriptMessage } from './types.js';
 
@@ -106,21 +107,34 @@ export class ChatBeastDispatchAdapter {
       };
     }
 
-    const run = context.agentId
-      ? await this.options.agentInit.dispatchAgent(context.agentId, {
+    let run;
+    try {
+      run = context.agentId
+        ? await this.options.agentInit.dispatchAgent(context.agentId, {
+            definitionId,
+            chatSessionId: sessionId,
+            config: progress.config,
+            ...(context.executionMode ? { executionMode: context.executionMode } : {}),
+          })
+        : await this.options.dispatch.createRun({
+            definitionId,
+            config: progress.config,
+            dispatchedBy: 'chat',
+            dispatchedByUser: `chat-session:${sessionId}`,
+            startNow: true,
+            ...(context.executionMode ? { executionMode: context.executionMode } : {}),
+          });
+    } catch (error) {
+      if (error instanceof MaintenanceModeError) {
+        return {
+          kind: 'dispatch',
           definitionId,
-          chatSessionId: sessionId,
-          config: progress.config,
-          ...(context.executionMode ? { executionMode: context.executionMode } : {}),
-        })
-      : await this.options.dispatch.createRun({
-          definitionId,
-          config: progress.config,
-          dispatchedBy: 'chat',
-          dispatchedByUser: `chat-session:${sessionId}`,
-          startNow: true,
-          ...(context.executionMode ? { executionMode: context.executionMode } : {}),
-        });
+          assistantMessage: `${error.message} Allowed commands: ${error.state.allowedCommands.join(', ')}.`,
+          beastContext: context,
+        };
+      }
+      throw error;
+    }
 
     return {
       kind: 'dispatch',

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -46,6 +46,7 @@ export type BeastAction =
   | 'restart'
   | 'resume'
   | 'delete'
+  | 'maintenance'
   | undefined;
 
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
@@ -139,7 +140,7 @@ const VALID_DR_ACTIONS = new Set([
   'dead-letter-replay-dry-run',
   'dead-letter-retire',
 ]);
-const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete']);
+const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete', 'maintenance']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
 const STRING_OPTIONS = new Set([
@@ -299,6 +300,7 @@ Beast Commands:
   beasts restart <run-id>             Restart a Beast with a new attempt
   beasts resume <agent-id>            Resume a tracked agent's linked run
   beasts delete <agent-id>            Soft-delete a tracked agent
+  beasts maintenance [status|on|off]  Show, activate, or deactivate dispatch maintenance mode
 
 Skill Commands:
   skill list                          List installed skills
@@ -322,6 +324,7 @@ Module Toggles (for beasts spawn):
   --no-critique                       Disable critique module
   --no-governor                       Disable governor module
   --no-heartbeat                      Disable heartbeat module
+  --set reason=<text>                 Maintenance activation reason for beasts maintenance on
 
 Examples:
   frankenbeast                              # full interactive flow
@@ -473,6 +476,7 @@ function maxBeastPositionals(action: BeastAction): number {
     || action === 'restart'
     || action === 'resume'
     || action === 'delete'
+    || action === 'maintenance'
   ) {
     return 2;
   }

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -6,7 +6,7 @@ import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
 import type { BeastExecutionMode, BeastRun, BeastRunAttempt } from '../beasts/types.js';
-import type { MaintenanceModeState } from '../beasts/services/maintenance-mode-service.js';
+import { MaintenanceModeService, type MaintenanceModeState } from '../beasts/services/maintenance-mode-service.js';
 import { spawnSync } from 'node:child_process';
 
 type BeastControlClient = Omit<ReturnType<typeof createBeastControlClient>, 'dispose'> & {
@@ -104,6 +104,24 @@ interface BeastCommandDeps {
 
 export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> {
   const { args, io, paths, print } = deps;
+  if (args.beastAction === 'maintenance') {
+    const maintenance = MaintenanceModeService.forProjectRoot(paths.root);
+    const action = args.beastTarget ?? 'status';
+    if (action === 'on') {
+      print(JSON.stringify(maintenance.activate({ reason: maintenanceReason(args.networkSet) }), null, 2));
+      return;
+    }
+    if (action === 'off') {
+      print(JSON.stringify(maintenance.deactivate(), null, 2));
+      return;
+    }
+    if (action !== 'status') {
+      throw new Error(`Unknown maintenance action: ${action}. Valid: status, on, off`);
+    }
+    print(JSON.stringify(maintenance.getState(), null, 2));
+    return;
+  }
+
   const services = createBeastServices(paths);
   let control = deps.control;
   let ownsControl = false;
@@ -226,22 +244,6 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
         const header = run ? containerLogHeader(run, services.runs.listAttempts(args.beastTarget)) : [];
         const logs = await services.runs.readLogs(args.beastTarget);
         print([...header, ...logs].join('\n'));
-        return;
-      }
-      case 'maintenance': {
-        const action = args.beastTarget ?? 'status';
-        if (action === 'on') {
-          print(JSON.stringify(services.maintenance.activate({ reason: maintenanceReason(args.networkSet) }), null, 2));
-          return;
-        }
-        if (action === 'off') {
-          print(JSON.stringify(services.maintenance.deactivate(), null, 2));
-          return;
-        }
-        if (action !== 'status') {
-          throw new Error(`Unknown maintenance action: ${action}. Valid: status, on, off`);
-        }
-        print(JSON.stringify(services.maintenance.getState(), null, 2));
         return;
       }
       case 'stop': {

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -6,6 +6,7 @@ import { collectBeastConfig } from './beast-prompts.js';
 import type { ProjectPaths } from './project-root.js';
 import { createBeastControlClient } from './beast-control-client.js';
 import type { BeastExecutionMode, BeastRun, BeastRunAttempt } from '../beasts/types.js';
+import type { MaintenanceModeState } from '../beasts/services/maintenance-mode-service.js';
 import { spawnSync } from 'node:child_process';
 
 type BeastControlClient = Omit<ReturnType<typeof createBeastControlClient>, 'dispose'> & {
@@ -58,7 +59,7 @@ function pickContainerMetadata(metadata: Readonly<Record<string, unknown>> | und
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-function statusPayload(run: BeastRun, attempts: readonly BeastRunAttempt[]) {
+function statusPayload(run: BeastRun, attempts: readonly BeastRunAttempt[], maintenance?: MaintenanceModeState) {
   const currentAttempt = latestAttempt(run, attempts);
   const containerMetadata = run.executionMode === 'container'
     ? pickContainerMetadata(currentAttempt?.executorMetadata)
@@ -69,7 +70,14 @@ function statusPayload(run: BeastRun, attempts: readonly BeastRunAttempt[]) {
     ...(containerMetadata
       ? { container: containerMetadata }
       : {}),
+    ...(maintenance ? { maintenance } : {}),
   };
+}
+
+function maintenanceReason(values: readonly string[] | undefined): string | undefined {
+  const entry = values?.find((value) => value.startsWith('reason='));
+  const reason = entry?.slice('reason='.length).trim();
+  return reason ? reason : undefined;
 }
 
 function containerLogHeader(run: BeastRun, attempts: readonly BeastRunAttempt[]): string[] {
@@ -207,7 +215,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           throw new UnknownBeastRunError(args.beastTarget);
         }
         const attempts = services.runs.listAttempts(args.beastTarget);
-        print(JSON.stringify(statusPayload(run, attempts), null, 2));
+        print(JSON.stringify(statusPayload(run, attempts, services.maintenance.getState()), null, 2));
         return;
       }
       case 'logs': {
@@ -218,6 +226,22 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
         const header = run ? containerLogHeader(run, services.runs.listAttempts(args.beastTarget)) : [];
         const logs = await services.runs.readLogs(args.beastTarget);
         print([...header, ...logs].join('\n'));
+        return;
+      }
+      case 'maintenance': {
+        const action = args.beastTarget ?? 'status';
+        if (action === 'on') {
+          print(JSON.stringify(services.maintenance.activate({ reason: maintenanceReason(args.networkSet) }), null, 2));
+          return;
+        }
+        if (action === 'off') {
+          print(JSON.stringify(services.maintenance.deactivate(), null, 2));
+          return;
+        }
+        if (action !== 'status') {
+          throw new Error(`Unknown maintenance action: ${action}. Valid: status, on, off`);
+        }
+        print(JSON.stringify(services.maintenance.getState(), null, 2));
         return;
       }
       case 'stop': {

--- a/packages/franken-orchestrator/src/cli/beast-cli.ts
+++ b/packages/franken-orchestrator/src/cli/beast-cli.ts
@@ -215,7 +215,7 @@ export async function handleBeastCommand(deps: BeastCommandDeps): Promise<void> 
           throw new UnknownBeastRunError(args.beastTarget);
         }
         const attempts = services.runs.listAttempts(args.beastTarget);
-        print(JSON.stringify(statusPayload(run, attempts, services.maintenance.getState()), null, 2));
+        print(JSON.stringify(statusPayload(run, attempts, services.maintenance?.getState()), null, 2));
         return;
       }
       case 'logs': {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -60,7 +60,7 @@ import type { ISecretStore } from '../network/secret-store.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
-import { MaintenanceModeService } from '../beasts/services/maintenance-mode-service.js';
+import { MaintenanceModeService, type MaintenanceModeState } from '../beasts/services/maintenance-mode-service.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
 import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
 import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from '../network/network-url.js';
@@ -880,6 +880,39 @@ async function waitForBeastsDaemonEndpoint(baseUrl: string, expected: { root: st
   return 'unavailable';
 }
 
+function isMaintenanceModeState(value: unknown): value is MaintenanceModeState {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.enabled === 'boolean'
+    && Array.isArray(record.allowedCommands)
+    && record.allowedCommands.every((command) => typeof command === 'string');
+}
+
+async function fetchBeastsDaemonMaintenanceMode(baseUrl: string, operatorToken: string): Promise<MaintenanceModeState> {
+  const guardedFetch = createEgressGuardedFetch({ lane: 'test' });
+  const response = await guardedFetch(`${baseUrl}/v1/beasts/maintenance`, {
+    headers: { Authorization: `Bearer ${operatorToken}` },
+    signal: AbortSignal.timeout(1000),
+  });
+  if (!response.ok) {
+    return {
+      enabled: true,
+      reason: `Unable to read beasts-daemon maintenance state (${response.status}); dispatch visibility is degraded.`,
+      allowedCommands: [],
+    };
+  }
+  const body: unknown = await response.json();
+  const data = body && typeof body === 'object' ? (body as Record<string, unknown>).data : undefined;
+  if (isMaintenanceModeState(data)) {
+    return data;
+  }
+  return {
+    enabled: true,
+    reason: 'Unable to parse beasts-daemon maintenance state; dispatch visibility is degraded.',
+    allowedCommands: [],
+  };
+}
+
 async function resolveDetectedBeastsDaemonUrl(
   root: string,
   config: OrchestratorConfig,
@@ -1350,7 +1383,13 @@ async function runChatCommandIfRequested(
               skillManager,
               getSecurityConfig: () => resolveConfigSecurity(mutableConfig),
               getProviders: () => buildDashboardProviderSnapshot(mutableConfig, providerRegistry, [resolveSelectedProvider(args, mutableConfig), ...(args.providers ?? [])]),
-              getMaintenanceMode: () => (localBeastServices?.maintenance ?? MaintenanceModeService.forProjectRoot(root)).getState(),
+              getMaintenanceMode: () => {
+                if (localBeastServices) return localBeastServices.maintenance.getState();
+                if (beastDaemonUrl && beastOperatorToken) {
+                  return fetchBeastsDaemonMaintenanceMode(beastDaemonUrl, beastOperatorToken);
+                }
+                return MaintenanceModeService.forProjectRoot(root).getState();
+              },
             },
           }
         : {}),

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -890,8 +890,7 @@ function isMaintenanceModeState(value: unknown): value is MaintenanceModeState {
 
 async function fetchBeastsDaemonMaintenanceMode(baseUrl: string, operatorToken: string): Promise<MaintenanceModeState> {
   try {
-    const guardedFetch = createEgressGuardedFetch({ lane: 'test' });
-    const response = await guardedFetch(`${baseUrl}/v1/beasts/maintenance`, {
+    const response = await fetch(`${baseUrl}/v1/beasts/maintenance`, {
       headers: { Authorization: `Bearer ${operatorToken}` },
       signal: AbortSignal.timeout(1000),
     });

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -889,28 +889,36 @@ function isMaintenanceModeState(value: unknown): value is MaintenanceModeState {
 }
 
 async function fetchBeastsDaemonMaintenanceMode(baseUrl: string, operatorToken: string): Promise<MaintenanceModeState> {
-  const guardedFetch = createEgressGuardedFetch({ lane: 'test' });
-  const response = await guardedFetch(`${baseUrl}/v1/beasts/maintenance`, {
-    headers: { Authorization: `Bearer ${operatorToken}` },
-    signal: AbortSignal.timeout(1000),
-  });
-  if (!response.ok) {
+  try {
+    const guardedFetch = createEgressGuardedFetch({ lane: 'test' });
+    const response = await guardedFetch(`${baseUrl}/v1/beasts/maintenance`, {
+      headers: { Authorization: `Bearer ${operatorToken}` },
+      signal: AbortSignal.timeout(1000),
+    });
+    if (!response.ok) {
+      return {
+        enabled: true,
+        reason: `Unable to read beasts-daemon maintenance state (${response.status}); dispatch visibility is degraded.`,
+        allowedCommands: [],
+      };
+    }
+    const body: unknown = await response.json();
+    const data = body && typeof body === 'object' ? (body as Record<string, unknown>).data : undefined;
+    if (isMaintenanceModeState(data)) {
+      return data;
+    }
     return {
       enabled: true,
-      reason: `Unable to read beasts-daemon maintenance state (${response.status}); dispatch visibility is degraded.`,
+      reason: 'Unable to parse beasts-daemon maintenance state; dispatch visibility is degraded.',
+      allowedCommands: [],
+    };
+  } catch {
+    return {
+      enabled: true,
+      reason: 'Unable to reach beasts-daemon maintenance state; dispatch visibility is degraded.',
       allowedCommands: [],
     };
   }
-  const body: unknown = await response.json();
-  const data = body && typeof body === 'object' ? (body as Record<string, unknown>).data : undefined;
-  if (isMaintenanceModeState(data)) {
-    return data;
-  }
-  return {
-    enabled: true,
-    reason: 'Unable to parse beasts-daemon maintenance state; dispatch visibility is degraded.',
-    allowedCommands: [],
-  };
 }
 
 async function resolveDetectedBeastsDaemonUrl(

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -60,6 +60,7 @@ import type { ISecretStore } from '../network/secret-store.js';
 import { resolveSecurityConfig, type SecurityConfig } from '../middleware/security-profiles.js';
 import { startBeastDaemon } from '../http/beast-daemon-server.js';
 import { createBeastServices } from '../beasts/create-beast-services.js';
+import { MaintenanceModeService } from '../beasts/services/maintenance-mode-service.js';
 import { TransportSecurityService } from '../http/security/transport-security.js';
 import { CommsConfigSchema, type CommsConfig } from '../comms/config/comms-config.js';
 import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from '../network/network-url.js';
@@ -1349,6 +1350,7 @@ async function runChatCommandIfRequested(
               skillManager,
               getSecurityConfig: () => resolveConfigSecurity(mutableConfig),
               getProviders: () => buildDashboardProviderSnapshot(mutableConfig, providerRegistry, [resolveSelectedProvider(args, mutableConfig), ...(args.providers ?? [])]),
+              getMaintenanceMode: () => (localBeastServices?.maintenance ?? MaintenanceModeService.forProjectRoot(root)).getState(),
             },
           }
         : {}),

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -100,6 +100,7 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   app.route('/', agentRoutes({
     agents: services.agents,
     dispatch: services.dispatch,
+    maintenance: services.maintenance,
     runs: services.runs,
     operatorToken: options.operatorToken,
     security,

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -269,6 +269,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     app.route('/', agentRoutes({
       agents: opts.beastControl.agents,
       dispatch: opts.beastControl.dispatch,
+      maintenance: opts.beastControl.maintenance,
       runs: opts.beastControl.runs,
       operatorToken: opts.beastControl.operatorToken,
       security: opts.beastControl.security ?? transportSecurity,

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -169,6 +169,13 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
       });
     } catch (error) {
       if (error instanceof MaintenanceModeError) {
+        deps.agents.updateAgent(agent.id, { status: 'stopped' });
+        deps.agents.appendEvent(agent.id, {
+          level: 'warning',
+          type: 'agent.dispatch.paused',
+          message: error.message,
+          payload: { maintenance: error.state },
+        });
         return c.json({
           error: {
             code: 'MAINTENANCE_MODE_ACTIVE',

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -623,6 +623,7 @@ async function dispatchReplacementAgentRun(
   agent: TrackedAgent,
   existingRun: ReturnType<BeastRunService['getRun']>,
 ) {
+  deps.maintenance?.assertDispatchAllowed();
   assertAgentCapacityAvailable(deps, agent);
   if (existingRun?.status === 'running') {
     await deps.runs.stop(existingRun.id, 'operator');

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -4,6 +4,7 @@ import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../../beasts/errors.js';
 import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
+import { MaintenanceModeError, type MaintenanceModeService } from '../../beasts/services/maintenance-mode-service.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import type { BeastRunService } from '../../beasts/services/beast-run-service.js';
@@ -51,6 +52,7 @@ const PatchAgentConfigBody = z.object({
 export interface AgentRoutesDeps {
   agents: AgentService;
   dispatch?: BeastDispatchService;
+  maintenance?: MaintenanceModeService | undefined;
   runs: BeastRunService;
   operatorToken: string;
   security: TransportSecurityService;
@@ -81,6 +83,20 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
     const body = validateBody(CreateAgentBody, await parseJsonBody(c));
     const shouldAutoDispatch = body.autoDispatch !== false && deps.dispatch && shouldDispatchOnCreate(body.initAction.kind);
     if (shouldAutoDispatch) {
+      try {
+        deps.maintenance?.assertDispatchAllowed();
+      } catch (error) {
+        if (error instanceof MaintenanceModeError) {
+          return c.json({
+            error: {
+              code: 'MAINTENANCE_MODE_ACTIVE',
+              message: error.message,
+              details: { maintenance: error.state },
+            },
+          }, 423);
+        }
+        throw error;
+      }
       const capacityDecision = deps.agents.canStartInitConfig(body.initConfig);
       if (!capacityDecision.allowed) {
         return c.json({
@@ -152,6 +168,15 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
         ...(body.moduleConfig ? { moduleConfig: body.moduleConfig } : {}),
       });
     } catch (error) {
+      if (error instanceof MaintenanceModeError) {
+        return c.json({
+          error: {
+            code: 'MAINTENANCE_MODE_ACTIVE',
+            message: error.message,
+            details: { maintenance: error.state },
+          },
+        }, 423);
+      }
       if (error instanceof CapacityReservationError) {
         return c.json({
           error: {
@@ -310,6 +335,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwMaintenanceModeError(error);
       throwCapacityReservationError(error);
       throw error;
     }
@@ -398,6 +424,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwMaintenanceModeError(error);
       throwCapacityReservationError(error);
       throw error;
     }
@@ -482,6 +509,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
           `Tracked agent '${agentId}' was not found`,
         );
       }
+      throwMaintenanceModeError(error);
       throwCapacityReservationError(error);
       throw error;
     }
@@ -568,6 +596,12 @@ function shouldDispatchFreshRunForModuleConfig(
 ): boolean {
   if (!run || agent.moduleConfig === undefined || run.attemptCount === 0) return false;
   return JSON.stringify(run.configSnapshot.modules ?? {}) !== JSON.stringify(agent.moduleConfig);
+}
+
+function throwMaintenanceModeError(error: unknown): void {
+  if (error instanceof MaintenanceModeError) {
+    throw new HttpError(423, 'MAINTENANCE_MODE_ACTIVE', error.message, { maintenance: error.state });
+  }
 }
 
 function throwCapacityReservationError(error: unknown): void {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -231,13 +231,16 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       if (error instanceof MaintenanceModeError) {
         if (body.trackedAgentId) {
           try {
-            deps.agents.updateAgent(body.trackedAgentId, { status: 'stopped' });
-            deps.agents.appendEvent(body.trackedAgentId, {
-              level: 'warning',
-              type: 'agent.dispatch.paused',
-              message: error.message,
-              payload: { maintenance: error.state },
-            });
+            const trackedAgent = deps.agents.getAgent(body.trackedAgentId);
+            if (trackedAgent.status === 'initializing') {
+              deps.agents.updateAgent(body.trackedAgentId, { status: 'stopped' });
+              deps.agents.appendEvent(body.trackedAgentId, {
+                level: 'warning',
+                type: 'agent.dispatch.paused',
+                message: error.message,
+                payload: { maintenance: error.state },
+              });
+            }
           } catch (cleanupError) {
             if (!(cleanupError instanceof UnknownTrackedAgentError)) {
               throw cleanupError;

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -13,6 +13,7 @@ import {
 } from '../../beasts/services/beast-interview-service.js';
 import { BeastRunService, UnknownBeastRunError } from '../../beasts/services/beast-run-service.js';
 import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
+import type { MaintenanceModeService } from '../../beasts/services/maintenance-mode-service.js';
 import { MaintenanceModeError } from '../../beasts/services/maintenance-mode-service.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
@@ -102,6 +103,9 @@ class InterviewSessionNotFoundHttpError extends HttpError {
 }
 
 function throwKnownRunError(runId: string, error: unknown): never {
+  if (error instanceof MaintenanceModeError) {
+    throw new HttpError(423, 'MAINTENANCE_MODE_ACTIVE', error.message, { maintenance: error.state });
+  }
   throwCapacityReservationError(error);
   if (error instanceof UnknownBeastRunError) {
     throw beastRunNotFound(runId);
@@ -147,6 +151,7 @@ export interface BeastRoutesDeps {
   dispatch: BeastDispatchService;
   runs: BeastRunService;
   interviews: BeastInterviewService;
+  maintenance?: MaintenanceModeService | undefined;
   metrics: BeastMetrics;
   operatorToken: string;
   security: TransportSecurityService;

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -13,6 +13,7 @@ import {
 } from '../../beasts/services/beast-interview-service.js';
 import { BeastRunService, UnknownBeastRunError } from '../../beasts/services/beast-run-service.js';
 import { CapacityReservationError } from '../../beasts/services/capacity-reservation-policy.js';
+import { MaintenanceModeError } from '../../beasts/services/maintenance-mode-service.js';
 import type { AgentService } from '../../beasts/services/agent-service.js';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -213,6 +214,9 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
         ...(body.moduleConfig ? { moduleConfig: body.moduleConfig } : {}),
       });
     } catch (error) {
+      if (error instanceof MaintenanceModeError) {
+        throw new HttpError(423, 'MAINTENANCE_MODE_ACTIVE', error.message, { maintenance: error.state });
+      }
       if (error instanceof UnknownBeastDefinitionError) {
         throw new HttpError(
           404,

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -204,6 +204,15 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     return c.json({ data: await getContainerRuntimeStatus() });
   });
 
+  app.get('/v1/beasts/maintenance', (c) => {
+    return c.json({
+      data: deps.maintenance?.getState() ?? {
+        enabled: false,
+        allowedCommands: [],
+      },
+    });
+  });
+
   app.post('/v1/beasts/runs', async (c) => {
     const body = validateBody(CreateRunBody, await parseJsonBody(c));
     let run;

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -230,13 +230,19 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     } catch (error) {
       if (error instanceof MaintenanceModeError) {
         if (body.trackedAgentId) {
-          deps.agents.updateAgent(body.trackedAgentId, { status: 'stopped' });
-          deps.agents.appendEvent(body.trackedAgentId, {
-            level: 'warning',
-            type: 'agent.dispatch.paused',
-            message: error.message,
-            payload: { maintenance: error.state },
-          });
+          try {
+            deps.agents.updateAgent(body.trackedAgentId, { status: 'stopped' });
+            deps.agents.appendEvent(body.trackedAgentId, {
+              level: 'warning',
+              type: 'agent.dispatch.paused',
+              message: error.message,
+              payload: { maintenance: error.state },
+            });
+          } catch (cleanupError) {
+            if (!(cleanupError instanceof UnknownTrackedAgentError)) {
+              throw cleanupError;
+            }
+          }
         }
         throw new HttpError(423, 'MAINTENANCE_MODE_ACTIVE', error.message, { maintenance: error.state });
       }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -229,6 +229,15 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       });
     } catch (error) {
       if (error instanceof MaintenanceModeError) {
+        if (body.trackedAgentId) {
+          deps.agents.updateAgent(body.trackedAgentId, { status: 'stopped' });
+          deps.agents.appendEvent(body.trackedAgentId, {
+            level: 'warning',
+            type: 'agent.dispatch.paused',
+            message: error.message,
+            payload: { maintenance: error.state },
+          });
+        }
         throw new HttpError(423, 'MAINTENANCE_MODE_ACTIVE', error.message, { maintenance: error.state });
       }
       if (error instanceof UnknownBeastDefinitionError) {

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -21,12 +21,12 @@ export interface DashboardRouteDeps {
   getSecurityConfig: () => SecurityConfig;
   getProviders: () => DashboardProviderSnapshot[];
   getDependencies?: (() => DashboardDependencySnapshot[]) | undefined;
-  getMaintenanceMode?: (() => MaintenanceModeState) | undefined;
+  getMaintenanceMode?: (() => MaintenanceModeState | Promise<MaintenanceModeState>) | undefined;
   operatorToken?: string | undefined;
   ticketStore?: SseConnectionTicketStore | undefined;
 }
 
-function buildSnapshot(deps: DashboardRouteDeps) {
+async function buildSnapshot(deps: DashboardRouteDeps) {
   const skills = deps.skillManager.listInstalled();
   const enabledSkills = new Set(deps.skillManager.getEnabledSkills());
   const security = deps.getSecurityConfig();
@@ -41,7 +41,7 @@ function buildSnapshot(deps: DashboardRouteDeps) {
     security,
     providers,
     availability,
-    maintenance: deps.getMaintenanceMode?.(),
+    maintenance: await deps.getMaintenanceMode?.(),
   };
 }
 
@@ -83,8 +83,8 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   const operatorToken = deps.operatorToken;
 
   // GET /api/dashboard — aggregated snapshot of all dashboard state
-  app.get('/', (c) => {
-    return c.json(buildSnapshot(deps));
+  app.get('/', async (c) => {
+    return c.json(await buildSnapshot(deps));
   });
 
   // POST /api/dashboard/events/ticket — authenticated callers mint a one-shot
@@ -120,7 +120,7 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
     }
 
     return streamSSE(c, async (stream) => {
-      let lastSnapshot = JSON.stringify(buildSnapshot(deps));
+      let lastSnapshot = JSON.stringify(await buildSnapshot(deps));
 
       // Send initial snapshot
       await stream.writeSSE({
@@ -138,7 +138,7 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
       const snapshotInterval = setInterval(async () => {
         let nextSnapshot: string;
         try {
-          nextSnapshot = JSON.stringify(buildSnapshot(deps));
+          nextSnapshot = JSON.stringify(await buildSnapshot(deps));
         } catch {
           return;
         }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -10,6 +10,7 @@ import {
   type DashboardDependencySnapshot,
   type DashboardProviderSnapshot,
 } from './dashboard-status.js';
+import type { MaintenanceModeState } from '../../beasts/services/maintenance-mode-service.js';
 
 const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
 const DASHBOARD_HEARTBEAT_MS = 30_000;
@@ -20,6 +21,7 @@ export interface DashboardRouteDeps {
   getSecurityConfig: () => SecurityConfig;
   getProviders: () => DashboardProviderSnapshot[];
   getDependencies?: (() => DashboardDependencySnapshot[]) | undefined;
+  getMaintenanceMode?: (() => MaintenanceModeState) | undefined;
   operatorToken?: string | undefined;
   ticketStore?: SseConnectionTicketStore | undefined;
 }
@@ -39,6 +41,7 @@ function buildSnapshot(deps: DashboardRouteDeps) {
     security,
     providers,
     availability,
+    maintenance: deps.getMaintenanceMode?.(),
   };
 }
 

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -11,6 +11,7 @@ import { BeastInterviewService } from '../../../src/beasts/services/beast-interv
 import { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import { BeastRunService } from '../../../src/beasts/services/beast-run-service.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
+import { MaintenanceModeError } from '../../../src/beasts/services/maintenance-mode-service.js';
 import { CapacityReservationError, CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import { errorHandler } from '../../../src/http/middleware.js';
@@ -304,6 +305,58 @@ describe('agent routes integration', () => {
     });
     expect(repository.listTrackedAgents()).toHaveLength(1);
     expect(repository.listTrackedAgents()[0]).toMatchObject({ status: 'initializing' });
+  });
+
+  it('stops tracked agents when auto-dispatch loses a maintenance race', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const repository = new SQLiteBeastRepository(join(TMP, 'auto-dispatch-maintenance.db'));
+    const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
+    const runs = { getRun: vi.fn(), start: vi.fn(), stop: vi.fn(), kill: vi.fn(), restart: vi.fn() };
+    const dispatch = {
+      createRun: vi.fn(async () => {
+        throw new MaintenanceModeError({
+          enabled: true,
+          reason: 'deploy',
+          allowedCommands: ['beasts list'],
+        });
+      }),
+    };
+    const app = new Hono();
+    app.onError(errorHandler);
+    app.route('/', agentRoutes({
+      agents,
+      dispatch: dispatch as never,
+      runs: runs as never,
+      operatorToken: TEST_SUPER_SECRET_OPERATOR_TOKEN,
+      security: new TransportSecurityService(),
+    }));
+
+    const response = await app.request('/v1/beasts/agents', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_SUPER_SECRET_OPERATOR_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        initAction: {
+          kind: 'martin-loop',
+          command: 'martin-loop',
+          config: { provider: 'claude', objective: 'Race maintenance', chunkDirectory: 'docs/chunks' },
+        },
+        initConfig: { provider: 'claude', objective: 'Race maintenance', chunkDirectory: 'docs/chunks' },
+      }),
+    });
+
+    expect(response.status).toBe(423);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'MAINTENANCE_MODE_ACTIVE',
+      },
+    });
+    const [agent] = repository.listTrackedAgents();
+    expect(agent).toMatchObject({ status: 'stopped' });
+    expect(agents.getAgentDetail(agent.id).events.map((event) => event.type)).toContain('agent.dispatch.paused');
   });
 
   it('returns validation errors for invalid tracked agent payloads', async () => {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -274,6 +274,42 @@ describe('beast routes', () => {
     });
   });
 
+  it('does not stop unrelated tracked agents when maintenance blocks direct run creation', async () => {
+    const { app, operatorToken, agents } = createBeastApp({ maintenanceEnabled: true });
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'chat',
+      createdByUser: 'chat-session:chat-1',
+      chatSessionId: 'chat-1',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { provider: 'claude', objective: 'ship', chunkDirectory: 'docs/chunks' },
+    });
+    agents.updateAgent(agent.id, { status: 'running' });
+
+    const response = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ' + operatorToken,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        trackedAgentId: agent.id,
+        chatSessionId: 'chat-1',
+        config: {
+          provider: 'claude',
+          objective: 'Implement beast routes',
+          chunkDirectory: 'docs/chunks',
+        },
+        executionMode: 'process',
+        startNow: true,
+      }),
+    });
+
+    expect(response.status).toBe(423);
+    expect(agents.getAgent(agent.id).status).toBe('running');
+  });
+
   it.each([
     ['/v1/beasts/runs/missing-run-id'],
     ['/v1/beasts/runs/missing-run-id/events'],

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -10,6 +10,7 @@ import { BeastInterviewService } from '../../../src/beasts/services/beast-interv
 import { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import { BeastRunService } from '../../../src/beasts/services/beast-run-service.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
+import { MaintenanceModeService } from '../../../src/beasts/services/maintenance-mode-service.js';
 import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus-beast-metrics.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
@@ -25,7 +26,7 @@ const TEST_SUPER_SECRET_OPERATOR_TOKEN = testCredential('TEST_SUPER_SECRET_OPERA
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/beast-routes');
 
-function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; realContainer?: boolean }) {
+function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; realContainer?: boolean; maintenanceEnabled?: boolean }) {
   mkdirSync(TMP, { recursive: true });
   const repository = new SQLiteBeastRepository(join(TMP, 'beasts.db'));
   const logStore = new BeastLogStore(join(TMP, 'logs'));
@@ -99,7 +100,13 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; 
       kill: vi.fn(),
     },
   };
-  const dispatch = new BeastDispatchService(repository, catalog, executors, metrics, logStore);
+  const maintenance = options?.maintenanceEnabled
+    ? new MaintenanceModeService(join(TMP, 'maintenance.json'))
+    : undefined;
+  if (maintenance) {
+    maintenance.activate({ reason: 'deploy', startedAt: '2026-03-10T00:00:00.000Z' });
+  }
+  const dispatch = new BeastDispatchService(repository, catalog, executors, metrics, logStore, { maintenance });
   const runs = new BeastRunService(repository, catalog, executors, metrics, logStore);
   const interviews = new BeastInterviewService(repository, catalog);
   const agents = new AgentService(repository, () => '2026-03-10T00:00:00.000Z');
@@ -116,6 +123,7 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; 
       dispatch,
       runs,
       interviews,
+      maintenance,
       metrics,
       security,
       operatorToken,
@@ -128,7 +136,7 @@ function createBeastApp(options?: { rateLimitMax?: number; failStart?: boolean; 
     },
   });
 
-  return { app, operatorToken, fakeContainerSupervisor, repository };
+  return { app, operatorToken, fakeContainerSupervisor, repository, agents };
 }
 
 describe('beast routes', () => {
@@ -196,6 +204,43 @@ describe('beast routes', () => {
     });
     const logsBody = await logsResponse.json() as { data: { logs: string[] } };
     expect(logsBody.data.logs.some((line) => line.includes('started'))).toBe(true);
+  });
+
+  it('stops tracked agents when direct run creation is paused by maintenance mode', async () => {
+    const { app, operatorToken, agents } = createBeastApp({ maintenanceEnabled: true });
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'chat',
+      createdByUser: 'chat-session:chat-1',
+      chatSessionId: 'chat-1',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { provider: 'claude', objective: 'ship', chunkDirectory: 'docs/chunks' },
+    });
+
+    const response = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        trackedAgentId: agent.id,
+        chatSessionId: 'chat-1',
+        config: {
+          provider: 'claude',
+          objective: 'Implement beast routes',
+          chunkDirectory: 'docs/chunks',
+        },
+        executionMode: 'process',
+        startNow: true,
+      }),
+    });
+
+    expect(response.status).toBe(423);
+    expect(agents.getAgent(agent.id).status).toBe('stopped');
+    expect(agents.getAgentDetail(agent.id).events.map((event) => event.type)).toContain('agent.dispatch.paused');
   });
 
   it.each([

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -243,6 +243,37 @@ describe('beast routes', () => {
     expect(agents.getAgentDetail(agent.id).events.map((event) => event.type)).toContain('agent.dispatch.paused');
   });
 
+  it('returns maintenance response instead of 500 when stale tracked agent cleanup cannot run', async () => {
+    const { app, operatorToken } = createBeastApp({ maintenanceEnabled: true });
+    const response = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ' + operatorToken,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        trackedAgentId: 'missing-agent',
+        chatSessionId: 'chat-1',
+        config: {
+          provider: 'claude',
+          objective: 'Implement beast routes',
+          chunkDirectory: 'docs/chunks',
+        },
+        executionMode: 'process',
+        startNow: true,
+      }),
+    });
+
+    expect(response.status).toBe(423);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'MAINTENANCE_MODE_ACTIVE',
+        message: 'Maintenance mode is active; new Beast dispatch is paused. Reason: deploy',
+      },
+    });
+  });
+
   it.each([
     ['/v1/beasts/runs/missing-run-id'],
     ['/v1/beasts/runs/missing-run-id/events'],

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-init-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-init-service.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
 import { AgentInitService } from '../../../src/beasts/services/agent-init-service.js';
+import { MaintenanceModeError } from '../../../src/beasts/services/maintenance-mode-service.js';
 
 describe('AgentInitService', () => {
   let workDir: string | undefined;
@@ -94,5 +95,39 @@ describe('AgentInitService', () => {
     });
     expect(run.id).toBe('run-123');
     expect(detail.events.map((event) => event.type)).toContain('agent.dispatch.requested');
+  });
+
+  it('marks chat-created agents stopped when maintenance blocks dispatch', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-agent-init-'));
+    const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
+    const createRun = vi.fn().mockRejectedValue(new MaintenanceModeError({
+      enabled: true,
+      reason: 'deploy',
+      allowedCommands: ['status'],
+    }));
+    const init = new AgentInitService(agents, {
+      createRun,
+    } as never, () => '2026-03-11T00:00:00.000Z');
+
+    const agent = agents.createAgent({
+      definitionId: 'martin-loop',
+      source: 'chat',
+      createdByUser: 'chat-session:sess-1',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {}, chatSessionId: 'sess-1' },
+      initConfig: { provider: 'claude', objective: 'ship' },
+      chatSessionId: 'sess-1',
+    });
+
+    await expect(init.dispatchAgent(agent.id, {
+      definitionId: 'martin-loop',
+      chatSessionId: 'sess-1',
+      config: { provider: 'claude', objective: 'ship' },
+      executionMode: 'process',
+    })).rejects.toThrow(MaintenanceModeError);
+
+    const detail = agents.getAgentDetail(agent.id);
+    expect(detail.agent.status).toBe('stopped');
+    expect(detail.events.map((event) => event.type)).toContain('agent.dispatch.paused');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -10,6 +10,7 @@ import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-bea
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
+import { MaintenanceModeError, MaintenanceModeService } from '../../../src/beasts/services/maintenance-mode-service.js';
 
 describe('BeastDispatchService', () => {
   let workDir: string | undefined;
@@ -18,6 +19,42 @@ describe('BeastDispatchService', () => {
     if (workDir) {
       await rm(workDir, { recursive: true, force: true });
     }
+  });
+
+  it('blocks new dispatches while maintenance mode is active', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const maintenance = new MaintenanceModeService(join(workDir, 'maintenance-mode.json'));
+    maintenance.activate({ reason: 'database migration', startedAt: '2026-07-16T10:00:00.000Z' });
+    const executors = {
+      process: {
+        start: vi.fn(async () => repo.createAttempt('placeholder', { status: 'running' })),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs, { maintenance });
+
+    await expect(dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Implement the dispatch panel',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      executionMode: 'process',
+    })).rejects.toThrow(MaintenanceModeError);
+    expect(executors.process.start).not.toHaveBeenCalled();
+    expect(repo.listRuns()).toHaveLength(0);
   });
 
   it('creates a run with an immutable config snapshot and records metrics', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -47,6 +48,47 @@ describe('BeastDispatchService', () => {
       config: {
         provider: 'claude',
         objective: 'Implement the dispatch panel',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      executionMode: 'process',
+    })).rejects.toThrow(MaintenanceModeError);
+    expect(executors.process.start).not.toHaveBeenCalled();
+    expect(repo.listRuns()).toHaveLength(0);
+  });
+
+  it('fails closed when a persisted maintenance state file is not an object', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const maintenanceStateFile = join(workDir, 'maintenance-mode.json');
+    writeFileSync(maintenanceStateFile, 'null\n');
+    const maintenance = new MaintenanceModeService(maintenanceStateFile);
+    const executors = {
+      process: {
+        start: vi.fn(async () => repo.createAttempt('placeholder', { status: 'running' })),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs, { maintenance });
+
+    expect(maintenance.getState()).toMatchObject({
+      enabled: true,
+      reason: expect.stringContaining('Maintenance state is unreadable'),
+    });
+    await expect(dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Do not fail open',
         chunkDirectory: 'docs/chunks',
       },
       dispatchedBy: 'dashboard',

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -11,6 +11,7 @@ import { PrometheusBeastMetrics } from '../../../src/beasts/telemetry/prometheus
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
 import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
+import { MaintenanceModeError, MaintenanceModeService } from '../../../src/beasts/services/maintenance-mode-service.js';
 
 describe('BeastRunService', () => {
   let workDir: string | undefined;
@@ -434,6 +435,53 @@ describe('BeastRunService', () => {
     expect(executors.process.stop).not.toHaveBeenCalled();
     expect(repo.getRun(run.id)).toMatchObject({ id: run.id, status: 'running' });
     expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'running', dispatchRunId: run.id });
+  });
+
+  it('does not stop a running run when restart is blocked by maintenance mode', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async (run: { id: string }) => repo.createAttempt(run.id, {
+          status: 'running',
+          pid: 2001,
+          startedAt: '2026-03-10T00:03:00.000Z',
+        })),
+        stop: vi.fn(async (runId: string, attemptId: string) => {
+          repo.updateAttempt(attemptId, { status: 'stopped' });
+          return repo.updateRun(runId, { status: 'stopped', stopReason: 'operator_stop' });
+        }),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+    const maintenance = new MaintenanceModeService(join(workDir, 'maintenance-mode.json'));
+    const runs = new BeastRunService(repo, new BeastCatalogService(), executors, metrics, logs, { maintenance });
+    const run = await dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'claude',
+        objective: 'Restart safely',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      executionMode: 'process',
+      startNow: true,
+    });
+    maintenance.activate({ reason: 'database migration', startedAt: '2026-07-16T10:00:00.000Z' });
+
+    await expect(runs.restart(run.id, 'operator')).rejects.toThrow(MaintenanceModeError);
+
+    expect(executors.process.stop).not.toHaveBeenCalled();
+    expect(repo.getRun(run.id)).toMatchObject({ id: run.id, status: 'running' });
   });
 
   it('starts queued linked runs using reservation metadata from the run config snapshot', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/module-config-plumbing.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/module-config-plumbing.test.ts
@@ -383,5 +383,12 @@ describe('ModuleConfig plumbing', () => {
       const args = parseArgs(['beasts', 'spawn', 'martin-loop']);
       expect(args.moduleConfig).toBeUndefined();
     });
+    it('parses maintenance mode action and reason guardrail commands', async () => {
+      const { parseArgs } = await import('../../../src/cli/args.js');
+      const args = parseArgs(['beasts', 'maintenance', 'on', '--set', 'reason=database migration']);
+      expect(args.beastAction).toBe('maintenance');
+      expect(args.beastTarget).toBe('on');
+      expect(args.networkSet).toEqual(['reason=database migration']);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
@@ -165,7 +165,7 @@ describe('BeastDaemonDispatchAdapter', () => {
       kind: 'dispatch',
       definitionId: 'martin-loop',
       assistantMessage: expect.stringContaining('Maintenance mode is active'),
-      beastContext: context,
+      beastContext: null,
     });
     expect(result?.assistantMessage).toContain('Reason: deploy');
     expect(result?.assistantMessage).toContain('beasts maintenance off');

--- a/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
@@ -110,6 +110,67 @@ describe('BeastDaemonDispatchAdapter', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('returns maintenance guidance when daemon dispatch is paused', async () => {
+    const context = {
+      agentId: 'agent-1',
+      definitionId: 'martin-loop',
+      interviewSessionId: 'interview-1',
+      status: 'interviewing' as const,
+    };
+    const fetchMock = vi.fn(async (url: URL | RequestInfo) => {
+      const target = url.toString();
+      if (target.endsWith('/v1/beasts/catalog')) {
+        return Response.json({ data: definitions });
+      }
+      if (target.endsWith('/v1/beasts/interviews/interview-1/answer')) {
+        return Response.json({
+          data: {
+            complete: true,
+            config: { objective: 'Ship it' },
+            session: { id: 'interview-1', definitionId: 'martin-loop' },
+          },
+        });
+      }
+      if (target.endsWith('/v1/beasts/runs')) {
+        return Response.json({
+          error: {
+            code: 'MAINTENANCE_MODE_ACTIVE',
+            message: 'Maintenance mode is active; new Beast dispatch is paused. Reason: deploy',
+            details: {
+              maintenance: {
+                enabled: true,
+                reason: 'deploy',
+                allowedCommands: ['beasts list', 'beasts maintenance off'],
+              },
+            },
+          },
+        }, { status: 423, statusText: 'Locked' });
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new BeastDaemonDispatchAdapter({
+      baseUrl: 'http://127.0.0.1:4050',
+      operatorToken: TEST_DAEMON_TOKEN,
+    });
+
+    const result = await adapter.handle('Ship it', {
+      projectId: 'project',
+      sessionId: 'session-1',
+      transcript: [],
+      beastContext: context,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'dispatch',
+      definitionId: 'martin-loop',
+      assistantMessage: expect.stringContaining('Maintenance mode is active'),
+      beastContext: context,
+    });
+    expect(result?.assistantMessage).toContain('Reason: deploy');
+    expect(result?.assistantMessage).toContain('beasts maintenance off');
+  });
+
   it('propagates daemon catalog failures for launch requests', async () => {
     const fetchMock = vi.fn(async () => Response.json({ error: 'unauthorized' }, { status: 401, statusText: 'Unauthorized' }));
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
@@ -4,6 +4,7 @@ import type { BeastCatalogService } from '../../../src/beasts/services/beast-cat
 import type { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import type { BeastInterviewService } from '../../../src/beasts/services/beast-interview-service.js';
 import type { AgentInitService } from '../../../src/beasts/services/agent-init-service.js';
+import { MaintenanceModeError } from '../../../src/beasts/services/maintenance-mode-service.js';
 import type { BeastInterviewPrompt } from '../../../src/beasts/types.js';
 
 const providerPrompt: BeastInterviewPrompt = {
@@ -172,6 +173,55 @@ describe('ChatBeastDispatchAdapter', () => {
       assistantMessage: expect.stringContaining('run-1'),
       beastContext: null,
       runId: 'run-1',
+    });
+  });
+
+  it('clears completed interview context when maintenance blocks dispatch', async () => {
+    const answer = vi.fn().mockReturnValueOnce({
+      session: {
+        id: 'interview-1',
+        definitionId: 'martin-loop',
+        status: 'completed',
+        answers: { provider: 'claude', objective: 'Ship Beast monitoring' },
+        createdAt: '2026-03-10T00:00:00.000Z',
+        updatedAt: '2026-03-10T00:00:02.000Z',
+      },
+      complete: true,
+      config: { provider: 'claude', objective: 'Ship Beast monitoring' },
+    });
+    const dispatchAgent = vi.fn().mockRejectedValue(new MaintenanceModeError({
+      enabled: true,
+      reason: 'deploy',
+      allowedCommands: ['status'],
+    }));
+    const adapter = new ChatBeastDispatchAdapter({
+      catalog: {
+        listDefinitions: () => [
+          { id: 'martin-loop', label: 'Martin Loop' },
+        ],
+      } as unknown as BeastCatalogService,
+      interviews: { answer } as unknown as BeastInterviewService,
+      dispatch: {} as unknown as BeastDispatchService,
+      agentInit: { dispatchAgent } as unknown as AgentInitService,
+    });
+
+    const result = await adapter.handle('Ship Beast monitoring', {
+      projectId: 'proj',
+      sessionId: 'chat-1',
+      transcript: [],
+      beastContext: {
+        agentId: 'agent-1',
+        definitionId: 'martin-loop',
+        interviewSessionId: 'interview-1',
+        status: 'interviewing',
+      },
+    });
+
+    expect(result).toMatchObject({
+      kind: 'dispatch',
+      definitionId: 'martin-loop',
+      assistantMessage: expect.stringContaining('Maintenance mode is active'),
+      beastContext: null,
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-cli.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { handleBeastCommand } from '../../../src/cli/beast-cli.js';
 import type { CliArgs } from '../../../src/cli/args.js';
 import type { ProjectPaths } from '../../../src/cli/project-root.js';
@@ -28,8 +31,10 @@ const mockServices = vi.hoisted(() => ({
   dispose: vi.fn(),
 }));
 
+const mockCreateBeastServices = vi.hoisted(() => vi.fn(() => mockServices));
+
 vi.mock('../../../src/beasts/create-beast-services.js', () => ({
-  createBeastServices: () => mockServices,
+  createBeastServices: mockCreateBeastServices,
 }));
 
 const mockControlClient = vi.hoisted(() => ({
@@ -83,6 +88,25 @@ beforeEach(() => {
   }
   vi.clearAllMocks();
   vi.mocked(spawnSync).mockReturnValue({ status: 0, stderr: '' } as any);
+});
+
+describe('handleBeastCommand() maintenance', () => {
+  it('reads maintenance status without starting the Beast service bundle', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'franken-maint-cli-'));
+    const deps = makeDeps({
+      args: { subcommand: 'beasts', beastAction: 'maintenance', beastTarget: 'status' } as CliArgs,
+      paths: { root, fbeast: join(root, '.fbeast') } as unknown as ProjectPaths,
+    });
+
+    try {
+      await handleBeastCommand(deps);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+
+    expect(mockCreateBeastServices).not.toHaveBeenCalled();
+    expect(deps.print).toHaveBeenCalledWith(expect.stringContaining('"enabled": false'));
+  });
 });
 
 describe('handleBeastCommand() catalog', () => {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -38,6 +38,12 @@ function createMockDeps(): DashboardRouteDeps {
     getProviders: vi.fn().mockReturnValue([
       { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
     ]),
+    getMaintenanceMode: vi.fn().mockReturnValue({
+      enabled: true,
+      reason: 'database migration',
+      startedAt: '2026-07-16T10:00:00.000Z',
+      allowedCommands: ['beasts list', 'beasts status <run-id>'],
+    }),
     operatorToken: TEST_DASHBOARD_TOKEN,
     ticketStore: ticketStore = new SseConnectionTicketStore(),
   };
@@ -79,6 +85,12 @@ describe('dashboard routes', () => {
       expect(body.providers).toEqual([
         { name: 'claude', type: 'claude-cli', available: true, failoverOrder: 0 },
       ]);
+      expect(body.maintenance).toEqual({
+        enabled: true,
+        reason: 'database migration',
+        startedAt: '2026-07-16T10:00:00.000Z',
+        allowedCommands: ['beasts list', 'beasts status <run-id>'],
+      });
       expect(body.availability).toEqual({
         status: 'healthy',
         dependencies: [

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -39,11 +39,19 @@ export interface DashboardAvailability {
   dependencies: DashboardDependency[];
 }
 
+export interface DashboardMaintenanceMode {
+  enabled: boolean;
+  reason?: string;
+  startedAt?: string;
+  allowedCommands: string[];
+}
+
 export interface DashboardSnapshot {
   skills: DashboardSkill[];
   security: DashboardSecurity;
   providers: DashboardProvider[];
   availability?: DashboardAvailability;
+  maintenance?: DashboardMaintenanceMode;
 }
 
 export class DashboardApiClient {

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -91,6 +91,27 @@ describe('DashboardPage', () => {
     expect(screen.getByText('[degraded]')).toBeTruthy();
   });
 
+  it('renders a maintenance mode banner with dispatch guardrail guidance', async () => {
+    const client = mockClient({
+      fetchSnapshot: vi.fn().mockResolvedValue({
+        ...snapshot,
+        maintenance: {
+          enabled: true,
+          reason: 'database migration',
+          startedAt: '2026-07-16T10:00:00.000Z',
+          allowedCommands: ['beasts list', 'beasts status <run-id>'],
+        },
+      }),
+    });
+
+    render(<DashboardPage client={client} />);
+
+    const banner = await screen.findByRole('status');
+    expect(banner.textContent).toContain('Maintenance mode is active');
+    expect(banner.textContent).toContain('database migration');
+    expect(banner.textContent).toContain('beasts status <run-id>');
+  });
+
   it('shows a load failure with a retry action instead of hiding it in the console', async () => {
     const client = mockClient({
       fetchSnapshot: vi.fn()

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -102,6 +102,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
         security: confirmedSecurity,
         providers: currentSnapshot.providers,
         availability: currentSnapshot.availability ?? undefined,
+        maintenance: currentSnapshot.maintenance ?? undefined,
       });
     }
   }, [setSnapshot]);

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -31,6 +31,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
     security,
     providers,
     availability,
+    maintenance,
     loading,
     setSnapshot,
     setSkillEnabled,
@@ -115,6 +116,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
       security: currentSnapshot.security ?? confirmedSnapshot.security,
       providers: currentSnapshot.providers,
       availability: currentSnapshot.availability ?? undefined,
+      maintenance: currentSnapshot.maintenance ?? undefined,
     });
   }, [setSnapshot]);
 
@@ -127,6 +129,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
       security: confirmedSecurity,
       providers: currentSnapshot.providers,
       availability: currentSnapshot.availability ?? undefined,
+      maintenance: currentSnapshot.maintenance ?? undefined,
     });
   }, [setSnapshot]);
 
@@ -319,6 +322,24 @@ export function DashboardPage({ client }: DashboardPageProps) {
   return (
     <div className="dashboard-page">
       <h2>Dashboard</h2>
+      {maintenance?.enabled && (
+        <section className="maintenance-banner" role="status" aria-live="polite">
+          <div>
+            <strong>Maintenance mode is active</strong>
+            <p>{maintenance.reason ?? 'New Beast dispatch is paused while operators perform maintenance.'}</p>
+          </div>
+          <dl>
+            {maintenance.startedAt && (
+              <>
+                <dt>Started</dt>
+                <dd>{maintenance.startedAt}</dd>
+              </>
+            )}
+            <dt>Allowed commands</dt>
+            <dd>{maintenance.allowedCommands.join(', ')}</dd>
+          </dl>
+        </section>
+      )}
       {(loadError || Object.keys(skillErrors).length > 0 || securityError) && (
         <section className="dashboard-alerts" aria-label="Dashboard errors" aria-live="assertive">
           {loadError && (

--- a/packages/franken-web/src/stores/dashboard-store.test.ts
+++ b/packages/franken-web/src/stores/dashboard-store.test.ts
@@ -48,6 +48,25 @@ describe('dashboard-store', () => {
       useDashboardStore.getState().setSnapshot(makeMockSnapshot());
       expect(useDashboardStore.getState().loading).toBe(false);
     });
+
+    it('preserves maintenance state across partial snapshots that omit it', () => {
+      useDashboardStore.getState().setSnapshot({
+        ...makeMockSnapshot(),
+        maintenance: {
+          enabled: true,
+          reason: 'database migration',
+          startedAt: '2026-07-16T10:00:00.000Z',
+          allowedCommands: ['beasts maintenance off'],
+        },
+      });
+
+      useDashboardStore.getState().setSnapshot(makeMockSnapshot());
+
+      expect(useDashboardStore.getState().maintenance).toMatchObject({
+        enabled: true,
+        reason: 'database migration',
+      });
+    });
   });
 
   describe('toggleSkill', () => {

--- a/packages/franken-web/src/stores/dashboard-store.ts
+++ b/packages/franken-web/src/stores/dashboard-store.ts
@@ -33,15 +33,15 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
   ...initialState,
 
   setSnapshot: (snapshot) =>
-    set({
+    set((current) => ({
       skills: snapshot.skills,
       security: snapshot.security,
       providers: snapshot.providers,
       availability: snapshot.availability ?? null,
-      maintenance: snapshot.maintenance ?? null,
+      maintenance: snapshot.maintenance ?? current.maintenance,
       loading: false,
       error: null,
-    }),
+    })),
 
   toggleSkill: (name) =>
     set((s) => ({

--- a/packages/franken-web/src/stores/dashboard-store.ts
+++ b/packages/franken-web/src/stores/dashboard-store.ts
@@ -1,15 +1,16 @@
 import { create } from 'zustand';
-import type { DashboardSkill, DashboardSecurity, DashboardProvider, DashboardAvailability } from '../lib/dashboard-api';
+import type { DashboardSkill, DashboardSecurity, DashboardProvider, DashboardAvailability, DashboardMaintenanceMode } from '../lib/dashboard-api';
 
 interface DashboardStore {
   skills: DashboardSkill[];
   security: DashboardSecurity | null;
   providers: DashboardProvider[];
   availability: DashboardAvailability | null;
+  maintenance: DashboardMaintenanceMode | null;
   loading: boolean;
   error: string | null;
 
-  setSnapshot: (snapshot: { skills: DashboardSkill[]; security: DashboardSecurity; providers: DashboardProvider[]; availability?: DashboardAvailability | undefined }) => void;
+  setSnapshot: (snapshot: { skills: DashboardSkill[]; security: DashboardSecurity; providers: DashboardProvider[]; availability?: DashboardAvailability | undefined; maintenance?: DashboardMaintenanceMode | undefined }) => void;
   toggleSkill: (name: string) => void;
   setSkillEnabled: (name: string, enabled: boolean) => void;
   setSecurityProfile: (profile: string) => void;
@@ -23,6 +24,7 @@ const initialState = {
   security: null as DashboardSecurity | null,
   providers: [] as DashboardProvider[],
   availability: null as DashboardAvailability | null,
+  maintenance: null as DashboardMaintenanceMode | null,
   loading: true,
   error: null as string | null,
 };
@@ -36,6 +38,7 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
       security: snapshot.security,
       providers: snapshot.providers,
       availability: snapshot.availability ?? null,
+      maintenance: snapshot.maintenance ?? null,
       loading: false,
       error: null,
     }),

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -1439,6 +1439,42 @@ button {
   color: #ffd0ca;
 }
 
+.maintenance-banner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(255, 205, 86, 0.42);
+  border-radius: 1rem;
+  background: rgba(255, 205, 86, 0.1);
+  color: #ffe7a3;
+}
+
+.maintenance-banner strong {
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.maintenance-banner p,
+.maintenance-banner dl {
+  margin: 0;
+}
+
+.maintenance-banner dl {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.25rem 0.6rem;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.maintenance-banner dd {
+  margin: 0;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
 .dashboard-alerts {
   display: grid;
   gap: 0.75rem;

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -272,6 +272,8 @@
 ## 2026-07-16 — Maintenance-mode tracked-agent cleanup
 - When maintenance blocks Beast dispatch after a tracked agent has been created, mark the agent `stopped` and append an `agent.dispatch.paused` event in every dispatch path, including chat-backed `AgentInitService.dispatchAgent`.
 - HTTP maintenance cleanup for stale `trackedAgentId` values must never mask the intended 423 response; ignore missing-agent cleanup failures but rethrow unexpected cleanup errors.
+- Do not keep daemon chat Beast context after a 423 maintenance response from final dispatch; clear it so a later arbitrary chat message cannot auto-resume a completed interview after maintenance is disabled.
+- Only stop maintenance-blocked tracked agents that are still `initializing`; direct run requests can name unrelated running/deleted agents, and maintenance errors happen before createRun validates/links that ID.
 
 ## 2026-07-16 — LlmCacheStore read-path schema validation
 - For JSON cache stores, validate both schemaVersion and the runtime shape (`content` type) before returning entries, otherwise stale/malformed files can be reused as cache hits.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -269,6 +269,10 @@
 - 2026-07-15 — MCP memory scoping: avoid encoding agent scope solely in user-visible keys or summaries. Store explicit scope metadata, use reversible internal key encoding for physical storage, keep logical keys in query/frontload output, and fetch/filter uncapped episodic rows before applying visible result limits so other agents' rows cannot starve the requested scope.
 - 2026-07-15 — DR backup review hardening: encrypted state backups should back up only the requested state tree plus explicit sibling DBs, never keys/cache/old artifacts; reject live SQLite sidecars (`-wal`, `-shm`, `-journal`), validate dry-run restore targets, and quarantine approval ledgers rather than reactivating stale approvals.
 
+## 2026-07-16 — Maintenance-mode tracked-agent cleanup
+- When maintenance blocks Beast dispatch after a tracked agent has been created, mark the agent `stopped` and append an `agent.dispatch.paused` event in every dispatch path, including chat-backed `AgentInitService.dispatchAgent`.
+- HTTP maintenance cleanup for stale `trackedAgentId` values must never mask the intended 423 response; ignore missing-agent cleanup failures but rethrow unexpected cleanup errors.
+
 ## 2026-07-16 — LlmCacheStore read-path schema validation
 - For JSON cache stores, validate both schemaVersion and the runtime shape (`content` type) before returning entries, otherwise stale/malformed files can be reused as cache hits.
 - Add regression tests that write an explicitly mismatched schema version and a wrong-shaped payload to prove stale cache entries are rejected.


### PR DESCRIPTION
## Summary
- Add persisted Beast maintenance mode state and block new dispatches while active
- Expose maintenance state through dashboard snapshots and show a banner with safe commands
- Add CLI commands to inspect/toggle maintenance mode and targeted route/UI/dispatch tests

## Test Plan
- npm ci
- npm test -- tests/unit/beasts/beast-dispatch-service.test.ts tests/unit/http/dashboard-routes.test.ts tests/unit/beasts/module-config-plumbing.test.ts (packages/franken-orchestrator)
- npm test -- src/pages/dashboard-page.test.tsx (packages/franken-web)
- npm run build
- npm run typecheck (packages/franken-orchestrator)
- npm run typecheck (packages/franken-web)
- npm run lint (packages/franken-orchestrator; warnings only)
- npm run lint (packages/franken-web; warnings only)

Closes #1718