### PR TITLE
feat(observer): add decision outcome attribution

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -18,6 +18,7 @@ npm install @franken/observer
 - [Quick start](#quick-start)
 - [Core tracing](#core-tracing)
 - [Token & cost tracking](#token--cost-tracking)
+- [Decision outcome attribution](#decision-outcome-attribution)
 - [Export backends](#export-backends)
 - [OTEL serialisation](#otel-serialisation)
 - [Evaluation framework](#evaluation-framework)
@@ -260,6 +261,44 @@ attribution.report()
 //     { model: 'claude-sonnet-4-6', totalCalls: 1, successfulCalls: 1, failedCalls: 0, successRate: 1.0, totalCostUsd: 0.0045 },
 //     { model: 'claude-opus-4-6',   totalCalls: 1, successfulCalls: 0, failedCalls: 1, successRate: 0.0, totalCostUsd: 0.0105 },
 //   ]
+```
+
+---
+
+## Decision outcome attribution
+
+`OutcomeAttribution` records compact decision summaries and joins them to later workflow outcomes so learning dashboards can compare which choices correlate with merge success, approval churn, blockers, rollback, or failure. It intentionally stores summaries and labels rather than raw prompts; metadata keys such as `rawPrompt`, `prompt`, `input`, `secret`, `token`, `password`, `credential`, and API key variants are dropped by default.
+
+```ts
+import { OutcomeAttribution } from '@franken/observer'
+
+const attribution = new OutcomeAttribution()
+
+const decision = attribution.recordDecision({
+  workflowId: 'issue-1693',
+  decisionType: 'review-gate',
+  contextSummary: 'PR needs real Codex connector before merge',
+  chosenAction: 'trigger @codex review',
+  alternatives: ['manual-review fallback'],
+})
+
+attribution.recordOutcome({
+  decisionId: decision.decisionId,
+  workflowId: 'issue-1693',
+  verification: 'CI green and current-head Codex clean',
+  prState: 'merged',
+  issueState: 'closed',
+  elapsedMs: 3_600_000,
+  blockers: [],
+  rollback: false,
+  failure: false,
+})
+
+attribution.joinedOutcomes()
+// → [{ decisionType: 'review-gate', chosenAction: 'trigger @codex review', success: true, ... }]
+
+attribution.reportByWorkflow()
+// → [{ workflowId: 'issue-1693', decisionCount: 1, attributedOutcomeCount: 1, ... }]
 ```
 
 ---

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -7,6 +7,7 @@ export { TokenCounter } from './cost/TokenCounter.js'
 export { CostCalculator } from './cost/CostCalculator.js'
 export { CircuitBreaker } from './cost/CircuitBreaker.js'
 export { ModelAttribution } from './cost/ModelAttribution.js'
+export { OutcomeAttribution } from './learning/OutcomeAttribution.js'
 export { DEFAULT_PRICING } from './cost/defaultPricing.js'
 export { InMemoryAdapter } from './export/InMemoryAdapter.js'
 export type { InMemoryAdapterOptions } from './export/InMemoryAdapter.js'
@@ -123,6 +124,16 @@ export type { TokenRecord, TokenTotals } from './cost/TokenCounter.js'
 export type { CostCalculatorOptions } from './cost/CostCalculator.js'
 export type { CircuitBreakerOptions, CircuitBreakerResult } from './cost/CircuitBreaker.js'
 export type { AttributionEntry, AttributionRow } from './cost/ModelAttribution.js'
+export type {
+  AgentDecisionRecord,
+  AgentDecisionRecordInput,
+  DecisionOutcomeIssueState,
+  DecisionOutcomePrState,
+  DecisionOutcomeRecord,
+  DecisionOutcomeRecordInput,
+  JoinedDecisionOutcome,
+  WorkflowOutcomeAttributionReport,
+} from './learning/OutcomeAttribution.js'
 export type { ModelPricing, PricingTable } from './cost/defaultPricing.js'
 export type {
   OTELPayload,

--- a/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
@@ -290,4 +290,65 @@ describe('OutcomeAttribution', () => {
       }),
     ).toThrow(/outcome timestamp must be greater than or equal to decision timestamp/)
   })
+
+  it('preserves non-cyclic shared metadata references after sanitizing each path', () => {
+    const attribution = new OutcomeAttribution()
+    const shared = { safeContext: 'kept', accessKey: 'drop-me' }
+
+    attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'shared-metadata',
+      contextSummary: 'Two labels point at same object',
+      chosenAction: 'sanitize per traversal path',
+      metadata: { first: shared, second: shared, privateKey: 'drop-top' },
+    })
+
+    expect(attribution.decisions()[0]!.metadata).toEqual({
+      first: { safeContext: 'kept' },
+      second: { safeContext: 'kept' },
+    })
+  })
+
+  it('rejects malformed alternatives and aggregate elapsed-time overflow', () => {
+    const attribution = new OutcomeAttribution()
+
+    expect(() =>
+      attribution.recordDecision({
+        workflowId: 'issue-1693',
+        decisionType: 'bad-alternatives',
+        contextSummary: 'Validate JS alternatives',
+        chosenAction: 'reject malformed alternatives',
+        alternatives: 'abc' as never,
+      }),
+    ).toThrow(/alternatives must be an array/)
+
+    const firstDecision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'overflow',
+      contextSummary: 'First large elapsed value',
+      chosenAction: 'record safe integer',
+      timestamp: '2026-07-16T18:00:00.000Z',
+    })
+    const secondDecision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'overflow',
+      contextSummary: 'Second large elapsed value',
+      chosenAction: 'detect unsafe aggregate',
+      timestamp: '2026-07-16T18:00:00.000Z',
+    })
+
+    for (const decision of [firstDecision, secondDecision]) {
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-1693',
+        verification: 'large but individually safe',
+        prState: 'merged',
+        issueState: 'closed',
+        elapsedMs: Number.MAX_SAFE_INTEGER,
+        timestamp: '2026-07-16T18:00:00.000Z',
+      })
+    }
+
+    expect(() => attribution.reportByWorkflow()).toThrow(/totalElapsedMs.*exceeds Number.MAX_SAFE_INTEGER/)
+  })
 })

--- a/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
@@ -309,6 +309,30 @@ describe('OutcomeAttribution', () => {
     })
   })
 
+  it('accepts and normalizes common ISO timestamp forms', () => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'timestamp-normalization',
+      contextSummary: 'External systems omit milliseconds',
+      chosenAction: 'normalize parseable ISO timestamps',
+      timestamp: '2026-07-16T18:00:00Z',
+    })
+
+    const outcome = attribution.recordOutcome({
+      decisionId: decision.decisionId,
+      workflowId: 'issue-1693',
+      verification: 'offset timestamp accepted',
+      prState: 'merged',
+      issueState: 'closed',
+      elapsedMs: 1,
+      timestamp: '2026-07-16T13:00:01-05:00',
+    })
+
+    expect(decision.timestamp).toBe('2026-07-16T18:00:00.000Z')
+    expect(outcome.timestamp).toBe('2026-07-16T18:00:01.000Z')
+  })
+
   it('rejects malformed alternatives and aggregate elapsed-time overflow', () => {
     const attribution = new OutcomeAttribution()
 

--- a/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
@@ -208,4 +208,86 @@ describe('OutcomeAttribution', () => {
       }),
     ).toThrow(/must be one of/)
   })
+
+  it('drops authorization metadata keys and handles cycles while sanitizing', () => {
+    const attribution = new OutcomeAttribution()
+    const metadata: Record<string, unknown> = {
+      authorization: 'Bearer abc123',
+      headers: { Authorization: 'Bearer nested', safeHeader: 'ok' },
+      safe: 'kept',
+    }
+    metadata.self = metadata
+
+    attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'metadata-safety',
+      contextSummary: 'Copied span metadata includes headers',
+      chosenAction: 'sanitize recursively',
+      metadata,
+    })
+
+    expect(attribution.decisions()[0]!.metadata).toEqual({
+      headers: { safeHeader: 'ok' },
+      safe: 'kept',
+      self: '[Circular]',
+    })
+    expect(JSON.stringify(attribution.decisions())).not.toContain('Bearer')
+  })
+
+  it('rejects malformed optional outcome fields from JavaScript callers', () => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'runtime-validation',
+      contextSummary: 'Validate optional fields',
+      chosenAction: 'reject malformed optionals',
+    })
+
+    expect(() =>
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-1693',
+        verification: 'bad blockers',
+        prState: 'open',
+        issueState: 'open',
+        elapsedMs: 1,
+        blockers: 'codex-usage-limit' as never,
+      }),
+    ).toThrow(/blockers must be an array/)
+
+    expect(() =>
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-1693',
+        verification: 'bad failure flag',
+        prState: 'open',
+        issueState: 'open',
+        elapsedMs: 1,
+        failure: 'false' as never,
+      }),
+    ).toThrow(/failure must be a boolean/)
+  })
+
+  it('rejects outcomes that predate their decision timestamp', () => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'ordering',
+      contextSummary: 'Outcome must happen after decision',
+      chosenAction: 'compare timestamps',
+      timestamp: '2026-07-16T18:00:00.000Z',
+    })
+
+    expect(() =>
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-1693',
+        verification: 'impossible ordering',
+        prState: 'merged',
+        issueState: 'closed',
+        elapsedMs: 1,
+        timestamp: '2026-07-16T17:59:59.999Z',
+      }),
+    ).toThrow(/outcome timestamp must be greater than or equal to decision timestamp/)
+  })
 })

--- a/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { OutcomeAttribution } from './OutcomeAttribution.js'
+
+describe('OutcomeAttribution', () => {
+  it('joins routing decision records to merge outcomes without retaining raw prompts', () => {
+    const attribution = new OutcomeAttribution()
+
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'model-routing',
+      contextSummary: 'Need a low-risk observer feature with tests',
+      chosenAction: 'use gpt-5.3-codex-spark for implementation',
+      alternatives: ['wait for gpt-5.5 quota', 'use Ollama Cloud fallback'],
+      timestamp: '2026-07-16T18:00:00.000Z',
+      metadata: {
+        rawPrompt: 'DO NOT STORE: user secret token abc123',
+        token: 'abc123',
+        safeSignal: 'P2 feature',
+      },
+    })
+
+    attribution.recordOutcome({
+      decisionId: decision.decisionId,
+      workflowId: 'issue-1693',
+      verification: 'CI green and current-head Codex clean',
+      prState: 'merged',
+      issueState: 'closed',
+      elapsedMs: 3_600_000,
+      blockers: [],
+      rollback: false,
+      failure: false,
+      timestamp: '2026-07-16T19:00:00.000Z',
+    })
+
+    expect(attribution.joinedOutcomes()).toEqual([
+      expect.objectContaining({
+        workflowId: 'issue-1693',
+        decisionType: 'model-routing',
+        chosenAction: 'use gpt-5.3-codex-spark for implementation',
+        verification: 'CI green and current-head Codex clean',
+        prState: 'merged',
+        issueState: 'closed',
+        elapsedMs: 3_600_000,
+        blockerCount: 0,
+        rollback: false,
+        failure: false,
+        success: true,
+      }),
+    ])
+    expect(attribution.decisions()[0]!.metadata).toEqual({ safeSignal: 'P2 feature' })
+    expect(JSON.stringify(attribution.decisions())).not.toContain('DO NOT STORE')
+    expect(JSON.stringify(attribution.decisions())).not.toContain('abc123')
+  })
+
+  it('joins delegation decisions to blocked outcomes and reports workflow quality signals', () => {
+    const attribution = new OutcomeAttribution()
+
+    const routing = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'worker-delegation',
+      contextSummary: 'Feature implementation needs observer package changes',
+      chosenAction: 'assign one fresh issue worker',
+      timestamp: '2026-07-16T18:10:00.000Z',
+    })
+    const review = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'review-gate',
+      contextSummary: 'PR needs real Codex connector before merge',
+      chosenAction: 'trigger @codex review',
+      alternatives: ['manual-review fallback'],
+      timestamp: '2026-07-16T18:20:00.000Z',
+    })
+
+    attribution.recordOutcome({
+      decisionId: routing.decisionId,
+      workflowId: 'issue-1693',
+      verification: 'PR opened',
+      prState: 'open',
+      issueState: 'open',
+      elapsedMs: 1_200_000,
+      blockers: [],
+      rollback: false,
+      failure: false,
+      timestamp: '2026-07-16T18:30:00.000Z',
+    })
+    attribution.recordOutcome({
+      decisionId: review.decisionId,
+      workflowId: 'issue-1693',
+      verification: 'Codex usage limit response',
+      prState: 'open',
+      issueState: 'open',
+      elapsedMs: 600_000,
+      blockers: ['codex-usage-limit'],
+      rollback: false,
+      failure: false,
+      timestamp: '2026-07-16T18:35:00.000Z',
+    })
+
+    expect(attribution.joinedOutcomes()).toEqual([
+      expect.objectContaining({ decisionId: routing.decisionId, success: true, blockerCount: 0 }),
+      expect.objectContaining({ decisionId: review.decisionId, success: false, blockerCount: 1 }),
+    ])
+    expect(attribution.reportByWorkflow()).toEqual([
+      {
+        workflowId: 'issue-1693',
+        decisionCount: 2,
+        attributedOutcomeCount: 2,
+        successfulOutcomeCount: 1,
+        blockerCount: 1,
+        rollbackCount: 0,
+        failureCount: 0,
+        totalElapsedMs: 1_800_000,
+      },
+    ])
+  })
+})

--- a/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.test.ts
@@ -113,4 +113,99 @@ describe('OutcomeAttribution', () => {
       },
     ])
   })
+
+  it('recursively drops nested prompt and secret metadata keys', () => {
+    const attribution = new OutcomeAttribution()
+
+    attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'tool-choice',
+      contextSummary: 'Need a safe query helper',
+      chosenAction: 'capture summaries only',
+      metadata: {
+        payload: {
+          rawPrompt: 'DO NOT STORE nested prompt',
+          nested: { token: 'nested-token', safeNestedSignal: 'ok' },
+        },
+        safeTopLevel: 'kept',
+      },
+    })
+
+    expect(attribution.decisions()[0]!.metadata).toEqual({
+      payload: { nested: { safeNestedSignal: 'ok' } },
+      safeTopLevel: 'kept',
+    })
+    expect(JSON.stringify(attribution.decisions())).not.toContain('DO NOT STORE')
+    expect(JSON.stringify(attribution.decisions())).not.toContain('nested-token')
+  })
+
+  it('rejects outcome workflow ids that do not match the decision workflow', () => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'review-gate',
+      contextSummary: 'PR needs review',
+      chosenAction: 'trigger Codex',
+    })
+
+    expect(() =>
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-9999',
+        verification: 'wrong workflow',
+        prState: 'open',
+        issueState: 'open',
+        elapsedMs: 1,
+      }),
+    ).toThrow(/workflowId issue-9999 does not match decision workflowId issue-1693/)
+  })
+
+  it.each([
+    ['closed PR', { prState: 'closed' as const, issueState: 'open' as const }],
+    ['not-planned issue', { prState: 'none' as const, issueState: 'not-planned' as const }],
+  ])('counts %s terminal outcomes as unsuccessful by default', (_name, state) => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'scope-choice',
+      contextSummary: 'Decide whether to continue',
+      chosenAction: 'stop work',
+    })
+
+    attribution.recordOutcome({
+      decisionId: decision.decisionId,
+      workflowId: 'issue-1693',
+      verification: 'terminal without merge',
+      prState: state.prState,
+      issueState: state.issueState,
+      elapsedMs: 5,
+    })
+
+    expect(attribution.joinedOutcomes()[0]!.success).toBe(false)
+    expect(attribution.reportByWorkflow()[0]!.successfulOutcomeCount).toBe(0)
+  })
+
+  it.each([
+    ['bad PR state', { prState: 'merge', issueState: 'open' }],
+    ['bad issue state', { prState: 'open', issueState: 'done' }],
+  ])('rejects invalid runtime state values for %s', (_name, state) => {
+    const attribution = new OutcomeAttribution()
+    const decision = attribution.recordDecision({
+      workflowId: 'issue-1693',
+      decisionType: 'state-validation',
+      contextSummary: 'Validate JS callers',
+      chosenAction: 'reject invalid states',
+    })
+
+    expect(() =>
+      attribution.recordOutcome({
+        decisionId: decision.decisionId,
+        workflowId: 'issue-1693',
+        verification: 'invalid state',
+        prState: state.prState as never,
+        issueState: state.issueState as never,
+        elapsedMs: 1,
+      }),
+    ).toThrow(/must be one of/)
+  })
 })

--- a/packages/franken-observer/src/learning/OutcomeAttribution.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.ts
@@ -83,6 +83,8 @@ export interface WorkflowOutcomeAttributionReport {
 }
 
 const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key)/i
+const VALID_PR_STATES = ['none', 'draft', 'open', 'merged', 'closed'] as const
+const VALID_ISSUE_STATES = ['open', 'closed', 'not-planned', 'unknown'] as const
 
 function assertNonEmptyString(value: string, field: string): void {
   if (value.trim().length === 0) {
@@ -103,6 +105,12 @@ function assertElapsedMs(value: number): void {
   }
 }
 
+function assertOneOf(value: string, field: string, allowed: readonly string[]): void {
+  if (!allowed.includes(value)) {
+    throw new Error(`OutcomeAttribution: ${field} must be one of ${allowed.join(', ')}, received ${value}`)
+  }
+}
+
 function defaultTimestamp(): string {
   return new Date().toISOString()
 }
@@ -111,20 +119,39 @@ function freezeRecord<T extends Record<string, unknown>>(value: T): Readonly<T> 
   return Object.freeze({ ...value })
 }
 
+function sanitizeMetadataValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map(item => sanitizeMetadataValue(item)))
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value
+  }
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) continue
+    sanitized[key] = sanitizeMetadataValue(nestedValue)
+  }
+
+  return freezeRecord(sanitized)
+}
+
 function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Readonly<Record<string, unknown>> | undefined {
   if (metadata === undefined) return undefined
 
-  const sanitized: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(metadata)) {
-    if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) continue
-    sanitized[key] = value
-  }
-
-  return Object.keys(sanitized).length === 0 ? undefined : freezeRecord(sanitized)
+  const sanitized = sanitizeMetadataValue(metadata) as Readonly<Record<string, unknown>>
+  return Object.keys(sanitized).length === 0 ? undefined : sanitized
 }
 
 function successfulOutcome(outcome: DecisionOutcomeRecord): boolean {
-  return outcome.blockers.length === 0 && !outcome.rollback && !outcome.failure
+  return (
+    outcome.blockers.length === 0 &&
+    !outcome.rollback &&
+    !outcome.failure &&
+    outcome.prState !== 'closed' &&
+    outcome.issueState !== 'not-planned'
+  )
 }
 
 /**
@@ -164,11 +191,19 @@ export class OutcomeAttribution {
     assertNonEmptyString(input.workflowId, 'workflowId')
     assertNonEmptyString(input.verification, 'verification')
     assertElapsedMs(input.elapsedMs)
+    assertOneOf(input.prState, 'prState', VALID_PR_STATES)
+    assertOneOf(input.issueState, 'issueState', VALID_ISSUE_STATES)
     const timestamp = input.timestamp ?? defaultTimestamp()
     assertIsoTimestamp(timestamp, 'timestamp')
 
-    if (!this.decisionRecords.some(decision => decision.decisionId === input.decisionId)) {
+    const decision = this.decisionRecords.find(decisionRecord => decisionRecord.decisionId === input.decisionId)
+    if (decision === undefined) {
       throw new Error(`OutcomeAttribution: decisionId ${input.decisionId} has not been recorded`)
+    }
+    if (decision.workflowId !== input.workflowId) {
+      throw new Error(
+        `OutcomeAttribution: workflowId ${input.workflowId} does not match decision workflowId ${decision.workflowId}`,
+      )
     }
 
     const record: DecisionOutcomeRecord = Object.freeze({

--- a/packages/franken-observer/src/learning/OutcomeAttribution.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.ts
@@ -92,11 +92,12 @@ function assertNonEmptyString(value: string, field: string): void {
   }
 }
 
-function assertIsoTimestamp(value: string, field: string): void {
+function normalizeIsoTimestamp(value: string, field: string): string {
   const parsed = Date.parse(value)
-  if (Number.isNaN(parsed) || new Date(parsed).toISOString() !== value) {
+  if (Number.isNaN(parsed)) {
     throw new Error(`OutcomeAttribution: ${field} must be an ISO timestamp`)
   }
+  return new Date(parsed).toISOString()
 }
 
 function assertElapsedMs(value: number): void {
@@ -190,8 +191,7 @@ export class OutcomeAttribution {
     assertNonEmptyString(input.contextSummary, 'contextSummary')
     assertNonEmptyString(input.chosenAction, 'chosenAction')
     assertOptionalStringArray(input.alternatives, 'alternatives')
-    const timestamp = input.timestamp ?? defaultTimestamp()
-    assertIsoTimestamp(timestamp, 'timestamp')
+    const timestamp = normalizeIsoTimestamp(input.timestamp ?? defaultTimestamp(), 'timestamp')
 
     const record: AgentDecisionRecord = Object.freeze({
       decisionId: randomUUID(),
@@ -217,8 +217,7 @@ export class OutcomeAttribution {
     assertOptionalStringArray(input.blockers, 'blockers')
     assertOptionalBoolean(input.rollback, 'rollback')
     assertOptionalBoolean(input.failure, 'failure')
-    const timestamp = input.timestamp ?? defaultTimestamp()
-    assertIsoTimestamp(timestamp, 'timestamp')
+    const timestamp = normalizeIsoTimestamp(input.timestamp ?? defaultTimestamp(), 'timestamp')
 
     const decision = this.decisionRecords.find(decisionRecord => decisionRecord.decisionId === input.decisionId)
     if (decision === undefined) {

--- a/packages/franken-observer/src/learning/OutcomeAttribution.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from 'node:crypto'
+
+export type DecisionOutcomePrState = 'none' | 'draft' | 'open' | 'merged' | 'closed'
+export type DecisionOutcomeIssueState = 'open' | 'closed' | 'not-planned' | 'unknown'
+
+export interface AgentDecisionRecordInput {
+  workflowId: string
+  decisionType: string
+  contextSummary: string
+  chosenAction: string
+  alternatives?: readonly string[]
+  timestamp?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface AgentDecisionRecord {
+  decisionId: string
+  workflowId: string
+  decisionType: string
+  contextSummary: string
+  chosenAction: string
+  alternatives: readonly string[]
+  timestamp: string
+  metadata?: Readonly<Record<string, unknown>>
+}
+
+export interface DecisionOutcomeRecordInput {
+  decisionId: string
+  workflowId: string
+  verification: string
+  prState: DecisionOutcomePrState
+  issueState: DecisionOutcomeIssueState
+  elapsedMs: number
+  blockers?: readonly string[]
+  rollback?: boolean
+  failure?: boolean
+  timestamp?: string
+}
+
+export interface DecisionOutcomeRecord {
+  outcomeId: string
+  decisionId: string
+  workflowId: string
+  verification: string
+  prState: DecisionOutcomePrState
+  issueState: DecisionOutcomeIssueState
+  elapsedMs: number
+  blockers: readonly string[]
+  rollback: boolean
+  failure: boolean
+  timestamp: string
+}
+
+export interface JoinedDecisionOutcome {
+  decisionId: string
+  outcomeId: string
+  workflowId: string
+  decisionType: string
+  contextSummary: string
+  chosenAction: string
+  alternatives: readonly string[]
+  decidedAt: string
+  outcomeAt: string
+  verification: string
+  prState: DecisionOutcomePrState
+  issueState: DecisionOutcomeIssueState
+  elapsedMs: number
+  blockerCount: number
+  rollback: boolean
+  failure: boolean
+  success: boolean
+}
+
+export interface WorkflowOutcomeAttributionReport {
+  workflowId: string
+  decisionCount: number
+  attributedOutcomeCount: number
+  successfulOutcomeCount: number
+  blockerCount: number
+  rollbackCount: number
+  failureCount: number
+  totalElapsedMs: number
+}
+
+const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key)/i
+
+function assertNonEmptyString(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`OutcomeAttribution: ${field} must be a non-empty string`)
+  }
+}
+
+function assertIsoTimestamp(value: string, field: string): void {
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new Error(`OutcomeAttribution: ${field} must be an ISO timestamp`)
+  }
+}
+
+function assertElapsedMs(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`OutcomeAttribution: elapsedMs must be a non-negative safe integer, received ${value}`)
+  }
+}
+
+function defaultTimestamp(): string {
+  return new Date().toISOString()
+}
+
+function freezeRecord<T extends Record<string, unknown>>(value: T): Readonly<T> {
+  return Object.freeze({ ...value })
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Readonly<Record<string, unknown>> | undefined {
+  if (metadata === undefined) return undefined
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(metadata)) {
+    if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) continue
+    sanitized[key] = value
+  }
+
+  return Object.keys(sanitized).length === 0 ? undefined : freezeRecord(sanitized)
+}
+
+function successfulOutcome(outcome: DecisionOutcomeRecord): boolean {
+  return outcome.blockers.length === 0 && !outcome.rollback && !outcome.failure
+}
+
+/**
+ * Captures lightweight decision/outcome attribution without storing raw prompts
+ * or secret-bearing metadata by default. The records are intentionally compact:
+ * callers provide summaries, action labels, state, and verification evidence
+ * rather than full transcripts or prompt bodies.
+ */
+export class OutcomeAttribution {
+  private readonly decisionRecords: AgentDecisionRecord[] = []
+  private readonly outcomeRecords: DecisionOutcomeRecord[] = []
+
+  recordDecision(input: AgentDecisionRecordInput): AgentDecisionRecord {
+    assertNonEmptyString(input.workflowId, 'workflowId')
+    assertNonEmptyString(input.decisionType, 'decisionType')
+    assertNonEmptyString(input.contextSummary, 'contextSummary')
+    assertNonEmptyString(input.chosenAction, 'chosenAction')
+    const timestamp = input.timestamp ?? defaultTimestamp()
+    assertIsoTimestamp(timestamp, 'timestamp')
+
+    const record: AgentDecisionRecord = Object.freeze({
+      decisionId: randomUUID(),
+      workflowId: input.workflowId,
+      decisionType: input.decisionType,
+      contextSummary: input.contextSummary,
+      chosenAction: input.chosenAction,
+      alternatives: Object.freeze([...(input.alternatives ?? [])]),
+      timestamp,
+      metadata: sanitizeMetadata(input.metadata),
+    })
+    this.decisionRecords.push(record)
+    return record
+  }
+
+  recordOutcome(input: DecisionOutcomeRecordInput): DecisionOutcomeRecord {
+    assertNonEmptyString(input.decisionId, 'decisionId')
+    assertNonEmptyString(input.workflowId, 'workflowId')
+    assertNonEmptyString(input.verification, 'verification')
+    assertElapsedMs(input.elapsedMs)
+    const timestamp = input.timestamp ?? defaultTimestamp()
+    assertIsoTimestamp(timestamp, 'timestamp')
+
+    if (!this.decisionRecords.some(decision => decision.decisionId === input.decisionId)) {
+      throw new Error(`OutcomeAttribution: decisionId ${input.decisionId} has not been recorded`)
+    }
+
+    const record: DecisionOutcomeRecord = Object.freeze({
+      outcomeId: randomUUID(),
+      decisionId: input.decisionId,
+      workflowId: input.workflowId,
+      verification: input.verification,
+      prState: input.prState,
+      issueState: input.issueState,
+      elapsedMs: input.elapsedMs,
+      blockers: Object.freeze([...(input.blockers ?? [])]),
+      rollback: input.rollback ?? false,
+      failure: input.failure ?? false,
+      timestamp,
+    })
+    this.outcomeRecords.push(record)
+    return record
+  }
+
+  decisions(): readonly AgentDecisionRecord[] {
+    return [...this.decisionRecords]
+  }
+
+  outcomes(): readonly DecisionOutcomeRecord[] {
+    return [...this.outcomeRecords]
+  }
+
+  joinedOutcomes(): JoinedDecisionOutcome[] {
+    const decisionsById = new Map(this.decisionRecords.map(decision => [decision.decisionId, decision]))
+
+    return this.outcomeRecords.flatMap(outcome => {
+      const decision = decisionsById.get(outcome.decisionId)
+      if (decision === undefined) return []
+      return [{
+        decisionId: decision.decisionId,
+        outcomeId: outcome.outcomeId,
+        workflowId: decision.workflowId,
+        decisionType: decision.decisionType,
+        contextSummary: decision.contextSummary,
+        chosenAction: decision.chosenAction,
+        alternatives: decision.alternatives,
+        decidedAt: decision.timestamp,
+        outcomeAt: outcome.timestamp,
+        verification: outcome.verification,
+        prState: outcome.prState,
+        issueState: outcome.issueState,
+        elapsedMs: outcome.elapsedMs,
+        blockerCount: outcome.blockers.length,
+        rollback: outcome.rollback,
+        failure: outcome.failure,
+        success: successfulOutcome(outcome),
+      }]
+    })
+  }
+
+  reportByWorkflow(): WorkflowOutcomeAttributionReport[] {
+    const reports = new Map<string, WorkflowOutcomeAttributionReport>()
+    for (const decision of this.decisionRecords) {
+      reports.set(decision.workflowId, {
+        workflowId: decision.workflowId,
+        decisionCount: (reports.get(decision.workflowId)?.decisionCount ?? 0) + 1,
+        attributedOutcomeCount: reports.get(decision.workflowId)?.attributedOutcomeCount ?? 0,
+        successfulOutcomeCount: reports.get(decision.workflowId)?.successfulOutcomeCount ?? 0,
+        blockerCount: reports.get(decision.workflowId)?.blockerCount ?? 0,
+        rollbackCount: reports.get(decision.workflowId)?.rollbackCount ?? 0,
+        failureCount: reports.get(decision.workflowId)?.failureCount ?? 0,
+        totalElapsedMs: reports.get(decision.workflowId)?.totalElapsedMs ?? 0,
+      })
+    }
+
+    for (const joined of this.joinedOutcomes()) {
+      const report = reports.get(joined.workflowId) ?? {
+        workflowId: joined.workflowId,
+        decisionCount: 0,
+        attributedOutcomeCount: 0,
+        successfulOutcomeCount: 0,
+        blockerCount: 0,
+        rollbackCount: 0,
+        failureCount: 0,
+        totalElapsedMs: 0,
+      }
+      report.attributedOutcomeCount += 1
+      report.successfulOutcomeCount += joined.success ? 1 : 0
+      report.blockerCount += joined.blockerCount
+      report.rollbackCount += joined.rollback ? 1 : 0
+      report.failureCount += joined.failure ? 1 : 0
+      report.totalElapsedMs += joined.elapsedMs
+      reports.set(joined.workflowId, report)
+    }
+
+    return Array.from(reports.values())
+  }
+}

--- a/packages/franken-observer/src/learning/OutcomeAttribution.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.ts
@@ -82,7 +82,7 @@ export interface WorkflowOutcomeAttributionReport {
   totalElapsedMs: number
 }
 
-const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key)/i
+const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key|authorization|auth[-_]?header|bearer)/i
 const VALID_PR_STATES = ['none', 'draft', 'open', 'merged', 'closed'] as const
 const VALID_ISSUE_STATES = ['open', 'closed', 'not-planned', 'unknown'] as const
 
@@ -111,6 +111,18 @@ function assertOneOf(value: string, field: string, allowed: readonly string[]): 
   }
 }
 
+function assertOptionalBoolean(value: boolean | undefined, field: string): void {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new Error(`OutcomeAttribution: ${field} must be a boolean when present`)
+  }
+}
+
+function assertOptionalStringArray(value: readonly string[] | undefined, field: string): void {
+  if (value !== undefined && (!Array.isArray(value) || value.some(item => typeof item !== 'string'))) {
+    throw new Error(`OutcomeAttribution: ${field} must be an array of strings when present`)
+  }
+}
+
 function defaultTimestamp(): string {
   return new Date().toISOString()
 }
@@ -119,19 +131,24 @@ function freezeRecord<T extends Record<string, unknown>>(value: T): Readonly<T> 
   return Object.freeze({ ...value })
 }
 
-function sanitizeMetadataValue(value: unknown): unknown {
+function sanitizeMetadataValue(value: unknown, seen = new WeakSet<object>()): unknown {
   if (Array.isArray(value)) {
-    return Object.freeze(value.map(item => sanitizeMetadataValue(item)))
+    if (seen.has(value)) return '[Circular]'
+    seen.add(value)
+    return Object.freeze(value.map(item => sanitizeMetadataValue(item, seen)))
   }
 
   if (typeof value !== 'object' || value === null) {
     return value
   }
 
+  if (seen.has(value)) return '[Circular]'
+  seen.add(value)
+
   const sanitized: Record<string, unknown> = {}
   for (const [key, nestedValue] of Object.entries(value)) {
     if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) continue
-    sanitized[key] = sanitizeMetadataValue(nestedValue)
+    sanitized[key] = sanitizeMetadataValue(nestedValue, seen)
   }
 
   return freezeRecord(sanitized)
@@ -193,6 +210,9 @@ export class OutcomeAttribution {
     assertElapsedMs(input.elapsedMs)
     assertOneOf(input.prState, 'prState', VALID_PR_STATES)
     assertOneOf(input.issueState, 'issueState', VALID_ISSUE_STATES)
+    assertOptionalStringArray(input.blockers, 'blockers')
+    assertOptionalBoolean(input.rollback, 'rollback')
+    assertOptionalBoolean(input.failure, 'failure')
     const timestamp = input.timestamp ?? defaultTimestamp()
     assertIsoTimestamp(timestamp, 'timestamp')
 
@@ -204,6 +224,9 @@ export class OutcomeAttribution {
       throw new Error(
         `OutcomeAttribution: workflowId ${input.workflowId} does not match decision workflowId ${decision.workflowId}`,
       )
+    }
+    if (Date.parse(timestamp) < Date.parse(decision.timestamp)) {
+      throw new Error('OutcomeAttribution: outcome timestamp must be greater than or equal to decision timestamp')
     }
 
     const record: DecisionOutcomeRecord = Object.freeze({

--- a/packages/franken-observer/src/learning/OutcomeAttribution.ts
+++ b/packages/franken-observer/src/learning/OutcomeAttribution.ts
@@ -82,7 +82,7 @@ export interface WorkflowOutcomeAttributionReport {
   totalElapsedMs: number
 }
 
-const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key|authorization|auth[-_]?header|bearer)/i
+const SENSITIVE_METADATA_KEY_PATTERN = /(raw.*prompt|prompt|input|secret|token|password|credential|api[-_]?key|authorization|auth[-_]?header|bearer|private[-_]?key|access[-_]?key|cookie|^auth$)/i
 const VALID_PR_STATES = ['none', 'draft', 'open', 'merged', 'closed'] as const
 const VALID_ISSUE_STATES = ['open', 'closed', 'not-planned', 'unknown'] as const
 
@@ -135,7 +135,9 @@ function sanitizeMetadataValue(value: unknown, seen = new WeakSet<object>()): un
   if (Array.isArray(value)) {
     if (seen.has(value)) return '[Circular]'
     seen.add(value)
-    return Object.freeze(value.map(item => sanitizeMetadataValue(item, seen)))
+    const sanitizedArray = Object.freeze(value.map(item => sanitizeMetadataValue(item, seen)))
+    seen.delete(value)
+    return sanitizedArray
   }
 
   if (typeof value !== 'object' || value === null) {
@@ -150,6 +152,7 @@ function sanitizeMetadataValue(value: unknown, seen = new WeakSet<object>()): un
     if (SENSITIVE_METADATA_KEY_PATTERN.test(key)) continue
     sanitized[key] = sanitizeMetadataValue(nestedValue, seen)
   }
+  seen.delete(value)
 
   return freezeRecord(sanitized)
 }
@@ -186,6 +189,7 @@ export class OutcomeAttribution {
     assertNonEmptyString(input.decisionType, 'decisionType')
     assertNonEmptyString(input.contextSummary, 'contextSummary')
     assertNonEmptyString(input.chosenAction, 'chosenAction')
+    assertOptionalStringArray(input.alternatives, 'alternatives')
     const timestamp = input.timestamp ?? defaultTimestamp()
     assertIsoTimestamp(timestamp, 'timestamp')
 
@@ -313,7 +317,11 @@ export class OutcomeAttribution {
       report.blockerCount += joined.blockerCount
       report.rollbackCount += joined.rollback ? 1 : 0
       report.failureCount += joined.failure ? 1 : 0
-      report.totalElapsedMs += joined.elapsedMs
+      const nextTotalElapsedMs = report.totalElapsedMs + joined.elapsedMs
+      if (!Number.isSafeInteger(nextTotalElapsedMs)) {
+        throw new RangeError(`OutcomeAttribution: totalElapsedMs for workflow ${joined.workflowId} exceeds Number.MAX_SAFE_INTEGER`)
+      }
+      report.totalElapsedMs = nextTotalElapsedMs
       reports.set(joined.workflowId, report)
     }
 


### PR DESCRIPTION
## Summary
- Adds `OutcomeAttribution` to record compact agent decision records and later outcome records.
- Joins decisions to PR/issue verification, elapsed time, blockers, rollback, and failure signals for learning dashboards.
- Filters raw prompt/secret-like metadata keys by default and documents the workflow.

## Test Plan
- npm run test --workspace @franken/observer -- src/learning/OutcomeAttribution.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer

Closes #1693
