### PR TITLE
feat(availability): add read-only degraded mode

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -857,6 +857,9 @@ async function getBeastsDaemonEndpointState(baseUrl: string, expected: { root: s
     if (response.ok && record.ok === true) {
       return 'attachable';
     }
+    if (response.status === 503 && record.status === 'degraded' && record.ok === false) {
+      return 'attachable';
+    }
     if (response.status === 503 && record.status === 'draining' && record.ok === false) {
       return 'draining';
     }

--- a/packages/franken-orchestrator/src/http/availability-mode.ts
+++ b/packages/franken-orchestrator/src/http/availability-mode.ts
@@ -29,6 +29,9 @@ export class InMemoryAvailabilityModeState implements AvailabilityModeState {
     source: 'automatic' | 'operator',
     now = new Date().toISOString(),
   ): AvailabilityModeSnapshot {
+    if (this.current.readOnly && source === 'automatic') {
+      return this.current;
+    }
     this.current = {
       mode: 'read-only-degraded',
       readOnly: true,

--- a/packages/franken-orchestrator/src/http/availability-mode.ts
+++ b/packages/franken-orchestrator/src/http/availability-mode.ts
@@ -1,0 +1,65 @@
+export type AvailabilityMode = 'read-write' | 'read-only-degraded';
+
+export interface AvailabilityModeSnapshot {
+  readonly mode: AvailabilityMode;
+  readonly readOnly: boolean;
+  readonly enteredAt?: string | undefined;
+  readonly reason?: string | undefined;
+  readonly source?: 'automatic' | 'operator' | undefined;
+}
+
+export interface AvailabilityModeState {
+  snapshot(): AvailabilityModeSnapshot;
+  enterReadOnlyDegraded(reason: string, source: 'automatic' | 'operator', now?: string): AvailabilityModeSnapshot;
+  leaveReadOnlyDegraded(): AvailabilityModeSnapshot;
+}
+
+export class InMemoryAvailabilityModeState implements AvailabilityModeState {
+  private current: AvailabilityModeSnapshot = {
+    mode: 'read-write',
+    readOnly: false,
+  };
+
+  snapshot(): AvailabilityModeSnapshot {
+    return this.current;
+  }
+
+  enterReadOnlyDegraded(
+    reason: string,
+    source: 'automatic' | 'operator',
+    now = new Date().toISOString(),
+  ): AvailabilityModeSnapshot {
+    this.current = {
+      mode: 'read-only-degraded',
+      readOnly: true,
+      enteredAt: now,
+      reason,
+      source,
+    };
+    return this.current;
+  }
+
+  leaveReadOnlyDegraded(): AvailabilityModeSnapshot {
+    this.current = {
+      mode: 'read-write',
+      readOnly: false,
+    };
+    return this.current;
+  }
+}
+
+export function availabilityModeDenialDetails(snapshot: AvailabilityModeSnapshot): {
+  readonly mode: AvailabilityMode;
+  readonly readOnly: boolean;
+  readonly enteredAt?: string | undefined;
+  readonly reason?: string | undefined;
+  readonly source?: 'automatic' | 'operator' | undefined;
+} {
+  return {
+    mode: snapshot.mode,
+    readOnly: snapshot.readOnly,
+    enteredAt: snapshot.enteredAt,
+    reason: snapshot.reason,
+    source: snapshot.source,
+  };
+}

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -170,17 +170,20 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
 
   app.delete('/v1/beasts/availability/degraded', auth, (c) => {
     const snapshot = availabilityMode.snapshot();
-    if (snapshot.source === 'automatic') {
-      const recovered = dependencyCountSnapshot(services, availabilityMode).availability;
-      if (recovered.readOnly) {
+    if (snapshot.readOnly) {
+      try {
+        services.agents.listAgents();
+        services.runs.listRuns();
+      } catch (error) {
+        console.warn('[beasts-daemon] Dependency read failed while leaving read-only degraded mode', error);
+        const blocked = availabilityMode.enterReadOnlyDegraded('Health dependency read failed', 'automatic');
         throw new HttpError(
           503,
           'READ_ONLY_DEGRADED_MODE_ACTIVE',
-          'Automatic read-only degraded mode remains active because dependency reads are still failing',
-          availabilityModeDenialDetails(recovered),
+          'Read-only degraded mode remains active because dependency reads are still failing',
+          availabilityModeDenialDetails(blocked),
         );
       }
-      return c.json({ data: recovered });
     }
     return c.json({ data: availabilityMode.leaveReadOnlyDegraded() });
   });

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -1,11 +1,18 @@
 import { Hono } from 'hono';
 import type { BeastServiceBundle } from '../beasts/create-beast-services.js';
+import { requireBeastOperatorAuth } from '../beasts/http/beast-auth.js';
 import { agentRoutes } from './routes/agent-routes.js';
 import { beastRoutes } from './routes/beast-routes.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
 import { HttpError, errorHandler, localBrowserControlProtection } from './middleware.js';
 import { TransportSecurityService } from './security/transport-security.js';
 import { isoNow } from '@franken/types';
+import {
+  availabilityModeDenialDetails,
+  InMemoryAvailabilityModeState,
+  type AvailabilityModeSnapshot,
+  type AvailabilityModeState,
+} from './availability-mode.js';
 
 export interface BeastDaemonDrainState {
   isDraining(): boolean;
@@ -25,6 +32,44 @@ export interface BeastDaemonAppOptions {
     max: number;
   };
   drainState?: BeastDaemonDrainState | undefined;
+  availabilityMode?: AvailabilityModeState | undefined;
+}
+
+const READ_ONLY_DEGRADED_POST_ALLOWLIST = new Set([
+  '/v1/beasts/availability/degraded',
+  '/v1/beasts/events/ticket',
+]);
+
+const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function isReadOnlyDegradedAllowlisted(method: string, pathname: string): boolean {
+  if (method === 'DELETE' && pathname === '/v1/beasts/availability/degraded') {
+    return true;
+  }
+  return method === 'POST' && READ_ONLY_DEGRADED_POST_ALLOWLIST.has(pathname);
+}
+
+function dependencyCountSnapshot(services: BeastServiceBundle, availabilityMode: AvailabilityModeState): {
+  readonly agents: number | null;
+  readonly runs: number | null;
+  readonly availability: AvailabilityModeSnapshot;
+} {
+  try {
+    return {
+      agents: services.agents.listAgents().length,
+      runs: services.runs.listRuns().length,
+      availability: availabilityMode.snapshot(),
+    };
+  } catch (error) {
+    const reason = error instanceof Error && error.message
+      ? `Health dependency read failed: ${error.message}`
+      : 'Health dependency read failed';
+    return {
+      agents: null,
+      runs: null,
+      availability: availabilityMode.enterReadOnlyDegraded(reason, 'automatic'),
+    };
+  }
 }
 
 export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
@@ -33,30 +78,87 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   const rateLimit = options.rateLimit ?? { windowMs: 60_000, max: 20 };
   const startedAt = options.startedAt ?? isoNow();
   const services = options.services;
+  const availabilityMode = options.availabilityMode ?? new InMemoryAvailabilityModeState();
+  const auth = requireBeastOperatorAuth({
+    operatorToken: options.operatorToken,
+    security,
+  });
 
   app.onError(errorHandler);
   app.use('*', localBrowserControlProtection());
 
+  app.use('/v1/beasts/*', async (c, next) => {
+    const method = c.req.method.toUpperCase();
+    if (!UNSAFE_METHODS.has(method)) {
+      await next();
+      return;
+    }
+    const pathname = new URL(c.req.url).pathname;
+    if (isReadOnlyDegradedAllowlisted(method, pathname)) {
+      await next();
+      return;
+    }
+
+    let authenticated = false;
+    await auth(c, async () => {
+      authenticated = true;
+    });
+    if (!authenticated) {
+      return;
+    }
+
+    const snapshot = availabilityMode.snapshot();
+    if (snapshot.mode === 'read-only-degraded') {
+      throw new HttpError(
+        503,
+        'READ_ONLY_DEGRADED_MODE',
+        'Orchestrator is in read-only degraded mode; mutating operations are disabled',
+        availabilityModeDenialDetails(snapshot),
+      );
+    }
+    await next();
+  });
+
   app.get('/health', (c) => {
     c.header('x-frankenbeast-service', 'beasts-daemon');
     const draining = options.drainState?.isDraining() ?? false;
+    const dependencyCounts = dependencyCountSnapshot(services, availabilityMode);
     return c.json({
-      ok: !draining,
-      status: draining ? 'draining' : 'ok',
+      ok: !draining && !dependencyCounts.availability.readOnly,
+      status: draining ? 'draining' : dependencyCounts.availability.readOnly ? 'degraded' : 'ok',
       service: 'beasts-daemon',
       startedAt,
       root: options.root,
       pid: options.pid,
-      agents: services.agents.listAgents().length,
-      runs: services.runs.listRuns().length,
+      agents: dependencyCounts.agents,
+      runs: dependencyCounts.runs,
       draining,
+      availability: dependencyCounts.availability,
       ...(draining ? {
         drain: {
           enteredAt: options.drainState?.enteredAt,
           reason: options.drainState?.reason ?? 'shutdown',
         },
       } : {}),
-    }, draining ? 503 : 200);
+    }, draining || dependencyCounts.availability.readOnly ? 503 : 200);
+  });
+
+  app.post('/v1/beasts/availability/degraded', auth, async (c) => {
+    let reason = 'operator-requested';
+    try {
+      const body = await c.req.json() as { reason?: unknown };
+      if (typeof body.reason === 'string' && body.reason.trim()) {
+        reason = body.reason.trim();
+      }
+    } catch {
+      // Treat an empty/malformed body as a manual degraded-mode request with
+      // the default reason; this route is an operator safety valve.
+    }
+    return c.json({ data: availabilityMode.enterReadOnlyDegraded(reason, 'operator') });
+  });
+
+  app.delete('/v1/beasts/availability/degraded', auth, (c) => {
+    return c.json({ data: availabilityMode.leaveReadOnlyDegraded() });
   });
 
   const drainMutatingRequest = async (next: () => Promise<void>): Promise<void> => {

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -4,7 +4,13 @@ import { requireBeastOperatorAuth } from '../beasts/http/beast-auth.js';
 import { agentRoutes } from './routes/agent-routes.js';
 import { beastRoutes } from './routes/beast-routes.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
-import { HttpError, errorHandler, localBrowserControlProtection } from './middleware.js';
+import {
+  BEAST_CONTROL_MAX_BODY_SIZE,
+  HttpError,
+  errorHandler,
+  localBrowserControlProtection,
+  requestSizeLimit,
+} from './middleware.js';
 import { TransportSecurityService } from './security/transport-security.js';
 import { isoNow } from '@franken/types';
 import {
@@ -143,7 +149,7 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
     }, draining || dependencyCounts.availability.readOnly ? 503 : 200);
   });
 
-  app.post('/v1/beasts/availability/degraded', auth, async (c) => {
+  app.post('/v1/beasts/availability/degraded', auth, requestSizeLimit(BEAST_CONTROL_MAX_BODY_SIZE), async (c) => {
     let reason = 'operator-requested';
     try {
       const body = await c.req.json() as { reason?: unknown };

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -169,6 +169,19 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   });
 
   app.delete('/v1/beasts/availability/degraded', auth, (c) => {
+    const snapshot = availabilityMode.snapshot();
+    if (snapshot.source === 'automatic') {
+      const recovered = dependencyCountSnapshot(services, availabilityMode).availability;
+      if (recovered.readOnly) {
+        throw new HttpError(
+          503,
+          'READ_ONLY_DEGRADED_MODE_ACTIVE',
+          'Automatic read-only degraded mode remains active because dependency reads are still failing',
+          availabilityModeDenialDetails(recovered),
+        );
+      }
+      return c.json({ data: recovered });
+    }
     return c.json({ data: availabilityMode.leaveReadOnlyDegraded() });
   });
 

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -61,19 +61,24 @@ function dependencyCountSnapshot(services: BeastServiceBundle, availabilityMode:
   readonly availability: AvailabilityModeSnapshot;
 } {
   try {
+    const agents = services.agents.listAgents().length;
+    const runs = services.runs.listRuns().length;
+    const availability = availabilityMode.snapshot();
+    const recoveredAvailability = availability.readOnly && availability.source === 'automatic'
+      ? availabilityMode.leaveReadOnlyDegraded()
+      : availability;
     return {
-      agents: services.agents.listAgents().length,
-      runs: services.runs.listRuns().length,
-      availability: availabilityMode.snapshot(),
+      agents,
+      runs,
+      availability: recoveredAvailability,
     };
   } catch (error) {
-    const reason = error instanceof Error && error.message
-      ? `Health dependency read failed: ${error.message}`
-      : 'Health dependency read failed';
+    const diagnostic = error instanceof Error && error.message ? error.message : String(error);
+    console.warn('[beasts-daemon] Health dependency read failed; entering read-only degraded mode', diagnostic);
     return {
       agents: null,
       runs: null,
-      availability: availabilityMode.enterReadOnlyDegraded(reason, 'automatic'),
+      availability: availabilityMode.enterReadOnlyDegraded('Health dependency read failed', 'automatic'),
     };
   }
 }

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -351,7 +351,7 @@ export async function healthcheckNetworkService(service: ManagedNetworkServiceSt
       const response = await fetch(probeUrl, {
         signal: AbortSignal.timeout(HTTP_CHECK_TIMEOUT_MS),
       });
-      return response.ok;
+      return response.ok || await isDegradedHealthResponse(response);
     } catch {
       // Fall back to PID checks for services that have not opened HTTP yet.
     }
@@ -434,12 +434,33 @@ async function fetchServiceIdentity(url: string): Promise<string | undefined> {
       return undefined;
     }
 
-    const body = await response.json() as { service?: string; reason?: string };
+    const body = await response.json() as { service?: string; reason?: string; status?: string; ok?: boolean };
     if (!response.ok) {
-      return body.reason === 'dashboard-build-building' ? (headerIdentity ?? body.service) : undefined;
+      return body.reason === 'dashboard-build-building' || isDegradedHealthBody(body)
+        ? (headerIdentity ?? body.service)
+        : undefined;
     }
     return body.service;
   } catch {
     return undefined;
+  }
+}
+
+function isDegradedHealthBody(body: { status?: string; ok?: boolean }): boolean {
+  return body.status === 'degraded' && body.ok === false;
+}
+
+async function isDegradedHealthResponse(response: Response): Promise<boolean> {
+  if (response.status !== 503) {
+    return false;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return false;
+  }
+  try {
+    return isDegradedHealthBody(await response.json() as { status?: string; ok?: boolean });
+  } catch {
+    return false;
   }
 }

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -284,6 +284,48 @@ describe('beast daemon', () => {
     }
   });
 
+  it('does not leave operator read-only degraded mode while dependency reads fail', async () => {
+    const services = makeDaemonServices([]).services;
+    const app = createBeastDaemonApp({ services, operatorToken });
+
+    const enter = await app.request('/v1/beasts/availability/degraded', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${operatorToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ reason: 'operator maintenance' }),
+    });
+    expect(enter.status).toBe(200);
+
+    vi.mocked(services.agents.listAgents).mockImplementation(() => {
+      throw new Error('agent store offline');
+    });
+    const deniedLeave = await app.request('/v1/beasts/availability/degraded', {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(deniedLeave.status).toBe(503);
+    expect(await deniedLeave.json()).toMatchObject({
+      error: {
+        code: 'READ_ONLY_DEGRADED_MODE_ACTIVE',
+        details: {
+          mode: 'read-only-degraded',
+          readOnly: true,
+          source: 'operator',
+        },
+      },
+    });
+
+    vi.mocked(services.agents.listAgents).mockReturnValue([]);
+    const leave = await app.request('/v1/beasts/availability/degraded', {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(leave.status).toBe(200);
+    expect(await leave.json()).toMatchObject({ data: { mode: 'read-write', readOnly: false } });
+  });
+
   it('enters read-only degraded mode automatically when health dependency reads fail', async () => {
     const services = makeDaemonServices([]).services;
     vi.mocked(services.agents.listAgents).mockImplementation(() => {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -327,6 +327,22 @@ describe('beast daemon', () => {
       },
     });
 
+    const deniedLeave = await app.request('/v1/beasts/availability/degraded', {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(deniedLeave.status).toBe(503);
+    expect(await deniedLeave.json()).toMatchObject({
+      error: {
+        code: 'READ_ONLY_DEGRADED_MODE_ACTIVE',
+        details: {
+          mode: 'read-only-degraded',
+          readOnly: true,
+          source: 'automatic',
+        },
+      },
+    });
+
     vi.mocked(services.agents.listAgents).mockReturnValue([]);
     const recoveredHealth = await app.request('/health');
     expect(recoveredHealth.status).toBe(200);

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -244,6 +244,19 @@ describe('beast daemon', () => {
         },
       });
 
+      const oversizedEnter = await app.request('/v1/beasts/availability/degraded', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${operatorToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ reason: 'x'.repeat(1024 * 1024) }),
+      });
+      expect(oversizedEnter.status).toBe(413);
+      expect(await oversizedEnter.json()).toMatchObject({
+        error: { code: 'PAYLOAD_TOO_LARGE' },
+      });
+
       const leave = await app.request('/v1/beasts/availability/degraded', {
         method: 'DELETE',
         headers: { authorization: `Bearer ${operatorToken}` },
@@ -280,7 +293,8 @@ describe('beast daemon', () => {
 
     const health = await app.request('/health');
     expect(health.status).toBe(503);
-    expect(await health.json()).toMatchObject({
+    const healthBody = await health.json();
+    expect(healthBody).toMatchObject({
       status: 'degraded',
       agents: null,
       runs: null,
@@ -291,6 +305,11 @@ describe('beast daemon', () => {
         source: 'automatic',
       },
     });
+
+    const repeatHealth = await app.request('/health');
+    expect(repeatHealth.status).toBe(503);
+    const repeatHealthBody = await repeatHealth.json();
+    expect(repeatHealthBody.availability.enteredAt).toBe(healthBody.availability.enteredAt);
 
     const deniedMutation = await app.request('/v1/beasts/agents/agent-1/start', {
       method: 'POST',

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -173,6 +173,142 @@ describe('beast daemon', () => {
     }
   });
 
+  it('supports read-only degraded mode with manual enter and leave controls', async () => {
+    const paths = await makePaths();
+    const services = createBeastServices(paths);
+    const app = createBeastDaemonApp({
+      services,
+      operatorToken,
+      startedAt: '2026-07-02T00:00:00.000Z',
+    });
+
+    try {
+      const enter = await app.request('/v1/beasts/availability/degraded', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${operatorToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ reason: 'sqlite unavailable' }),
+      });
+      expect(enter.status).toBe(200);
+      expect(await enter.json()).toMatchObject({
+        data: {
+          mode: 'read-only-degraded',
+          readOnly: true,
+          reason: 'sqlite unavailable',
+          source: 'operator',
+        },
+      });
+
+      const health = await app.request('/health');
+      expect(health.status).toBe(503);
+      expect(await health.json()).toMatchObject({
+        ok: false,
+        status: 'degraded',
+        availability: {
+          mode: 'read-only-degraded',
+          readOnly: true,
+          reason: 'sqlite unavailable',
+          source: 'operator',
+        },
+      });
+
+      const catalog = await app.request('/v1/beasts/catalog', {
+        headers: { authorization: `Bearer ${operatorToken}` },
+      });
+      expect(catalog.status).toBe(200);
+
+      const deniedMutation = await app.request('/v1/beasts/runs', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${operatorToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          definitionId: 'martin-loop',
+          config: { provider: 'codex', objective: 'Ship it', chunkDirectory: 'chunks' },
+          startNow: false,
+        }),
+      });
+      expect(deniedMutation.status).toBe(503);
+      expect(await deniedMutation.json()).toMatchObject({
+        error: {
+          code: 'READ_ONLY_DEGRADED_MODE',
+          details: {
+            mode: 'read-only-degraded',
+            readOnly: true,
+            reason: 'sqlite unavailable',
+            source: 'operator',
+          },
+        },
+      });
+
+      const leave = await app.request('/v1/beasts/availability/degraded', {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${operatorToken}` },
+      });
+      expect(leave.status).toBe(200);
+      expect(await leave.json()).toMatchObject({
+        data: { mode: 'read-write', readOnly: false },
+      });
+
+      const allowedMutation = await app.request('/v1/beasts/runs', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${operatorToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          definitionId: 'martin-loop',
+          config: { provider: 'codex', objective: 'Ship it', chunkDirectory: 'chunks' },
+          startNow: false,
+        }),
+      });
+      expect(allowedMutation.status).toBe(201);
+    } finally {
+      services.dispose();
+    }
+  });
+
+  it('enters read-only degraded mode automatically when health dependency reads fail', async () => {
+    const services = makeDaemonServices([]).services;
+    vi.mocked(services.agents.listAgents).mockImplementation(() => {
+      throw new Error('agent store offline');
+    });
+    const app = createBeastDaemonApp({ services, operatorToken });
+
+    const health = await app.request('/health');
+    expect(health.status).toBe(503);
+    expect(await health.json()).toMatchObject({
+      status: 'degraded',
+      agents: null,
+      runs: null,
+      availability: {
+        mode: 'read-only-degraded',
+        readOnly: true,
+        reason: 'Health dependency read failed: agent store offline',
+        source: 'automatic',
+      },
+    });
+
+    const deniedMutation = await app.request('/v1/beasts/agents/agent-1/start', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(deniedMutation.status).toBe(503);
+    expect(await deniedMutation.json()).toMatchObject({
+      error: {
+        code: 'READ_ONLY_DEGRADED_MODE',
+        details: {
+          mode: 'read-only-degraded',
+          readOnly: true,
+          source: 'automatic',
+        },
+      },
+    });
+  });
+
   it('preserves chat attribution for daemon-created tracked runs', async () => {
     const paths = await makePaths();
     const services = createBeastServices(paths);

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -301,7 +301,7 @@ describe('beast daemon', () => {
       availability: {
         mode: 'read-only-degraded',
         readOnly: true,
-        reason: 'Health dependency read failed: agent store offline',
+        reason: 'Health dependency read failed',
         source: 'automatic',
       },
     });
@@ -324,6 +324,18 @@ describe('beast daemon', () => {
           readOnly: true,
           source: 'automatic',
         },
+      },
+    });
+
+    vi.mocked(services.agents.listAgents).mockReturnValue([]);
+    const recoveredHealth = await app.request('/health');
+    expect(recoveredHealth.status).toBe(200);
+    expect(await recoveredHealth.json()).toMatchObject({
+      ok: true,
+      status: 'ok',
+      availability: {
+        mode: 'read-write',
+        readOnly: false,
       },
     });
   });

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -2408,6 +2408,44 @@ describe('main() execution', () => {
     }));
   });
 
+  it('auto-proxies chat-server beast routes when a live local daemon is read-only degraded', async () => {
+    const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-degraded`);
+    tempDirs.push(root);
+    mkdirSync(join(root, '.frankenbeast'), { recursive: true });
+    writeFileSync(join(root, '.frankenbeast', 'beasts-daemon.pid'), `${process.pid}\n`);
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      ok: false,
+      status: 'degraded',
+      service: 'beasts-daemon',
+      root,
+      pid: process.pid,
+      availability: {
+        mode: 'read-only-degraded',
+        readOnly: true,
+        reason: 'sqlite unavailable',
+        source: 'automatic',
+      },
+    }, { status: 503 })));
+    mockParseArgs.mockReturnValue({
+      ...mockParseArgs(),
+      subcommand: 'chat-server',
+      baseDir: root,
+    });
+
+    await main();
+
+    expect(mockCreateBeastServices).not.toHaveBeenCalled();
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.objectContaining({
+      beastDaemon: expect.objectContaining({
+        baseUrl: 'http://127.0.0.1:4050',
+        operatorToken: TEST_DASHBOARD_OPERATOR_TOKEN,
+      }),
+    }));
+    expect(mockStartChatServer).toHaveBeenCalledWith(expect.not.objectContaining({
+      beastControl: expect.anything(),
+    }));
+  });
+
   it('refuses to start chat-server while detected daemon is draining', async () => {
     const root = join(tmpdir(), `frankenbeast-run-test-${Date.now()}-daemon-draining`);
     tempDirs.push(root);

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,6 +1,12 @@
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
-import { startNetworkService, stopNetworkService } from '../../../src/network/network-supervisor-runtime.js';
+import {
+  healthcheckNetworkService,
+  preflightNetworkService,
+  startNetworkService,
+  stopNetworkService,
+} from '../../../src/network/network-supervisor-runtime.js';
 import type { ResolvedNetworkService } from '../../../src/network/network-registry.js';
 
 const spawnMock = vi.hoisted(() => vi.fn(() => ({
@@ -251,5 +257,70 @@ describe('stopNetworkService', () => {
     await stopNetworkService({ pid: 0, detached: true });
 
     expect(killSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('network degraded health handling', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('treats read-only degraded health as reachable for stored-service healthchecks', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      ok: false,
+      status: 'degraded',
+      service: 'beasts-daemon',
+      availability: { mode: 'read-only-degraded', readOnly: true },
+    }, { status: 503 })));
+
+    await expect(healthcheckNetworkService({
+      id: 'beasts-daemon',
+      displayName: 'Beast Daemon',
+      pid: 4242,
+      healthUrl: 'http://127.0.0.1:4050/health',
+      startedAt: '2026-07-16T00:00:00.000Z',
+    })).resolves.toBe(true);
+  });
+
+  it('reuses a port whose health identity is read-only degraded', async () => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 503;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('x-frankenbeast-service', 'beasts-daemon');
+      res.end(JSON.stringify({
+        ok: false,
+        status: 'degraded',
+        service: 'beasts-daemon',
+        availability: { mode: 'read-only-degraded', readOnly: true },
+      }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('test server did not bind to a TCP port');
+      }
+      const service: ResolvedNetworkService = {
+        id: 'beasts-daemon',
+        displayName: 'Beast Daemon',
+        kind: 'app',
+        dependsOn: [],
+        configPaths: [],
+        enabled: () => true,
+        describe: () => 'test daemon',
+        buildRuntimeConfig: () => ({}),
+        explanation: 'test daemon',
+        runtimeConfig: {
+          process: { command: 'npm', args: CHAT_SERVER_ARGS, cwd: process.cwd() },
+          host: '127.0.0.1',
+          port: address.port,
+          healthUrl: `http://127.0.0.1:${address.port}/health`,
+          serviceIdentity: 'beasts-daemon',
+        },
+      };
+      await expect(preflightNetworkService(service)).resolves.toEqual({ action: 'reuse' });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
   });
 });

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -125,6 +125,12 @@ Path-style fields entered in the dashboard are normalized client-side before sub
 
 Execution controls (`start`, `stop`, `restart`, `kill`) still target Beast runs after a tracked agent has dispatched.
 
+### Read-only degraded mode
+
+When Beast daemon health detects dependency read failures, or when an operator manually enters degraded mode with `POST /v1/beasts/availability/degraded`, the daemon reports `status: "degraded"` and an `availability` object from `/health`. Read-only diagnostics such as `/health`, `/v1/beasts/catalog`, `/v1/beasts/runs`, `/v1/beasts/agents`, run events/logs, dashboard snapshots, and SSE tickets remain available so operators can inspect state during partial outages.
+
+Mutating Beast control routes fail closed with `503 READ_ONLY_DEGRADED_MODE` and structured details that include the degraded-mode reason/source. Operators can leave manual degraded mode with `DELETE /v1/beasts/availability/degraded` after the dependency outage is resolved.
+
 ## Environment Variables
 
 Preferred: set shared local values in the repo root `.env` so the backend and the Vite dev proxy can read the same server-side token. Do not define a `VITE_*` operator token; Vite exposes `VITE_*` values to browser code.


### PR DESCRIPTION
## Summary
- add Beast daemon read-only degraded availability state with manual enter/leave controls
- keep read-only diagnostics available while denying unsafe Beast mutations with structured 503 responses
- document degraded-mode behavior and add integration coverage for manual and automatic degraded entry

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/integration/beasts/beast-daemon.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run lint (passes with existing warnings)
- npm run build

Closes #1716