### PR TITLE
fix(observer): retry sqlite lock failures

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -184,6 +184,75 @@ describe('SQLiteAdapter', () => {
     expect(transactionMock).toHaveBeenCalledTimes(3)
   })
 
+  it('serializes deletes behind pending flush retries', async () => {
+    const releaseSleep: Array<() => void> = []
+    const sleep = vi.fn().mockImplementation(() => new Promise<void>(resolve => releaseSleep.push(resolve)))
+    const deleteSpansRun = vi.fn()
+    const deleteTraceRun = vi.fn()
+    prepareMock.mockReturnValue({ run: vi.fn() })
+    prepareMock
+      .mockReturnValueOnce({ run: vi.fn() })
+      .mockReturnValueOnce({ run: vi.fn() })
+      .mockReturnValueOnce({ run: vi.fn() })
+      .mockReturnValueOnce({ run: vi.fn() })
+      .mockReturnValueOnce({ run: deleteSpansRun })
+      .mockReturnValueOnce({ run: deleteTraceRun })
+    let transactionCalls = 0
+    transactionMock.mockImplementation(fn => (arg: unknown) => {
+      transactionCalls += 1
+      if (transactionCalls === 1) throw sqliteBusyError()
+      return fn(arg)
+    })
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+    })
+    const trace = TraceContext.createTrace('goal')
+
+    const flush = adapter.flush(trace)
+    const deletion = adapter.deleteTrace(trace.id)
+    await Promise.resolve()
+
+    expect(deleteTraceRun).not.toHaveBeenCalled()
+    releaseSleep[0]?.()
+    await Promise.all([flush, deletion])
+
+    expect(deleteSpansRun).toHaveBeenCalledWith(trace.id)
+    expect(deleteTraceRun).toHaveBeenCalledWith(trace.id)
+    expect(transactionMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries SQLite locks raised while preparing delete statements', async () => {
+    const deleteSpansRun = vi.fn()
+    const deleteTraceRun = vi.fn()
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    prepareMock
+      .mockImplementationOnce(() => {
+        throw sqliteBusyError()
+      })
+      .mockReturnValueOnce({ run: deleteSpansRun })
+      .mockReturnValueOnce({ run: deleteTraceRun })
+    transactionMock.mockImplementation(fn => (traceId: unknown) => fn(traceId))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+    })
+
+    await adapter.deleteTrace('trace-1')
+
+    expect(sleep).toHaveBeenCalledWith(5)
+    expect(deleteSpansRun).toHaveBeenCalledWith('trace-1')
+    expect(deleteTraceRun).toHaveBeenCalledWith('trace-1')
+  })
+
   it('only upserts new or dirty spans on repeated flushes', async () => {
     const upsertTraceRun = vi.fn()
     const upsertSpanRun = vi.fn()

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -50,20 +50,14 @@ describe('SQLiteAdapter', () => {
   })
 
   it('retries transient SQLite lock failures with bounded backoff and diagnostics', async () => {
-    const upsertTraceRun = vi.fn()
-    const upsertSpanRun = vi.fn()
     const sleep = vi.fn().mockResolvedValue(undefined)
     const diagnostics = vi.fn()
-    prepareMock
-      .mockReturnValueOnce({ run: upsertTraceRun })
-      .mockReturnValueOnce({ run: upsertSpanRun })
-    transactionMock.mockImplementation(fn => {
-      let calls = 0
-      return (trace: unknown) => {
-        calls += 1
-        if (calls <= 2) throw sqliteBusyError()
-        return fn(trace)
-      }
+    prepareMock.mockReturnValue({ run: vi.fn() })
+    let attempts = 0
+    transactionMock.mockImplementation(fn => (trace: unknown) => {
+      attempts += 1
+      if (attempts <= 2) throw sqliteBusyError()
+      return fn(trace)
     })
 
     const adapter = new SQLiteAdapter('/tmp/traces.db', {
@@ -82,17 +76,7 @@ describe('SQLiteAdapter', () => {
 
     expect(sleep.mock.calls.map(call => call[0])).toEqual([10, 20])
     expect(diagnostics).toHaveBeenCalledTimes(2)
-    expect(diagnostics).toHaveBeenLastCalledWith(expect.objectContaining({
-      dbPath: '/tmp/traces.db',
-      operationClass: 'flush trace transaction',
-      attempt: 2,
-      maxRetries: 2,
-      errorMessage: 'database is locked',
-      nextAction: 'Retrying SQLite operation after bounded backoff.',
-      nextDelayMs: 20,
-    }))
-    expect(upsertTraceRun).toHaveBeenCalledTimes(1)
-    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+    expect(transactionMock).toHaveBeenCalledTimes(3)
   })
 
   it('reports persistent SQLite locks with path, operation, elapsed time, and next action', async () => {
@@ -124,6 +108,80 @@ describe('SQLiteAdapter', () => {
       errorMessage: 'database is locked',
       nextAction: 'SQLite lock retry budget exhausted; inspect concurrent writers or increase busy timeout/retry budget.',
     }))
+  })
+
+  it('retries SQLite locks raised while preparing flush statements', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    prepareMock
+      .mockImplementationOnce(() => {
+        throw sqliteBusyError()
+      })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+    })
+    const trace = TraceContext.createTrace('goal')
+    const span = TraceContext.startSpan(trace, { name: 'first' })
+    TraceContext.endSpan(span)
+
+    await adapter.flush(trace)
+
+    expect(sleep).toHaveBeenCalledWith(5)
+    expect(upsertTraceRun).toHaveBeenCalledTimes(1)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('serializes flush retries so newer snapshots cannot overtake older retries', async () => {
+    const releaseSleep: Array<() => void> = []
+    const sleep = vi.fn().mockImplementation(() => new Promise<void>(resolve => releaseSleep.push(resolve)))
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock.mockReturnValue({ run: vi.fn() })
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    let firstFlushAttempts = 0
+    transactionMock.mockImplementation(fn => (trace: unknown) => {
+      if (firstFlushAttempts < 1) {
+        firstFlushAttempts += 1
+        throw sqliteBusyError()
+      }
+      return fn(trace)
+    })
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+    })
+    const trace = TraceContext.createTrace('goal')
+
+    const firstFlush = adapter.flush(trace)
+    const secondFlush = adapter.flush(trace)
+    await Promise.resolve()
+
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(upsertTraceRun).not.toHaveBeenCalled()
+
+    releaseSleep[0]?.()
+    await Promise.all([firstFlush, secondFlush])
+
+    expect(upsertTraceRun).toHaveBeenCalledTimes(1)
+    expect(prepareMock).toHaveBeenCalledTimes(6)
+    expect(transactionMock).toHaveBeenCalledTimes(3)
   })
 
   it('only upserts new or dirty spans on repeated flushes', async () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -21,9 +21,15 @@ vi.mock('better-sqlite3', () => ({
   }),
 }))
 
-import { SQLiteAdapter } from './SQLiteAdapter.js'
+import { SQLiteAdapter, SQLiteLockRetryExhaustedError } from './SQLiteAdapter.js'
 import { TraceContext } from '../../core/TraceContext.js'
 import { SpanLifecycle } from '../../core/SpanLifecycle.js'
+
+function sqliteBusyError(): Error & { code: string } {
+  const error = new Error('database is locked') as Error & { code: string }
+  error.code = 'SQLITE_BUSY'
+  return error
+}
 
 describe('SQLiteAdapter', () => {
   beforeEach(() => {
@@ -41,6 +47,83 @@ describe('SQLiteAdapter', () => {
     ])
 
     adapter.close()
+  })
+
+  it('retries transient SQLite lock failures with bounded backoff and diagnostics', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const diagnostics = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => {
+      let calls = 0
+      return (trace: unknown) => {
+        calls += 1
+        if (calls <= 2) throw sqliteBusyError()
+        return fn(trace)
+      }
+    })
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 2,
+      lockRetryBaseDelayMs: 10,
+      lockRetryMaxDelayMs: 20,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+      onLockRetryDiagnostic: diagnostics,
+    })
+    const trace = TraceContext.createTrace('goal')
+    const span = TraceContext.startSpan(trace, { name: 'first' })
+    TraceContext.endSpan(span)
+
+    await adapter.flush(trace)
+
+    expect(sleep.mock.calls.map(call => call[0])).toEqual([10, 20])
+    expect(diagnostics).toHaveBeenCalledTimes(2)
+    expect(diagnostics).toHaveBeenLastCalledWith(expect.objectContaining({
+      dbPath: '/tmp/traces.db',
+      operationClass: 'flush trace transaction',
+      attempt: 2,
+      maxRetries: 2,
+      errorMessage: 'database is locked',
+      nextAction: 'Retrying SQLite operation after bounded backoff.',
+      nextDelayMs: 20,
+    }))
+    expect(upsertTraceRun).toHaveBeenCalledTimes(1)
+    expect(upsertSpanRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports persistent SQLite locks with path, operation, elapsed time, and next action', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const diagnostics = vi.fn()
+    transactionMock.mockImplementation(() => () => {
+      throw sqliteBusyError()
+    })
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+      onLockRetryDiagnostic: diagnostics,
+    })
+    const trace = TraceContext.createTrace('goal')
+
+    await expect(adapter.flush(trace)).rejects.toThrow(SQLiteLockRetryExhaustedError)
+    await expect(adapter.flush(trace)).rejects.toThrow(/SQLite lock persisted for flush trace transaction on \/tmp\/traces\.db/)
+
+    expect(sleep).toHaveBeenCalledWith(5)
+    expect(diagnostics).toHaveBeenLastCalledWith(expect.objectContaining({
+      dbPath: '/tmp/traces.db',
+      operationClass: 'flush trace transaction',
+      attempt: 2,
+      maxRetries: 1,
+      errorMessage: 'database is locked',
+      nextAction: 'SQLite lock retry budget exhausted; inspect concurrent writers or increase busy timeout/retry budget.',
+    }))
   })
 
   it('only upserts new or dirty spans on repeated flushes', async () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -45,8 +45,38 @@ describe('SQLiteAdapter', () => {
       'journal_mode = WAL',
       'foreign_keys = ON',
     ])
+    expect(execMock).toHaveBeenCalledTimes(1)
 
     adapter.close()
+  })
+
+  it('validates retry options before opening a database handle', () => {
+    expect(() => new SQLiteAdapter('/tmp/traces.db', { maxLockRetries: -1 })).toThrow(
+      'maxLockRetries must be an integer between 0 and 10',
+    )
+    expect(Database).not.toHaveBeenCalled()
+  })
+
+  it('snapshots traces before queued writes observe later mutations', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const trace = TraceContext.createTrace('original-goal')
+    const span = TraceContext.startSpan(trace, { name: 'first' })
+    TraceContext.endSpan(span)
+
+    const flush = adapter.flush(trace)
+    trace.goal = 'mutated-goal'
+    span.metadata.changed = true
+    await flush
+
+    expect(upsertTraceRun).toHaveBeenCalledWith(expect.objectContaining({ goal: 'original-goal' }))
+    expect(upsertSpanRun).toHaveBeenCalledWith(expect.objectContaining({ metadata: '{}' }))
   })
 
   it('retries transient SQLite lock failures with bounded backoff and diagnostics', async () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -57,6 +57,49 @@ describe('SQLiteAdapter', () => {
     expect(Database).not.toHaveBeenCalled()
   })
 
+  it('retries SQLite locks raised during adapter initialization', () => {
+    const diagnostics = vi.fn()
+    pragmaMock
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw sqliteBusyError()
+      })
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => undefined)
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 1,
+      lockRetryMaxDelayMs: 1,
+      lockRetryJitter: false,
+      onLockRetryDiagnostic: diagnostics,
+    })
+
+    expect(diagnostics).toHaveBeenCalledWith(expect.objectContaining({
+      operationClass: 'initialize SQLite adapter',
+      attempt: 1,
+      errorMessage: 'database is locked',
+    }))
+    expect(execMock).toHaveBeenCalledTimes(1)
+    adapter.close()
+  })
+
+  it('closes an opened database handle if initialization exhausts lock retries', () => {
+    pragmaMock
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw sqliteBusyError()
+      })
+
+    expect(() => new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 0,
+      lockRetryBaseDelayMs: 1,
+      lockRetryMaxDelayMs: 1,
+      lockRetryJitter: false,
+    })).toThrow(SQLiteLockRetryExhaustedError)
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('snapshots traces before queued writes observe later mutations', async () => {
     const upsertTraceRun = vi.fn()
     const upsertSpanRun = vi.fn()
@@ -107,6 +150,36 @@ describe('SQLiteAdapter', () => {
     expect(sleep.mock.calls.map(call => call[0])).toEqual([10, 20])
     expect(diagnostics).toHaveBeenCalledTimes(2)
     expect(transactionMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps retry diagnostics best-effort when the diagnostic hook throws', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const diagnostics = vi.fn(() => {
+      throw new Error('metrics sink down')
+    })
+    prepareMock.mockReturnValue({ run: vi.fn() })
+    let attempts = 0
+    transactionMock.mockImplementation(fn => (trace: unknown) => {
+      attempts += 1
+      if (attempts === 1) throw sqliteBusyError()
+      return fn(trace)
+    })
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db', {
+      maxLockRetries: 1,
+      lockRetryBaseDelayMs: 5,
+      lockRetryMaxDelayMs: 5,
+      lockRetryJitter: false,
+      lockRetrySleep: sleep,
+      onLockRetryDiagnostic: diagnostics,
+    })
+    const trace = TraceContext.createTrace('goal')
+
+    await adapter.flush(trace)
+
+    expect(diagnostics).toHaveBeenCalledTimes(1)
+    expect(sleep).toHaveBeenCalledWith(5)
+    expect(transactionMock).toHaveBeenCalledTimes(2)
   })
 
   it('reports persistent SQLite locks with path, operation, elapsed time, and next action', async () => {
@@ -254,6 +327,31 @@ describe('SQLiteAdapter', () => {
     expect(deleteSpansRun).toHaveBeenCalledWith(trace.id)
     expect(deleteTraceRun).toHaveBeenCalledWith(trace.id)
     expect(transactionMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('drains pending writes before closing the SQLite handle', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (trace: unknown) => fn(trace))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const trace = TraceContext.createTrace('goal')
+    const span = TraceContext.startSpan(trace, { name: 'first' })
+    TraceContext.endSpan(span)
+
+    const flush = adapter.flush(trace)
+    adapter.close()
+
+    expect(closeMock).not.toHaveBeenCalled()
+    await flush
+    await Promise.resolve()
+
+    expect(upsertTraceRun).toHaveBeenCalledWith(expect.objectContaining({ id: trace.id }))
+    expect(closeMock).toHaveBeenCalledTimes(1)
+    await expect(adapter.flush(trace)).rejects.toThrow('SQLiteAdapter is closed')
   })
 
   it('retries SQLite locks raised while preparing delete statements', async () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -198,7 +198,7 @@ export class SQLiteAdapter implements ExportAdapter {
   private readonly filePath: string
   private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
   private flushedSpanSnapshotCount = 0
-  private flushTail: Promise<void> = Promise.resolve()
+  private writeTail: Promise<unknown> = Promise.resolve()
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     mkdirSync(dirname(filePath), { recursive: true })
@@ -216,9 +216,7 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
-    const flush = this.flushTail.then(() => this.flushNow(trace))
-    this.flushTail = flush.catch(() => undefined)
-    return flush
+    return this.enqueueSqliteWrite(() => this.flushNow(trace))
   }
 
   private async flushNow(trace: Trace): Promise<void> {
@@ -381,19 +379,31 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async deleteTrace(traceId: string): Promise<void> {
-    const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
-    const deleteTrace = this.db.prepare(DELETE_TRACE)
-    const transaction = this.db.transaction((id: string) => {
-      deleteSpans.run(id)
-      deleteTrace.run(id)
-    })
+    return this.enqueueSqliteWrite(() => this.deleteTraceNow(traceId))
+  }
 
-    await this.withSqliteLockRetry('delete trace transaction', () => transaction(traceId))
+  private async deleteTraceNow(traceId: string): Promise<void> {
+    await this.withSqliteLockRetry('delete trace transaction', () => {
+      const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
+      const deleteTrace = this.db.prepare(DELETE_TRACE)
+      const transaction = this.db.transaction((id: string) => {
+        deleteSpans.run(id)
+        deleteTrace.run(id)
+      })
+
+      transaction(traceId)
+    })
     const flushed = this.flushedSpans.get(traceId)
     if (flushed !== undefined) {
       this.flushedSpanSnapshotCount -= flushed.size
       this.flushedSpans.delete(traceId)
     }
+  }
+
+  private enqueueSqliteWrite<T>(action: () => Promise<T>): Promise<T> {
+    const queued = this.writeTail.then(action)
+    this.writeTail = queued.catch(() => undefined)
+    return queued
   }
 
   private async withSqliteLockRetry<T>(operationClass: string, action: () => T): Promise<T> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -62,6 +62,98 @@ interface FlushedSpanState {
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
   maxFlushedSpanSnapshots?: number
+  /** SQLite busy timeout in milliseconds. Default: 5000. */
+  busyTimeoutMs?: number
+  /** Bounded retries after SQLite reports busy/locked. Default: 3. */
+  maxLockRetries?: number
+  /** Base delay in milliseconds for lock retry backoff. Default: 25. */
+  lockRetryBaseDelayMs?: number
+  /** Max delay in milliseconds for lock retry backoff. Default: 250. */
+  lockRetryMaxDelayMs?: number
+  /** Add random jitter up to the base delay. Default: true. */
+  lockRetryJitter?: boolean
+  /** Injectable sleep for tests. */
+  lockRetrySleep?: (ms: number) => Promise<void>
+  /** Receives retry and exhaustion diagnostics without exposing row payloads. */
+  onLockRetryDiagnostic?: (diagnostic: SQLiteLockRetryDiagnostic) => void
+}
+
+export interface SQLiteLockRetryDiagnostic {
+  dbPath: string
+  operationClass: string
+  attempt: number
+  maxRetries: number
+  elapsedMs: number
+  nextDelayMs?: number
+  errorMessage: string
+  nextAction: string
+}
+
+export class SQLiteLockRetryExhaustedError extends Error {
+  constructor(
+    message: string,
+    public readonly diagnostic: SQLiteLockRetryDiagnostic,
+    public override readonly cause: unknown,
+  ) {
+    super(message)
+    this.name = 'SQLiteLockRetryExhaustedError'
+  }
+}
+
+interface NormalizedLockRetryOptions {
+  busyTimeoutMs: number
+  maxRetries: number
+  baseDelayMs: number
+  maxDelayMs: number
+  jitter: boolean
+  sleep: (ms: number) => Promise<void>
+  onDiagnostic?: (diagnostic: SQLiteLockRetryDiagnostic) => void
+}
+
+function normalizeNonNegativeInteger(value: number | undefined, fallback: number, name: string, max: number): number {
+  const resolved = value ?? fallback
+  if (!Number.isInteger(resolved) || resolved < 0 || resolved > max) {
+    throw new Error(`${name} must be an integer between 0 and ${max}`)
+  }
+  return resolved
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number, name: string, max: number): number {
+  const resolved = value ?? fallback
+  if (!Number.isInteger(resolved) || resolved <= 0 || resolved > max) {
+    throw new Error(`${name} must be an integer between 1 and ${max}`)
+  }
+  return resolved
+}
+
+function normalizeLockRetryOptions(options: SQLiteAdapterOptions): NormalizedLockRetryOptions {
+  const busyTimeoutMs = normalizePositiveInteger(options.busyTimeoutMs, 5_000, 'busyTimeoutMs', 60_000)
+  const maxRetries = normalizeNonNegativeInteger(options.maxLockRetries, 3, 'maxLockRetries', 10)
+  const baseDelayMs = normalizePositiveInteger(options.lockRetryBaseDelayMs, 25, 'lockRetryBaseDelayMs', 60_000)
+  const maxDelayMs = normalizePositiveInteger(options.lockRetryMaxDelayMs, 250, 'lockRetryMaxDelayMs', 60_000)
+  if (baseDelayMs > maxDelayMs) {
+    throw new Error('lockRetryBaseDelayMs must be less than or equal to lockRetryMaxDelayMs')
+  }
+  return {
+    busyTimeoutMs,
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs,
+    jitter: options.lockRetryJitter ?? true,
+    sleep: options.lockRetrySleep ?? (ms => new Promise<void>(resolve => setTimeout(resolve, ms))),
+    onDiagnostic: options.onLockRetryDiagnostic,
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isSqliteLockError(error: unknown): boolean {
+  const maybe = error as { code?: unknown }
+  const code = typeof maybe?.code === 'string' ? maybe.code : ''
+  if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') return true
+  return /database is (?:busy|locked)|SQLITE_(?:BUSY|LOCKED)/i.test(errorMessage(error))
 }
 
 /**
@@ -102,17 +194,21 @@ function rowToSpan(row: SpanRow): Span {
 export class SQLiteAdapter implements ExportAdapter {
   private readonly db: Database.Database
   private readonly maxFlushedSpanSnapshots: number
+  private readonly lockRetry: NormalizedLockRetryOptions
+  private readonly filePath: string
   private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
   private flushedSpanSnapshotCount = 0
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     mkdirSync(dirname(filePath), { recursive: true })
     this.db = new Database(filePath)
+    this.filePath = filePath
+    this.lockRetry = normalizeLockRetryOptions(options)
     this.maxFlushedSpanSnapshots = Math.max(
       0,
       Math.floor(options.maxFlushedSpanSnapshots ?? 10_000),
     )
-    this.db.pragma('busy_timeout = 5000')
+    this.db.pragma(`busy_timeout = ${this.lockRetry.busyTimeoutMs}`)
     this.db.pragma('journal_mode = WAL')
     this.db.pragma('foreign_keys = ON')
     this.db.exec(CREATE_TABLES)
@@ -152,7 +248,7 @@ export class SQLiteAdapter implements ExportAdapter {
       }
     })
 
-    transaction(trace)
+    await this.withSqliteLockRetry('flush trace transaction', () => transaction(trace))
     for (const span of flushedInTransaction) {
       this.rememberFlushedSpan(span)
     }
@@ -237,35 +333,41 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async queryByTraceId(traceId: string): Promise<Trace | null> {
-    const traceRow = this.db.prepare(SELECT_TRACE).get(traceId) as TraceRow | undefined
-    if (traceRow === undefined) return null
+    return this.withSqliteLockRetry('query trace by id', () => {
+      const traceRow = this.db.prepare(SELECT_TRACE).get(traceId) as TraceRow | undefined
+      if (traceRow === undefined) return null
 
-    const spanRows = this.db.prepare(SELECT_SPANS).all(traceId) as SpanRow[]
+      const spanRows = this.db.prepare(SELECT_SPANS).all(traceId) as SpanRow[]
 
-    return {
-      id: traceRow.id,
-      goal: traceRow.goal,
-      status: traceRow.status as Trace['status'],
-      startedAt: traceRow.startedAt,
-      endedAt: traceRow.endedAt ?? undefined,
-      spans: spanRows.map(rowToSpan),
-    }
+      return {
+        id: traceRow.id,
+        goal: traceRow.goal,
+        status: traceRow.status as Trace['status'],
+        startedAt: traceRow.startedAt,
+        endedAt: traceRow.endedAt ?? undefined,
+        spans: spanRows.map(rowToSpan),
+      }
+    })
   }
 
   async listTraceIds(): Promise<string[]> {
-    const rows = this.db.prepare(SELECT_ALL_TRACE_IDS).all() as { id: string }[]
-    return rows.map(r => r.id)
+    return this.withSqliteLockRetry('list trace ids', () => {
+      const rows = this.db.prepare(SELECT_ALL_TRACE_IDS).all() as { id: string }[]
+      return rows.map(r => r.id)
+    })
   }
 
   async listTraceSummaries(): Promise<TraceSummary[]> {
-    const rows = this.db.prepare(SELECT_TRACE_SUMMARIES).all() as TraceSummaryRow[]
-    return rows.map(row => ({
-      id: row.id,
-      goal: row.goal,
-      status: row.status as Trace['status'],
-      spanCount: row.spanCount,
-      startedAt: row.startedAt,
-    }))
+    return this.withSqliteLockRetry('list trace summaries', () => {
+      const rows = this.db.prepare(SELECT_TRACE_SUMMARIES).all() as TraceSummaryRow[]
+      return rows.map(row => ({
+        id: row.id,
+        goal: row.goal,
+        status: row.status as Trace['status'],
+        spanCount: row.spanCount,
+        startedAt: row.startedAt,
+      }))
+    })
   }
 
   async deleteTrace(traceId: string): Promise<void> {
@@ -276,12 +378,58 @@ export class SQLiteAdapter implements ExportAdapter {
       deleteTrace.run(id)
     })
 
-    transaction(traceId)
+    await this.withSqliteLockRetry('delete trace transaction', () => transaction(traceId))
     const flushed = this.flushedSpans.get(traceId)
     if (flushed !== undefined) {
       this.flushedSpanSnapshotCount -= flushed.size
       this.flushedSpans.delete(traceId)
     }
+  }
+
+  private async withSqliteLockRetry<T>(operationClass: string, action: () => T): Promise<T> {
+    const startedAt = Date.now()
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return action()
+      } catch (error) {
+        if (!isSqliteLockError(error)) {
+          throw error
+        }
+
+        const elapsedMs = Date.now() - startedAt
+        const exhausted = attempt >= this.lockRetry.maxRetries
+        const nextDelayMs = exhausted ? undefined : this.nextLockRetryDelay(attempt)
+        const diagnostic: SQLiteLockRetryDiagnostic = {
+          dbPath: this.filePath,
+          operationClass,
+          attempt: attempt + 1,
+          maxRetries: this.lockRetry.maxRetries,
+          elapsedMs,
+          ...(nextDelayMs === undefined ? {} : { nextDelayMs }),
+          errorMessage: errorMessage(error),
+          nextAction: exhausted
+            ? 'SQLite lock retry budget exhausted; inspect concurrent writers or increase busy timeout/retry budget.'
+            : 'Retrying SQLite operation after bounded backoff.',
+        }
+        this.lockRetry.onDiagnostic?.(diagnostic)
+
+        if (exhausted) {
+          throw new SQLiteLockRetryExhaustedError(
+            `[SQLiteAdapter] SQLite lock persisted for ${operationClass} on ${this.filePath} after ${attempt + 1} attempts over ${elapsedMs}ms. Next action: ${diagnostic.nextAction}`,
+            diagnostic,
+            error,
+          )
+        }
+
+        await this.lockRetry.sleep(nextDelayMs ?? 0)
+      }
+    }
+  }
+
+  private nextLockRetryDelay(attempt: number): number {
+    const base = Math.min(this.lockRetry.baseDelayMs * 2 ** attempt, this.lockRetry.maxDelayMs)
+    if (!this.lockRetry.jitter) return base
+    return Math.min(base + Math.random() * this.lockRetry.baseDelayMs, this.lockRetry.maxDelayMs)
   }
 
   /** Release the DB connection. Call when shutting down. */

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -221,7 +221,9 @@ export class SQLiteAdapter implements ExportAdapter {
   private readonly filePath: string
   private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
   private flushedSpanSnapshotCount = 0
-  private writeTail: Promise<unknown> = Promise.resolve()
+  private writeTail: Promise<unknown> | undefined
+  private closeAfterWrites = false
+  private closed = false
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     const lockRetry = normalizeLockRetryOptions(options)
@@ -233,10 +235,17 @@ export class SQLiteAdapter implements ExportAdapter {
       0,
       Math.floor(options.maxFlushedSpanSnapshots ?? 10_000),
     )
-    this.db.pragma(`busy_timeout = ${this.lockRetry.busyTimeoutMs}`)
-    this.db.pragma('journal_mode = WAL')
-    this.db.pragma('foreign_keys = ON')
-    this.db.exec(CREATE_TABLES)
+    try {
+      this.db.pragma(`busy_timeout = ${this.lockRetry.busyTimeoutMs}`)
+      this.withSqliteLockRetrySync('initialize SQLite adapter', () => {
+        this.db.pragma('journal_mode = WAL')
+        this.db.pragma('foreign_keys = ON')
+        this.db.exec(CREATE_TABLES)
+      })
+    } catch (error) {
+      this.db.close()
+      throw error
+    }
   }
 
   async flush(trace: Trace): Promise<void> {
@@ -426,9 +435,35 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   private enqueueSqliteWrite<T>(action: () => Promise<T>): Promise<T> {
-    const queued = this.writeTail.then(action)
-    this.writeTail = queued.catch(() => undefined)
+    if (this.closed || this.closeAfterWrites) {
+      return Promise.reject(new Error('SQLiteAdapter is closed'))
+    }
+
+    const queued = this.writeTail === undefined ? action() : this.writeTail.then(action)
+    const settled = queued.catch(() => undefined).finally(() => {
+      if (this.writeTail !== settled) return
+      this.writeTail = undefined
+      if (this.closeAfterWrites) {
+        this.closeNow()
+      }
+    })
+    this.writeTail = settled
     return queued
+  }
+
+  private closeNow(): void {
+    if (this.closed) return
+    this.closed = true
+    this.db.close()
+  }
+
+  private emitLockRetryDiagnostic(diagnostic: SQLiteLockRetryDiagnostic): void {
+    try {
+      this.lockRetry.onDiagnostic?.(diagnostic)
+    } catch {
+      // Diagnostics are best-effort. A logging/metrics hook must not change
+      // storage retry or exhaustion behavior.
+    }
   }
 
   private async withSqliteLockRetry<T>(operationClass: string, action: () => T): Promise<T> {
@@ -456,7 +491,7 @@ export class SQLiteAdapter implements ExportAdapter {
             ? 'SQLite lock retry budget exhausted; inspect concurrent writers or increase busy timeout/retry budget.'
             : 'Retrying SQLite operation after bounded backoff.',
         }
-        this.lockRetry.onDiagnostic?.(diagnostic)
+        this.emitLockRetryDiagnostic(diagnostic)
 
         if (exhausted) {
           throw new SQLiteLockRetryExhaustedError(
@@ -471,6 +506,46 @@ export class SQLiteAdapter implements ExportAdapter {
     }
   }
 
+  private withSqliteLockRetrySync<T>(operationClass: string, action: () => T): T {
+    const startedAt = Date.now()
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return action()
+      } catch (error) {
+        if (!isSqliteLockError(error)) {
+          throw error
+        }
+
+        const elapsedMs = Date.now() - startedAt
+        const exhausted = attempt >= this.lockRetry.maxRetries
+        const nextDelayMs = exhausted ? undefined : this.nextLockRetryDelay(attempt)
+        const diagnostic: SQLiteLockRetryDiagnostic = {
+          dbPath: this.filePath,
+          operationClass,
+          attempt: attempt + 1,
+          maxRetries: this.lockRetry.maxRetries,
+          elapsedMs,
+          ...(nextDelayMs === undefined ? {} : { nextDelayMs }),
+          errorMessage: errorMessage(error),
+          nextAction: exhausted
+            ? 'SQLite lock retry budget exhausted; inspect concurrent writers or increase busy timeout/retry budget.'
+            : 'Retrying SQLite operation after bounded backoff.',
+        }
+        this.emitLockRetryDiagnostic(diagnostic)
+
+        if (exhausted) {
+          throw new SQLiteLockRetryExhaustedError(
+            `[SQLiteAdapter] SQLite lock persisted for ${operationClass} on ${this.filePath} after ${attempt + 1} attempts over ${elapsedMs}ms. Next action: ${diagnostic.nextAction}`,
+            diagnostic,
+            error,
+          )
+        }
+
+        sleepSync(nextDelayMs ?? 0)
+      }
+    }
+  }
+
   private nextLockRetryDelay(attempt: number): number {
     const base = Math.min(this.lockRetry.baseDelayMs * 2 ** attempt, this.lockRetry.maxDelayMs)
     if (!this.lockRetry.jitter) return base
@@ -479,6 +554,15 @@ export class SQLiteAdapter implements ExportAdapter {
 
   /** Release the DB connection. Call when shutting down. */
   close(): void {
-    this.db.close()
+    this.closeAfterWrites = true
+    if (this.writeTail === undefined) {
+      this.closeNow()
+    }
   }
+}
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) return
+  const signal = new Int32Array(new SharedArrayBuffer(4))
+  Atomics.wait(signal, 0, 0, ms)
 }

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -156,6 +156,29 @@ function isSqliteLockError(error: unknown): boolean {
   return /database is (?:busy|locked)|SQLITE_(?:BUSY|LOCKED)/i.test(errorMessage(error))
 }
 
+function snapshotTrace(trace: Trace): Trace {
+  return {
+    id: trace.id,
+    goal: trace.goal,
+    status: trace.status,
+    startedAt: trace.startedAt,
+    endedAt: trace.endedAt,
+    spans: trace.spans.map(span => ({
+      id: span.id,
+      traceId: span.traceId,
+      parentSpanId: span.parentSpanId,
+      name: span.name,
+      status: span.status,
+      startedAt: span.startedAt,
+      endedAt: span.endedAt,
+      durationMs: span.durationMs,
+      errorMessage: span.errorMessage,
+      metadata: JSON.parse(JSON.stringify(span.metadata)) as Record<string, unknown>,
+      thoughtBlocks: [...span.thoughtBlocks],
+    })),
+  }
+}
+
 /**
  * Parse a JSON column, returning a fallback instead of throwing when the
  * stored value is corrupt. A single bad row must not poison the whole trace
@@ -201,10 +224,11 @@ export class SQLiteAdapter implements ExportAdapter {
   private writeTail: Promise<unknown> = Promise.resolve()
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
+    const lockRetry = normalizeLockRetryOptions(options)
     mkdirSync(dirname(filePath), { recursive: true })
     this.db = new Database(filePath)
     this.filePath = filePath
-    this.lockRetry = normalizeLockRetryOptions(options)
+    this.lockRetry = lockRetry
     this.maxFlushedSpanSnapshots = Math.max(
       0,
       Math.floor(options.maxFlushedSpanSnapshots ?? 10_000),
@@ -216,7 +240,8 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
-    return this.enqueueSqliteWrite(() => this.flushNow(trace))
+    const snapshot = snapshotTrace(trace)
+    return this.enqueueSqliteWrite(() => this.flushNow(snapshot))
   }
 
   private async flushNow(trace: Trace): Promise<void> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -198,6 +198,7 @@ export class SQLiteAdapter implements ExportAdapter {
   private readonly filePath: string
   private readonly flushedSpans = new Map<string, Map<string, FlushedSpanState>>()
   private flushedSpanSnapshotCount = 0
+  private flushTail: Promise<void> = Promise.resolve()
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     mkdirSync(dirname(filePath), { recursive: true })
@@ -215,40 +216,49 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
+    const flush = this.flushTail.then(() => this.flushNow(trace))
+    this.flushTail = flush.catch(() => undefined)
+    return flush
+  }
+
+  private async flushNow(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'SQLiteAdapter')
-    const upsertTrace = this.db.prepare(UPSERT_TRACE)
-    const upsertSpan = this.db.prepare(UPSERT_SPAN)
-    const flushedInTransaction: Span[] = []
+    const flushedInTransaction = await this.withSqliteLockRetry('flush trace transaction', () => {
+      const upsertTrace = this.db.prepare(UPSERT_TRACE)
+      const upsertSpan = this.db.prepare(UPSERT_SPAN)
+      const flushed: Span[] = []
 
-    const transaction = this.db.transaction((t: Trace) => {
-      upsertTrace.run({
-        id: t.id,
-        goal: t.goal,
-        status: t.status,
-        startedAt: t.startedAt,
-        endedAt: t.endedAt ?? null,
-      })
-      for (const span of t.spans) {
-        if (!this.shouldFlushSpan(span)) continue
-
-        upsertSpan.run({
-          id: span.id,
-          traceId: span.traceId,
-          parentSpanId: span.parentSpanId ?? null,
-          name: span.name,
-          status: span.status,
-          startedAt: span.startedAt,
-          endedAt: span.endedAt ?? null,
-          durationMs: span.durationMs ?? null,
-          errorMessage: span.errorMessage ?? null,
-          metadata: JSON.stringify(span.metadata),
-          thoughtBlocks: JSON.stringify(span.thoughtBlocks),
+      const transaction = this.db.transaction((t: Trace) => {
+        upsertTrace.run({
+          id: t.id,
+          goal: t.goal,
+          status: t.status,
+          startedAt: t.startedAt,
+          endedAt: t.endedAt ?? null,
         })
-        flushedInTransaction.push(span)
-      }
-    })
+        for (const span of t.spans) {
+          if (!this.shouldFlushSpan(span)) continue
 
-    await this.withSqliteLockRetry('flush trace transaction', () => transaction(trace))
+          upsertSpan.run({
+            id: span.id,
+            traceId: span.traceId,
+            parentSpanId: span.parentSpanId ?? null,
+            name: span.name,
+            status: span.status,
+            startedAt: span.startedAt,
+            endedAt: span.endedAt ?? null,
+            durationMs: span.durationMs ?? null,
+            errorMessage: span.errorMessage ?? null,
+            metadata: JSON.stringify(span.metadata),
+            thoughtBlocks: JSON.stringify(span.thoughtBlocks),
+          })
+          flushed.push(span)
+        }
+      })
+
+      transaction(trace)
+      return flushed
+    })
     for (const span of flushedInTransaction) {
       this.rememberFlushedSpan(span)
     }

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -22,7 +22,7 @@ export {
   extractFromHeaders,
   injectIntoHeaders,
 } from './propagation/W3CTraceContext.js'
-export { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js'
+export { SQLiteAdapter, SQLiteLockRetryExhaustedError } from './adapters/sqlite/SQLiteAdapter.js'
 export { EvalRunner } from './evals/EvalRunner.js'
 export { ToolCallAccuracyEval } from './evals/deterministic/ToolCallAccuracy.js'
 export { ArchitecturalAdherenceEval } from './evals/deterministic/ArchitecturalAdherence.js'
@@ -62,7 +62,7 @@ export type { LoopDetectionResult, LoopDetectorOptions } from './incident/LoopDe
 export type { InterruptSignal } from './incident/InterruptEmitter.js'
 export type { PostMortemOptions } from './incident/PostMortemGenerator.js'
 export type { LangfuseAdapterOptions, FetchFn } from './adapters/langfuse/LangfuseAdapter.js'
-export type { SQLiteAdapterOptions } from './adapters/sqlite/SQLiteAdapter.js'
+export type { SQLiteAdapterOptions, SQLiteLockRetryDiagnostic } from './adapters/sqlite/SQLiteAdapter.js'
 export type { PrometheusAdapterOptions } from './adapters/prometheus/PrometheusAdapter.js'
 export type { TempoAdapterOptions, TempoBasicAuth } from './adapters/tempo/TempoAdapter.js'
 export type {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -4,6 +4,7 @@
 - When adding async retries around sync SQLite adapters, serialize all mutating operations that can overlap through one write queue; otherwise a sleeping retry can be overtaken by later flush/delete calls and reintroduce stale rows.
 - Capture mutable trace/span payloads before enqueueing delayed SQLite writes, and include statement preparation inside the retry wrapper so schema/contention locks during `prepare()` get the same diagnostics as transaction failures.
 - Validate retry/backoff options before opening a native SQLite handle; constructor validation failures should not leak a handle that can keep the database locked.
+- Retry initialization pragmas/schema creation too, make diagnostic callbacks best-effort, and defer `close()` until pending queued writes settle so shutdown cannot race an async write tail.
 
 ## 2026-07-16 — Queue priority aging
 - For issue scheduler aging, score only eligible work with age boosts; blocked/HITL work should carry a large safety penalty and zero age boost so stale unsafe cards never bypass human/dependency gates. Include priority rank, effective rank, age, blocker status, risk lane, freshness, and an explanation string in liveness/fairness output.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,10 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-16 — SQLite lock retry review fixes
+- When adding async retries around sync SQLite adapters, serialize all mutating operations that can overlap through one write queue; otherwise a sleeping retry can be overtaken by later flush/delete calls and reintroduce stale rows.
+- Capture mutable trace/span payloads before enqueueing delayed SQLite writes, and include statement preparation inside the retry wrapper so schema/contention locks during `prepare()` get the same diagnostics as transaction failures.
+- Validate retry/backoff options before opening a native SQLite handle; constructor validation failures should not leak a handle that can keep the database locked.
+
 ## 2026-07-16 — Dead-letter queue Codex closeout
 - DLQ/DR restore output redaction must cover provider token literals (for example `sk-*`, `xox*`) and credentialed database URLs even when they appear inside free-text fields such as `target`, `lastError`, or nested payload strings; test fixtures should prove output does not leak the original secret substrings.
 - For DLQ file locks, treat unparseable lock timestamps as malformed stale-lock candidates and fall back to mtime-based reaping; otherwise a syntactically valid lock JSON with `acquiredAt: not-a-date` can wedge writers forever.


### PR DESCRIPTION
## Summary
- add bounded SQLite busy/locked retry handling to the observer SQLite adapter
- retain busy_timeout configuration while adding configurable backoff, jitter, and retry diagnostics
- cover transient lock recovery and persistent lock exhaustion diagnostics in targeted tests

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm --prefix packages/franken-observer test -- src/adapters/sqlite/SQLiteAdapter.test.ts
- npm --prefix packages/franken-observer run typecheck
- npm --prefix packages/franken-observer run lint -- src/adapters/sqlite/SQLiteAdapter.ts src/adapters/sqlite/SQLiteAdapter.test.ts
- npm --prefix packages/franken-observer run build

Closes #1713