### PR TITLE
fix(orchestrator): reconcile beast queue on restart

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -11,6 +11,7 @@ import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './services/beast-catalog-service.js';
 import { BeastDispatchService } from './services/beast-dispatch-service.js';
 import { assertDispatcherStartupIntegrity } from './services/dispatcher-startup-integrity.js';
+import { reconcileDispatcherQueueAfterRestart } from './services/dispatcher-queue-reconciliation.js';
 import { BeastInterviewService } from './services/beast-interview-service.js';
 import { AgentService } from './services/agent-service.js';
 import { CapacityReservationPolicy, type CapacityReservationRule } from './services/capacity-reservation-policy.js';
@@ -84,6 +85,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     definitions: catalog.listDefinitions(),
     executors,
   });
+  reconcileDispatcherQueueAfterRestart(repository);
 
   runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy });
 

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -47,13 +47,6 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const ticketStore = new SseConnectionTicketStore();
   const capacityPolicy = createCapacityReservationPolicyFromEnv();
 
-  cleanupAbandonedBeastWorktrees({
-    agents: repository.listTrackedAgents(),
-    dryRun: false,
-    projectRoot,
-    runs: repository.listRuns(),
-  });
-
   // Deferred reference to break circular dep: executor → runService → executors → executor
   // eslint-disable-next-line prefer-const
   let runService: BeastRunService;
@@ -86,6 +79,12 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     executors,
   });
   reconcileDispatcherQueueAfterRestart(repository);
+  cleanupAbandonedBeastWorktrees({
+    agents: repository.listTrackedAgents(),
+    dryRun: false,
+    projectRoot,
+    runs: repository.listRuns(),
+  });
 
   runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy });
 

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -97,6 +97,7 @@ export function reconcileDispatcherQueueAfterRestart(
         getProcessStartTimeTicks,
         isProcessGroupAlive,
       );
+      if (!finding) continue;
       findings.push(finding);
       if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
         changedRuns += 1;
