### PR TITLE
feat(security): add external helper allowlist

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,17 @@ When deploying Frankenbeast services, apply defense-in-depth controls around the
 - Store logs and traces in locations with restricted access and retention appropriate for their sensitivity.
 - Monitor security scan output and GitHub security alerts regularly.
 
+## External helper allowlist
+
+Repository helper scripts that invoke external commands must be reviewed before use in high-risk automation lanes. The signed/checksum allowlist lives at `scripts/external-helper-allowlist.json` and records each helper's repository-relative path, SHA-256 checksum, owner, and allowed argument classes. Helpers that opt in call `scripts/lib/external-helper-allowlist.mjs` before spawning commands; checksum mismatches, missing files, unlisted helpers, and disallowed command classes fail closed before execution.
+
+When changing an allowlisted helper:
+
+1. Review the helper diff and confirm the owner still accepts the command classes it may invoke.
+2. Update `scripts/external-helper-allowlist.json` with the new SHA-256 of the changed helper file.
+3. Add or update tests for the helper's allowed command classes.
+4. Run the targeted allowlist tests before requesting review.
+
 ## Security checks
 
 Useful local checks before opening or merging security-sensitive changes:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "ci:test:observer-eval": "node scripts/retry-ci-command.mjs -- npm run test:eval --workspace @franken/observer",
     "ci:test:e2e": "node scripts/retry-ci-command.mjs -- npm run test:e2e -- tests/e2e/smoke.test.ts tests/e2e/chat/chat-e2e.test.ts",
     "test:root": "vitest run",
+    "test:ci-retry-fixture": "node tests/fixtures/ci-retry-fixture.cjs",
+    "test:ci-retry-fail-fixture": "node tests/fixtures/ci-retry-fail-fixture.cjs",
     "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",
     "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1",

--- a/scripts/external-helper-allowlist.json
+++ b/scripts/external-helper-allowlist.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "description": "Signed/checksum allowlist for repository helper scripts that invoke external commands. Update hashes after reviewing helper changes.",
+  "helpers": [
+    {
+      "id": "issue-worktree-bootstrap",
+      "path": "scripts/issue-worktree-bootstrap.mjs",
+      "sha256": "9f02ad7fd48dbfec38dacf69dea0977f0c795653e7885cb0d7ae0594ad3f7682",
+      "owner": "Frankenbeast maintainers",
+      "allowedArgumentClasses": ["git-readonly", "git-worktree-create", "git-worktree-config", "gh-pr-readonly"]
+    },
+    {
+      "id": "ci-retry-command",
+      "path": "scripts/retry-ci-command.mjs",
+      "sha256": "338ec145d0373be6d75f6f8b934f2cd9a397a28d26d2cad81e65176b58dc8a02",
+      "owner": "Frankenbeast maintainers",
+      "allowedArgumentClasses": ["npm-test-runner", "npx-turbo-test-runner"]
+    }
+  ]
+}

--- a/scripts/external-helper-allowlist.json
+++ b/scripts/external-helper-allowlist.json
@@ -5,14 +5,14 @@
     {
       "id": "issue-worktree-bootstrap",
       "path": "scripts/issue-worktree-bootstrap.mjs",
-      "sha256": "9f02ad7fd48dbfec38dacf69dea0977f0c795653e7885cb0d7ae0594ad3f7682",
+      "sha256": "09cd329ef37d91165034c3c86aa5ca6c5774e65358419fa93af80179883a43b9",
       "owner": "Frankenbeast maintainers",
       "allowedArgumentClasses": ["git-readonly", "git-worktree-create", "git-worktree-config", "gh-pr-readonly"]
     },
     {
       "id": "ci-retry-command",
       "path": "scripts/retry-ci-command.mjs",
-      "sha256": "338ec145d0373be6d75f6f8b934f2cd9a397a28d26d2cad81e65176b58dc8a02",
+      "sha256": "ca4049e88860fcf780f62f16835f270df9b85f41d4fa683dcf4557a76b796bfe",
       "owner": "Frankenbeast maintainers",
       "allowedArgumentClasses": ["npm-test-runner", "npx-turbo-test-runner"]
     }

