### PR TITLE
feat(onboarding): add profile capability self-test

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -61,6 +61,14 @@ Use this checklist for a first local checkout or when rebuilding a development e
 
   The command prints stable `[new-worker-preflight:<check>] ok|warn|fail - ...` badges by default, or a JSON object with `ok` and `checks` when `--json` is supplied. Use `npm --silent` or `node scripts/new-worker-preflight.mjs --json` for machine-parsed JSON so npm lifecycle banners do not prefix stdout. It verifies the supported Node.js/npm pin, required `git`/`gh`/`jq` commands, GitHub CLI authentication for `github.com`, the project git identity (`David Mendez <me@davidmendez.dev>`), Frankenbeast repository root, and whether the current worktree already has uncommitted files. Use `--skip-github-auth` only for offline docs/tests; run without it before opening PRs.
 
+- [ ] PMs or workers that need profile-specific evidence: run the capability self-test with the expected profile schema or explicit flags before dispatching PR-producing work:
+
+  ```bash
+  npm --silent run profile:capability-self-test -- --json --repo djm204/frankenbeast --require-repo-write --toolset terminal,file --delivery-target discord:1523806555047333968
+  ```
+
+  The command is read-only: even a failing self-test checks GitHub repository permission with `gh repo view --json viewerPermission` and never creates, edits, pushes, comments, or merges. It verifies expected model/provider labels, required toolsets, `gh` auth, git identity, optional repo write permission, approval-cop availability, and delivery target wiring. Human output uses stable `[profile-capability-self-test:<check>] ok|warn|fail - ...` badges; `--json` returns `{ ok, profile, checks }` for Kanban/Discord reports.
+
 - [ ] Generate a guided checklist when you need a smaller first-run path than the full document. Pick the persona that matches the work:
 
   ```bash

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "tsx scripts/verify-setup.ts",
     "new-worker:preflight": "node scripts/new-worker-preflight.mjs",
+    "profile:capability-self-test": "node scripts/profile-capability-self-test.mjs",
     "first-run:checklist": "node scripts/first-run-checklist.mjs",
     "workspace:tour": "node scripts/workspace-tour.mjs",
     "test": "turbo run test",

--- a/scripts/profile-capability-self-test.mjs
+++ b/scripts/profile-capability-self-test.mjs
@@ -170,6 +170,45 @@ function run(command, args = [], options = {}) {
   };
 }
 
+function splitCommand(value) {
+  const tokens = [];
+  let current = '';
+  let quote;
+  let escaped = false;
+  for (const char of String(value).trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+    } else if (char === '\\') {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = undefined;
+      else current += char;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (/\s/u.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (escaped) current += '\\';
+  if (quote) throw new Error(`unterminated quote in command route: ${value}`);
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function rootManifest(root) {
+  try {
+    return JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
 function checkLabel(id, label, expected, actual, envName) {
   if (!expected) {
     return { id, status: 'warn', detail: `no expected ${label} configured`, action: `Pass --${label} or include ${label} in the expectation schema.` };
@@ -201,9 +240,9 @@ function checkRepositoryRoot(root) {
   if (!repoRoot.ok) {
     return { id: 'repository-root', status: 'fail', detail: 'not inside a git checkout', action: 'Run from a Frankenbeast checkout or pass --root.' };
   }
-  return existsSync(resolve(repoRoot.stdout, 'package.json'))
+  return existsSync(resolve(repoRoot.stdout, 'package.json')) && rootManifest(repoRoot.stdout)?.name === 'frankenbeast'
     ? { id: 'repository-root', status: 'ok', detail: repoRoot.stdout }
-    : { id: 'repository-root', status: 'fail', detail: `${repoRoot.stdout} has no package.json`, action: 'Run from the repository root or an isolated issue worktree.' };
+    : { id: 'repository-root', status: 'fail', detail: `${repoRoot.stdout} is not the Frankenbeast repository root`, action: 'Run from the Frankenbeast repository root or an isolated issue worktree.' };
 }
 
 function checkGitIdentity(root, expectedUser, expectedEmail) {
@@ -249,7 +288,11 @@ function checkApprovalCop(command) {
   if (!command) {
     return { id: 'approval-cop-route', status: 'warn', detail: 'no approval-cop route required by schema', action: 'Pass --approval-cop for profiles that need approval-gated side effects.' };
   }
-  const result = run(command, ['--help']);
+  const [executable, ...args] = splitCommand(command);
+  if (!executable) {
+    return { id: 'approval-cop-route', status: 'fail', detail: 'approval-cop route is empty', action: 'Pass an executable approval-cop route such as approval-cop or approval-cop run --.' };
+  }
+  const result = run(executable, [...args, '--help']);
   return result.ok
     ? { id: 'approval-cop-route', status: 'ok', detail: `${command} is available` }
     : { id: 'approval-cop-route', status: 'fail', detail: `${command} is not available`, action: `Install or expose ${command} on PATH for this profile. ${result.detail}` };

--- a/scripts/profile-capability-self-test.mjs
+++ b/scripts/profile-capability-self-test.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const DEFAULT_GIT_USER = 'David Mendez';
+const DEFAULT_GIT_EMAIL = 'me@davidmendez.dev';
+const WRITE_PERMISSIONS = new Set(['ADMIN', 'MAINTAIN', 'WRITE']);
+
+function splitList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    root: process.cwd(),
+    profile: undefined,
+    provider: undefined,
+    model: undefined,
+    actualProvider: process.env.HERMES_PROVIDER,
+    actualModel: process.env.HERMES_MODEL,
+    requiredToolsets: [],
+    repo: undefined,
+    requireRepoWrite: false,
+    skipGithubAuth: false,
+    gitUser: DEFAULT_GIT_USER,
+    gitEmail: DEFAULT_GIT_EMAIL,
+    approvalCop: undefined,
+    deliveryTargets: [],
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--root') {
+      options.root = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--root=')) {
+      options.root = arg.slice('--root='.length);
+    } else if (arg === '--profile') {
+      options.profile = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--profile=')) {
+      options.profile = arg.slice('--profile='.length);
+    } else if (arg === '--provider') {
+      options.provider = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--provider=')) {
+      options.provider = arg.slice('--provider='.length);
+    } else if (arg === '--model') {
+      options.model = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--model=')) {
+      options.model = arg.slice('--model='.length);
+    } else if (arg === '--actual-provider') {
+      options.actualProvider = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--actual-provider=')) {
+      options.actualProvider = arg.slice('--actual-provider='.length);
+    } else if (arg === '--actual-model') {
+      options.actualModel = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--actual-model=')) {
+      options.actualModel = arg.slice('--actual-model='.length);
+    } else if (arg === '--toolset') {
+      options.requiredToolsets.push(...splitList(readValue(argv, i, arg)));
+      i += 1;
+    } else if (arg?.startsWith('--toolset=')) {
+      options.requiredToolsets.push(...splitList(arg.slice('--toolset='.length)));
+    } else if (arg === '--repo') {
+      options.repo = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--repo=')) {
+      options.repo = arg.slice('--repo='.length);
+    } else if (arg === '--require-repo-write') {
+      options.requireRepoWrite = true;
+    } else if (arg === '--skip-github-auth') {
+      options.skipGithubAuth = true;
+    } else if (arg === '--git-user') {
+      options.gitUser = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--git-user=')) {
+      options.gitUser = arg.slice('--git-user='.length);
+    } else if (arg === '--git-email') {
+      options.gitEmail = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--git-email=')) {
+      options.gitEmail = arg.slice('--git-email='.length);
+    } else if (arg === '--approval-cop') {
+      options.approvalCop = readValue(argv, i, arg);
+      i += 1;
+    } else if (arg?.startsWith('--approval-cop=')) {
+      options.approvalCop = arg.slice('--approval-cop='.length);
+    } else if (arg === '--delivery-target') {
+      options.deliveryTargets.push(...splitList(readValue(argv, i, arg)));
+      i += 1;
+    } else if (arg?.startsWith('--delivery-target=')) {
+      options.deliveryTargets.push(...splitList(arg.slice('--delivery-target='.length)));
+    } else if (arg === '--expect') {
+      Object.assign(options, readExpectationFile(readValue(argv, i, arg)));
+      i += 1;
+    } else if (arg?.startsWith('--expect=')) {
+      Object.assign(options, readExpectationFile(arg.slice('--expect='.length)));
+    } else if (arg === '-h' || arg === '--help') {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readExpectationFile(path) {
+  const value = JSON.parse(readFileSync(resolve(path), 'utf8'));
+  return {
+    profile: value.profile,
+    provider: value.provider,
+    model: value.model,
+    requiredToolsets: value.requiredToolsets ?? value.toolsets ?? [],
+    repo: value.repo,
+    requireRepoWrite: Boolean(value.requireRepoWrite),
+    gitUser: value.gitIdentity?.name ?? value.gitUser ?? DEFAULT_GIT_USER,
+    gitEmail: value.gitIdentity?.email ?? value.gitEmail ?? DEFAULT_GIT_EMAIL,
+    approvalCop: value.approvalCop,
+    deliveryTargets: value.deliveryTargets ?? [],
+  };
+}
+
+function printUsage() {
+  console.info(`Usage: npm run profile:capability-self-test -- [--json] [--expect profile-capabilities.json]
+       [--profile LABEL] [--provider PROVIDER] [--model MODEL]
+       [--toolset terminal,file] [--repo owner/name] [--require-repo-write]
+       [--approval-cop approval-cop] [--delivery-target discord:channel]
+
+Runs a read-only capability self-test for an agent profile. It checks expected
+model/provider labels, required toolsets, gh auth, git identity, optional repo
+write permission, approval-cop route, and delivery target wiring.
+
+JSON output is { ok, profile, checks: [{ id, status, detail, action? }] }.`);
+}
+
+function run(command, args = [], options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: process.platform === 'win32',
+  });
+  return {
+    status: result.status,
+    error: result.error,
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? '',
+    ok: !result.error && result.status === 0,
+    detail: result.error?.message ?? result.stderr?.trim() ?? result.stdout?.trim() ?? '',
+  };
+}
+
+function checkLabel(id, label, expected, actual, envName) {
+  if (!expected) {
+    return { id, status: 'warn', detail: `no expected ${label} configured`, action: `Pass --${label} or include ${label} in the expectation schema.` };
+  }
+  if (actual === expected) {
+    return { id, status: 'ok', detail: `${label} ${actual}` };
+  }
+  return {
+    id,
+    status: 'fail',
+    detail: `expected ${label} ${expected}, found ${actual || '<unset>'}`,
+    action: `Set ${envName} or pass --actual-${label} from the profile runtime before dispatching work.`,
+  };
+}
+
+function checkToolsets(required) {
+  if (required.length === 0) {
+    return { id: 'required-toolsets', status: 'warn', detail: 'no required toolsets configured', action: 'Pass --toolset or include requiredToolsets in the expectation schema.' };
+  }
+  const actual = new Set(splitList(process.env.HERMES_ENABLED_TOOLSETS || process.env.HERMES_TOOLSETS || process.env.HERMES_TOOLS));
+  const missing = required.filter((toolset) => !actual.has(toolset));
+  return missing.length === 0
+    ? { id: 'required-toolsets', status: 'ok', detail: `available: ${required.join(', ')}` }
+    : { id: 'required-toolsets', status: 'fail', detail: `missing: ${missing.join(', ')}; available: ${[...actual].join(', ') || '<none>'}`, action: 'Enable the required Hermes toolsets for this profile before dispatching the card.' };
+}
+
+function checkRepositoryRoot(root) {
+  const repoRoot = run('git', ['rev-parse', '--show-toplevel'], { cwd: root });
+  if (!repoRoot.ok) {
+    return { id: 'repository-root', status: 'fail', detail: 'not inside a git checkout', action: 'Run from a Frankenbeast checkout or pass --root.' };
+  }
+  return existsSync(resolve(repoRoot.stdout, 'package.json'))
+    ? { id: 'repository-root', status: 'ok', detail: repoRoot.stdout }
+    : { id: 'repository-root', status: 'fail', detail: `${repoRoot.stdout} has no package.json`, action: 'Run from the repository root or an isolated issue worktree.' };
+}
+
+function checkGitIdentity(root, expectedUser, expectedEmail) {
+  const name = run('git', ['config', 'user.name'], { cwd: root }).stdout;
+  const email = run('git', ['config', 'user.email'], { cwd: root }).stdout;
+  return name === expectedUser && email === expectedEmail
+    ? { id: 'git-identity', status: 'ok', detail: `${expectedUser} <${expectedEmail}>` }
+    : { id: 'git-identity', status: 'fail', detail: `expected ${expectedUser} <${expectedEmail}>, found ${name || '<unset>'} <${email || '<unset>'}>`, action: `Run: git config user.name '${expectedUser}' && git config user.email '${expectedEmail}'` };
+}
+
+function checkGithubAuth(root, skip) {
+  if (skip) {
+    return { id: 'github-auth', status: 'warn', detail: 'skipped by --skip-github-auth', action: 'Run without --skip-github-auth before opening PRs or reading private issues.' };
+  }
+  const result = run('gh', ['auth', 'status', '--hostname', 'github.com'], { cwd: root });
+  return result.ok
+    ? { id: 'github-auth', status: 'ok', detail: 'gh auth status succeeded' }
+    : { id: 'github-auth', status: 'fail', detail: 'gh auth status failed', action: `Run: gh auth login. ${result.detail}` };
+}
+
+function checkRepoWrite(root, repo, required) {
+  if (!required) {
+    return { id: 'repo-write-access', status: 'warn', detail: 'not required by schema', action: 'Pass --require-repo-write for workers that must push branches or open PRs.' };
+  }
+  if (!repo) {
+    return { id: 'repo-write-access', status: 'fail', detail: 'repo write access required but no repo configured', action: 'Pass --repo owner/name.' };
+  }
+  const result = run('gh', ['repo', 'view', repo, '--json', 'viewerPermission'], { cwd: root });
+  if (!result.ok) {
+    return { id: 'repo-write-access', status: 'fail', detail: 'unable to read viewerPermission via gh repo view', action: `Verify gh auth and repo access. ${result.detail}` };
+  }
+  try {
+    const permission = JSON.parse(result.stdout).viewerPermission;
+    return WRITE_PERMISSIONS.has(permission)
+      ? { id: 'repo-write-access', status: 'ok', detail: `viewerPermission=${permission}` }
+      : { id: 'repo-write-access', status: 'fail', detail: `viewerPermission=${permission || '<unknown>'}`, action: `Grant write access to ${repo} before assigning PR-producing work.` };
+  } catch (error) {
+    return { id: 'repo-write-access', status: 'fail', detail: `could not parse gh repo view output: ${error instanceof Error ? error.message : String(error)}`, action: 'Retry after updating gh or inspect the repository permissions manually.' };
+  }
+}
+
+function checkApprovalCop(command) {
+  if (!command) {
+    return { id: 'approval-cop-route', status: 'warn', detail: 'no approval-cop route required by schema', action: 'Pass --approval-cop for profiles that need approval-gated side effects.' };
+  }
+  const result = run(command, ['--help']);
+  return result.ok
+    ? { id: 'approval-cop-route', status: 'ok', detail: `${command} is available` }
+    : { id: 'approval-cop-route', status: 'fail', detail: `${command} is not available`, action: `Install or expose ${command} on PATH for this profile. ${result.detail}` };
+}
+
+function checkDeliveryTargets(required) {
+  if (required.length === 0) {
+    return { id: 'delivery-targets', status: 'warn', detail: 'no delivery targets required by schema', action: 'Pass --delivery-target for profiles that must report to Discord/Telegram/etc.' };
+  }
+  const actual = new Set(splitList(process.env.HERMES_DELIVER_TARGETS || process.env.HERMES_DELIVERY_TARGETS || process.env.HERMES_DELIVER));
+  const missing = required.filter((target) => !actual.has(target));
+  return missing.length === 0
+    ? { id: 'delivery-targets', status: 'ok', detail: `available: ${required.join(', ')}` }
+    : { id: 'delivery-targets', status: 'fail', detail: `missing: ${missing.join(', ')}; available: ${[...actual].join(', ') || '<none>'}`, action: 'Configure the profile gateway delivery target before dispatching reporting work.' };
+}
+
+function buildReport(options) {
+  const root = resolve(options.root);
+  const checks = [
+    checkLabel('provider-label', 'provider', options.provider, options.actualProvider, 'HERMES_PROVIDER'),
+    checkLabel('model-label', 'model', options.model, options.actualModel, 'HERMES_MODEL'),
+    checkToolsets(options.requiredToolsets),
+    checkRepositoryRoot(root),
+    checkGitIdentity(root, options.gitUser, options.gitEmail),
+    checkGithubAuth(root, options.skipGithubAuth),
+    checkRepoWrite(root, options.repo, options.requireRepoWrite),
+    checkApprovalCop(options.approvalCop),
+    checkDeliveryTargets(options.deliveryTargets),
+  ];
+  return {
+    ok: checks.every((check) => check.status !== 'fail'),
+    profile: options.profile ?? process.env.HERMES_PROFILE ?? '<unknown>',
+    checks,
+  };
+}
+
+function printHuman(report) {
+  for (const check of report.checks) {
+    const suffix = check.action ? ` Action: ${check.action}` : '';
+    console.info(`[profile-capability-self-test:${check.id}] ${check.status} - ${check.detail}${suffix}`);
+  }
+  console.info(report.ok
+    ? 'Profile capability self-test passed. Profile is ready for matching worker assignments.'
+    : 'Profile capability self-test failed. Fix failed checks before dispatching matching worker assignments.');
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const report = buildReport(options);
+  if (options.json) {
+    console.info(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+  process.exit(report.ok ? 0 : 1);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`profile capability self-test failed before checks: ${message}`);
+  process.exit(2);
+}

--- a/tests/unit/profile-capability-self-test.test.ts
+++ b/tests/unit/profile-capability-self-test.test.ts
@@ -99,4 +99,43 @@ describe('profile capability self-test', () => {
     expect(ghCalls).toContain('repo view djm204/frankenbeast --json viewerPermission');
     expect(ghCalls).not.toMatch(/\b(issue|pr|repo)\s+(create|edit|delete|merge|close)|\bapi\s+-X\s+(POST|PUT|PATCH|DELETE)/u);
   });
+
+  it('verifies the local checkout package identity before passing repository-root', () => {
+    const checkout = mkdtempSync(join(tmpdir(), 'profile-self-test-other-repo-'));
+    spawnSync('git', ['init'], { cwd: checkout, encoding: 'utf8' });
+    writeFileSync(join(checkout, 'package.json'), JSON.stringify({ name: 'not-frankenbeast' }));
+
+    const result = runSelfTest(['--json', '--root', checkout, '--skip-github-auth'], {
+      HERMES_ENABLED_TOOLSETS: '',
+      HERMES_DELIVER_TARGETS: '',
+    });
+
+    expect(result.status).toBe(1);
+    const report = parseJson(result.stdout);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'repository-root', status: 'fail' })]),
+    );
+  });
+
+  it('parses approval-cop routes with arguments before appending --help', () => {
+    const binDir = mkdtempSync(join(tmpdir(), 'profile-self-test-bin-'));
+    const callsPath = join(binDir, 'approval-cop-calls.log');
+    writeFileSync(join(binDir, 'approval-cop'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsPath)}\nif [ "$1 $2 $3" = "run -- --help" ]; then exit 0; fi\nexit 9\n`, { mode: 0o755 });
+
+    const result = runSelfTest([
+      '--json',
+      '--approval-cop', 'approval-cop run --',
+      '--skip-github-auth',
+    ], {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HERMES_ENABLED_TOOLSETS: '',
+      HERMES_DELIVER_TARGETS: '',
+    });
+
+    const report = parseJson(result.stdout);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'approval-cop-route', status: 'ok' })]),
+    );
+    expect(readFileSync(callsPath, 'utf8')).toContain('run -- --help');
+  });
 });