@@ -121,7 +122,7 @@ function reconcileActiveRun(
   isPidAlive: (pid: number) => boolean,
   getProcessStartTimeTicks: (pid: number) => string | undefined,
   isProcessGroupAlive: (pid: number) => boolean,
-): DispatcherQueueReconciliationFinding {
+): DispatcherQueueReconciliationFinding | undefined {
   if (attempt && TERMINAL_RUN_STATUSES.has(attempt.status)) {
     const restoredRun = repository.updateRun(run.id, {
       status: attempt.status,
@@ -145,7 +146,9 @@ function reconcileActiveRun(
   }
 
   if (run.status === 'pending_approval') {
-    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'awaiting_approval', reconciledAt);
+    if (!syncTrackedAgentIfRunOwnsDispatch(repository, run, 'awaiting_approval', reconciledAt)) {
+      return undefined;
+    }
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'pending-approval-restored',
       runId: run.id,
@@ -161,7 +164,9 @@ function reconcileActiveRun(
   }
 
   if (run.status === 'queued' || run.status === 'interviewing') {
-    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'dispatching', reconciledAt);
+    if (!syncTrackedAgentIfRunOwnsDispatch(repository, run, 'dispatching', reconciledAt)) {
+      return undefined;
+    }
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'queued-run-restored',
       runId: run.id,
@@ -181,6 +186,7 @@ function reconcileActiveRun(
       status: 'failed',
       finishedAt: reconciledAt,
       currentAttemptId: null,
+      latestExitCode: null,
       stopReason: 'dispatcher_restart_missing_attempt',
     });
     syncTrackedAgentIfRunOwnsDispatch(repository, failedRun, 'failed', reconciledAt);
@@ -406,10 +412,17 @@ function attemptOwnsLiveProcess(
 ): boolean {
   const pid = attempt.pid;
   if (typeof pid !== 'number' || pid <= 0) return false;
-  if (attempt.executorMetadata?.processGroupOwned !== true) return false;
-  if (attempt.executorMetadata?.processGroupLeaderPid !== pid) return false;
-  const expectedStartTime = attempt.executorMetadata?.processStartTimeTicks;
-  if (typeof expectedStartTime !== 'string' || expectedStartTime.length === 0) return false;
+  const metadata = attempt.executorMetadata;
+  const hasOwnershipMetadata = metadata?.processGroupOwned !== undefined
+    || metadata?.processGroupLeaderPid !== undefined
+    || metadata?.processStartTimeTicks !== undefined;
+  if (metadata?.processGroupOwned !== true || metadata?.processGroupLeaderPid !== pid) {
+    return !hasOwnershipMetadata && isPidAlive(pid);
+  }
+  const expectedStartTime = metadata.processStartTimeTicks;
+  if (typeof expectedStartTime !== 'string' || expectedStartTime.length === 0) {
+    return isPidAlive(pid);
+  }
   if (isPidAlive(pid)) {
     return getProcessStartTimeTicks(pid) === expectedStartTime;
   }

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -1,0 +1,321 @@
+import type { BeastRun, BeastRunAttempt, BeastRunStatus, TrackedAgentStatus } from '../types.js';
+import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
+import { isoNow } from '@franken/types';
+
+export type DispatcherQueueReconciliationCode =
+  | 'queued-run-restored'
+  | 'live-running-attempt-restored'
+  | 'stale-running-attempt-failed'
+  | 'missing-running-attempt-failed'
+  | 'pending-approval-restored'
+  | 'terminal-run-restored'
+  | 'duplicate-live-agent-run';
+
+export interface DispatcherQueueReconciliationFinding {
+  readonly code: DispatcherQueueReconciliationCode;
+  readonly runId: string;
+  readonly trackedAgentId?: string | undefined;
+  readonly attemptId?: string | undefined;
+  readonly pid?: number | undefined;
+  readonly fromStatus: BeastRunStatus;
+  readonly toStatus: BeastRunStatus;
+  readonly message: string;
+}
+
+export interface DispatcherQueueReconciliationReport {
+  readonly checkedRuns: number;
+  readonly findings: readonly DispatcherQueueReconciliationFinding[];
+  readonly changedRuns: number;
+  readonly duplicateLiveAgentRunCount: number;
+  readonly reconciledAt: string;
+}
+
+export interface DispatcherQueueReconciliationOptions {
+  readonly now?: () => string;
+  readonly isPidAlive?: (pid: number) => boolean;
+}
+
+const ACTIVE_RUN_STATUSES = new Set<BeastRunStatus>(['queued', 'interviewing', 'running', 'pending_approval']);
+const TERMINAL_RUN_STATUSES = new Set<BeastRunStatus>(['completed', 'failed', 'stopped']);
+
+export function reconcileDispatcherQueueAfterRestart(
+  repository: SQLiteBeastRepository,
+  options: DispatcherQueueReconciliationOptions = {},
+): DispatcherQueueReconciliationReport {
+  const now = options.now ?? isoNow;
+  const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+  const reconciledAt = now();
+  const findings: DispatcherQueueReconciliationFinding[] = [];
+  let changedRuns = 0;
+
+  repository.transaction(() => {
+    for (const run of repository.listRuns()) {
+      if (TERMINAL_RUN_STATUSES.has(run.status)) {
+        findings.push(reconcileTerminalRun(repository, run, reconciledAt));
+        continue;
+      }
+
+      if (!ACTIVE_RUN_STATUSES.has(run.status)) {
+        continue;
+      }
+
+      const currentAttempt = run.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
+      const finding = reconcileActiveRun(repository, run, currentAttempt, reconciledAt, isPidAlive);
+      findings.push(finding);
+      if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
+        changedRuns += 1;
+      }
+    }
+
+    const duplicates = detectDuplicateLiveAgentRuns(repository, isPidAlive);
+    for (const duplicate of duplicates) {
+      findings.push(duplicate);
+      repository.appendEvent(duplicate.runId, {
+        attemptId: duplicate.attemptId,
+        type: 'run.reconciliation.duplicate_live_agent_run',
+        payload: {
+          code: duplicate.code,
+          trackedAgentId: duplicate.trackedAgentId,
+          pid: duplicate.pid,
+          message: duplicate.message,
+        },
+        createdAt: reconciledAt,
+      });
+    }
+  });
+
+  return {
+    checkedRuns: repository.listRuns().length,
+    findings,
+    changedRuns,
+    duplicateLiveAgentRunCount: findings.filter((finding) => finding.code === 'duplicate-live-agent-run').length,
+    reconciledAt,
+  };
+}
+
+function reconcileActiveRun(
+  repository: SQLiteBeastRepository,
+  run: BeastRun,
+  attempt: BeastRunAttempt | undefined,
+  reconciledAt: string,
+  isPidAlive: (pid: number) => boolean,
+): DispatcherQueueReconciliationFinding {
+  if (run.status === 'pending_approval') {
+    syncTrackedAgent(repository, run, 'awaiting_approval', reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'pending-approval-restored',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      attemptId: attempt?.id,
+      pid: attempt?.pid,
+      fromStatus: run.status,
+      toStatus: run.status,
+      message: `Run ${run.id} remains pending approval after dispatcher restart; no worker process is assumed live.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
+  if (run.status === 'queued' || run.status === 'interviewing') {
+    syncTrackedAgent(repository, run, 'dispatching', reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'queued-run-restored',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      attemptId: attempt?.id,
+      pid: attempt?.pid,
+      fromStatus: run.status,
+      toStatus: run.status,
+      message: `Run ${run.id} remains ${run.status} after dispatcher restart and is eligible for normal dispatch handling.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
+  if (!attempt) {
+    const failedRun = repository.updateRun(run.id, {
+      status: 'failed',
+      finishedAt: reconciledAt,
+      currentAttemptId: null,
+      stopReason: 'dispatcher_restart_missing_attempt',
+    });
+    syncTrackedAgent(repository, failedRun, 'failed', reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'missing-running-attempt-failed',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      fromStatus: run.status,
+      toStatus: 'failed',
+      message: `Run ${run.id} was running but had no current attempt after dispatcher restart; marked failed for retry instead of assuming in-memory state.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
+  const pid = attempt.pid;
+  if (typeof pid === 'number' && pid > 0 && isPidAlive(pid)) {
+    syncTrackedAgent(repository, run, 'running', reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'live-running-attempt-restored',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      attemptId: attempt.id,
+      pid,
+      fromStatus: run.status,
+      toStatus: run.status,
+      message: `Run ${run.id} has a live recorded worker PID ${pid} after dispatcher restart.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
+  const failedAttempt = repository.updateAttempt(attempt.id, {
+    status: 'failed',
+    finishedAt: reconciledAt,
+    stopReason: typeof pid === 'number' && pid > 0
+      ? 'dispatcher_restart_stale_pid'
+      : 'dispatcher_restart_missing_pid',
+  });
+  const failedRun = repository.updateRun(run.id, {
+    status: 'failed',
+    finishedAt: reconciledAt,
+    latestExitCode: null,
+    stopReason: failedAttempt.stopReason,
+  });
+  syncTrackedAgent(repository, failedRun, 'failed', reconciledAt);
+  const finding: DispatcherQueueReconciliationFinding = {
+    code: typeof pid === 'number' && pid > 0 ? 'stale-running-attempt-failed' : 'missing-running-attempt-failed',
+    runId: run.id,
+    trackedAgentId: run.trackedAgentId,
+    attemptId: attempt.id,
+    pid,
+    fromStatus: run.status,
+    toStatus: 'failed',
+    message: typeof pid === 'number' && pid > 0
+      ? `Run ${run.id} recorded PID ${pid}, but it is not live after dispatcher restart; marked failed for retry.`
+      : `Run ${run.id} was running with no positive PID after dispatcher restart; marked failed for retry.`,
+  };
+  appendReconciliationEvent(repository, finding, reconciledAt);
+  return finding;
+}
+
+function reconcileTerminalRun(
+  repository: SQLiteBeastRepository,
+  run: BeastRun,
+  reconciledAt: string,
+): DispatcherQueueReconciliationFinding {
+  syncTrackedAgent(repository, run, trackedAgentStatusForRun(run.status), reconciledAt);
+  const finding: DispatcherQueueReconciliationFinding = {
+    code: 'terminal-run-restored',
+    runId: run.id,
+    trackedAgentId: run.trackedAgentId,
+    attemptId: run.currentAttemptId,
+    fromStatus: run.status,
+    toStatus: run.status,
+    message: `Run ${run.id} is terminal (${run.status}) after dispatcher restart; terminal state preserved.`,
+  };
+  appendReconciliationEvent(repository, finding, reconciledAt);
+  return finding;
+}
+
+function detectDuplicateLiveAgentRuns(
+  repository: SQLiteBeastRepository,
+  isPidAlive: (pid: number) => boolean,
+): DispatcherQueueReconciliationFinding[] {
+  const liveRunsByAgent = new Map<string, Array<{ run: BeastRun; attempt: BeastRunAttempt; pid: number }>>();
+  for (const run of repository.listRuns()) {
+    if (!run.trackedAgentId || run.status !== 'running' || !run.currentAttemptId) continue;
+    const attempt = repository.getAttempt(run.currentAttemptId);
+    const pid = attempt?.pid;
+    if (!attempt || typeof pid !== 'number' || pid <= 0 || !isPidAlive(pid)) continue;
+    const existing = liveRunsByAgent.get(run.trackedAgentId) ?? [];
+    existing.push({ run, attempt, pid });
+    liveRunsByAgent.set(run.trackedAgentId, existing);
+  }
+
+  return [...liveRunsByAgent.entries()].flatMap(([trackedAgentId, entries]) => {
+    if (entries.length <= 1) return [];
+    const runIds = entries.map(entry => entry.run.id);
+    return entries.map(({ run, attempt, pid }) => ({
+      code: 'duplicate-live-agent-run' as const,
+      runId: run.id,
+      trackedAgentId,
+      attemptId: attempt.id,
+      pid,
+      fromStatus: run.status,
+      toStatus: run.status,
+      message: `Tracked agent ${trackedAgentId} has duplicate live running runs after dispatcher restart: ${runIds.join(', ')}.`,
+    }));
+  });
+}
+
+function syncTrackedAgent(
+  repository: SQLiteBeastRepository,
+  run: BeastRun,
+  status: TrackedAgentStatus,
+  updatedAt: string,
+): void {
+  if (!run.trackedAgentId) return;
+  const agent = repository.getTrackedAgent(run.trackedAgentId);
+  if (!agent || agent.status === 'deleted') return;
+  if (agent.status === status && agent.dispatchRunId === run.id) return;
+  repository.updateTrackedAgent(run.trackedAgentId, {
+    status,
+    dispatchRunId: run.id,
+    updatedAt,
+  });
+  repository.appendTrackedAgentEvent(run.trackedAgentId, {
+    level: status === 'failed' ? 'error' : 'info',
+    type: 'agent.dispatch.reconciled',
+    message: `Dispatcher restart reconciled agent ${run.trackedAgentId} to ${status}`,
+    payload: { runId: run.id, status },
+    createdAt: updatedAt,
+  });
+}
+
+function appendReconciliationEvent(
+  repository: SQLiteBeastRepository,
+  finding: DispatcherQueueReconciliationFinding,
+  createdAt: string,
+): void {
+  repository.appendEvent(finding.runId, {
+    attemptId: finding.attemptId,
+    type: 'run.reconciliation.dispatcher_restart',
+    payload: {
+      code: finding.code,
+      fromStatus: finding.fromStatus,
+      toStatus: finding.toStatus,
+      trackedAgentId: finding.trackedAgentId,
+      pid: finding.pid,
+      message: finding.message,
+    },
+    createdAt,
+  });
+}
+
+function trackedAgentStatusForRun(status: BeastRunStatus): TrackedAgentStatus {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'pending_approval':
+      return 'awaiting_approval';
+    case 'completed':
+      return 'completed';
+    case 'failed':
+      return 'failed';
+    case 'queued':
+    case 'interviewing':
+      return 'dispatching';
+    case 'stopped':
+      return 'stopped';
+  }
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -4,7 +4,7 @@ import { isoNow } from '@franken/types';
 
 export type DispatcherQueueReconciliationCode =
   | 'queued-run-restored'
-  | 'live-running-attempt-restored'
+  | 'terminal-attempt-restored'
   | 'stale-running-attempt-failed'
   | 'missing-running-attempt-failed'
   | 'pending-approval-restored'
@@ -152,29 +152,37 @@ function reconcileActiveRun(
     return finding;
   }
 
-  const pid = attempt.pid;
-  if (typeof pid === 'number' && pid > 0 && isPidAlive(pid)) {
-    syncTrackedAgent(repository, run, 'running', reconciledAt);
+  if (TERMINAL_RUN_STATUSES.has(attempt.status)) {
+    const restoredRun = repository.updateRun(run.id, {
+      status: attempt.status,
+      finishedAt: attempt.finishedAt ?? reconciledAt,
+      latestExitCode: attempt.exitCode ?? null,
+      stopReason: attempt.stopReason ?? null,
+    });
+    syncTrackedAgent(repository, restoredRun, trackedAgentStatusForRun(attempt.status), reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
-      code: 'live-running-attempt-restored',
+      code: 'terminal-attempt-restored',
       runId: run.id,
       trackedAgentId: run.trackedAgentId,
       attemptId: attempt.id,
-      pid,
+      pid: attempt.pid,
       fromStatus: run.status,
-      toStatus: run.status,
-      message: `Run ${run.id} has a live recorded worker PID ${pid} after dispatcher restart.`,
+      toStatus: attempt.status,
+      message: `Run ${run.id} was running but its current attempt was already ${attempt.status}; restored the persisted terminal attempt result.`,
     };
     appendReconciliationEvent(repository, finding, reconciledAt);
     return finding;
   }
 
+  const pid = attempt.pid;
   const failedAttempt = repository.updateAttempt(attempt.id, {
     status: 'failed',
     finishedAt: reconciledAt,
-    stopReason: typeof pid === 'number' && pid > 0
-      ? 'dispatcher_restart_stale_pid'
-      : 'dispatcher_restart_missing_pid',
+    stopReason: typeof pid === 'number' && pid > 0 && isPidAlive(pid)
+      ? 'dispatcher_restart_unattached_pid'
+      : typeof pid === 'number' && pid > 0
+        ? 'dispatcher_restart_stale_pid'
+        : 'dispatcher_restart_missing_pid',
   });
   const failedRun = repository.updateRun(run.id, {
     status: 'failed',
@@ -192,7 +200,7 @@ function reconcileActiveRun(
     fromStatus: run.status,
     toStatus: 'failed',
     message: typeof pid === 'number' && pid > 0
-      ? `Run ${run.id} recorded PID ${pid}, but it is not live after dispatcher restart; marked failed for retry.`
+      ? `Run ${run.id} recorded PID ${pid}, but the restarted dispatcher cannot reattach exit handling safely; marked failed for retry.`
       : `Run ${run.id} was running with no positive PID after dispatcher restart; marked failed for retry.`,
   };
   appendReconciliationEvent(repository, finding, reconciledAt);
@@ -204,7 +212,10 @@ function reconcileTerminalRun(
   run: BeastRun,
   reconciledAt: string,
 ): DispatcherQueueReconciliationFinding {
-  syncTrackedAgent(repository, run, trackedAgentStatusForRun(run.status), reconciledAt);
+  const trackedAgent = run.trackedAgentId ? repository.getTrackedAgent(run.trackedAgentId) : undefined;
+  if (!trackedAgent?.dispatchRunId || trackedAgent.dispatchRunId === run.id) {
+    syncTrackedAgent(repository, run, trackedAgentStatusForRun(run.status), reconciledAt);
+  }
   const finding: DispatcherQueueReconciliationFinding = {
     code: 'terminal-run-restored',
     runId: run.id,

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import type { BeastRun, BeastRunAttempt, BeastRunStatus, TrackedAgentStatus } from '../types.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import { isoNow } from '@franken/types';
@@ -34,6 +35,7 @@ export interface DispatcherQueueReconciliationReport {
 export interface DispatcherQueueReconciliationOptions {
   readonly now?: () => string;
   readonly isPidAlive?: (pid: number) => boolean;
+  readonly getProcessStartTimeTicks?: (pid: number) => string | undefined;
 }
 
 const ACTIVE_RUN_STATUSES = new Set<BeastRunStatus>(['queued', 'interviewing', 'running', 'pending_approval']);
@@ -45,12 +47,13 @@ export function reconcileDispatcherQueueAfterRestart(
 ): DispatcherQueueReconciliationReport {
   const now = options.now ?? isoNow;
   const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+  const getProcessStartTimeTicks = options.getProcessStartTimeTicks ?? defaultProcessStartTimeTicks;
   const reconciledAt = now();
   const findings: DispatcherQueueReconciliationFinding[] = [];
   let changedRuns = 0;
 
   repository.transaction(() => {
-    const duplicates = detectDuplicateLiveAgentRuns(repository, isPidAlive);
+    const duplicates = detectDuplicateLiveAgentRuns(repository, isPidAlive, getProcessStartTimeTicks);
     for (const duplicate of duplicates) {
       findings.push(duplicate);
       repository.appendEvent(duplicate.runId, {
@@ -78,7 +81,14 @@ export function reconcileDispatcherQueueAfterRestart(
       }
 
       const currentAttempt = run.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
-      const finding = reconcileActiveRun(repository, run, currentAttempt, reconciledAt, isPidAlive);
+      const finding = reconcileActiveRun(
+        repository,
+        run,
+        currentAttempt,
+        reconciledAt,
+        isPidAlive,
+        getProcessStartTimeTicks,
+      );
       findings.push(finding);
       if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
         changedRuns += 1;
@@ -101,6 +111,7 @@ function reconcileActiveRun(
   attempt: BeastRunAttempt | undefined,
   reconciledAt: string,
   isPidAlive: (pid: number) => boolean,
+  getProcessStartTimeTicks: (pid: number) => string | undefined,
 ): DispatcherQueueReconciliationFinding {
   if (run.status === 'pending_approval') {
     syncTrackedAgentIfRunOwnsDispatch(repository, run, 'awaiting_approval', reconciledAt);
@@ -177,7 +188,7 @@ function reconcileActiveRun(
   }
 
   const pid = attempt.pid;
-  if (typeof pid === 'number' && pid > 0 && isPidAlive(pid)) {
+  if (attemptOwnsLiveProcess(attempt, isPidAlive, getProcessStartTimeTicks)) {
     syncTrackedAgentIfRunOwnsDispatch(repository, run, 'running', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'live-running-attempt-quarantined',
@@ -247,13 +258,14 @@ function reconcileTerminalRun(
 function detectDuplicateLiveAgentRuns(
   repository: SQLiteBeastRepository,
   isPidAlive: (pid: number) => boolean,
+  getProcessStartTimeTicks: (pid: number) => string | undefined,
 ): DispatcherQueueReconciliationFinding[] {
   const liveRunsByAgent = new Map<string, Array<{ run: BeastRun; attempt: BeastRunAttempt; pid: number }>>();
   for (const run of repository.listRuns()) {
     if (!run.trackedAgentId || run.status !== 'running' || !run.currentAttemptId) continue;
     const attempt = repository.getAttempt(run.currentAttemptId);
     const pid = attempt?.pid;
-    if (!attempt || typeof pid !== 'number' || pid <= 0 || !isPidAlive(pid)) continue;
+    if (!attempt || typeof pid !== 'number' || pid <= 0 || !attemptOwnsLiveProcess(attempt, isPidAlive, getProcessStartTimeTicks)) continue;
     const existing = liveRunsByAgent.get(run.trackedAgentId) ?? [];
     existing.push({ run, attempt, pid });
     liveRunsByAgent.set(run.trackedAgentId, existing);
@@ -350,6 +362,33 @@ function trackedAgentStatusForRun(status: BeastRunStatus): TrackedAgentStatus {
     case 'stopped':
       return 'stopped';
   }
+}
+
+function defaultProcessStartTimeTicks(pid: number): string | undefined {
+  if (pid <= 0 || process.platform !== 'linux') return undefined;
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const endOfCommand = stat.lastIndexOf(')');
+    if (endOfCommand < 0) return undefined;
+    const fieldsFromState = stat.slice(endOfCommand + 2).trim().split(/\s+/);
+    return fieldsFromState[19];
+  } catch {
+    return undefined;
+  }
+}
+
+function attemptOwnsLiveProcess(
+  attempt: BeastRunAttempt,
+  isPidAlive: (pid: number) => boolean,
+  getProcessStartTimeTicks: (pid: number) => string | undefined,
+): boolean {
+  const pid = attempt.pid;
+  if (typeof pid !== 'number' || pid <= 0 || !isPidAlive(pid)) return false;
+  if (attempt.executorMetadata?.processGroupOwned !== true) return false;
+  if (attempt.executorMetadata?.processGroupLeaderPid !== pid) return false;
+  const expectedStartTime = attempt.executorMetadata?.processStartTimeTicks;
+  if (typeof expectedStartTime !== 'string' || expectedStartTime.length === 0) return false;
+  return getProcessStartTimeTicks(pid) === expectedStartTime;
 }
 
 function defaultIsPidAlive(pid: number): boolean {

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -4,6 +4,7 @@ import { isoNow } from '@franken/types';
 
 export type DispatcherQueueReconciliationCode =
   | 'queued-run-restored'
+  | 'live-running-attempt-quarantined'
   | 'terminal-attempt-restored'
   | 'stale-running-attempt-failed'
   | 'missing-running-attempt-failed'
@@ -49,24 +50,6 @@ export function reconcileDispatcherQueueAfterRestart(
   let changedRuns = 0;
 
   repository.transaction(() => {
-    for (const run of repository.listRuns()) {
-      if (TERMINAL_RUN_STATUSES.has(run.status)) {
-        findings.push(reconcileTerminalRun(repository, run, reconciledAt));
-        continue;
-      }
-
-      if (!ACTIVE_RUN_STATUSES.has(run.status)) {
-        continue;
-      }
-
-      const currentAttempt = run.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
-      const finding = reconcileActiveRun(repository, run, currentAttempt, reconciledAt, isPidAlive);
-      findings.push(finding);
-      if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
-        changedRuns += 1;
-      }
-    }
-
     const duplicates = detectDuplicateLiveAgentRuns(repository, isPidAlive);
     for (const duplicate of duplicates) {
       findings.push(duplicate);
@@ -81,6 +64,25 @@ export function reconcileDispatcherQueueAfterRestart(
         },
         createdAt: reconciledAt,
       });
+    }
+
+    for (const run of repository.listRuns()) {
+      if (TERMINAL_RUN_STATUSES.has(run.status)) {
+        const finding = reconcileTerminalRun(repository, run, reconciledAt);
+        if (finding) findings.push(finding);
+        continue;
+      }
+
+      if (!ACTIVE_RUN_STATUSES.has(run.status)) {
+        continue;
+      }
+
+      const currentAttempt = run.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
+      const finding = reconcileActiveRun(repository, run, currentAttempt, reconciledAt, isPidAlive);
+      findings.push(finding);
+      if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
+        changedRuns += 1;
+      }
     }
   });
 
@@ -101,7 +103,7 @@ function reconcileActiveRun(
   isPidAlive: (pid: number) => boolean,
 ): DispatcherQueueReconciliationFinding {
   if (run.status === 'pending_approval') {
-    syncTrackedAgent(repository, run, 'awaiting_approval', reconciledAt);
+    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'awaiting_approval', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'pending-approval-restored',
       runId: run.id,
@@ -117,7 +119,7 @@ function reconcileActiveRun(
   }
 
   if (run.status === 'queued' || run.status === 'interviewing') {
-    syncTrackedAgent(repository, run, 'dispatching', reconciledAt);
+    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'dispatching', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'queued-run-restored',
       runId: run.id,
@@ -139,7 +141,7 @@ function reconcileActiveRun(
       currentAttemptId: null,
       stopReason: 'dispatcher_restart_missing_attempt',
     });
-    syncTrackedAgent(repository, failedRun, 'failed', reconciledAt);
+    syncTrackedAgentIfRunOwnsDispatch(repository, failedRun, 'failed', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'missing-running-attempt-failed',
       runId: run.id,
@@ -159,7 +161,7 @@ function reconcileActiveRun(
       latestExitCode: attempt.exitCode ?? null,
       stopReason: attempt.stopReason ?? null,
     });
-    syncTrackedAgent(repository, restoredRun, trackedAgentStatusForRun(attempt.status), reconciledAt);
+    syncTrackedAgentIfRunOwnsDispatch(repository, restoredRun, trackedAgentStatusForRun(attempt.status), reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'terminal-attempt-restored',
       runId: run.id,
@@ -175,14 +177,28 @@ function reconcileActiveRun(
   }
 
   const pid = attempt.pid;
+  if (typeof pid === 'number' && pid > 0 && isPidAlive(pid)) {
+    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'running', reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'live-running-attempt-quarantined',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      attemptId: attempt.id,
+      pid,
+      fromStatus: run.status,
+      toStatus: run.status,
+      message: `Run ${run.id} recorded live PID ${pid} after dispatcher restart; preserved it as non-startable running state for operator reconciliation.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
   const failedAttempt = repository.updateAttempt(attempt.id, {
     status: 'failed',
     finishedAt: reconciledAt,
-    stopReason: typeof pid === 'number' && pid > 0 && isPidAlive(pid)
-      ? 'dispatcher_restart_unattached_pid'
-      : typeof pid === 'number' && pid > 0
-        ? 'dispatcher_restart_stale_pid'
-        : 'dispatcher_restart_missing_pid',
+    stopReason: typeof pid === 'number' && pid > 0
+      ? 'dispatcher_restart_stale_pid'
+      : 'dispatcher_restart_missing_pid',
   });
   const failedRun = repository.updateRun(run.id, {
     status: 'failed',
@@ -190,7 +206,7 @@ function reconcileActiveRun(
     latestExitCode: null,
     stopReason: failedAttempt.stopReason,
   });
-  syncTrackedAgent(repository, failedRun, 'failed', reconciledAt);
+  syncTrackedAgentIfRunOwnsDispatch(repository, failedRun, 'failed', reconciledAt);
   const finding: DispatcherQueueReconciliationFinding = {
     code: typeof pid === 'number' && pid > 0 ? 'stale-running-attempt-failed' : 'missing-running-attempt-failed',
     runId: run.id,
@@ -211,10 +227,9 @@ function reconcileTerminalRun(
   repository: SQLiteBeastRepository,
   run: BeastRun,
   reconciledAt: string,
-): DispatcherQueueReconciliationFinding {
-  const trackedAgent = run.trackedAgentId ? repository.getTrackedAgent(run.trackedAgentId) : undefined;
-  if (!trackedAgent?.dispatchRunId || trackedAgent.dispatchRunId === run.id) {
-    syncTrackedAgent(repository, run, trackedAgentStatusForRun(run.status), reconciledAt);
+): DispatcherQueueReconciliationFinding | undefined {
+  if (!syncTrackedAgentIfRunOwnsDispatch(repository, run, trackedAgentStatusForRun(run.status), reconciledAt)) {
+    return undefined;
   }
   const finding: DispatcherQueueReconciliationFinding = {
     code: 'terminal-run-restored',
@@ -223,7 +238,7 @@ function reconcileTerminalRun(
     attemptId: run.currentAttemptId,
     fromStatus: run.status,
     toStatus: run.status,
-    message: `Run ${run.id} is terminal (${run.status}) after dispatcher restart; terminal state preserved.`,
+    message: `Run ${run.id} is terminal (${run.status}) after dispatcher restart; repaired tracked agent linkage.`,
   };
   appendReconciliationEvent(repository, finding, reconciledAt);
   return finding;
@@ -258,6 +273,21 @@ function detectDuplicateLiveAgentRuns(
       message: `Tracked agent ${trackedAgentId} has duplicate live running runs after dispatcher restart: ${runIds.join(', ')}.`,
     }));
   });
+}
+
+function syncTrackedAgentIfRunOwnsDispatch(
+  repository: SQLiteBeastRepository,
+  run: BeastRun,
+  status: TrackedAgentStatus,
+  updatedAt: string,
+): boolean {
+  if (!run.trackedAgentId) return false;
+  const agent = repository.getTrackedAgent(run.trackedAgentId);
+  if (!agent || agent.status === 'deleted') return false;
+  if (agent.dispatchRunId && agent.dispatchRunId !== run.id) return false;
+  if (agent.status === status && agent.dispatchRunId === run.id) return false;
+  syncTrackedAgent(repository, run, status, updatedAt);
+  return true;
 }
 
 function syncTrackedAgent(

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -36,6 +36,7 @@ export interface DispatcherQueueReconciliationOptions {
   readonly now?: () => string;
   readonly isPidAlive?: (pid: number) => boolean;
   readonly getProcessStartTimeTicks?: (pid: number) => string | undefined;
+  readonly isProcessGroupAlive?: (pid: number) => boolean;
 }
 
 const ACTIVE_RUN_STATUSES = new Set<BeastRunStatus>(['queued', 'interviewing', 'running', 'pending_approval']);
@@ -48,12 +49,18 @@ export function reconcileDispatcherQueueAfterRestart(
   const now = options.now ?? isoNow;
   const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
   const getProcessStartTimeTicks = options.getProcessStartTimeTicks ?? defaultProcessStartTimeTicks;
+  const isProcessGroupAlive = options.isProcessGroupAlive ?? defaultIsProcessGroupAlive;
   const reconciledAt = now();
   const findings: DispatcherQueueReconciliationFinding[] = [];
   let changedRuns = 0;
 
   repository.transaction(() => {
-    const duplicates = detectDuplicateLiveAgentRuns(repository, isPidAlive, getProcessStartTimeTicks);
+    const duplicates = detectDuplicateLiveAgentRuns(
+      repository,
+      isPidAlive,
+      getProcessStartTimeTicks,
+      isProcessGroupAlive,
+    );
     for (const duplicate of duplicates) {
       findings.push(duplicate);
       repository.appendEvent(duplicate.runId, {
@@ -88,6 +95,7 @@ export function reconcileDispatcherQueueAfterRestart(
         reconciledAt,
         isPidAlive,
         getProcessStartTimeTicks,
+        isProcessGroupAlive,
       );
       findings.push(finding);
       if (finding.fromStatus !== finding.toStatus || finding.code === 'missing-running-attempt-failed' || finding.code === 'stale-running-attempt-failed') {
@@ -112,7 +120,30 @@ function reconcileActiveRun(
   reconciledAt: string,
   isPidAlive: (pid: number) => boolean,
   getProcessStartTimeTicks: (pid: number) => string | undefined,
+  isProcessGroupAlive: (pid: number) => boolean,
 ): DispatcherQueueReconciliationFinding {
+  if (attempt && TERMINAL_RUN_STATUSES.has(attempt.status)) {
+    const restoredRun = repository.updateRun(run.id, {
+      status: attempt.status,
+      finishedAt: attempt.finishedAt ?? reconciledAt,
+      latestExitCode: attempt.exitCode ?? null,
+      stopReason: attempt.stopReason ?? null,
+    });
+    syncTrackedAgentIfRunOwnsDispatch(repository, restoredRun, trackedAgentStatusForRun(attempt.status), reconciledAt);
+    const finding: DispatcherQueueReconciliationFinding = {
+      code: 'terminal-attempt-restored',
+      runId: run.id,
+      trackedAgentId: run.trackedAgentId,
+      attemptId: attempt.id,
+      pid: attempt.pid,
+      fromStatus: run.status,
+      toStatus: attempt.status,
+      message: `Run ${run.id} was ${run.status} but its current attempt was already ${attempt.status}; restored the persisted terminal attempt result.`,
+    };
+    appendReconciliationEvent(repository, finding, reconciledAt);
+    return finding;
+  }
+
   if (run.status === 'pending_approval') {
     syncTrackedAgentIfRunOwnsDispatch(repository, run, 'awaiting_approval', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
@@ -165,31 +196,15 @@ function reconcileActiveRun(
     return finding;
   }
 
-  if (TERMINAL_RUN_STATUSES.has(attempt.status)) {
-    const restoredRun = repository.updateRun(run.id, {
-      status: attempt.status,
-      finishedAt: attempt.finishedAt ?? reconciledAt,
-      latestExitCode: attempt.exitCode ?? null,
-      stopReason: attempt.stopReason ?? null,
-    });
-    syncTrackedAgentIfRunOwnsDispatch(repository, restoredRun, trackedAgentStatusForRun(attempt.status), reconciledAt);
-    const finding: DispatcherQueueReconciliationFinding = {
-      code: 'terminal-attempt-restored',
-      runId: run.id,
-      trackedAgentId: run.trackedAgentId,
-      attemptId: attempt.id,
-      pid: attempt.pid,
-      fromStatus: run.status,
-      toStatus: attempt.status,
-      message: `Run ${run.id} was running but its current attempt was already ${attempt.status}; restored the persisted terminal attempt result.`,
-    };
-    appendReconciliationEvent(repository, finding, reconciledAt);
-    return finding;
-  }
-
   const pid = attempt.pid;
-  if (attemptOwnsLiveProcess(attempt, isPidAlive, getProcessStartTimeTicks)) {
-    syncTrackedAgentIfRunOwnsDispatch(repository, run, 'running', reconciledAt);
+  if (attemptOwnsLiveProcess(attempt, isPidAlive, getProcessStartTimeTicks, isProcessGroupAlive)) {
+    const liveRun = repository.updateRun(run.id, {
+      status: 'running',
+      finishedAt: null,
+      latestExitCode: null,
+      stopReason: null,
+    });
+    syncTrackedAgentIfRunOwnsDispatch(repository, liveRun, 'running', reconciledAt);
     const finding: DispatcherQueueReconciliationFinding = {
       code: 'live-running-attempt-quarantined',
       runId: run.id,
@@ -259,13 +274,19 @@ function detectDuplicateLiveAgentRuns(
   repository: SQLiteBeastRepository,
   isPidAlive: (pid: number) => boolean,
   getProcessStartTimeTicks: (pid: number) => string | undefined,
+  isProcessGroupAlive: (pid: number) => boolean,
 ): DispatcherQueueReconciliationFinding[] {
   const liveRunsByAgent = new Map<string, Array<{ run: BeastRun; attempt: BeastRunAttempt; pid: number }>>();
   for (const run of repository.listRuns()) {
     if (!run.trackedAgentId || run.status !== 'running' || !run.currentAttemptId) continue;
     const attempt = repository.getAttempt(run.currentAttemptId);
     const pid = attempt?.pid;
-    if (!attempt || typeof pid !== 'number' || pid <= 0 || !attemptOwnsLiveProcess(attempt, isPidAlive, getProcessStartTimeTicks)) continue;
+    if (!attempt || typeof pid !== 'number' || pid <= 0 || !attemptOwnsLiveProcess(
+      attempt,
+      isPidAlive,
+      getProcessStartTimeTicks,
+      isProcessGroupAlive,
+    )) continue;
     const existing = liveRunsByAgent.get(run.trackedAgentId) ?? [];
     existing.push({ run, attempt, pid });
     liveRunsByAgent.set(run.trackedAgentId, existing);
@@ -381,14 +402,28 @@ function attemptOwnsLiveProcess(
   attempt: BeastRunAttempt,
   isPidAlive: (pid: number) => boolean,
   getProcessStartTimeTicks: (pid: number) => string | undefined,
+  isProcessGroupAlive: (pid: number) => boolean,
 ): boolean {
   const pid = attempt.pid;
-  if (typeof pid !== 'number' || pid <= 0 || !isPidAlive(pid)) return false;
+  if (typeof pid !== 'number' || pid <= 0) return false;
   if (attempt.executorMetadata?.processGroupOwned !== true) return false;
   if (attempt.executorMetadata?.processGroupLeaderPid !== pid) return false;
   const expectedStartTime = attempt.executorMetadata?.processStartTimeTicks;
   if (typeof expectedStartTime !== 'string' || expectedStartTime.length === 0) return false;
-  return getProcessStartTimeTicks(pid) === expectedStartTime;
+  if (isPidAlive(pid)) {
+    return getProcessStartTimeTicks(pid) === expectedStartTime;
+  }
+  return isProcessGroupAlive(pid);
+}
+
+function defaultIsProcessGroupAlive(pid: number): boolean {
+  if (pid <= 0 || process.platform === 'win32') return false;
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
 }
 
 function defaultIsPidAlive(pid: number): boolean {

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -35,12 +35,13 @@ describe('dispatcher queue reconciliation after restart', () => {
 
   it('reconciles queued, running, approval, and terminal runs from persisted records', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
-    const repo = createRepo(workDir!);
+    const repo = createRepo(workDir);
     const liveAgent = createAgent(repo, 'live worker');
     const deadAgent = createAgent(repo, 'dead worker');
     const queuedAgent = createAgent(repo, 'queued worker');
     const approvalAgent = createAgent(repo, 'approval worker');
     const completedAgent = createAgent(repo, 'completed worker');
+    const terminalAttemptAgent = createAgent(repo, 'terminal attempt worker');
 
     const liveRun = repo.createRun({
       trackedAgentId: liveAgent.id,
@@ -115,21 +116,51 @@ describe('dispatcher queue reconciliation after restart', () => {
       finishedAt: '2026-03-20T00:03:00.000Z',
     });
 
+    const terminalAttemptRun = repo.createRun({
+      trackedAgentId: terminalAttemptAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'terminal attempt', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:06.000Z',
+    });
+    const terminalAttempt = repo.createAttempt(terminalAttemptRun.id, {
+      status: 'completed',
+      pid: 6262,
+      startedAt: '2026-03-20T00:01:00.000Z',
+    });
+    repo.updateAttempt(terminalAttempt.id, {
+      status: 'completed',
+      finishedAt: '2026-03-20T00:04:00.000Z',
+      exitCode: 0,
+    });
+    repo.updateRun(terminalAttemptRun.id, { status: 'running', finishedAt: null });
+
     const report = reconcileDispatcherQueueAfterRestart(repo, {
       now: () => '2026-03-20T00:05:00.000Z',
       isPidAlive: (pid) => pid === 4242,
     });
 
-    expect(report.checkedRuns).toBe(5);
+    expect(report.checkedRuns).toBe(6);
     expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
-      'live-running-attempt-restored',
       'stale-running-attempt-failed',
       'queued-run-restored',
       'pending-approval-restored',
       'terminal-run-restored',
+      'terminal-attempt-restored',
     ]));
-    expect(repo.getRun(liveRun.id)).toMatchObject({ status: 'running', currentAttemptId: liveAttempt.id });
-    expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'running', dispatchRunId: liveRun.id });
+    expect(repo.getRun(liveRun.id)).toMatchObject({
+      status: 'failed',
+      stopReason: 'dispatcher_restart_unattached_pid',
+      finishedAt: '2026-03-20T00:05:00.000Z',
+    });
+    expect(repo.getAttempt(liveAttempt.id)).toMatchObject({
+      status: 'failed',
+      stopReason: 'dispatcher_restart_unattached_pid',
+    });
+    expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'failed', dispatchRunId: liveRun.id });
 
     expect(repo.getRun(deadRun.id)).toMatchObject({
       status: 'failed',
@@ -147,6 +178,12 @@ describe('dispatcher queue reconciliation after restart', () => {
     expect(repo.getRun(approvalRun.id)).toMatchObject({ status: 'pending_approval' });
     expect(repo.getTrackedAgent(approvalAgent.id)).toMatchObject({ status: 'awaiting_approval', dispatchRunId: approvalRun.id });
     expect(repo.getTrackedAgent(completedAgent.id)).toMatchObject({ status: 'completed', dispatchRunId: completedRun.id });
+    expect(repo.getRun(terminalAttemptRun.id)).toMatchObject({
+      status: 'completed',
+      finishedAt: '2026-03-20T00:04:00.000Z',
+      latestExitCode: 0,
+    });
+    expect(repo.getTrackedAgent(terminalAttemptAgent.id)).toMatchObject({ status: 'completed', dispatchRunId: terminalAttemptRun.id });
 
     expect(repo.listEvents(deadRun.id)).toEqual(expect.arrayContaining([
       expect.objectContaining({
@@ -156,47 +193,49 @@ describe('dispatcher queue reconciliation after restart', () => {
     ]));
   });
 
-  it('reports duplicate live processes for the same tracked agent without blindly killing either worker', async () => {
+  it('does not relink an agent to an older terminal run when a newer run already owns dispatch', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
-    const repo = createRepo(workDir!);
-    const agent = createAgent(repo, 'duplicate worker');
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'replacement worker');
 
-    const runOne = repo.createRun({
+    const oldRun = repo.createRun({
       trackedAgentId: agent.id,
       definitionId: 'martin-loop',
       definitionVersion: 1,
       executionMode: 'process',
-      configSnapshot: { objective: 'first', chunkDirectory: '.' },
+      configSnapshot: { objective: 'old', chunkDirectory: '.' },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'operator',
       createdAt: '2026-03-20T00:00:01.000Z',
     });
-    const attemptOne = repo.createAttempt(runOne.id, { status: 'running', pid: 1111 });
-    const runTwo = repo.createRun({
+    repo.updateRun(oldRun.id, {
+      status: 'completed',
+      finishedAt: '2026-03-20T00:03:00.000Z',
+    });
+    const newRun = repo.createRun({
       trackedAgentId: agent.id,
       definitionId: 'martin-loop',
       definitionVersion: 1,
       executionMode: 'process',
-      configSnapshot: { objective: 'second', chunkDirectory: '.' },
+      configSnapshot: { objective: 'replacement', chunkDirectory: '.' },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'operator',
       createdAt: '2026-03-20T00:00:02.000Z',
     });
-    const attemptTwo = repo.createAttempt(runTwo.id, { status: 'running', pid: 2222 });
+    repo.createAttempt(newRun.id, { status: 'pending_approval' });
 
     const report = reconcileDispatcherQueueAfterRestart(repo, {
       now: () => '2026-03-20T00:05:00.000Z',
-      isPidAlive: (pid) => pid === 1111 || pid === 2222,
+      isPidAlive: () => false,
     });
 
-    expect(report.duplicateLiveAgentRunCount).toBe(2);
-    expect(report.findings.filter(finding => finding.code === 'duplicate-live-agent-run')).toEqual([
-      expect.objectContaining({ runId: runTwo.id, attemptId: attemptTwo.id, pid: 2222 }),
-      expect.objectContaining({ runId: runOne.id, attemptId: attemptOne.id, pid: 1111 }),
-    ]);
-    expect(repo.getRun(runOne.id)).toMatchObject({ status: 'running' });
-    expect(repo.getRun(runTwo.id)).toMatchObject({ status: 'running' });
-    expect(repo.listEvents(runOne.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
-    expect(repo.listEvents(runTwo.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
+    expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
+      'pending-approval-restored',
+      'terminal-run-restored',
+    ]));
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({
+      status: 'awaiting_approval',
+      dispatchRunId: newRun.id,
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -145,22 +145,16 @@ describe('dispatcher queue reconciliation after restart', () => {
 
     expect(report.checkedRuns).toBe(6);
     expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
+      'live-running-attempt-quarantined',
       'stale-running-attempt-failed',
       'queued-run-restored',
       'pending-approval-restored',
       'terminal-run-restored',
       'terminal-attempt-restored',
     ]));
-    expect(repo.getRun(liveRun.id)).toMatchObject({
-      status: 'failed',
-      stopReason: 'dispatcher_restart_unattached_pid',
-      finishedAt: '2026-03-20T00:05:00.000Z',
-    });
-    expect(repo.getAttempt(liveAttempt.id)).toMatchObject({
-      status: 'failed',
-      stopReason: 'dispatcher_restart_unattached_pid',
-    });
-    expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'failed', dispatchRunId: liveRun.id });
+    expect(repo.getRun(liveRun.id)).toMatchObject({ status: 'running', currentAttemptId: liveAttempt.id });
+    expect(repo.getAttempt(liveAttempt.id)).toMatchObject({ status: 'running', pid: 4242 });
+    expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'running', dispatchRunId: liveRun.id });
 
     expect(repo.getRun(deadRun.id)).toMatchObject({
       status: 'failed',
@@ -193,7 +187,7 @@ describe('dispatcher queue reconciliation after restart', () => {
     ]));
   });
 
-  it('does not relink an agent to an older terminal run when a newer run already owns dispatch', async () => {
+  it('does not relink an agent to an older queued run when a newer run already owns dispatch', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
     const repo = createRepo(workDir);
     const agent = createAgent(repo, 'replacement worker');
@@ -207,10 +201,6 @@ describe('dispatcher queue reconciliation after restart', () => {
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'operator',
       createdAt: '2026-03-20T00:00:01.000Z',
-    });
-    repo.updateRun(oldRun.id, {
-      status: 'completed',
-      finishedAt: '2026-03-20T00:03:00.000Z',
     });
     const newRun = repo.createRun({
       trackedAgentId: agent.id,
@@ -231,8 +221,9 @@ describe('dispatcher queue reconciliation after restart', () => {
 
     expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
       'pending-approval-restored',
-      'terminal-run-restored',
+      'queued-run-restored',
     ]));
+    expect(repo.getRun(oldRun.id)).toMatchObject({ status: 'queued' });
     expect(repo.getTrackedAgent(agent.id)).toMatchObject({
       status: 'awaiting_approval',
       dispatchRunId: newRun.id,

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -63,6 +63,12 @@ describe('dispatcher queue reconciliation after restart', () => {
         processStartTimeTicks: '4242-start',
       },
     });
+    repo.updateRun(liveRun.id, {
+      status: 'running',
+      finishedAt: '2026-03-20T00:00:30.000Z',
+      latestExitCode: 1,
+      stopReason: 'previous_failure',
+    });
 
     const deadRun = repo.createRun({
       trackedAgentId: deadAgent.id,
@@ -158,7 +164,13 @@ describe('dispatcher queue reconciliation after restart', () => {
       'terminal-run-restored',
       'terminal-attempt-restored',
     ]));
-    expect(repo.getRun(liveRun.id)).toMatchObject({ status: 'running', currentAttemptId: liveAttempt.id });
+    expect(repo.getRun(liveRun.id)).toMatchObject({
+      status: 'running',
+      currentAttemptId: liveAttempt.id,
+    });
+    expect(repo.getRun(liveRun.id)?.finishedAt).toBeUndefined();
+    expect(repo.getRun(liveRun.id)?.latestExitCode).toBeUndefined();
+    expect(repo.getRun(liveRun.id)?.stopReason).toBeUndefined();
     expect(repo.getAttempt(liveAttempt.id)).toMatchObject({ status: 'running', pid: 4242 });
     expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'running', dispatchRunId: liveRun.id });
 
@@ -331,5 +343,88 @@ describe('dispatcher queue reconciliation after restart', () => {
     expect(report.findings.map(finding => finding.code)).toContain('stale-running-attempt-failed');
     expect(repo.getRun(run.id)).toMatchObject({ status: 'failed', stopReason: 'dispatcher_restart_stale_pid' });
     expect(repo.getAttempt(attempt.id)).toMatchObject({ status: 'failed', stopReason: 'dispatcher_restart_stale_pid' });
+  });
+
+  it('restores terminal current attempts before preserving pending approval state', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'stopped approval worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'approval stop', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'stopped',
+    });
+    repo.updateAttempt(attempt.id, {
+      status: 'stopped',
+      stopReason: 'operator_kill',
+      finishedAt: '2026-03-20T00:02:00.000Z',
+    });
+    repo.updateRun(run.id, { status: 'pending_approval' });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => false,
+    });
+
+    expect(report.findings).toContainEqual(expect.objectContaining({
+      code: 'terminal-attempt-restored',
+      runId: run.id,
+      attemptId: attempt.id,
+      toStatus: 'stopped',
+    }));
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'stopped',
+      stopReason: 'operator_kill',
+      finishedAt: '2026-03-20T00:02:00.000Z',
+    });
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'stopped', dispatchRunId: run.id });
+  });
+
+  it('preserves owned process groups when the original group leader has exited', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'process group worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'group', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 4444,
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 4444,
+        processStartTimeTicks: '4444-start',
+      },
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => false,
+      getProcessStartTimeTicks: () => undefined,
+      isProcessGroupAlive: (pid) => pid === 4444,
+    });
+
+    expect(report.findings).toContainEqual(expect.objectContaining({
+      code: 'live-running-attempt-quarantined',
+      runId: run.id,
+      pid: 4444,
+    }));
+    expect(repo.getRun(run.id)).toMatchObject({ status: 'running' });
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'running', dispatchRunId: run.id });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -57,6 +57,11 @@ describe('dispatcher queue reconciliation after restart', () => {
       status: 'running',
       pid: 4242,
       startedAt: '2026-03-20T00:01:00.000Z',
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 4242,
+        processStartTimeTicks: '4242-start',
+      },
     });
 
     const deadRun = repo.createRun({
@@ -141,6 +146,7 @@ describe('dispatcher queue reconciliation after restart', () => {
     const report = reconcileDispatcherQueueAfterRestart(repo, {
       now: () => '2026-03-20T00:05:00.000Z',
       isPidAlive: (pid) => pid === 4242,
+      getProcessStartTimeTicks: (pid) => pid === 4242 ? '4242-start' : undefined,
     });
 
     expect(report.checkedRuns).toBe(6);
@@ -228,5 +234,102 @@ describe('dispatcher queue reconciliation after restart', () => {
       status: 'awaiting_approval',
       dispatchRunId: newRun.id,
     });
+  });
+
+  it('reports duplicate owned live processes for the same tracked agent before mutating restart state', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'duplicate worker');
+
+    const runOne = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'first', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attemptOne = repo.createAttempt(runOne.id, {
+      status: 'running',
+      pid: 1111,
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 1111,
+        processStartTimeTicks: '1111-start',
+      },
+    });
+    const runTwo = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'second', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:02.000Z',
+    });
+    const attemptTwo = repo.createAttempt(runTwo.id, {
+      status: 'running',
+      pid: 2222,
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 2222,
+        processStartTimeTicks: '2222-start',
+      },
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: (pid) => pid === 1111 || pid === 2222,
+      getProcessStartTimeTicks: (pid) => `${pid}-start`,
+    });
+
+    expect(report.duplicateLiveAgentRunCount).toBe(2);
+    expect(report.findings.filter(finding => finding.code === 'duplicate-live-agent-run')).toEqual([
+      expect.objectContaining({ runId: runTwo.id, attemptId: attemptTwo.id, pid: 2222 }),
+      expect.objectContaining({ runId: runOne.id, attemptId: attemptOne.id, pid: 1111 }),
+    ]);
+    expect(repo.getRun(runOne.id)).toMatchObject({ status: 'running' });
+    expect(repo.getRun(runTwo.id)).toMatchObject({ status: 'running' });
+    expect(repo.listEvents(runOne.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
+    expect(repo.listEvents(runTwo.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
+  });
+
+  it('fails closed when a live PID does not match the attempt process ownership metadata', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'pid reuse worker');
+
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'pid reuse', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 3333,
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 3333,
+        processStartTimeTicks: 'original-start',
+      },
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: (pid) => pid === 3333,
+      getProcessStartTimeTicks: () => 'reused-start',
+    });
+
+    expect(report.findings.map(finding => finding.code)).toContain('stale-running-attempt-failed');
+    expect(repo.getRun(run.id)).toMatchObject({ status: 'failed', stopReason: 'dispatcher_restart_stale_pid' });
+    expect(repo.getAttempt(attempt.id)).toMatchObject({ status: 'failed', stopReason: 'dispatcher_restart_stale_pid' });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -239,8 +239,8 @@ describe('dispatcher queue reconciliation after restart', () => {
 
     expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
       'pending-approval-restored',
-      'queued-run-restored',
     ]));
+    expect(report.findings.map(finding => finding.code)).not.toContain('queued-run-restored');
     expect(repo.getRun(oldRun.id)).toMatchObject({ status: 'queued' });
     expect(repo.getTrackedAgent(agent.id)).toMatchObject({
       status: 'awaiting_approval',
@@ -386,6 +386,108 @@ describe('dispatcher queue reconciliation after restart', () => {
       finishedAt: '2026-03-20T00:02:00.000Z',
     });
     expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'stopped', dispatchRunId: run.id });
+  });
+
+  it('does not log reconciliation events for already-linked queued runs', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'already queued worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'queued', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    repo.updateTrackedAgent(agent.id, {
+      status: 'dispatching',
+      dispatchRunId: run.id,
+      updatedAt: '2026-03-20T00:00:02.000Z',
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => false,
+    });
+
+    expect(report.findings.map(finding => finding.code)).not.toContain('queued-run-restored');
+    expect(repo.listEvents(run.id).some(event => event.type === 'run.reconciliation.dispatcher_restart')).toBe(false);
+  });
+
+  it('clears stale exit metadata when failing running runs with missing attempts', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'missing attempt worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'missing attempt', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    repo.updateRun(run.id, {
+      status: 'running',
+      currentAttemptId: 'attempt_missing',
+      latestExitCode: 42,
+      finishedAt: '2026-03-20T00:00:30.000Z',
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => false,
+    });
+
+    expect(report.findings).toContainEqual(expect.objectContaining({
+      code: 'missing-running-attempt-failed',
+      runId: run.id,
+    }));
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'failed',
+      stopReason: 'dispatcher_restart_missing_attempt',
+      finishedAt: '2026-03-20T00:05:00.000Z',
+    });
+    expect(repo.getRun(run.id)?.currentAttemptId).toBeUndefined();
+    expect(repo.getRun(run.id)?.latestExitCode).toBeUndefined();
+  });
+
+  it('quarantines live legacy attempts that predate process ownership metadata', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'legacy live worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'legacy', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 5555,
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: (pid) => pid === 5555,
+    });
+
+    expect(report.findings).toContainEqual(expect.objectContaining({
+      code: 'live-running-attempt-quarantined',
+      runId: run.id,
+      attemptId: attempt.id,
+      pid: 5555,
+    }));
+    expect(repo.getRun(run.id)).toMatchObject({ status: 'running', currentAttemptId: attempt.id });
+    expect(repo.getTrackedAgent(agent.id)).toMatchObject({ status: 'running', dispatchRunId: run.id });
   });
 
   it('preserves owned process groups when the original group leader has exited', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
+import { reconcileDispatcherQueueAfterRestart } from '../../../src/beasts/services/dispatcher-queue-reconciliation.js';
+import type { TrackedAgent } from '../../../src/beasts/types.js';
+
+function createRepo(workDir: string): SQLiteBeastRepository {
+  return new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+}
+
+function createAgent(repo: SQLiteBeastRepository, name: string): TrackedAgent {
+  return repo.createTrackedAgent({
+    definitionId: 'martin-loop',
+    source: 'dashboard',
+    status: 'initializing',
+    createdByUser: 'operator',
+    initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+    initConfig: { identity: { name }, labels: ['reconciliation'] },
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-20T00:00:00.000Z',
+  });
+}
+
+describe('dispatcher queue reconciliation after restart', () => {
+  let workDir: string | undefined;
+
+  afterEach(async () => {
+    if (workDir) {
+      await rm(workDir, { recursive: true, force: true });
+      workDir = undefined;
+    }
+  });
+
+  it('reconciles queued, running, approval, and terminal runs from persisted records', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir!);
+    const liveAgent = createAgent(repo, 'live worker');
+    const deadAgent = createAgent(repo, 'dead worker');
+    const queuedAgent = createAgent(repo, 'queued worker');
+    const approvalAgent = createAgent(repo, 'approval worker');
+    const completedAgent = createAgent(repo, 'completed worker');
+
+    const liveRun = repo.createRun({
+      trackedAgentId: liveAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'live', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const liveAttempt = repo.createAttempt(liveRun.id, {
+      status: 'running',
+      pid: 4242,
+      startedAt: '2026-03-20T00:01:00.000Z',
+    });
+
+    const deadRun = repo.createRun({
+      trackedAgentId: deadAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'dead', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:02.000Z',
+    });
+    const deadAttempt = repo.createAttempt(deadRun.id, {
+      status: 'running',
+      pid: 5150,
+      startedAt: '2026-03-20T00:01:00.000Z',
+    });
+
+    const queuedRun = repo.createRun({
+      trackedAgentId: queuedAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'queued', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:03.000Z',
+    });
+
+    const approvalRun = repo.createRun({
+      trackedAgentId: approvalAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'approval', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:04.000Z',
+    });
+    repo.createAttempt(approvalRun.id, {
+      status: 'pending_approval',
+      startedAt: '2026-03-20T00:01:00.000Z',
+    });
+
+    const completedRun = repo.createRun({
+      trackedAgentId: completedAgent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'done', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:05.000Z',
+    });
+    repo.updateRun(completedRun.id, {
+      status: 'completed',
+      finishedAt: '2026-03-20T00:03:00.000Z',
+    });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: (pid) => pid === 4242,
+    });
+
+    expect(report.checkedRuns).toBe(5);
+    expect(report.findings.map(finding => finding.code)).toEqual(expect.arrayContaining([
+      'live-running-attempt-restored',
+      'stale-running-attempt-failed',
+      'queued-run-restored',
+      'pending-approval-restored',
+      'terminal-run-restored',
+    ]));
+    expect(repo.getRun(liveRun.id)).toMatchObject({ status: 'running', currentAttemptId: liveAttempt.id });
+    expect(repo.getTrackedAgent(liveAgent.id)).toMatchObject({ status: 'running', dispatchRunId: liveRun.id });
+
+    expect(repo.getRun(deadRun.id)).toMatchObject({
+      status: 'failed',
+      stopReason: 'dispatcher_restart_stale_pid',
+      finishedAt: '2026-03-20T00:05:00.000Z',
+    });
+    expect(repo.getAttempt(deadAttempt.id)).toMatchObject({
+      status: 'failed',
+      stopReason: 'dispatcher_restart_stale_pid',
+    });
+    expect(repo.getTrackedAgent(deadAgent.id)).toMatchObject({ status: 'failed', dispatchRunId: deadRun.id });
+
+    expect(repo.getRun(queuedRun.id)).toMatchObject({ status: 'queued' });
+    expect(repo.getTrackedAgent(queuedAgent.id)).toMatchObject({ status: 'dispatching', dispatchRunId: queuedRun.id });
+    expect(repo.getRun(approvalRun.id)).toMatchObject({ status: 'pending_approval' });
+    expect(repo.getTrackedAgent(approvalAgent.id)).toMatchObject({ status: 'awaiting_approval', dispatchRunId: approvalRun.id });
+    expect(repo.getTrackedAgent(completedAgent.id)).toMatchObject({ status: 'completed', dispatchRunId: completedRun.id });
+
+    expect(repo.listEvents(deadRun.id)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'run.reconciliation.dispatcher_restart',
+        payload: expect.objectContaining({ code: 'stale-running-attempt-failed' }),
+      }),
+    ]));
+  });
+
+  it('reports duplicate live processes for the same tracked agent without blindly killing either worker', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const repo = createRepo(workDir!);
+    const agent = createAgent(repo, 'duplicate worker');
+
+    const runOne = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'first', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attemptOne = repo.createAttempt(runOne.id, { status: 'running', pid: 1111 });
+    const runTwo = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'second', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:02.000Z',
+    });
+    const attemptTwo = repo.createAttempt(runTwo.id, { status: 'running', pid: 2222 });
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: (pid) => pid === 1111 || pid === 2222,
+    });
+
+    expect(report.duplicateLiveAgentRunCount).toBe(2);
+    expect(report.findings.filter(finding => finding.code === 'duplicate-live-agent-run')).toEqual([
+      expect.objectContaining({ runId: runTwo.id, attemptId: attemptTwo.id, pid: 2222 }),
+      expect.objectContaining({ runId: runOne.id, attemptId: attemptOne.id, pid: 1111 }),
+    ]);
+    expect(repo.getRun(runOne.id)).toMatchObject({ status: 'running' });
+    expect(repo.getRun(runTwo.id)).toMatchObject({ status: 'running' });
+    expect(repo.listEvents(runOne.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
+    expect(repo.listEvents(runTwo.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Beast dispatcher restart reconciliation for persisted queued, pending-approval, running, and terminal runs.
- Marks stale/missing running attempts failed instead of trusting lost in-memory state, while preserving live PIDs and flagging duplicate live runs for operator visibility.
- Runs reconciliation during Beast service startup and records run/agent reconciliation events.

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/beasts/dispatcher-queue-reconciliation.test.ts tests/unit/beasts/create-beast-services.test.ts tests/unit/beasts/beast-dispatch-service.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/observer && npm run build --workspace @franken/brain && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor && npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #1712