### PR TITLE
test(availability): simulate provider outage fallback paths

### DIFF
--- a/docs/dr/provider-outage-recovery-drill.md
+++ b/docs/dr/provider-outage-recovery-drill.md
@@ -32,6 +32,7 @@ The fixture script is safe to run from any checkout because it only prints deter
 
 ```bash
 node scripts/provider-outage-drill-fixture.mjs --scenario provider-outage
+node scripts/provider-outage-drill-fixture.mjs --scenario fallback-paths
 node scripts/provider-outage-drill-fixture.mjs --scenario recovery
 ```
 
@@ -138,6 +139,14 @@ Failure interpretations:
 - `fallback_only_mode` with lane width and allowed lanes;
 - backlog routes that include `resume-checkpointed`, `complete-checkpointed`, and `defer-fresh-start`;
 - `failureInterpretations` for fresh-start starvation, duplicate owners, unsafe gate bypass, and missing retry clock.
+
+`node scripts/provider-outage-drill-fixture.mjs --scenario fallback-paths` should print JSON containing:
+
+- `scenario: "fallback-paths"` and `safety.liveProviderCalls: false`;
+- fixtures named `primary-unavailable`, `spark-budget-exhausted`, `ollama-only-continuity`, and `primary-restored`;
+- transitions that park fresh backlog during primary outage, refuse Spark refill after budget exhaustion, keep Ollama Cloud fallback at five low-risk lanes, and resume primary blocked owners before new tickets;
+- `workerCounts` and `summaryLines` that expose primary, Spark, Ollama, and parked worker counts for every route transition;
+- `toolRestrictions` for Ollama-only continuity so fallback lanes cannot perform fresh implementation, production mutation, or live gate substitution.
 
 `node scripts/provider-outage-drill-fixture.mjs --scenario recovery` should print JSON containing:
 

