### PR TITLE
fix(orchestrator): bound beast run log growth

### DIFF
--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -214,14 +214,14 @@ curl -sS http://127.0.0.1:4050/v1/beasts/runs/<run-id>/logs \
 
 ## 6. Log retention
 
-Dashboard run logs are retained as line-oriented JSON under the Beast logs directory (`<state>/beasts/logs/<run-id>/<attempt-id>.log`). They are bounded by default to a 10 MiB active file plus three rotated siblings (`.1`, `.2`, `.3`) per attempt. Rotation keeps recent stdout/stderr records and their `stream`, `message`, and `createdAt` metadata available for incident review while preventing long-running agents or noisy background process output from exhausting disk.
+Dashboard run logs are retained as line-oriented JSON under the Beast logs directory (`.fbeast/.build/beasts/logs/<run-id>/<attempt-id>.log`). They are bounded by default to a 10 MiB active file plus three rotated siblings (`.1`, `.2`, `.3`) per attempt. Rotation keeps recent stdout/stderr records and their `stream`, `message`, and `createdAt` metadata available for incident review while preventing long-running agents or noisy background process output from exhausting disk.
 
 Operators can tune retention with environment variables before starting `beasts-daemon` or `chat-server`:
 
 | Variable | Default | Behavior |
 |----------|---------|----------|
 | `FBEAST_RUN_LOG_MAX_BYTES` | `10485760` | Maximum active per-attempt run log size in bytes before rotation. Values below 128 bytes are raised to the safety floor. |
-| `FBEAST_RUN_LOG_MAX_ROTATED_FILES` | `3` | Number of rotated per-attempt log files to retain. Set to `0` to truncate in place instead of preserving rotated evidence. |
+| `FBEAST_RUN_LOG_MAX_ROTATED_FILES` | `3` | Number of rotated per-attempt log files to retain, capped at 100 to keep rotation bounded. Set to `0` to truncate in place instead of preserving rotated evidence. |
 
 If a single stdout/stderr message is larger than the active-file cap, Frankenbeast truncates that one record and adds `truncatedBytes` plus a visible truncation marker rather than allowing one noisy line to break the configured bound. Keep the rotated-file count above zero in production so critical evidence is rotated before truncation.
 

--- a/docs/guides/deploy-beasts.md
+++ b/docs/guides/deploy-beasts.md
@@ -212,7 +212,20 @@ curl -sS http://127.0.0.1:4050/v1/beasts/runs/<run-id>/logs \
   -H "x-frankenbeast-operator-token: $OPERATOR_TOKEN"
 ```
 
-## 6. Stop, restart, resume, or delete
+## 6. Log retention
+
+Dashboard run logs are retained as line-oriented JSON under the Beast logs directory (`<state>/beasts/logs/<run-id>/<attempt-id>.log`). They are bounded by default to a 10 MiB active file plus three rotated siblings (`.1`, `.2`, `.3`) per attempt. Rotation keeps recent stdout/stderr records and their `stream`, `message`, and `createdAt` metadata available for incident review while preventing long-running agents or noisy background process output from exhausting disk.
+
+Operators can tune retention with environment variables before starting `beasts-daemon` or `chat-server`:
+
+| Variable | Default | Behavior |
+|----------|---------|----------|
+| `FBEAST_RUN_LOG_MAX_BYTES` | `10485760` | Maximum active per-attempt run log size in bytes before rotation. Values below 128 bytes are raised to the safety floor. |
+| `FBEAST_RUN_LOG_MAX_ROTATED_FILES` | `3` | Number of rotated per-attempt log files to retain. Set to `0` to truncate in place instead of preserving rotated evidence. |
+
+If a single stdout/stderr message is larger than the active-file cap, Frankenbeast truncates that one record and adds `truncatedBytes` plus a visible truncation marker rather than allowing one noisy line to break the configured bound. Keep the rotated-file count above zero in production so critical evidence is rotated before truncation.
+
+## 7. Stop, restart, resume, or delete
 
 From the selected agent detail panel:
 

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -37,7 +37,7 @@ export interface BeastServiceBundle {
 
 export function createBeastServices(paths: BeastServicePaths): BeastServiceBundle {
   const repository = new SQLiteBeastRepository(paths.beastsDb);
-  const logStore = new BeastLogStore(paths.beastLogsDir);
+  const logStore = new BeastLogStore(paths.beastLogsDir, createBeastLogStoreOptionsFromEnv());
   const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
   const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
   const catalog = new BeastCatalogService();
@@ -103,6 +103,18 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   };
 }
 
+function createBeastLogStoreOptionsFromEnv(): { maxLogFileBytes?: number; maxRotatedLogFiles?: number } {
+  const maxLogFileBytes = parsePositiveIntegerEnv('FBEAST_RUN_LOG_MAX_BYTES', process.env.FBEAST_RUN_LOG_MAX_BYTES);
+  const maxRotatedLogFiles = parseNonNegativeIntegerEnv(
+    'FBEAST_RUN_LOG_MAX_ROTATED_FILES',
+    process.env.FBEAST_RUN_LOG_MAX_ROTATED_FILES,
+  );
+  return {
+    ...(maxLogFileBytes === undefined ? {} : { maxLogFileBytes }),
+    ...(maxRotatedLogFiles === undefined ? {} : { maxRotatedLogFiles }),
+  };
+}
+
 function createCapacityReservationPolicyFromEnv(): CapacityReservationPolicy | undefined {
   const totalSlots = parsePositiveInteger(process.env.FBEAST_AGENT_CAPACITY_TOTAL);
   const reservations = parseCapacityReservations(process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS);
@@ -121,10 +133,23 @@ function createCapacityReservationPolicyFromEnv(): CapacityReservationPolicy | u
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
+  return parsePositiveIntegerEnv('FBEAST_AGENT_CAPACITY_TOTAL', value);
+}
+
+function parsePositiveIntegerEnv(name: string, value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) {
-    throw new RangeError(`FBEAST_AGENT_CAPACITY_TOTAL must be a positive integer, received ${value}`);
+    throw new RangeError(`${name} must be a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeIntegerEnv(name: string, value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new RangeError(`${name} must be a non-negative integer, received ${value}`);
   }
   return parsed;
 }

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -1,10 +1,9 @@
-import { appendFile, mkdir, readFile, rename, stat, truncate, unlink } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { appendFile, mkdir, readFile, readdir, rename, stat, truncate, unlink } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { isoNow } from '@franken/types';
 
 const DEFAULT_MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
 const DEFAULT_MAX_ROTATED_LOG_FILES = 3;