--- a/tests/unit/profile-capability-self-test.test.ts
+++ b/tests/unit/profile-capability-self-test.test.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/profile-capability-self-test.mjs');
+
+function runSelfTest(args: string[], env: Record<string, string | undefined> = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+
+function parseJson(stdout: string) {
+  return JSON.parse(stdout) as {
+    ok: boolean;
+    checks: Array<{ id: string; status: string; detail: string; action?: string }>;
+  };
+}
+
+describe('profile capability self-test', () => {
+  it('fails JSON mode when provider and model labels do not match expectations', () => {
+    const result = runSelfTest([
+      '--json',
+      '--provider', 'openai-codex',
+      '--model', 'gpt-5.3-codex-spark',
+      '--skip-github-auth',
+    ], {
+      HERMES_PROVIDER: 'ollama',
+      HERMES_MODEL: 'gpt-oss:120b-cloud',
+      HERMES_ENABLED_TOOLSETS: '',
+      HERMES_DELIVER_TARGETS: '',
+    });
+
+    expect(result.status).toBe(1);
+    const report = parseJson(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'provider-label', status: 'fail' }),
+        expect.objectContaining({ id: 'model-label', status: 'fail' }),
+      ]),
+    );
+  });
+
+  it('reports missing required toolsets, approval route, and delivery target without contacting GitHub', () => {
+    const result = runSelfTest([
+      '--json',
+      '--toolset', 'terminal,file,web',
+      '--approval-cop', 'approval-cop',
+      '--delivery-target', 'discord:1523806555047333968',
+      '--skip-github-auth',
+    ], {
+      PATH: '/usr/bin:/bin',
+      HERMES_ENABLED_TOOLSETS: 'terminal,file',
+      HERMES_DELIVER_TARGETS: 'local',
+    });
+
+    expect(result.status).toBe(1);
+    const report = parseJson(result.stdout);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'required-toolsets', status: 'fail' }),
+        expect.objectContaining({ id: 'approval-cop-route', status: 'fail' }),
+        expect.objectContaining({ id: 'delivery-targets', status: 'fail' }),
+        expect.objectContaining({ id: 'github-auth', status: 'warn' }),
+      ]),
+    );
+  });
+
+  it('checks repo write access read-only and never invokes remote mutation commands on failure', () => {
+    const binDir = mkdtempSync(join(tmpdir(), 'profile-self-test-bin-'));
+    const callsPath = join(binDir, 'gh-calls.log');
+    writeFileSync(join(binDir, 'gh'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsPath)}\nif [ "$1 $2" = "auth status" ]; then exit 0; fi\nif [ "$1 $2" = "repo view" ]; then printf '{"viewerPermission":"READ"}\\n'; exit 0; fi\nexit 7\n`, { mode: 0o755 });
+
+    const result = runSelfTest([
+      '--json',
+      '--repo', 'djm204/frankenbeast',
+      '--require-repo-write',
+    ], {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HERMES_ENABLED_TOOLSETS: '',
+      HERMES_DELIVER_TARGETS: '',
+    });
+
+    expect(result.status).toBe(1);
+    const report = parseJson(result.stdout);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'repo-write-access', status: 'fail' })]),
+    );
+
+    const ghCalls = readFileSync(callsPath, 'utf8');
+    expect(ghCalls).toContain('auth status');
+    expect(ghCalls).toContain('repo view djm204/frankenbeast --json viewerPermission');
+    expect(ghCalls).not.toMatch(/\b(issue|pr|repo)\s+(create|edit|delete|merge|close)|\bapi\s+-X\s+(POST|PUT|PATCH|DELETE)/u);
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only profile capability self-test command with text and JSON output
- cover model/provider, toolsets, gh auth, git identity, optional repo write permission, approval-cop, and delivery target checks
- document the self-test in onboarding

## Test Plan
- [x] npx vitest run tests/unit/profile-capability-self-test.test.ts
- [x] npm run test:root -- tests/unit/profile-capability-self-test.test.ts
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] node --check scripts/profile-capability-self-test.mjs
- [x] npm --silent run profile:capability-self-test -- --help
- [x] HERMES_PROVIDER=openai-codex HERMES_MODEL=gpt-5.3-codex-spark HERMES_ENABLED_TOOLSETS=terminal,file HERMES_DELIVER_TARGETS=discord:1523806555047333968 npm --silent run profile:capability-self-test -- --json --provider openai-codex --model gpt-5.3-codex-spark --toolset terminal,file --repo djm204/frankenbeast --require-repo-write --delivery-target discord:1523806555047333968

Closes #1702