--- a/scripts/provider-outage-drill-fixture.mjs
+++ b/scripts/provider-outage-drill-fixture.mjs
@@ -52,6 +52,92 @@ const scenarios = new Map([
     },
   ],
   [
+    'fallback-paths',
+    {
+      scenario: 'fallback-paths',
+      safety: {
+        mode: 'fixture-only',
+        mutatesState: false,
+        liveProviderCalls: false,
+        note: 'Deterministic fallback-path drill; uses synthetic provider and budget statuses only.',
+      },
+      fixtures: [
+        {
+          name: 'primary-unavailable',
+          providerStatus: { primary: 'unavailable', spark: 'available', ollama: 'available' },
+          budgetStatus: { sparkRemainingUsd: 12, ollamaFallbackLaneWidth: 5 },
+        },
+        {
+          name: 'spark-budget-exhausted',
+          providerStatus: { primary: 'unavailable', spark: 'budget-exhausted', ollama: 'available' },
+          budgetStatus: { sparkRemainingUsd: 0, ollamaFallbackLaneWidth: 5 },
+        },
+        {
+          name: 'ollama-only-continuity',
+          providerStatus: { primary: 'unavailable', spark: 'budget-exhausted', ollama: 'available' },
+          budgetStatus: { sparkRemainingUsd: 0, ollamaFallbackLaneWidth: 5 },
+          lowRiskScope: ['read-only-inventory', 'docs-only-updates', 'status-summary', 'checkpointed-closeout-only'],
+        },
+        {
+          name: 'primary-restored',
+          providerStatus: { primary: 'available', spark: 'budget-exhausted', ollama: 'draining' },
+          budgetStatus: { sparkRemainingUsd: 0, ollamaFallbackLaneWidth: 0 },
+        },
+      ],
+      transitions: [
+        {
+          from: 'normal-primary-refill',
+          to: 'provider-outage-freeze',
+          trigger: 'primary unavailable',
+          route: 'park-fresh-work',
+          parkedBacklog: ['fresh-issue-starts', 'unsafe-merge-gates'],
+          workerCounts: { primary: 0, spark: 5, ollama: 0, parked: 7 },
+        },
+        {
+          from: 'spark-fallback-refill',
+          to: 'spark-budget-freeze',
+          trigger: 'Spark budget exhausted',
+          route: 'keep-high-risk-parked',
+          refillDecision: 'do-not-refill-spark; keep backlog parked',
+          workerCounts: { primary: 0, spark: 0, ollama: 0, parked: 12 },
+        },
+        {
+          from: 'fallback-budget-freeze',
+          to: 'ollama-only-continuity',
+          trigger: 'Ollama fallback continuity',
+          route: 'refill-low-risk-only',
+          toolRestrictions: ['read-only-inventory', 'docs-only-updates', 'status-summary', 'checkpointed-closeout-only'],
+          workerCounts: { primary: 0, spark: 0, ollama: 5, parked: 12 },
+        },
+        {
+          from: 'ollama-only-continuity',
+          to: 'primary-recovery-drain',
+          trigger: 'primary restored',
+          route: 'resume-primary-before-new-tickets',
+          resumeOrdering: [
+            'unpark-provider-blocked-active-owners',
+            'finish-in-flight-before-fresh-issues',
+            'rerun-current-head-gates',
+            'restore-primary-refill-after-stability-tick',
+          ],
+          workerCounts: { primary: 5, spark: 0, ollama: 0, parked: 7 },
+        },
+      ],
+      summaryLines: [
+        '[fallback-drill] fixture primary-unavailable => route=park-fresh-work primary=0 spark=5 ollama=0 parked=7',
+        '[fallback-drill] fixture spark-budget-exhausted => route=keep-high-risk-parked primary=0 spark=0 ollama=0 parked=12',
+        '[fallback-drill] fixture ollama-only-continuity => route=refill-low-risk-only primary=0 spark=0 ollama=5 parked=12 restrictions=read-only-inventory,docs-only-updates,status-summary,checkpointed-closeout-only',
+        '[fallback-drill] fixture primary-restored => route=resume-primary-before-new-tickets primary=5 spark=0 ollama=0 parked=7',
+      ],
+      assertions: [
+        'Primary outage parks fresh issue starts and unsafe merge gates.',
+        'Spark budget exhaustion does not refill Spark lanes or unpark high-risk backlog.',
+        'Ollama-only continuity remains exactly five low-risk lanes with restricted tooling.',
+        'Primary recovery resumes provider-blocked active owners before fresh tickets.',
+      ],
+    },
+  ],
+  [
     'recovery',
     {
       scenario: 'recovery',
@@ -105,7 +191,7 @@ const scenarios = new Map([
 ]);
 
 function usage() {
-  return `Usage: node scripts/provider-outage-drill-fixture.mjs --scenario <provider-outage|recovery>`;
+  return `Usage: node scripts/provider-outage-drill-fixture.mjs --scenario <provider-outage|fallback-paths|recovery>`;
 }
 
 const args = process.argv.slice(2);

--- a/tests/docs-issue-1722.test.ts
+++ b/tests/docs-issue-1722.test.ts
@@ -106,4 +106,56 @@ describe('issue #1722 provider outage recovery drill docs', () => {
     expect(recovery.events[2]?.steps).toContain('finish or harden in-flight backlog before fresh issues');
     expect(recovery.failureInterpretations.join('\n')).toContain('aggressive resume ordering');
   });
+
+  it('covers issue #1681 fallback paths without live provider calls', () => {
+    const drill = runFixture('fallback-paths') as {
+      scenario: string;
+      safety: { mutatesState: boolean; liveProviderCalls: boolean };
+      fixtures: Array<{ name: string }>;
+      transitions: Array<{
+        from: string;
+        to: string;
+        trigger: string;
+        route: string;
+        workerCounts: { primary: number; spark: number; ollama: number; parked: number };
+        parkedBacklog?: string[];
+        toolRestrictions?: string[];
+        refillDecision?: string;
+        resumeOrdering?: string[];
+      }>;
+      summaryLines: string[];
+    };
+
+    expect(drill.scenario).toBe('fallback-paths');
+    expect(drill.safety.mutatesState).toBe(false);
+    expect(drill.safety.liveProviderCalls).toBe(false);
+    expect(drill.fixtures.map((fixture) => fixture.name)).toEqual([
+      'primary-unavailable',
+      'spark-budget-exhausted',
+      'ollama-only-continuity',
+      'primary-restored',
+    ]);
+    expect(drill.transitions.map((transition) => transition.trigger)).toEqual([
+      'primary unavailable',
+      'Spark budget exhausted',
+      'Ollama fallback continuity',
+      'primary restored',
+    ]);
+    expect(drill.transitions[0]?.parkedBacklog).toEqual(['fresh-issue-starts', 'unsafe-merge-gates']);
+    expect(drill.transitions[1]?.refillDecision).toBe('do-not-refill-spark; keep backlog parked');
+    expect(drill.transitions[2]?.toolRestrictions).toEqual([
+      'read-only-inventory',
+      'docs-only-updates',
+      'status-summary',
+      'checkpointed-closeout-only',
+    ]);
+    expect(drill.transitions[2]?.workerCounts).toEqual({ primary: 0, spark: 0, ollama: 5, parked: 12 });
+    expect(drill.transitions[3]?.resumeOrdering).toEqual([
+      'unpark-provider-blocked-active-owners',
+      'finish-in-flight-before-fresh-issues',
+      'rerun-current-head-gates',
+      'restore-primary-refill-after-stability-tick',
+    ]);
+    expect(drill.summaryLines.join('\n')).toContain('primary=0 spark=0 ollama=5 parked=12');
+  });
 });


### PR DESCRIPTION
## Summary
- add deterministic fallback-paths provider outage fixture for primary outage, Spark budget exhaustion, Ollama-only continuity, and primary recovery
- assert the fallback fixture remains fixture-only with no live provider calls and exactly five Ollama low-risk lanes
- document the new fallback-paths scenario in the provider outage recovery drill

## Test Plan
- npm ci
- node scripts/provider-outage-drill-fixture.mjs --scenario fallback-paths
- npm run test:root -- tests/docs-issue-1722.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #1681