-const TRUNCATION_SUFFIX_BYTES = 64;
 const MIN_LOG_FILE_BYTES = 128;
 
 export interface BeastLogStoreOptions {
@@ -24,6 +23,7 @@ interface LogRecord {
 export class BeastLogStore {
   private readonly maxLogFileBytes: number;
   private readonly maxRotatedLogFiles: number;
+  private readonly appendQueues = new Map<string, Promise<void>>();
 
   constructor(
     private readonly logDir: string,
@@ -41,6 +41,45 @@ export class BeastLogStore {
     createdAt = isoNow(),
   ): Promise<void> {
     const filePath = this.resolvePath(runId, attemptId);
+    const previous = this.appendQueues.get(filePath) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(() => this.appendSerialized(filePath, stream, message, createdAt));
+    const queued = current.finally(() => {
+      if (this.appendQueues.get(filePath) === queued) {
+        this.appendQueues.delete(filePath);
+      }
+    });
+    this.appendQueues.set(filePath, queued);
+    await current;
+  }
+
+  async read(runId: string, attemptId: string): Promise<string[]> {
+    const filePath = this.resolvePath(runId, attemptId);
+    const paths = await this.listReadableLogPaths(filePath);
+    const lines: string[] = [];
+
+    for (const path of paths) {
+      try {
+        const raw = await readFile(path, 'utf-8');
+        lines.push(
+          ...raw
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean),
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+
+    return lines;
+  }
+
+  private async appendSerialized(
+    filePath: string,
+    stream: 'stdout' | 'stderr',
+    message: string,
+    createdAt: string,
+  ): Promise<void> {
     try {
       await mkdir(dirname(filePath), { recursive: true });
       const line = this.serializeBoundedRecord({ stream, message, createdAt });
@@ -53,48 +92,27 @@ export class BeastLogStore {
     }
   }
 
-  async read(runId: string, attemptId: string): Promise<string[]> {
-    try {
-      const raw = await readFile(this.resolvePath(runId, attemptId), 'utf-8');
-      return raw
-        .split('\n')
-        .map((line) => line.trim())
-        .filter(Boolean);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return [];
-      }
-      throw error;
-    }
-  }
-
   private serializeBoundedRecord(record: LogRecord): string {
     const full = `${JSON.stringify(record)}\n`;
     if (Buffer.byteLength(full) <= this.maxLogFileBytes) {
       return full;
     }
 
-    const baseRecord = { ...record, message: '', truncatedBytes: 0 };
-    const overhead = Buffer.byteLength(`${JSON.stringify(baseRecord)}\n`) + TRUNCATION_SUFFIX_BYTES;
-    const maxMessageBytes = Math.max(0, this.maxLogFileBytes - overhead);
-    let currentMessage = truncateUtf8(record.message, maxMessageBytes);
-    let truncatedBytes = Math.max(0, Buffer.byteLength(record.message) - Buffer.byteLength(currentMessage));
-    let bounded = `${JSON.stringify({
-      ...record,
-      message: `${currentMessage}\n[truncated ${truncatedBytes} bytes to enforce log size cap]`,
-      truncatedBytes,
-    })}\n`;
+    const recordBytes = Buffer.byteLength(record.message);
+    let low = 0;
+    let high = recordBytes;
+    let bounded = this.serializeTruncatedRecord(record, '');
 
-    while (Buffer.byteLength(bounded) > this.maxLogFileBytes && currentMessage.length > 0) {
-      const previousMessage = currentMessage;
-      currentMessage = truncateUtf8(currentMessage, Math.max(0, Buffer.byteLength(currentMessage) - 16));
-      truncatedBytes = Math.max(0, Buffer.byteLength(record.message) - Buffer.byteLength(currentMessage));
-      bounded = `${JSON.stringify({
-        ...record,
-        message: `${currentMessage}\n[truncated ${truncatedBytes} bytes to enforce log size cap]`,
-        truncatedBytes,
-      })}\n`;
-      if (currentMessage === previousMessage) break;
+    while (low <= high) {
+      const midpoint = Math.floor((low + high) / 2);
+      const currentMessage = truncateUtf8(record.message, midpoint);
+      const candidate = this.serializeTruncatedRecord(record, currentMessage);
+      if (Buffer.byteLength(candidate) <= this.maxLogFileBytes) {
+        bounded = candidate;
+        low = midpoint + 1;
+      } else {
+        high = midpoint - 1;
+      }
     }
 
     if (Buffer.byteLength(bounded) > this.maxLogFileBytes) {
@@ -107,6 +125,15 @@ export class BeastLogStore {
     }
 
     return bounded;
+  }
+
+  private serializeTruncatedRecord(record: LogRecord, messagePrefix: string): string {
+    const truncatedBytes = Math.max(0, Buffer.byteLength(record.message) - Buffer.byteLength(messagePrefix));
+    return `${JSON.stringify({
+      ...record,
+      message: `${messagePrefix}\n[truncated ${truncatedBytes} bytes to enforce log size cap]`,
+      truncatedBytes,
+    })}\n`;
   }
 
   private async rotateOrTruncateBeforeAppend(filePath: string, nextWriteBytes: number): Promise<void> {
@@ -129,11 +156,45 @@ export class BeastLogStore {
   }
 
   private async rotateFiles(filePath: string): Promise<void> {
+    await this.removeRotationsAboveRetention(filePath);
     await rmIfExists(`${filePath}.${this.maxRotatedLogFiles}`);
     for (let index = this.maxRotatedLogFiles - 1; index >= 1; index -= 1) {
       await renameIfExists(`${filePath}.${index}`, `${filePath}.${index + 1}`);
     }
     await renameIfExists(filePath, `${filePath}.1`);
+  }
+
+  private async removeRotationsAboveRetention(filePath: string): Promise<void> {
+    const dir = dirname(filePath);
+    const prefix = `${basename(filePath)}.`;
+    try {
+      const entries = await readdir(dir);
+      await Promise.all(
+        entries
+          .map((entry) => ({ entry, index: parseRotationIndex(entry, prefix) }))
+          .filter(({ index }) => index > this.maxRotatedLogFiles)
+          .map(({ entry }) => rmIfExists(join(dir, entry))),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  private async listReadableLogPaths(filePath: string): Promise<string[]> {
+    const dir = dirname(filePath);
+    const prefix = `${basename(filePath)}.`;
+    try {
+      const entries = await readdir(dir);
+      const rotatedPaths = entries
+        .map((entry) => ({ entry, index: parseRotationIndex(entry, prefix) }))
+        .filter(({ index }) => index >= 1 && index <= this.maxRotatedLogFiles)
+        .sort((left, right) => right.index - left.index)
+        .map(({ entry }) => join(dir, entry));
+      return [...rotatedPaths, filePath];
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [filePath];
+      throw error;
+    }
   }
 
   private async truncateActiveFile(filePath: string): Promise<void> {
@@ -179,4 +240,11 @@ function truncateUtf8(value: string, maxBytes: number): string {
   const buffer = Buffer.from(value);
   if (buffer.length <= maxBytes) return value;
   return buffer.subarray(0, maxBytes).toString('utf8').replace(/\uFFFD+$/u, '');
+}
+
+function parseRotationIndex(entry: string, prefix: string): number {
+  if (!entry.startsWith(prefix)) return 0;
+  const suffix = entry.slice(prefix.length);
+  if (!/^\d+$/u.test(suffix)) return 0;
+  return Number(suffix);
 }

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -4,6 +4,7 @@ import { isoNow } from '@franken/types';
 
 const DEFAULT_MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
 const DEFAULT_MAX_ROTATED_LOG_FILES = 3;
+const MAX_ROTATED_LOG_FILES = 100;
 const MIN_LOG_FILE_BYTES = 128;
 
 export interface BeastLogStoreOptions {
@@ -30,7 +31,7 @@ export class BeastLogStore {
     options: BeastLogStoreOptions = {},
   ) {
     this.maxLogFileBytes = Math.max(options.maxLogFileBytes ?? DEFAULT_MAX_LOG_FILE_BYTES, MIN_LOG_FILE_BYTES);
-    this.maxRotatedLogFiles = options.maxRotatedLogFiles ?? DEFAULT_MAX_ROTATED_LOG_FILES;
+    this.maxRotatedLogFiles = Math.min(options.maxRotatedLogFiles ?? DEFAULT_MAX_ROTATED_LOG_FILES, MAX_ROTATED_LOG_FILES);
   }
 
   async append(
@@ -119,6 +120,7 @@ export class BeastLogStore {
     if (Buffer.byteLength(bounded) > this.maxLogFileBytes) {
       return `${JSON.stringify({
         stream: record.stream,
+        createdAt: record.createdAt,
         message: '[truncated]',
         truncatedBytes: Buffer.byteLength(record.message),
       })}\n`;
@@ -144,6 +146,7 @@ export class BeastLogStore {
 
     const currentBytes = await fileSize(filePath);
     if (currentBytes === 0 || currentBytes + nextWriteBytes <= this.maxLogFileBytes) {
+      await this.removeRotationsAboveRetention(filePath);
       return;
     }
 

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -145,6 +145,12 @@ export class BeastLogStore {
     }
 
     const currentBytes = await fileSize(filePath);
+    if (currentBytes > this.maxLogFileBytes) {
+      await this.removeRotationsAboveRetention(filePath);
+      await this.truncateActiveFile(filePath);
+      return;
+    }
+
     if (currentBytes === 0 || currentBytes + nextWriteBytes <= this.maxLogFileBytes) {
       await this.removeRotationsAboveRetention(filePath);
       return;

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -25,13 +25,17 @@ export class BeastLogStore {
   private readonly maxLogFileBytes: number;
   private readonly maxRotatedLogFiles: number;
   private readonly appendQueues = new Map<string, Promise<void>>();
+  private readonly retentionPrunedLogPaths = new Set<string>();
 
   constructor(
     private readonly logDir: string,
     options: BeastLogStoreOptions = {},
   ) {
     this.maxLogFileBytes = Math.max(options.maxLogFileBytes ?? DEFAULT_MAX_LOG_FILE_BYTES, MIN_LOG_FILE_BYTES);
-    this.maxRotatedLogFiles = Math.min(options.maxRotatedLogFiles ?? DEFAULT_MAX_ROTATED_LOG_FILES, MAX_ROTATED_LOG_FILES);
+    this.maxRotatedLogFiles = Math.max(
+      0,
+      Math.min(options.maxRotatedLogFiles ?? DEFAULT_MAX_ROTATED_LOG_FILES, MAX_ROTATED_LOG_FILES),
+    );
   }
 
   async append(
@@ -152,7 +156,7 @@ export class BeastLogStore {
     }
 
     if (currentBytes === 0 || currentBytes + nextWriteBytes <= this.maxLogFileBytes) {
-      await this.removeRotationsAboveRetention(filePath);
+      await this.removeRotationsAboveRetentionOnce(filePath);
       return;
     }
 
@@ -190,6 +194,12 @@ export class BeastLogStore {
     }
   }
 
+  private async removeRotationsAboveRetentionOnce(filePath: string): Promise<void> {
+    if (this.retentionPrunedLogPaths.has(filePath)) return;
+    await this.removeRotationsAboveRetention(filePath);
+    this.retentionPrunedLogPaths.add(filePath);
+  }
+
   private async listReadableLogPaths(filePath: string): Promise<string[]> {
     const dir = dirname(filePath);
     const prefix = `${basename(filePath)}.`;
@@ -197,7 +207,7 @@ export class BeastLogStore {
       const entries = await readdir(dir);
       const rotatedPaths = entries
         .map((entry) => ({ entry, index: parseRotationIndex(entry, prefix) }))
-        .filter(({ index }) => index >= 1 && index <= this.maxRotatedLogFiles)
+        .filter(({ index }) => index >= 1)
         .sort((left, right) => right.index - left.index)
         .map(({ entry }) => join(dir, entry));
       return [...rotatedPaths, filePath];

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -42,13 +42,14 @@ export class BeastLogStore {
   ): Promise<void> {
     const filePath = this.resolvePath(runId, attemptId);
     const previous = this.appendQueues.get(filePath) ?? Promise.resolve();
-    const current = previous.catch(() => undefined).then(() => this.appendSerialized(filePath, stream, message, createdAt));
-    const queued = current.finally(() => {
+    const current = previous.then(() => this.appendSerialized(filePath, stream, message, createdAt));
+    const queued = current.catch(() => undefined);
+    this.appendQueues.set(filePath, queued);
+    void queued.then(() => {
       if (this.appendQueues.get(filePath) === queued) {
         this.appendQueues.delete(filePath);
       }
     });
-    this.appendQueues.set(filePath, queued);
     await current;
   }
 
@@ -118,8 +119,7 @@ export class BeastLogStore {
     if (Buffer.byteLength(bounded) > this.maxLogFileBytes) {
       return `${JSON.stringify({
         stream: record.stream,
-        message: '[truncated oversized log record to enforce log size cap]',
-        createdAt: record.createdAt,
+        message: '[truncated]',
         truncatedBytes: Buffer.byteLength(record.message),
       })}\n`;
     }
@@ -148,6 +148,7 @@ export class BeastLogStore {
     }
 
     if (this.maxRotatedLogFiles < 1) {
+      await this.removeRotationsAboveRetention(filePath);
       await this.truncateActiveFile(filePath);
       return;
     }

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -1,9 +1,37 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, rename, stat, truncate, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { isoNow } from '@franken/types';
 
+const DEFAULT_MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MAX_ROTATED_LOG_FILES = 3;
+const TRUNCATION_SUFFIX_BYTES = 64;
+const MIN_LOG_FILE_BYTES = 128;
+
+export interface BeastLogStoreOptions {
+  /** Maximum active per-attempt log size before rotation. Defaults to 10 MiB. */
+  readonly maxLogFileBytes?: number | undefined;
+  /** Number of rotated per-attempt logs to retain. Defaults to 3; values < 1 truncate in place. */
+  readonly maxRotatedLogFiles?: number | undefined;
+}
+
+interface LogRecord {
+  readonly stream: 'stdout' | 'stderr';
+  readonly message: string;
+  readonly createdAt: string;
+  readonly truncatedBytes?: number | undefined;
+}
+
 export class BeastLogStore {
-  constructor(private readonly logDir: string) {}
+  private readonly maxLogFileBytes: number;
+  private readonly maxRotatedLogFiles: number;
+
+  constructor(
+    private readonly logDir: string,
+    options: BeastLogStoreOptions = {},
+  ) {
+    this.maxLogFileBytes = Math.max(options.maxLogFileBytes ?? DEFAULT_MAX_LOG_FILE_BYTES, MIN_LOG_FILE_BYTES);
+    this.maxRotatedLogFiles = options.maxRotatedLogFiles ?? DEFAULT_MAX_ROTATED_LOG_FILES;
+  }
 
   async append(
     runId: string,
@@ -15,15 +43,9 @@ export class BeastLogStore {
     const filePath = this.resolvePath(runId, attemptId);
     try {
       await mkdir(dirname(filePath), { recursive: true });
-      await appendFile(
-        filePath,
-        `${JSON.stringify({
-          stream,
-          message,
-          createdAt,
-        })}\n`,
-        'utf-8',
-      );
+      const line = this.serializeBoundedRecord({ stream, message, createdAt });
+      await this.rotateOrTruncateBeforeAppend(filePath, Buffer.byteLength(line));
+      await appendFile(filePath, line, 'utf-8');
     } catch (err) {
       // Log directory may have been removed (e.g., during test cleanup).
       // Swallow ENOENT — logging should never crash the caller.
@@ -46,7 +68,115 @@ export class BeastLogStore {
     }
   }
 
+  private serializeBoundedRecord(record: LogRecord): string {
+    const full = `${JSON.stringify(record)}\n`;
+    if (Buffer.byteLength(full) <= this.maxLogFileBytes) {
+      return full;
+    }
+
+    const baseRecord = { ...record, message: '', truncatedBytes: 0 };
+    const overhead = Buffer.byteLength(`${JSON.stringify(baseRecord)}\n`) + TRUNCATION_SUFFIX_BYTES;
+    const maxMessageBytes = Math.max(0, this.maxLogFileBytes - overhead);
+    let currentMessage = truncateUtf8(record.message, maxMessageBytes);
+    let truncatedBytes = Math.max(0, Buffer.byteLength(record.message) - Buffer.byteLength(currentMessage));
+    let bounded = `${JSON.stringify({
+      ...record,
+      message: `${currentMessage}\n[truncated ${truncatedBytes} bytes to enforce log size cap]`,
+      truncatedBytes,
+    })}\n`;
+
+    while (Buffer.byteLength(bounded) > this.maxLogFileBytes && currentMessage.length > 0) {
+      const previousMessage = currentMessage;
+      currentMessage = truncateUtf8(currentMessage, Math.max(0, Buffer.byteLength(currentMessage) - 16));
+      truncatedBytes = Math.max(0, Buffer.byteLength(record.message) - Buffer.byteLength(currentMessage));
+      bounded = `${JSON.stringify({
+        ...record,
+        message: `${currentMessage}\n[truncated ${truncatedBytes} bytes to enforce log size cap]`,
+        truncatedBytes,
+      })}\n`;
+      if (currentMessage === previousMessage) break;
+    }
+
+    if (Buffer.byteLength(bounded) > this.maxLogFileBytes) {
+      return `${JSON.stringify({
+        stream: record.stream,
+        message: '[truncated oversized log record to enforce log size cap]',
+        createdAt: record.createdAt,
+        truncatedBytes: Buffer.byteLength(record.message),
+      })}\n`;
+    }
+
+    return bounded;
+  }
+
+  private async rotateOrTruncateBeforeAppend(filePath: string, nextWriteBytes: number): Promise<void> {
+    if (nextWriteBytes > this.maxLogFileBytes) {
+      await this.truncateActiveFile(filePath);
+      return;
+    }
+
+    const currentBytes = await fileSize(filePath);
+    if (currentBytes === 0 || currentBytes + nextWriteBytes <= this.maxLogFileBytes) {
+      return;
+    }
+
+    if (this.maxRotatedLogFiles < 1) {
+      await this.truncateActiveFile(filePath);
+      return;
+    }
+
+    await this.rotateFiles(filePath);
+  }
+
+  private async rotateFiles(filePath: string): Promise<void> {
+    await rmIfExists(`${filePath}.${this.maxRotatedLogFiles}`);
+    for (let index = this.maxRotatedLogFiles - 1; index >= 1; index -= 1) {
+      await renameIfExists(`${filePath}.${index}`, `${filePath}.${index + 1}`);
+    }
+    await renameIfExists(filePath, `${filePath}.1`);
+  }
+
+  private async truncateActiveFile(filePath: string): Promise<void> {
+    try {
+      await truncate(filePath, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
   private resolvePath(runId: string, attemptId: string): string {
     return join(this.logDir, runId, `${attemptId}.log`);
   }
+}
+
+async function fileSize(filePath: string): Promise<number> {
+  try {
+    return (await stat(filePath)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    throw error;
+  }
+}
+
+async function rmIfExists(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+async function renameIfExists(from: string, to: string): Promise<void> {
+  try {
+    await rename(from, to);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  const buffer = Buffer.from(value);
+  if (buffer.length <= maxBytes) return value;
+  return buffer.subarray(0, maxBytes).toString('utf8').replace(/\uFFFD+$/u, '');
 }

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -95,6 +95,18 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('keeps the oversized-record fallback within the minimum cap', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 128, maxRotatedLogFiles: 1 });
+      await logs.append('run-minimum', 'attempt-1', 'stderr', '\u0000'.repeat(10_000), '2026-03-11T00:00:00.000Z');
+
+      const activePath = join(dir, 'run-minimum', 'attempt-1.log');
+      const contents = await readFile(activePath, 'utf-8');
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(128);
+      expect(JSON.parse(contents.trim())).toMatchObject({ message: expect.stringContaining('[truncated]') });
+    });
+  });
+
   it('serializes concurrent appends so active logs stay within the configured cap', async () => {
     await withTempDir(async (dir) => {
       const logs = new BeastLogStore(dir, { maxLogFileBytes: 260, maxRotatedLogFiles: 3 });
@@ -145,6 +157,23 @@ describe('BeastLogStore', () => {
       expect(existsSync(`${activePath}.1`)).toBe(true);
       expect(existsSync(`${activePath}.2`)).toBe(false);
       expect(existsSync(`${activePath}.3`)).toBe(false);
+    });
+  });
+
+  it('removes stale rotations when retention is disabled', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-no-retention', 'attempt-1.log');
+      await mkdir(join(dir, 'run-no-retention'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active', createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(`${activePath}.1`, 'old-1\n');
+      await writeFile(`${activePath}.2`, 'old-2\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: 0 });
+      await logs.append('run-no-retention', 'attempt-1', 'stdout', `new-${'z'.repeat(80)}`, '2026-03-11T00:00:01.000Z');
+
+      expect(existsSync(`${activePath}.1`)).toBe(false);
+      expect(existsSync(`${activePath}.2`)).toBe(false);
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(160);
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -1,35 +1,82 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
 
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'franken-beast-log-store-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 describe('BeastLogStore', () => {
-  let workDir: string | undefined;
-
-  afterEach(async () => {
-    if (workDir) {
-      await rm(workDir, { recursive: true, force: true });
-    }
-  });
-
   it('appends line-oriented stream records and reads them back', async () => {
-    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-logs-'));
-    const store = new BeastLogStore(join(workDir, 'logs'));
+    await withTempDir(async (dir) => {
+      const store = new BeastLogStore(dir);
 
-    await store.append('run-1', 'attempt-1', 'stdout', 'hello');
-    await store.append('run-1', 'attempt-1', 'stderr', 'boom');
+      await store.append('run-1', 'attempt-1', 'stdout', 'hello');
+      await store.append('run-1', 'attempt-1', 'stderr', 'boom');
 
-    await expect(store.read('run-1', 'attempt-1')).resolves.toEqual([
-      expect.stringContaining('"stream":"stdout"'),
-      expect.stringContaining('"stream":"stderr"'),
-    ]);
+      await expect(store.read('run-1', 'attempt-1')).resolves.toEqual([
+        expect.stringContaining('"stream":"stdout"'),
+        expect.stringContaining('"stream":"stderr"'),
+      ]);
+    });
   });
 
   it('returns an empty log when the attempt has not written anything yet', async () => {
-    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-logs-'));
-    const store = new BeastLogStore(join(workDir, 'logs'));
+    await withTempDir(async (dir) => {
+      const store = new BeastLogStore(dir);
 
-    await expect(store.read('run-1', 'attempt-404')).resolves.toEqual([]);
+      await expect(store.read('run-1', 'attempt-404')).resolves.toEqual([]);
+    });
+  });
+
+  it('rotates run output logs before appending past the configured active size cap', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 180, maxRotatedLogFiles: 2 });
+      await logs.append('run-1', 'attempt-1', 'stdout', 'first'.repeat(12), '2026-03-11T00:00:00.000Z');
+      await logs.append('run-1', 'attempt-1', 'stderr', 'second'.repeat(12), '2026-03-11T00:00:01.000Z');
+
+      const activePath = join(dir, 'run-1', 'attempt-1.log');
+      const rotatedPath = `${activePath}.1`;
+      expect(existsSync(rotatedPath)).toBe(true);
+      expect(await readFile(rotatedPath, 'utf-8')).toContain('firstfirst');
+      expect(await readFile(activePath, 'utf-8')).toContain('secondsecond');
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(180);
+    });
+  });
+
+  it('truncates oversized process-output messages so one noisy line cannot break the cap', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 260, maxRotatedLogFiles: 1 });
+      await logs.append('run-2', 'attempt-1', 'stdout', 'x'.repeat(5_000), '2026-03-11T00:00:00.000Z');
+
+      const activePath = join(dir, 'run-2', 'attempt-1.log');
+      const contents = await readFile(activePath, 'utf-8');
+      const parsed = JSON.parse(contents.trim()) as { message: string; truncatedBytes: number };
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(260);
+      expect(parsed.message).toContain('[truncated');
+      expect(parsed.truncatedBytes).toBeGreaterThan(0);
+    });
+  });
+
+  it('keeps only the configured number of rotated files', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: 1 });
+      for (let i = 0; i < 5; i += 1) {
+        await logs.append('run-3', 'attempt-1', 'stdout', `message-${i}-${'z'.repeat(60)}`, `2026-03-11T00:00:0${i}.000Z`);
+      }
+
+      const activePath = join(dir, 'run-3', 'attempt-1.log');
+      expect(existsSync(`${activePath}.1`)).toBe(true);
+      expect(existsSync(`${activePath}.2`)).toBe(false);
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(160);
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -181,6 +181,21 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('truncates an already oversized active log instead of rotating it into retained evidence', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-oversized-existing', 'attempt-1.log');
+      await mkdir(join(dir, 'run-oversized-existing'), { recursive: true });
+      await writeFile(activePath, 'legacy-unbounded-log\n'.repeat(50));
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: 2 });
+      await logs.append('run-oversized-existing', 'attempt-1', 'stdout', 'new-small-record', '2026-03-11T00:00:01.000Z');
+
+      expect(existsSync(`${activePath}.1`)).toBe(false);
+      expect(await readFile(activePath, 'utf-8')).toContain('new-small-record');
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(160);
+    });
+  });
+
   it('prunes stale rotations even when the active log stays below the size cap', async () => {
     await withTempDir(async (dir) => {
       const activePath = join(dir, 'run-prune-without-rotation', 'attempt-1.log');
@@ -202,7 +217,7 @@ describe('BeastLogStore', () => {
     await withTempDir(async (dir) => {
       const activePath = join(dir, 'run-capped-retention', 'attempt-1.log');
       await mkdir(join(dir, 'run-capped-retention'), { recursive: true });
-      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active'.repeat(20), createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active'.repeat(8), createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
       await writeFile(`${activePath}.99`, 'old-99\n');
       await writeFile(`${activePath}.100`, 'old-100\n');
       await writeFile(`${activePath}.101`, 'old-101\n');

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -102,8 +102,12 @@ describe('BeastLogStore', () => {
 
       const activePath = join(dir, 'run-minimum', 'attempt-1.log');
       const contents = await readFile(activePath, 'utf-8');
+      const parsed = JSON.parse(contents.trim()) as { createdAt?: string; message: string };
       expect((await stat(activePath)).size).toBeLessThanOrEqual(128);
-      expect(JSON.parse(contents.trim())).toMatchObject({ message: expect.stringContaining('[truncated]') });
+      expect(parsed).toMatchObject({
+        createdAt: '2026-03-11T00:00:00.000Z',
+        message: expect.stringContaining('[truncated]'),
+      });
     });
   });
 
@@ -174,6 +178,40 @@ describe('BeastLogStore', () => {
       expect(existsSync(`${activePath}.1`)).toBe(false);
       expect(existsSync(`${activePath}.2`)).toBe(false);
       expect((await stat(activePath)).size).toBeLessThanOrEqual(160);
+    });
+  });
+
+  it('prunes stale rotations even when the active log stays below the size cap', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-prune-without-rotation', 'attempt-1.log');
+      await mkdir(join(dir, 'run-prune-without-rotation'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active', createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(`${activePath}.1`, 'old-1\n');
+      await writeFile(`${activePath}.2`, 'old-2\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 1_000, maxRotatedLogFiles: 0 });
+      await logs.append('run-prune-without-rotation', 'attempt-1', 'stdout', 'small', '2026-03-11T00:00:01.000Z');
+
+      expect(existsSync(`${activePath}.1`)).toBe(false);
+      expect(existsSync(`${activePath}.2`)).toBe(false);
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(1_000);
+    });
+  });
+
+  it('caps configured rotated-file retention to avoid unbounded rotation loops', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-capped-retention', 'attempt-1.log');
+      await mkdir(join(dir, 'run-capped-retention'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active'.repeat(20), createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(`${activePath}.99`, 'old-99\n');
+      await writeFile(`${activePath}.100`, 'old-100\n');
+      await writeFile(`${activePath}.101`, 'old-101\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: Number.MAX_SAFE_INTEGER });
+      await logs.append('run-capped-retention', 'attempt-1', 'stdout', 'new'.repeat(30), '2026-03-11T00:00:01.000Z');
+
+      expect(await readFile(`${activePath}.100`, 'utf-8')).toBe('old-99\n');
+      expect(existsSync(`${activePath}.101`)).toBe(false);
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { existsSync } from 'node:fs';
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
@@ -52,6 +52,21 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('reads retained rotated logs oldest-first before the active log', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 180, maxRotatedLogFiles: 2 });
+      await logs.append('run-rotated', 'attempt-1', 'stdout', 'first'.repeat(12), '2026-03-11T00:00:00.000Z');
+      await logs.append('run-rotated', 'attempt-1', 'stdout', 'second'.repeat(12), '2026-03-11T00:00:01.000Z');
+      await logs.append('run-rotated', 'attempt-1', 'stdout', 'third'.repeat(12), '2026-03-11T00:00:02.000Z');
+
+      const records = await logs.read('run-rotated', 'attempt-1');
+      expect(records).toHaveLength(3);
+      expect(records[0]).toContain('firstfirst');
+      expect(records[1]).toContain('secondsecond');
+      expect(records[2]).toContain('thirdthird');
+    });
+  });
+
   it('truncates oversized process-output messages so one noisy line cannot break the cap', async () => {
     await withTempDir(async (dir) => {
       const logs = new BeastLogStore(dir, { maxLogFileBytes: 260, maxRotatedLogFiles: 1 });
@@ -66,6 +81,41 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('caps escaped oversized messages without an iterative event-loop stall', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 320, maxRotatedLogFiles: 1 });
+      await logs.append('run-escaped', 'attempt-1', 'stderr', '\\'.repeat(20_000), '2026-03-11T00:00:00.000Z');
+
+      const activePath = join(dir, 'run-escaped', 'attempt-1.log');
+      const contents = await readFile(activePath, 'utf-8');
+      const parsed = JSON.parse(contents.trim()) as { message: string; truncatedBytes: number };
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(320);
+      expect(parsed.message).toContain('[truncated');
+      expect(parsed.truncatedBytes).toBeGreaterThan(0);
+    });
+  });
+
+  it('serializes concurrent appends so active logs stay within the configured cap', async () => {
+    await withTempDir(async (dir) => {
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 260, maxRotatedLogFiles: 3 });
+
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) =>
+          logs.append(
+            'run-concurrent',
+            'attempt-1',
+            'stdout',
+            `message-${i}-${'x'.repeat(80)}`,
+            `2026-03-11T00:00:${String(i).padStart(2, '0')}.000Z`,
+          ),
+        ),
+      );
+
+      const activePath = join(dir, 'run-concurrent', 'attempt-1.log');
+      expect((await stat(activePath)).size).toBeLessThanOrEqual(260);
+    });
+  });
+
   it('keeps only the configured number of rotated files', async () => {
     await withTempDir(async (dir) => {
       const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: 1 });
@@ -77,6 +127,24 @@ describe('BeastLogStore', () => {
       expect(existsSync(`${activePath}.1`)).toBe(true);
       expect(existsSync(`${activePath}.2`)).toBe(false);
       expect((await stat(activePath)).size).toBeLessThanOrEqual(160);
+    });
+  });
+
+  it('removes stale rotations above a lowered retention count', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-stale', 'attempt-1.log');
+      await mkdir(join(dir, 'run-stale'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active', createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(`${activePath}.1`, 'old-1\n');
+      await writeFile(`${activePath}.2`, 'old-2\n');
+      await writeFile(`${activePath}.3`, 'old-3\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 160, maxRotatedLogFiles: 1 });
+      await logs.append('run-stale', 'attempt-1', 'stdout', `new-${'z'.repeat(80)}`, '2026-03-11T00:00:01.000Z');
+
+      expect(existsSync(`${activePath}.1`)).toBe(true);
+      expect(existsSync(`${activePath}.2`)).toBe(false);
+      expect(existsSync(`${activePath}.3`)).toBe(false);
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -67,6 +67,22 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('reads all existing rotations even when the reader uses default retention', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-reader-retention', 'attempt-1.log');
+      await mkdir(join(dir, 'run-reader-retention'), { recursive: true });
+      await writeFile(`${activePath}.4`, 'old-4\n');
+      await writeFile(`${activePath}.10`, 'old-10\n');
+      await writeFile(activePath, 'active\n');
+
+      await expect(new BeastLogStore(dir).read('run-reader-retention', 'attempt-1')).resolves.toEqual([
+        'old-10',
+        'old-4',
+        'active',
+      ]);
+    });
+  });
+
   it('truncates oversized process-output messages so one noisy line cannot break the cap', async () => {
     await withTempDir(async (dir) => {
       const logs = new BeastLogStore(dir, { maxLogFileBytes: 260, maxRotatedLogFiles: 1 });
@@ -181,6 +197,25 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('clamps negative rotated-file retention without deleting active or sibling logs', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-negative-retention', 'attempt-1.log');
+      const siblingPath = join(dir, 'run-negative-retention', 'attempt-2.log');
+      await mkdir(join(dir, 'run-negative-retention'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active', createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(siblingPath, 'sibling\n');
+      await writeFile(`${activePath}.1`, 'old-1\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 1_000, maxRotatedLogFiles: -1 });
+      await logs.append('run-negative-retention', 'attempt-1', 'stdout', 'small', '2026-03-11T00:00:01.000Z');
+
+      expect(existsSync(activePath)).toBe(true);
+      expect(await readFile(activePath, 'utf-8')).toContain('small');
+      expect(await readFile(siblingPath, 'utf-8')).toBe('sibling\n');
+      expect(existsSync(`${activePath}.1`)).toBe(false);
+    });
+  });
+
   it('truncates an already oversized active log instead of rotating it into retained evidence', async () => {
     await withTempDir(async (dir) => {
       const activePath = join(dir, 'run-oversized-existing', 'attempt-1.log');
@@ -210,6 +245,24 @@ describe('BeastLogStore', () => {
       expect(existsSync(`${activePath}.1`)).toBe(false);
       expect(existsSync(`${activePath}.2`)).toBe(false);
       expect((await stat(activePath)).size).toBeLessThanOrEqual(1_000);
+    });
+  });
+
+  it('does not scan and prune stale rotations on every below-cap append', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, 'run-prune-once', 'attempt-1.log');
+      await mkdir(join(dir, 'run-prune-once'), { recursive: true });
+      await writeFile(activePath, `${JSON.stringify({ stream: 'stdout', message: 'active', createdAt: '2026-03-11T00:00:00.000Z' })}\n`);
+      await writeFile(`${activePath}.2`, 'old-2\n');
+
+      const logs = new BeastLogStore(dir, { maxLogFileBytes: 1_000, maxRotatedLogFiles: 1 });
+      await logs.append('run-prune-once', 'attempt-1', 'stdout', 'first-small', '2026-03-11T00:00:01.000Z');
+      expect(existsSync(`${activePath}.2`)).toBe(false);
+
+      await writeFile(`${activePath}.2`, 'externally-recreated-stale-rotation\n');
+      await logs.append('run-prune-once', 'attempt-1', 'stdout', 'second-small', '2026-03-11T00:00:02.000Z');
+
+      expect(existsSync(`${activePath}.2`)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- add bounded rotation/retention for Beast per-attempt stdout/stderr run logs
- cap oversized single process-output records with metadata so one line cannot exceed the configured retention limit
- wire env-based retention controls and document defaults for operators

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/beasts/beast-log-store.test.ts tests/unit/logging/beast-logger.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npx eslint packages/franken-orchestrator/src/beasts/events/beast-log-store.ts packages/franken-orchestrator/src/beasts/create-beast-services.ts packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts

Closes #1715