--- a/scripts/issue-worktree-bootstrap.mjs
+++ b/scripts/issue-worktree-bootstrap.mjs
@@ -3,8 +3,11 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 import { verifyExternalHelperInvocation } from './lib/external-helper-allowlist.mjs';
+
+const THIS_HELPER = fileURLToPath(import.meta.url);
 
 const DEFAULT_REPO = 'djm204/frankenbeast';
 const DEFAULT_REMOTE = 'origin';
@@ -108,6 +111,7 @@ function formatCommand(command) {
 async function runCommand(command, cwd) {
   await verifyExternalHelperInvocation({
     helperId: 'issue-worktree-bootstrap',
+    helperPath: THIS_HELPER,
     command,
     repoRoot: cwd,
   });

--- a/scripts/issue-worktree-bootstrap.mjs
+++ b/scripts/issue-worktree-bootstrap.mjs
@@ -4,6 +4,8 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
 
+import { verifyExternalHelperInvocation } from './lib/external-helper-allowlist.mjs';
+
 const DEFAULT_REPO = 'djm204/frankenbeast';
 const DEFAULT_REMOTE = 'origin';
 const DEFAULT_BASE_BRANCH = 'main';
@@ -103,7 +105,12 @@ function formatCommand(command) {
   return command.map((arg) => quote(String(arg))).join(' ');
 }
 
-function runCommand(command, cwd) {
+async function runCommand(command, cwd) {
+  await verifyExternalHelperInvocation({
+    helperId: 'issue-worktree-bootstrap',
+    command,
+    repoRoot: cwd,
+  });
   const result = spawnSync(command[0], command.slice(1), { cwd, encoding: 'utf8' });
   if (result.status !== 0) {
     const detail = (result.stderr || result.stdout || '').trim();
@@ -119,9 +126,9 @@ export function findConflictingIssuePrs(plan, openPrs) {
     : openPrs;
 }
 
-function assertNoDuplicateIssueWork(plan) {
+async function assertNoDuplicateIssueWork(plan) {
   const [openPrCommand, branchCommand] = plan.commands.duplicateChecks;
-  const openPrOutput = runCommand(openPrCommand, process.cwd());
+  const openPrOutput = await runCommand(openPrCommand, process.cwd());
   const openPrs = JSON.parse(openPrOutput || '[]');
   const conflictingPrs = findConflictingIssuePrs(plan, openPrs);
   if (conflictingPrs.length > 0) {
@@ -131,7 +138,7 @@ function assertNoDuplicateIssueWork(plan) {
     throw new Error(`Issue #${plan.issue} already appears in an open PR: ${summary}`);
   }
 
-  const existingBranches = runCommand(branchCommand, process.cwd());
+  const existingBranches = await runCommand(branchCommand, process.cwd());
   if (existingBranches && !plan.reuse) {
     throw new Error(`Branch already exists for issue #${plan.issue}: ${plan.branch}. Use --reuse to attach a worktree to it.`);
   }
@@ -190,7 +197,7 @@ function usage() {
   return `Usage: node scripts/issue-worktree-bootstrap.mjs --issue <number> --title <issue title> [options]\n\nCreates a deterministic issue branch/worktree for one-issue/one-PR workers.\n\nOptions:\n  --dry-run               Print planned commands without executing them.\n  --json                  Print structured JSON instead of human text.\n  --repo OWNER/REPO       Repository used for duplicate-PR checks (default: ${DEFAULT_REPO}).\n  --branch NAME           Override generated branch name.\n  --base REF              Base ref for new worktrees (default: <remote>/${DEFAULT_BASE_BRANCH}).\n  --remote NAME           Git remote to fetch (default: ${DEFAULT_REMOTE}).\n  --worktree-root PATH    Directory that receives issue-<number> (default: ${DEFAULT_WORKTREE_ROOT}).\n  --reuse                 Add a worktree for an existing local branch instead of creating a branch.\n  -h, --help              Show this help.\n`;
 }
 
-function main() {
+async function main() {
   try {
     const options = parseArgs(process.argv.slice(2));
     if (options.help) {
@@ -215,10 +222,10 @@ function main() {
     }
     mkdirSync(resolve(plan.worktreePath, '..'), { recursive: true });
 
-    for (const command of plan.commands.preflight) runCommand(command, process.cwd());
-    assertNoDuplicateIssueWork(plan);
-    for (const command of plan.commands.create) runCommand(command, process.cwd());
-    for (const command of plan.commands.verify) runCommand(command, process.cwd());
+    for (const command of plan.commands.preflight) await runCommand(command, process.cwd());
+    await assertNoDuplicateIssueWork(plan);
+    for (const command of plan.commands.create) await runCommand(command, process.cwd());
+    for (const command of plan.commands.verify) await runCommand(command, process.cwd());
     if (options.json) {
       console.log(JSON.stringify({ status: 'ready', dryRun: false, ...plan }, null, 2));
     } else {
@@ -232,5 +239,5 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  await main();
 }

--- a/scripts/lib/external-helper-allowlist.mjs
+++ b/scripts/lib/external-helper-allowlist.mjs
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';
-import { dirname, relative, resolve, sep } from 'node:path';
+import { relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_ALLOWLIST_URL = new URL('../external-helper-allowlist.json', import.meta.url);
@@ -9,7 +9,11 @@ const HELPER_ID_RE = /^[a-z0-9][a-z0-9_.:-]{0,127}$/u;
 const ARG_CLASS_RE = /^[a-z][a-z0-9:-]{0,63}$/u;
 
 const KNOWN_ARGUMENT_CLASS_VALIDATORS = Object.freeze({
-  'git-readonly': (command) => command[0] === 'git' && new Set(['rev-parse', 'fetch', 'branch', '-C']).has(command[1]),
+  'git-readonly': (command) => {
+    if (command[0] !== 'git') return false;
+    const subcommand = command[1] === '-C' ? command[3] : command[1];
+    return new Set(['rev-parse', 'fetch', 'branch', 'status']).has(subcommand);
+  },
   'git-worktree-create': (command) => command[0] === 'git' && command[1] === 'worktree' && command[2] === 'add',
   'git-worktree-config': (command) => command[0] === 'git' && command[1] === '-C' && command[3] === 'config'
     && (command.includes('user.email') || command.includes('user.name') || command.includes('extensions.worktreeConfig')),
@@ -101,7 +105,7 @@ export function findAllowlistedHelper(allowlist, helperIdOrPath, repoRoot = proc
 }
 
 export async function verifyExternalHelperFile({ helperId, helperPath, repoRoot, allowlistPath } = {}) {
-  const resolvedRepoRoot = resolve(repoRoot ?? dirname(fileURLToPath(new URL('..', DEFAULT_ALLOWLIST_URL))));
+  const resolvedRepoRoot = resolve(repoRoot ?? fileURLToPath(new URL('..', DEFAULT_ALLOWLIST_URL)));
   const allowlist = await loadExternalHelperAllowlist(allowlistPath);
   const helper = findAllowlistedHelper(allowlist, helperId ?? helperPath, resolvedRepoRoot);
   if (!helper) {

--- a/scripts/lib/external-helper-allowlist.mjs
+++ b/scripts/lib/external-helper-allowlist.mjs
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_ALLOWLIST_URL = new URL('../external-helper-allowlist.json', import.meta.url);
+const SHA256_RE = /^[a-f0-9]{64}$/u;
+const HELPER_ID_RE = /^[a-z0-9][a-z0-9_.:-]{0,127}$/u;
+const ARG_CLASS_RE = /^[a-z][a-z0-9:-]{0,63}$/u;
+
+const KNOWN_ARGUMENT_CLASS_VALIDATORS = Object.freeze({
+  'git-readonly': (command) => command[0] === 'git' && new Set(['rev-parse', 'fetch', 'branch', '-C']).has(command[1]),
+  'git-worktree-create': (command) => command[0] === 'git' && command[1] === 'worktree' && command[2] === 'add',
+  'git-worktree-config': (command) => command[0] === 'git' && command[1] === '-C' && command[3] === 'config'
+    && (command.includes('user.email') || command.includes('user.name') || command.includes('extensions.worktreeConfig')),
+  'gh-pr-readonly': (command) => command[0] === 'gh' && command[1] === 'pr' && ['list', 'view', 'checks'].includes(command[2]),
+  'npm-test-runner': (command) => command[0] === 'npm' && command[1] === 'run' && typeof command[2] === 'string',
+  'npx-turbo-test-runner': (command) => command[0] === 'npx' && command[1] === 'turbo',
+});
+
+function normalizeRepoRelativePath(filePath, repoRoot) {
+  const absolute = resolve(filePath);
+  const relativePath = relative(repoRoot, absolute).split(sep).join('/');
+  if (relativePath === '' || relativePath.startsWith('../') || relativePath === '..' || resolve(repoRoot, relativePath) !== absolute) {
+    throw new Error(`Helper path must stay inside repository root: ${filePath}`);
+  }
+  return relativePath;
+}
+
+async function sha256File(filePath) {
+  return createHash('sha256').update(await readFile(filePath)).digest('hex');
+}
+
+export async function loadExternalHelperAllowlist(allowlistPath = fileURLToPath(DEFAULT_ALLOWLIST_URL)) {
+  const raw = await readFile(allowlistPath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`External helper allowlist is not valid JSON: ${reason}`);
+  }
+  validateAllowlist(parsed, allowlistPath);
+  return parsed;
+}
+
+export function validateAllowlist(allowlist, allowlistPath = 'external-helper-allowlist.json') {
+  if (!allowlist || typeof allowlist !== 'object' || Array.isArray(allowlist)) {
+    throw new Error(`External helper allowlist ${allowlistPath} must be a JSON object`);
+  }
+  if (allowlist.version !== 1) {
+    throw new Error(`External helper allowlist ${allowlistPath} must use version 1`);
+  }
+  if (!Array.isArray(allowlist.helpers)) {
+    throw new Error(`External helper allowlist ${allowlistPath} must contain helpers[]`);
+  }
+  const seenIds = new Set();
+  const seenPaths = new Set();
+  for (const helper of allowlist.helpers) {
+    if (!helper || typeof helper !== 'object' || Array.isArray(helper)) {
+      throw new Error('External helper allowlist entries must be objects');
+    }
+    if (typeof helper.id !== 'string' || !HELPER_ID_RE.test(helper.id)) {
+      throw new Error(`External helper allowlist entry has invalid id: ${helper.id}`);
+    }
+    if (seenIds.has(helper.id)) {
+      throw new Error(`External helper allowlist has duplicate helper id: ${helper.id}`);
+    }
+    seenIds.add(helper.id);
+    if (typeof helper.path !== 'string' || helper.path.startsWith('/') || helper.path.includes('..') || helper.path.includes('\\')) {
+      throw new Error(`External helper ${helper.id} has invalid repo-relative path: ${helper.path}`);
+    }
+    if (seenPaths.has(helper.path)) {
+      throw new Error(`External helper allowlist has duplicate path: ${helper.path}`);
+    }
+    seenPaths.add(helper.path);
+    if (helper.sha256 !== '<TO_BE_GENERATED>' && (typeof helper.sha256 !== 'string' || !SHA256_RE.test(helper.sha256))) {
+      throw new Error(`External helper ${helper.id} has invalid sha256`);
+    }
+    if (typeof helper.owner !== 'string' || helper.owner.trim() === '') {
+      throw new Error(`External helper ${helper.id} must record an owner`);
+    }
+    if (!Array.isArray(helper.allowedArgumentClasses) || helper.allowedArgumentClasses.length === 0) {
+      throw new Error(`External helper ${helper.id} must record allowedArgumentClasses[]`);
+    }
+    for (const argumentClass of helper.allowedArgumentClasses) {
+      if (typeof argumentClass !== 'string' || !ARG_CLASS_RE.test(argumentClass)) {
+        throw new Error(`External helper ${helper.id} has invalid argument class: ${argumentClass}`);
+      }
+    }
+  }
+}
+
+export function findAllowlistedHelper(allowlist, helperIdOrPath, repoRoot = process.cwd()) {
+  const needle = String(helperIdOrPath ?? '');
+  if (HELPER_ID_RE.test(needle)) {
+    return allowlist.helpers.find((helper) => helper.id === needle) ?? null;
+  }
+  const relativePath = normalizeRepoRelativePath(needle, resolve(repoRoot));
+  return allowlist.helpers.find((helper) => helper.path === relativePath) ?? null;
+}
+
+export async function verifyExternalHelperFile({ helperId, helperPath, repoRoot, allowlistPath } = {}) {
+  const resolvedRepoRoot = resolve(repoRoot ?? dirname(fileURLToPath(new URL('..', DEFAULT_ALLOWLIST_URL))));
+  const allowlist = await loadExternalHelperAllowlist(allowlistPath);
+  const helper = findAllowlistedHelper(allowlist, helperId ?? helperPath, resolvedRepoRoot);
+  if (!helper) {
+    throw new Error(`External helper is not allowlisted: ${helperId ?? helperPath}`);
+  }
+  const absolutePath = resolve(resolvedRepoRoot, helper.path);
+  const info = await stat(absolutePath).catch((error) => {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`Allowlisted external helper is missing: ${helper.path}`);
+    }
+    throw error;
+  });
+  if (!info.isFile()) {
+    throw new Error(`Allowlisted external helper is not a regular file: ${helper.path}`);
+  }
+  const actualSha256 = await sha256File(absolutePath);
+  if (actualSha256 !== helper.sha256) {
+    throw new Error(`External helper checksum mismatch for ${helper.path}: expected ${helper.sha256}, got ${actualSha256}`);
+  }
+  return { helper, path: absolutePath, sha256: actualSha256 };
+}
+
+export function classifyExternalCommand(command) {
+  const normalized = Array.from(command ?? [], (value) => String(value));
+  return Object.entries(KNOWN_ARGUMENT_CLASS_VALIDATORS)
+    .filter(([, matches]) => matches(normalized))
+    .map(([argumentClass]) => argumentClass);
+}
+
+export async function verifyExternalHelperInvocation({ helperId, helperPath, command, repoRoot, allowlistPath } = {}) {
+  const verification = await verifyExternalHelperFile({ helperId, helperPath, repoRoot, allowlistPath });
+  const allowed = new Set(verification.helper.allowedArgumentClasses);
+  const actualClasses = classifyExternalCommand(command);
+  if (!actualClasses.some((argumentClass) => allowed.has(argumentClass))) {
+    throw new Error(`External helper ${verification.helper.id} is not allowed to invoke command class for: ${Array.from(command ?? []).join(' ')}`);
+  }
+  return { ...verification, argumentClasses: actualClasses };
+}

--- a/scripts/lib/external-helper-allowlist.mjs
+++ b/scripts/lib/external-helper-allowlist.mjs
@@ -7,19 +7,32 @@ const DEFAULT_ALLOWLIST_URL = new URL('../external-helper-allowlist.json', impor
 const SHA256_RE = /^[a-f0-9]{64}$/u;
 const HELPER_ID_RE = /^[a-z0-9][a-z0-9_.:-]{0,127}$/u;
 const ARG_CLASS_RE = /^[a-z][a-z0-9:-]{0,63}$/u;
+const ALLOWED_NPM_TEST_SCRIPTS = new Set([
+  'test:root',
+  'test:integration',
+  'test:eval',
+  'test:e2e',
+  'test:ci-retry-fixture',
+  'test:ci-retry-fail-fixture',
+]);
 
 const KNOWN_ARGUMENT_CLASS_VALIDATORS = Object.freeze({
   'git-readonly': (command) => {
     if (command[0] !== 'git') return false;
     const subcommand = command[1] === '-C' ? command[3] : command[1];
-    return new Set(['rev-parse', 'fetch', 'branch', 'status']).has(subcommand);
+    if (subcommand === 'branch') {
+      const branchArgs = command.slice(command[1] === '-C' ? 4 : 2);
+      return branchArgs.every((arg) => ['--all', '--list'].includes(arg) || !arg.startsWith('-'))
+        && branchArgs.some((arg) => ['--all', '--list'].includes(arg));
+    }
+    return new Set(['rev-parse', 'fetch', 'status']).has(subcommand);
   },
   'git-worktree-create': (command) => command[0] === 'git' && command[1] === 'worktree' && command[2] === 'add',
   'git-worktree-config': (command) => command[0] === 'git' && command[1] === '-C' && command[3] === 'config'
     && (command.includes('user.email') || command.includes('user.name') || command.includes('extensions.worktreeConfig')),
   'gh-pr-readonly': (command) => command[0] === 'gh' && command[1] === 'pr' && ['list', 'view', 'checks'].includes(command[2]),
-  'npm-test-runner': (command) => command[0] === 'npm' && command[1] === 'run' && typeof command[2] === 'string',
-  'npx-turbo-test-runner': (command) => command[0] === 'npx' && command[1] === 'turbo',
+  'npm-test-runner': (command) => command[0] === 'npm' && command[1] === 'run' && ALLOWED_NPM_TEST_SCRIPTS.has(command[2]),
+  'npx-turbo-test-runner': (command) => command[0] === 'npx' && command[1] === 'turbo' && command[2] === 'run' && command[3] === 'test',
 });
 
 function normalizeRepoRelativePath(filePath, repoRoot) {
@@ -32,7 +45,8 @@ function normalizeRepoRelativePath(filePath, repoRoot) {
 }
 
 async function sha256File(filePath) {
-  return createHash('sha256').update(await readFile(filePath)).digest('hex');
+  const content = await readFile(filePath, 'utf8');
+  return createHash('sha256').update(content.replace(/\r\n/gu, '\n'), 'utf8').digest('hex');
 }
 
 export async function loadExternalHelperAllowlist(allowlistPath = fileURLToPath(DEFAULT_ALLOWLIST_URL)) {
@@ -110,6 +124,12 @@ export async function verifyExternalHelperFile({ helperId, helperPath, repoRoot,
   const helper = findAllowlistedHelper(allowlist, helperId ?? helperPath, resolvedRepoRoot);
   if (!helper) {
     throw new Error(`External helper is not allowlisted: ${helperId ?? helperPath}`);
+  }
+  if (helperPath) {
+    const invokingPath = normalizeRepoRelativePath(helperPath, resolvedRepoRoot);
+    if (invokingPath !== helper.path) {
+      throw new Error(`External helper id ${helper.id} is bound to ${helper.path}, not ${invokingPath}`);
+    }
   }
   const absolutePath = resolve(resolvedRepoRoot, helper.path);
   const info = await stat(absolutePath).catch((error) => {

--- a/scripts/retry-ci-command.mjs
+++ b/scripts/retry-ci-command.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 
+import { verifyExternalHelperInvocation } from './lib/external-helper-allowlist.mjs';
+
 const RETRY_ENV = 'CI_TEST_RETRIES';
 const DEFAULT_RETRIES = 0;
 
@@ -56,6 +58,12 @@ async function main() {
   const [command, ...args] = splitCommand(process.argv.slice(2));
   const retries = parseRetryCount(process.env[RETRY_ENV]);
   const totalAttempts = retries + 1;
+
+  await verifyExternalHelperInvocation({
+    helperId: 'ci-retry-command',
+    command: [command, ...args],
+    repoRoot: process.cwd(),
+  });
 
   let lastExitCode = 1;
   for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {

--- a/scripts/retry-ci-command.mjs
+++ b/scripts/retry-ci-command.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import { verifyExternalHelperInvocation } from './lib/external-helper-allowlist.mjs';
+
+const THIS_HELPER = fileURLToPath(import.meta.url);
 
 const RETRY_ENV = 'CI_TEST_RETRIES';
 const DEFAULT_RETRIES = 0;
@@ -61,8 +64,8 @@ async function main() {
 
   await verifyExternalHelperInvocation({
     helperId: 'ci-retry-command',
+    helperPath: THIS_HELPER,
     command: [command, ...args],
-    repoRoot: process.cwd(),
   });
 
   let lastExitCode = 1;

--- a/tests/fixtures/ci-retry-fail-fixture.cjs
+++ b/tests/fixtures/ci-retry-fail-fixture.cjs
@@ -1,0 +1,1 @@
+process.exit(9);

--- a/tests/fixtures/ci-retry-fixture.cjs
+++ b/tests/fixtures/ci-retry-fixture.cjs
@@ -1,0 +1,10 @@
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+
+const file = process.env.CI_RETRY_FIXTURE_COUNTER;
+if (!file) {
+  console.error('CI_RETRY_FIXTURE_COUNTER is required');
+  process.exit(2);
+}
+const count = existsSync(file) ? Number(readFileSync(file, 'utf8')) + 1 : 1;
+writeFileSync(file, String(count));
+process.exit(count < 2 ? 7 : 0);

--- a/tests/unit/external-helper-allowlist.test.ts
+++ b/tests/unit/external-helper-allowlist.test.ts
@@ -101,4 +101,35 @@ describe('external helper allowlist', () => {
       allowlistPath,
     })).rejects.toThrow(/not allowed to invoke/u);
   });
+
+  it('uses the repository root when no explicit repoRoot is provided', async () => {
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'ci-retry-command',
+      command: ['npm', 'run', 'test:root'],
+    })).resolves.toMatchObject({ helper: expect.objectContaining({ path: 'scripts/retry-ci-command.mjs' }) });
+  });
+
+  it('does not classify mutating git -C commands as readonly', async () => {
+    const { allowlistPath, scriptPath } = await makeFixture();
+    const sha256 = createHash('sha256').update(await readFile(scriptPath)).digest('hex');
+    await writeFile(allowlistPath, JSON.stringify({
+      version: 1,
+      helpers: [
+        {
+          id: 'safe-helper',
+          path: 'scripts/safe-helper.mjs',
+          sha256,
+          owner: 'Security team',
+          allowedArgumentClasses: ['git-readonly'],
+        },
+      ],
+    }), 'utf8');
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      command: ['git', '-C', '/tmp/repo', 'push', 'origin', 'main'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/not allowed to invoke/u);
+  });
 });

--- a/tests/unit/external-helper-allowlist.test.ts
+++ b/tests/unit/external-helper-allowlist.test.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  verifyExternalHelperFile,
+  verifyExternalHelperInvocation,
+} from '../../scripts/lib/external-helper-allowlist.mjs';
+
+let workDir: string | undefined;
+
+async function makeFixture() {
+  workDir = await mkdtemp(join(tmpdir(), 'fbeast-helper-allowlist-'));
+  const scriptPath = join(workDir, 'scripts', 'safe-helper.mjs');
+  await mkdir(join(workDir, 'scripts'), { recursive: true });
+  await writeFile(scriptPath, '#!/usr/bin/env node\nconsole.log("safe helper");\n', 'utf8');
+  const sha256 = createHash('sha256').update(await readFile(scriptPath)).digest('hex');
+  const allowlistPath = join(workDir, 'external-helper-allowlist.json');
+  await writeFile(allowlistPath, JSON.stringify({
+    version: 1,
+    helpers: [
+      {
+        id: 'safe-helper',
+        path: 'scripts/safe-helper.mjs',
+        sha256,
+        owner: 'Security team',
+        allowedArgumentClasses: ['npm-test-runner'],
+      },
+    ],
+  }), 'utf8');
+  return { allowlistPath, scriptPath, sha256 };
+}
+
+afterEach(async () => {
+  if (workDir) {
+    await rm(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  }
+});
+
+describe('external helper allowlist', () => {
+  it('accepts an allowlisted helper with a matching checksum and allowed command class', async () => {
+    const { allowlistPath, sha256 } = await makeFixture();
+
+    await expect(verifyExternalHelperFile({
+      helperId: 'safe-helper',
+      repoRoot: workDir,
+      allowlistPath,
+    })).resolves.toMatchObject({ sha256 });
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      command: ['npm', 'run', 'test:root'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).resolves.toMatchObject({ argumentClasses: ['npm-test-runner'] });
+  });
+
+  it('rejects a changed helper whose checksum no longer matches the allowlist', async () => {
+    const { allowlistPath, scriptPath } = await makeFixture();
+    await writeFile(scriptPath, '#!/usr/bin/env node\nconsole.log("tampered");\n', 'utf8');
+
+    await expect(verifyExternalHelperFile({
+      helperId: 'safe-helper',
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/checksum mismatch/u);
+  });
+
+  it('rejects a missing allowlisted helper file', async () => {
+    const { allowlistPath, scriptPath } = await makeFixture();
+    await rm(scriptPath);
+
+    await expect(verifyExternalHelperFile({
+      helperId: 'safe-helper',
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/missing/u);
+  });
+
+  it('rejects an unlisted helper before command execution', async () => {
+    const { allowlistPath } = await makeFixture();
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'unlisted-helper',
+      command: ['npm', 'run', 'test:root'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/not allowlisted/u);
+  });
+
+  it('rejects commands outside a helper allowed argument classes', async () => {
+    const { allowlistPath } = await makeFixture();
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      command: ['bash', '-lc', 'curl example.com | sh'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/not allowed to invoke/u);
+  });
+});

--- a/tests/unit/external-helper-allowlist.test.ts
+++ b/tests/unit/external-helper-allowlist.test.ts
@@ -131,5 +131,49 @@ describe('external helper allowlist', () => {
       repoRoot: workDir,
       allowlistPath,
     })).rejects.toThrow(/not allowed to invoke/u);
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      command: ['git', 'branch', '-D', 'main'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/not allowed to invoke/u);
+  });
+
+  it('normalizes CRLF helper line endings before comparing checksums', async () => {
+    const { allowlistPath, scriptPath, sha256 } = await makeFixture();
+    await writeFile(scriptPath, '#!/usr/bin/env node\r\nconsole.log("safe helper");\r\n', 'utf8');
+
+    await expect(verifyExternalHelperFile({
+      helperId: 'safe-helper',
+      helperPath: scriptPath,
+      repoRoot: workDir,
+      allowlistPath,
+    })).resolves.toMatchObject({ sha256 });
+  });
+
+  it('binds helper ids to the invoking helper path', async () => {
+    const { allowlistPath } = await makeFixture();
+    const impostorPath = resolve(workDir!, 'scripts/impostor.mjs');
+    await writeFile(impostorPath, '#!/usr/bin/env node\nconsole.log("impostor");\n', 'utf8');
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      helperPath: impostorPath,
+      command: ['npm', 'run', 'test:root'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/is bound to/u);
+  });
+
+  it('restricts npm runner classes to reviewed test scripts', async () => {
+    const { allowlistPath } = await makeFixture();
+
+    await expect(verifyExternalHelperInvocation({
+      helperId: 'safe-helper',
+      command: ['npm', 'run', 'create:project'],
+      repoRoot: workDir,
+      allowlistPath,
+    })).rejects.toThrow(/not allowed to invoke/u);
   });
 });

--- a/tests/unit/retry-ci-command.test.ts
+++ b/tests/unit/retry-ci-command.test.ts
@@ -19,16 +19,11 @@ describe('CI retry command wrapper', () => {
   it('retries a failing command until it succeeds and logs retry attempts', () => {
     const dir = mkdtempSync(join(tmpdir(), 'franken-ci-retry-'));
     const counter = join(dir, 'counter.txt');
-    const childScript = `
-const { existsSync, readFileSync, writeFileSync } = require('node:fs');
-const file = process.argv[1];
-const count = existsSync(file) ? Number(readFileSync(file, 'utf8')) + 1 : 1;
-writeFileSync(file, String(count));
-process.exit(count < 2 ? 7 : 0);
-`;
-
     try {
-      const result = runRetryCommand([process.execPath, '-e', childScript, counter], { CI_TEST_RETRIES: '2' });
+      const result = runRetryCommand(['npm', 'run', 'test:ci-retry-fixture'], {
+        CI_TEST_RETRIES: '2',
+        CI_RETRY_FIXTURE_COUNTER: counter,
+      });
 
       expect(result.status).toBe(0);
       expect(readFileSync(counter, 'utf8')).toBe('2');
@@ -42,7 +37,7 @@ process.exit(count < 2 ? 7 : 0);
   });
 
   it('preserves the final failure exit code after retries are exhausted', () => {
-    const result = runRetryCommand([process.execPath, '-e', 'process.exit(9)'], { CI_TEST_RETRIES: '1' });
+    const result = runRetryCommand(['npm', 'run', 'test:ci-retry-fail-fixture'], { CI_TEST_RETRIES: '1' });
 
     expect(result.status).toBe(9);
     expect(result.stderr).toContain('[ci-retry] attempt 1/2');


### PR DESCRIPTION
## Summary
- Add a checksum-backed external helper allowlist with owner and argument-class metadata
- Verify selected high-risk helper scripts before spawning external commands
- Document the allowlist update process and cover matching, tampered, missing, and unlisted helper cases

## Test Plan
- npm run test:root -- --run tests/unit/external-helper-allowlist.test.ts tests/unit/issue-worktree-bootstrap.test.ts tests/unit/retry-ci-command.test.ts
- npm run check:package-manager
- npm run lint:security
- npm run typecheck
- npm run build

Closes #1707