### PR TITLE
test(dr): add restore rehearsal CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           CI_BOOTSTRAP_DRY_RUN: "1"
         run: npm run bootstrap:dry-run
 
+      - name: Disaster recovery restore rehearsal
+        run: npm run ci:dr:restore-rehearsal
+
       - name: Restore dependency vulnerability SLA state
         uses: actions/cache/restore@v6
         with:

--- a/docs/dr/restore-rehearsal.md
+++ b/docs/dr/restore-rehearsal.md
@@ -15,12 +15,12 @@ CI runs the same command through `npm run ci:dr:restore-rehearsal` after the boo
 The script builds synthetic state under a temporary root only; it never reads or writes a live Hermes profile, live Kanban database, approval ledger, or user config. The fixture contains the minimal recoverable orchestration data that has caused restore risk in prior incidents:
 
 - `profiles/default/kanban.db` with one task and one task comment.
-- `profiles/default/approvals/ledger.json` with one approved approval entry.
+- `profiles/default/approvals/ledger.json` with one approved approval entry (restored under the production quarantine path).
 - `profiles/default/config.yaml` with liveness values, including `kanban.dispatch_stale_timeout_seconds`, `liveness.heartbeat_interval_seconds`, and `liveness.worker_ids`.
-- A backup manifest recording that the fixture was captured by `scripts/restore-rehearsal.mjs`.
+- An encrypted `.franken-dr.json` backup artifact recording the fixture manifest and ciphertext.
 
 ## What the rehearsal proves
 
-The rehearsal copies the fixture into a backup directory, restores that backup into a separate temporary target, and asserts that the task, comment, approval entry, and liveness values survived. It also runs a corrupted-fixture case by breaking the approval ledger JSON and requiring the restore assertion to fail with a clear `approval ledger is not valid JSON` error.
+The rehearsal writes the fixture into the encrypted DR backup implementation (`createEncryptedStateBackup`), restores it with `restoreEncryptedStateBackup` into a separate temporary target, and asserts that the task, comment, quarantined approval entry, and liveness values survived. It also runs a corrupted-fixture case by breaking the approval ledger JSON before backup and requiring the restore assertion to fail with a clear `approval ledger is not valid JSON` error.
 
-Use `node scripts/restore-rehearsal.mjs --format json` when automation needs machine-readable evidence. Use `--keep-temp --root <scratch-dir>` only for debugging the fixture contents; never point `--root` at a repository root, home directory, or live profile.
+Use `npm run dr:restore-rehearsal -- --format json` when automation needs machine-readable evidence. Use `--keep-temp --root <scratch-dir>` only for debugging the fixture contents; never point `--root` at a repository root, home directory, or live profile.

--- a/docs/dr/restore-rehearsal.md
+++ b/docs/dr/restore-rehearsal.md
@@ -1,0 +1,26 @@
+# Restore rehearsal fixture
+
+The restore rehearsal is an isolated disaster-recovery smoke test for the orchestration state that PM-swarm and approval-gated workers depend on.
+
+Run it locally with:
+
+```bash
+npm run dr:restore-rehearsal
+```
+
+CI runs the same command through `npm run ci:dr:restore-rehearsal` after the bootstrap dry-run and before later audit gates.
+
+## What the rehearsal creates
+
+The script builds synthetic state under a temporary root only; it never reads or writes a live Hermes profile, live Kanban database, approval ledger, or user config. The fixture contains the minimal recoverable orchestration data that has caused restore risk in prior incidents:
+
+- `profiles/default/kanban.db` with one task and one task comment.
+- `profiles/default/approvals/ledger.json` with one approved approval entry.
+- `profiles/default/config.yaml` with liveness values, including `kanban.dispatch_stale_timeout_seconds`, `liveness.heartbeat_interval_seconds`, and `liveness.worker_ids`.
+- A backup manifest recording that the fixture was captured by `scripts/restore-rehearsal.mjs`.
+
+## What the rehearsal proves
+
+The rehearsal copies the fixture into a backup directory, restores that backup into a separate temporary target, and asserts that the task, comment, approval entry, and liveness values survived. It also runs a corrupted-fixture case by breaking the approval ledger JSON and requiring the restore assertion to fail with a clear `approval ledger is not valid JSON` error.
+
+Use `node scripts/restore-rehearsal.mjs --format json` when automation needs machine-readable evidence. Use `--keep-temp --root <scratch-dir>` only for debugging the fixture contents; never point `--root` at a repository root, home directory, or live profile.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:root:watch": "vitest",
     "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1",
     "test:coverage:root": "vitest run --coverage",
-    "dr:restore-rehearsal": "node scripts/restore-rehearsal.mjs",
+    "dr:restore-rehearsal": "tsx scripts/restore-rehearsal.mjs",
     "ci:dr:restore-rehearsal": "npm run dr:restore-rehearsal"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1",
     "test:coverage:root": "vitest run --coverage",
     "dr:restore-rehearsal": "node scripts/restore-rehearsal.mjs",
-    "ci:dr:restore-rehearsal": "node scripts/retry-ci-command.mjs -- npm run dr:restore-rehearsal"
+    "ci:dr:restore-rehearsal": "npm run dr:restore-rehearsal"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",
     "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1",
-    "test:coverage:root": "vitest run --coverage"
+    "test:coverage:root": "vitest run --coverage",
+    "dr:restore-rehearsal": "node scripts/restore-rehearsal.mjs",
+    "ci:dr:restore-rehearsal": "node scripts/retry-ci-command.mjs -- npm run dr:restore-rehearsal"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/restore-rehearsal.mjs
+++ b/scripts/restore-rehearsal.mjs
@@ -40,7 +40,12 @@ function assertSafeIsolatedRoot(path, label) {
     REPO_ROOT,
     dirname(REPO_ROOT),
   ].filter(Boolean));
-  if (unsafeExact.has(target) || target.split(sep).filter(Boolean).length < 2 || isSameOrParent(target, REPO_ROOT)) {
+  if (
+    unsafeExact.has(target)
+    || target.split(sep).filter(Boolean).length < 2
+    || isSameOrParent(target, REPO_ROOT)
+    || isSameOrParent(REPO_ROOT, target)
+  ) {
     throw new Error(`${label} must be an isolated scratch directory, not a home, repository, or filesystem root`);
   }
 }

--- a/scripts/restore-rehearsal.mjs
+++ b/scripts/restore-rehearsal.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import Database from 'better-sqlite3';
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, parse, resolve, sep } from 'node:path';
@@ -28,23 +28,41 @@ function isSameOrParent(candidate, child) {
   return target === parent || target.startsWith(`${parent}${sep}`);
 }
 
-function assertSafeIsolatedRoot(path, label) {
+async function resolveExistingOrParent(path) {
   const target = resolve(path);
+  if (await pathExists(target)) {
+    return realpath(target);
+  }
+  return join(await realpath(dirname(target)), parse(target).base);
+}
+
+async function assertSafeIsolatedRoot(path, label) {
+  const target = resolve(path);
+  const realTarget = await resolveExistingOrParent(target);
   const home = process.env.HOME ? resolve(process.env.HOME) : undefined;
+  const realHome = home && await pathExists(home) ? await realpath(home) : undefined;
   const root = parse(target).root;
+  const realRepoRoot = await realpath(REPO_ROOT);
   const unsafeExact = new Set([
     root,
     home,
+    realHome,
     process.cwd(),
     dirname(process.cwd()),
     REPO_ROOT,
     dirname(REPO_ROOT),
+    realRepoRoot,
+    dirname(realRepoRoot),
   ].filter(Boolean));
   if (
     unsafeExact.has(target)
+    || unsafeExact.has(realTarget)
     || target.split(sep).filter(Boolean).length < 2
+    || realTarget.split(sep).filter(Boolean).length < 2
     || isSameOrParent(target, REPO_ROOT)
     || isSameOrParent(REPO_ROOT, target)
+    || isSameOrParent(realTarget, realRepoRoot)
+    || isSameOrParent(realRepoRoot, realTarget)
   ) {
     throw new Error(`${label} must be an isolated scratch directory, not a home, repository, or filesystem root`);
   }
@@ -249,7 +267,7 @@ export async function runRestoreRehearsal(options = {}) {
     ? resolve(options.root)
     : await mkdtemp(join(tmpdir(), 'frankenbeast-restore-rehearsal-'));
   if (options.root) {
-    assertSafeIsolatedRoot(root, 'restore rehearsal root');
+    await assertSafeIsolatedRoot(root, 'restore rehearsal root');
     await rm(root, { recursive: true, force: true });
     await mkdir(root, { recursive: true });
   }

--- a/scripts/restore-rehearsal.mjs
+++ b/scripts/restore-rehearsal.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import Database from 'better-sqlite3';
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
-import { access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, dirname, parse, resolve, sep, join } from 'node:path';
+import { dirname, join, parse, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { load as parseYaml } from 'js-yaml';
+import { createEncryptedStateBackup, restoreEncryptedStateBackup } from '../packages/franken-orchestrator/src/dr/state-backup.ts';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(SCRIPT_PATH), '..');
 
 const EXPECTED = Object.freeze({
   taskId: 'fixture-task-restore-rehearsal',
@@ -18,17 +22,25 @@ const EXPECTED = Object.freeze({
   heartbeatIntervalSeconds: 300,
 });
 
+function isSameOrParent(candidate, child) {
+  const parent = resolve(candidate);
+  const target = resolve(child);
+  return target === parent || target.startsWith(`${parent}${sep}`);
+}
+
 function assertSafeIsolatedRoot(path, label) {
   const target = resolve(path);
   const home = process.env.HOME ? resolve(process.env.HOME) : undefined;
   const root = parse(target).root;
-  const unsafe = new Set([
+  const unsafeExact = new Set([
     root,
     home,
     process.cwd(),
     dirname(process.cwd()),
+    REPO_ROOT,
+    dirname(REPO_ROOT),
   ].filter(Boolean));
-  if (unsafe.has(target) || target.split(sep).filter(Boolean).length < 2) {
+  if (unsafeExact.has(target) || target.split(sep).filter(Boolean).length < 2 || isSameOrParent(target, REPO_ROOT)) {
     throw new Error(`${label} must be an isolated scratch directory, not a home, repository, or filesystem root`);
   }
 }
@@ -79,6 +91,7 @@ async function buildFixtureState(sourceRoot) {
   const approvalDir = join(profileRoot, 'approvals');
   await ensureDir(approvalDir);
   await ensureDir(join(profileRoot, 'cron'));
+  await ensureDir(join(sourceRoot, 'runs', 'fixture-run-001'));
 
   writeKanbanFixture(join(profileRoot, 'kanban.db'));
   await writeFile(join(approvalDir, 'ledger.json'), `${JSON.stringify({
@@ -104,43 +117,43 @@ async function buildFixtureState(sourceRoot) {
     '  - default',
     '',
   ].join('\n'));
+  await writeFile(join(sourceRoot, 'runs', 'fixture-run-001', 'metadata.json'), `${JSON.stringify({
+    taskId: EXPECTED.taskId,
+    workerId: EXPECTED.workerId,
+  }, null, 2)}\n`);
   await writeFile(join(sourceRoot, 'manifest.json'), `${JSON.stringify({
     fixture: 'restore-rehearsal',
     createdBy: 'scripts/restore-rehearsal.mjs',
-    includes: ['profiles/default/kanban.db', 'profiles/default/approvals/ledger.json', 'profiles/default/config.yaml'],
+    includes: [
+      'profiles/default/kanban.db',
+      'profiles/default/approvals/ledger.json',
+      'profiles/default/config.yaml',
+      'runs/fixture-run-001/metadata.json',
+    ],
   }, null, 2)}\n`);
 }
 
-async function copyRecursive(source, target) {
-  await ensureDir(dirname(target));
-  await rm(target, { recursive: true, force: true });
-  await mkdir(target, { recursive: true });
-  const { cp } = await import('node:fs/promises');
-  await cp(source, target, {
-    recursive: true,
-    dereference: false,
-    errorOnExist: false,
-    force: true,
+async function backupState(sourceRoot, backupRoot, keyFilePath) {
+  await ensureDir(backupRoot);
+  const backupPath = join(backupRoot, 'fixture-source.franken-dr.json');
+  await createEncryptedStateBackup({
+    stateDir: sourceRoot,
+    outputPath: backupPath,
+    keyFilePath,
+    generatedAt: '2026-07-16T00:00:00.000Z',
   });
-}
-
-async function backupState(sourceRoot, backupRoot) {
-  const sourceName = basename(sourceRoot);
-  const backupPath = join(backupRoot, `${sourceName}-backup`);
-  await copyRecursive(sourceRoot, backupPath);
-  await writeFile(join(backupPath, 'backup-manifest.json'), `${JSON.stringify({
-    sourceName,
-    backedUpAt: 'fixture-time',
-    tool: 'restore-rehearsal',
-  }, null, 2)}\n`);
   return backupPath;
 }
 
-async function restoreState(backupPath, restoreRoot) {
-  if (!(await pathExists(join(backupPath, 'backup-manifest.json')))) {
-    throw new Error(`backup manifest missing from ${backupPath}`);
+async function restoreState(backupPath, restoreRoot, keyFilePath) {
+  if (!(await pathExists(backupPath))) {
+    throw new Error(`backup artifact missing from ${backupPath}`);
   }
-  await copyRecursive(backupPath, restoreRoot);
+  await restoreEncryptedStateBackup({
+    backupPath,
+    targetDir: restoreRoot,
+    keyFilePath,
+  });
   return restoreRoot;
 }
 
@@ -166,8 +179,9 @@ async function assertRestoredState(restoreRoot) {
   }
 
   let ledger;
+  const restoredApprovalLedgerPath = join(restoreRoot, '_quarantine', 'approvals', 'profiles', 'default', 'approvals', 'ledger.json');
   try {
-    ledger = JSON.parse(await readFile(join(profileRoot, 'approvals', 'ledger.json'), 'utf8'));
+    ledger = JSON.parse(await readFile(restoredApprovalLedgerPath, 'utf8'));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`approval ledger is not valid JSON: ${message}`);
@@ -206,10 +220,12 @@ async function runCorruptedFixtureCase(root) {
   const sourceRoot = join(root, 'corrupt-source');
   const backupRoot = join(root, 'corrupt-backups');
   const restoreRoot = join(root, 'corrupt-restore');
+  const keyFilePath = join(root, 'corrupt-backup.key');
+  await writeFile(keyFilePath, 'restore rehearsal corrupt fixture key material', { mode: 0o600 });
   await buildFixtureState(sourceRoot);
-  const backupPath = await backupState(sourceRoot, backupRoot);
-  await writeFile(join(backupPath, 'profiles', 'default', 'approvals', 'ledger.json'), '{"entries": [');
-  await restoreState(backupPath, restoreRoot);
+  await writeFile(join(sourceRoot, 'profiles', 'default', 'approvals', 'ledger.json'), '{"entries": [');
+  const backupPath = await backupState(sourceRoot, backupRoot, keyFilePath);
+  await restoreState(backupPath, restoreRoot, keyFilePath);
   try {
     await assertRestoredState(restoreRoot);
   } catch (error) {
@@ -237,9 +253,11 @@ export async function runRestoreRehearsal(options = {}) {
     const sourceRoot = join(root, 'fixture-source');
     const backupRoot = join(root, 'backups');
     const restoreRoot = join(root, 'restore-target');
+    const keyFilePath = join(root, 'restore-rehearsal.key');
+    await writeFile(keyFilePath, 'restore rehearsal fixture key material', { mode: 0o600 });
     await buildFixtureState(sourceRoot);
-    const backupPath = await backupState(sourceRoot, backupRoot);
-    await restoreState(backupPath, restoreRoot);
+    const backupPath = await backupState(sourceRoot, backupRoot, keyFilePath);
+    await restoreState(backupPath, restoreRoot, keyFilePath);
     const restored = await assertRestoredState(restoreRoot);
     const corruptError = options.includeCorruptCase === false
       ? undefined
@@ -283,7 +301,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.info(`Usage: node scripts/restore-rehearsal.mjs [--root TMP_DIR] [--keep-temp] [--skip-corrupt-case] [--format human|json]\n\nBuilds synthetic Kanban, approval-ledger, and liveness config fixture state, backs it up, restores it into an isolated temporary root, and verifies the expected records survive. The default run also corrupts a fixture approval ledger and requires a clear restore assertion error.`);
+  console.info(`Usage: tsx scripts/restore-rehearsal.mjs [--root TMP_DIR] [--keep-temp] [--skip-corrupt-case] [--format human|json]\n\nBuilds synthetic Kanban, approval-ledger, and liveness config fixture state, backs it up through the encrypted DR backup path, restores it into an isolated temporary root, and verifies the expected records survive. The default run also corrupts a fixture approval ledger and requires a clear restore assertion error.`);
 }
 
 async function main() {
@@ -296,7 +314,7 @@ async function main() {
   if (options.format === 'json') {
     console.log(JSON.stringify(result, null, 2));
   } else if (options.format === 'human') {
-    console.log('[restore-rehearsal] ok - fixture backup restored into isolated temp root');
+    console.log('[restore-rehearsal] ok - encrypted fixture backup restored into isolated temp root');
     console.log(`[restore-rehearsal] task=${result.restored.task.id} comments=${result.restored.comments} approval=${result.restored.approvalId} workers=${result.restored.workerIds.join(',')}`);
     if (result.corruptFixture.ok === true) {
       console.log(`[restore-rehearsal] corrupt-fixture ok - ${result.corruptFixture.error}`);
@@ -306,7 +324,7 @@ async function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/restore-rehearsal.mjs
+++ b/scripts/restore-rehearsal.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+import Database from 'better-sqlite3';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, parse, resolve, sep, join } from 'node:path';
+import { load as parseYaml } from 'js-yaml';
+
+const EXPECTED = Object.freeze({
+  taskId: 'fixture-task-restore-rehearsal',
+  taskTitle: 'fixture restore rehearsal task',
+  commentBody: 'fixture comment survives restore',
+  approvalId: 'approval-fixture-001',
+  approvalCommand: 'git merge --squash fixture',
+  workerId: 'worker-fixture-001',
+  dispatchStaleTimeout: 14400,
+  heartbeatIntervalSeconds: 300,
+});
+
+function assertSafeIsolatedRoot(path, label) {
+  const target = resolve(path);
+  const home = process.env.HOME ? resolve(process.env.HOME) : undefined;
+  const root = parse(target).root;
+  const unsafe = new Set([
+    root,
+    home,
+    process.cwd(),
+    dirname(process.cwd()),
+  ].filter(Boolean));
+  if (unsafe.has(target) || target.split(sep).filter(Boolean).length < 2) {
+    throw new Error(`${label} must be an isolated scratch directory, not a home, repository, or filesystem root`);
+  }
+}
+
+async function pathExists(path) {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true });
+}
+
+function writeKanbanFixture(dbPath) {
+  const db = new Database(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE tasks (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL,
+        assignee TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      CREATE TABLE comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        author TEXT NOT NULL,
+        body TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `);
+    db.prepare('INSERT INTO tasks (id, title, status, assignee, created_at) VALUES (?, ?, ?, ?, ?)')
+      .run(EXPECTED.taskId, EXPECTED.taskTitle, 'blocked', 'fixture-worker', 1_783_000_000);
+    db.prepare('INSERT INTO comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)')
+      .run(EXPECTED.taskId, 'fixture-worker', EXPECTED.commentBody, 1_783_000_100);
+  } finally {
+    db.close();
+  }
+}
+
+async function buildFixtureState(sourceRoot) {
+  const profileRoot = join(sourceRoot, 'profiles', 'default');
+  const approvalDir = join(profileRoot, 'approvals');
+  await ensureDir(approvalDir);
+  await ensureDir(join(profileRoot, 'cron'));
+
+  writeKanbanFixture(join(profileRoot, 'kanban.db'));
+  await writeFile(join(approvalDir, 'ledger.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    entries: [
+      {
+        id: EXPECTED.approvalId,
+        status: 'approved',
+        command: EXPECTED.approvalCommand,
+        approver: 'restore-rehearsal',
+        createdAt: '2026-07-16T00:00:00.000Z',
+      },
+    ],
+  }, null, 2)}\n`);
+  await writeFile(join(profileRoot, 'config.yaml'), [
+    'kanban:',
+    `  dispatch_stale_timeout_seconds: ${EXPECTED.dispatchStaleTimeout}`,
+    'liveness:',
+    `  heartbeat_interval_seconds: ${EXPECTED.heartbeatIntervalSeconds}`,
+    '  worker_ids:',
+    `    - ${EXPECTED.workerId}`,
+    'notification_sources:',
+    '  - default',
+    '',
+  ].join('\n'));
+  await writeFile(join(sourceRoot, 'manifest.json'), `${JSON.stringify({
+    fixture: 'restore-rehearsal',
+    createdBy: 'scripts/restore-rehearsal.mjs',
+    includes: ['profiles/default/kanban.db', 'profiles/default/approvals/ledger.json', 'profiles/default/config.yaml'],
+  }, null, 2)}\n`);
+}
+
+async function copyRecursive(source, target) {
+  await ensureDir(dirname(target));
+  await rm(target, { recursive: true, force: true });
+  await mkdir(target, { recursive: true });
+  const { cp } = await import('node:fs/promises');
+  await cp(source, target, {
+    recursive: true,
+    dereference: false,
+    errorOnExist: false,
+    force: true,
+  });
+}
+
+async function backupState(sourceRoot, backupRoot) {
+  const sourceName = basename(sourceRoot);
+  const backupPath = join(backupRoot, `${sourceName}-backup`);
+  await copyRecursive(sourceRoot, backupPath);
+  await writeFile(join(backupPath, 'backup-manifest.json'), `${JSON.stringify({
+    sourceName,
+    backedUpAt: 'fixture-time',
+    tool: 'restore-rehearsal',
+  }, null, 2)}\n`);
+  return backupPath;
+}
+
+async function restoreState(backupPath, restoreRoot) {
+  if (!(await pathExists(join(backupPath, 'backup-manifest.json')))) {
+    throw new Error(`backup manifest missing from ${backupPath}`);
+  }
+  await copyRecursive(backupPath, restoreRoot);
+  return restoreRoot;
+}
+
+function readKanbanState(dbPath) {
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const task = db.prepare('SELECT id, title, status, assignee FROM tasks WHERE id = ?').get(EXPECTED.taskId);
+    const comments = db.prepare('SELECT task_id, author, body FROM comments WHERE task_id = ? ORDER BY id').all(EXPECTED.taskId);
+    return { task, comments };
+  } finally {
+    db.close();
+  }
+}
+
+async function assertRestoredState(restoreRoot) {
+  const profileRoot = join(restoreRoot, 'profiles', 'default');
+  const kanban = readKanbanState(join(profileRoot, 'kanban.db'));
+  if (!kanban.task || kanban.task.title !== EXPECTED.taskTitle || kanban.task.status !== 'blocked') {
+    throw new Error('restored Kanban task does not match fixture task');
+  }
+  if (!kanban.comments.some((comment) => comment.body === EXPECTED.commentBody)) {
+    throw new Error('restored Kanban comments do not include fixture comment');
+  }
+
+  let ledger;
+  try {
+    ledger = JSON.parse(await readFile(join(profileRoot, 'approvals', 'ledger.json'), 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`approval ledger is not valid JSON: ${message}`);
+  }
+  const approval = Array.isArray(ledger.entries)
+    ? ledger.entries.find((entry) => entry.id === EXPECTED.approvalId)
+    : undefined;
+  if (!approval || approval.command !== EXPECTED.approvalCommand || approval.status !== 'approved') {
+    throw new Error('restored approval entries do not include expected approval ledger row');
+  }
+
+  const config = parseYaml(await readFile(join(profileRoot, 'config.yaml'), 'utf8'));
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    throw new Error('restored config.yaml did not parse to an object');
+  }
+  const record = config;
+  if (record.kanban?.dispatch_stale_timeout_seconds !== EXPECTED.dispatchStaleTimeout) {
+    throw new Error('restored liveness config lost kanban.dispatch_stale_timeout_seconds');
+  }
+  if (record.liveness?.heartbeat_interval_seconds !== EXPECTED.heartbeatIntervalSeconds) {
+    throw new Error('restored liveness config lost heartbeat interval');
+  }
+  if (!Array.isArray(record.liveness?.worker_ids) || !record.liveness.worker_ids.includes(EXPECTED.workerId)) {
+    throw new Error('restored liveness config lost worker_ids');
+  }
+
+  return {
+    task: kanban.task,
+    comments: kanban.comments.length,
+    approvalId: approval.id,
+    workerIds: record.liveness.worker_ids,
+  };
+}
+
+async function runCorruptedFixtureCase(root) {
+  const sourceRoot = join(root, 'corrupt-source');
+  const backupRoot = join(root, 'corrupt-backups');
+  const restoreRoot = join(root, 'corrupt-restore');
+  await buildFixtureState(sourceRoot);
+  const backupPath = await backupState(sourceRoot, backupRoot);
+  await writeFile(join(backupPath, 'profiles', 'default', 'approvals', 'ledger.json'), '{"entries": [');
+  await restoreState(backupPath, restoreRoot);
+  try {
+    await assertRestoredState(restoreRoot);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('approval ledger is not valid JSON')) {
+      throw new Error(`corrupted fixture failed with unclear error: ${message}`);
+    }
+    return message;
+  }
+  throw new Error('corrupted fixture unexpectedly passed restore assertions');
+}
+
+export async function runRestoreRehearsal(options = {}) {
+  const cleanup = options.cleanup !== false;
+  const root = options.root
+    ? resolve(options.root)
+    : await mkdtemp(join(tmpdir(), 'frankenbeast-restore-rehearsal-'));
+  if (options.root) {
+    assertSafeIsolatedRoot(root, 'restore rehearsal root');
+    await rm(root, { recursive: true, force: true });
+    await mkdir(root, { recursive: true });
+  }
+
+  try {
+    const sourceRoot = join(root, 'fixture-source');
+    const backupRoot = join(root, 'backups');
+    const restoreRoot = join(root, 'restore-target');
+    await buildFixtureState(sourceRoot);
+    const backupPath = await backupState(sourceRoot, backupRoot);
+    await restoreState(backupPath, restoreRoot);
+    const restored = await assertRestoredState(restoreRoot);
+    const corruptError = options.includeCorruptCase === false
+      ? undefined
+      : await runCorruptedFixtureCase(root);
+
+    return {
+      ok: true,
+      root,
+      backupPath,
+      restoreRoot,
+      restored,
+      corruptFixture: corruptError ? { ok: true, error: corruptError } : { ok: 'skipped' },
+    };
+  } finally {
+    if (cleanup) {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const options = { cleanup: true, includeCorruptCase: true, format: 'human' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    switch (arg) {
+      case '--root': options.root = readValue(); break;
+      case '--keep-temp': options.cleanup = false; break;
+      case '--skip-corrupt-case': options.includeCorruptCase = false; break;
+      case '--format': options.format = readValue(); break;
+      case '--help': options.help = true; break;
+      default: throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.info(`Usage: node scripts/restore-rehearsal.mjs [--root TMP_DIR] [--keep-temp] [--skip-corrupt-case] [--format human|json]\n\nBuilds synthetic Kanban, approval-ledger, and liveness config fixture state, backs it up, restores it into an isolated temporary root, and verifies the expected records survive. The default run also corrupts a fixture approval ledger and requires a clear restore assertion error.`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await runRestoreRehearsal(options);
+  if (options.format === 'json') {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (options.format === 'human') {
+    console.log('[restore-rehearsal] ok - fixture backup restored into isolated temp root');
+    console.log(`[restore-rehearsal] task=${result.restored.task.id} comments=${result.restored.comments} approval=${result.restored.approvalId} workers=${result.restored.workerIds.join(',')}`);
+    if (result.corruptFixture.ok === true) {
+      console.log(`[restore-rehearsal] corrupt-fixture ok - ${result.corruptFixture.error}`);
+    }
+  } else {
+    throw new Error(`Unsupported format: ${options.format}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -231,9 +231,7 @@ on:
       );
 
       expect(packageJson.scripts?.['dr:restore-rehearsal']).toBe('node scripts/restore-rehearsal.mjs');
-      expect(packageJson.scripts?.['ci:dr:restore-rehearsal']).toBe(
-        'node scripts/retry-ci-command.mjs -- npm run dr:restore-rehearsal',
-      );
+      expect(packageJson.scripts?.['ci:dr:restore-rehearsal']).toBe('npm run dr:restore-rehearsal');
       expect(restoreStep.run).toBe('npm run ci:dr:restore-rehearsal');
       expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run ci:dr:restore-rehearsal'));
       expect(content.indexOf('npm run ci:dr:restore-rehearsal')).toBeLessThan(content.indexOf('npm run audit:dependencies'));

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -230,7 +230,7 @@ on:
         'the DR restore rehearsal gate',
       );
 
-      expect(packageJson.scripts?.['dr:restore-rehearsal']).toBe('node scripts/restore-rehearsal.mjs');
+      expect(packageJson.scripts?.['dr:restore-rehearsal']).toBe('tsx scripts/restore-rehearsal.mjs');
       expect(packageJson.scripts?.['ci:dr:restore-rehearsal']).toBe('npm run dr:restore-rehearsal');
       expect(restoreStep.run).toBe('npm run ci:dr:restore-rehearsal');
       expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run ci:dr:restore-rehearsal'));

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -215,8 +215,28 @@ on:
       expect(content).toMatch(/name:\s*Validate bootstrap script \(dry-run\)/);
       expect(content).toContain('npm run bootstrap:dry-run');
       expect(content.indexOf('npm ci')).toBeLessThan(content.indexOf('npm run bootstrap:dry-run'));
-      expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run audit:dependencies'));
+      expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run ci:dr:restore-rehearsal'));
       expect(content).toContain('CI_BOOTSTRAP_DRY_RUN: "1"');
+    });
+
+    it('runs the isolated disaster recovery restore rehearsal before later audit gates', () => {
+      const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>;
+      };
+      const steps = expectSteps(expectCiJob(workflow));
+      const restoreStep = expectStepByName(
+        steps,
+        'Disaster recovery restore rehearsal',
+        'the DR restore rehearsal gate',
+      );
+
+      expect(packageJson.scripts?.['dr:restore-rehearsal']).toBe('node scripts/restore-rehearsal.mjs');
+      expect(packageJson.scripts?.['ci:dr:restore-rehearsal']).toBe(
+        'node scripts/retry-ci-command.mjs -- npm run dr:restore-rehearsal',
+      );
+      expect(restoreStep.run).toBe('npm run ci:dr:restore-rehearsal');
+      expect(content.indexOf('npm run bootstrap:dry-run')).toBeLessThan(content.indexOf('npm run ci:dr:restore-rehearsal'));
+      expect(content.indexOf('npm run ci:dr:restore-rehearsal')).toBeLessThan(content.indexOf('npm run audit:dependencies'));
     });
 
     it('runs CI test commands with a fixed deterministic seed matrix', () => {

--- a/tests/unit/restore-rehearsal.test.ts
+++ b/tests/unit/restore-rehearsal.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, expect, it, afterEach } from 'vitest';
@@ -84,5 +84,21 @@ describe('restore rehearsal fixture', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('must be an isolated scratch directory');
     }
+  });
+
+  it('refuses symlinked repository descendants as rehearsal roots', async () => {
+    const linkParent = await mkdtemp(join(tmpdir(), 'restore-rehearsal-link-'));
+    keepRoot = linkParent;
+    const repoLink = join(linkParent, 'repo-link');
+    await symlink(ROOT, repoLink, 'dir');
+
+    const result = spawnSync('npx', ['tsx', SCRIPT, '--root', join(repoLink, 'scripts')], {
+      cwd: tmpdir(),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('must be an isolated scratch directory');
+    expect(existsSync(resolve(ROOT, 'scripts', 'restore-rehearsal.mjs'))).toBe(true);
   });
 });

--- a/tests/unit/restore-rehearsal.test.ts
+++ b/tests/unit/restore-rehearsal.test.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it, afterEach } from 'vitest';
+
+import { runRestoreRehearsal } from '../../scripts/restore-rehearsal.mjs';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/restore-rehearsal.mjs');
+
+let keepRoot: string | undefined;
+
+afterEach(async () => {
+  if (keepRoot) {
+    await rm(keepRoot, { recursive: true, force: true });
+    keepRoot = undefined;
+  }
+});
+
+describe('restore rehearsal fixture', () => {
+  it('backs up and restores isolated Kanban, approval, and liveness fixture state', async () => {
+    const result = await runRestoreRehearsal();
+
+    expect(result.ok).toBe(true);
+    expect(result.restored.task).toMatchObject({
+      id: 'fixture-task-restore-rehearsal',
+      title: 'fixture restore rehearsal task',
+      status: 'blocked',
+      assignee: 'fixture-worker',
+    });
+    expect(result.restored.comments).toBe(1);
+    expect(result.restored.approvalId).toBe('approval-fixture-001');
+    expect(result.restored.workerIds).toContain('worker-fixture-001');
+    expect(result.corruptFixture.ok).toBe(true);
+    expect(result.corruptFixture.error).toMatch(/approval ledger is not valid JSON/u);
+    expect(existsSync(result.root)).toBe(false);
+  });
+
+  it('keeps the rehearsal under a caller-provided scratch root when requested', async () => {
+    keepRoot = await mkdtemp(join(tmpdir(), 'restore-rehearsal-test-'));
+    const result = await runRestoreRehearsal({ root: keepRoot, cleanup: false, includeCorruptCase: false });
+
+    expect(result.ok).toBe(true);
+    expect(result.root).toBe(resolve(keepRoot));
+    expect(existsSync(resolve(keepRoot, 'fixture-source', 'profiles', 'default', 'kanban.db'))).toBe(true);
+    expect(existsSync(resolve(keepRoot, 'restore-target', 'profiles', 'default', 'approvals', 'ledger.json'))).toBe(true);
+    expect(result.corruptFixture.ok).toBe('skipped');
+  });
+
+  it('prints deterministic CLI evidence and the corrupt-fixture failure reason', () => {
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('[restore-rehearsal] ok - fixture backup restored into isolated temp root');
+    expect(result.stdout).toContain('task=fixture-task-restore-rehearsal');
+    expect(result.stdout).toContain('approval=approval-fixture-001');
+    expect(result.stdout).toContain('workers=worker-fixture-001');
+    expect(result.stdout).toContain('corrupt-fixture ok - approval ledger is not valid JSON');
+  });
+
+  it('refuses to use the repository root as the rehearsal root', () => {
+    const result = spawnSync(process.execPath, [SCRIPT, '--root', ROOT], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('must be an isolated scratch directory');
+  });
+});

--- a/tests/unit/restore-rehearsal.test.ts
+++ b/tests/unit/restore-rehearsal.test.ts
@@ -45,19 +45,29 @@ describe('restore rehearsal fixture', () => {
     expect(result.ok).toBe(true);
     expect(result.root).toBe(resolve(keepRoot));
     expect(existsSync(resolve(keepRoot, 'fixture-source', 'profiles', 'default', 'kanban.db'))).toBe(true);
-    expect(existsSync(resolve(keepRoot, 'restore-target', 'profiles', 'default', 'approvals', 'ledger.json'))).toBe(true);
+    expect(existsSync(resolve(keepRoot, 'backups', 'fixture-source.franken-dr.json'))).toBe(true);
+    expect(existsSync(resolve(
+      keepRoot,
+      'restore-target',
+      '_quarantine',
+      'approvals',
+      'profiles',
+      'default',
+      'approvals',
+      'ledger.json',
+    ))).toBe(true);
     expect(result.corruptFixture.ok).toBe('skipped');
   });
 
   it('prints deterministic CLI evidence and the corrupt-fixture failure reason', () => {
-    const result = spawnSync(process.execPath, [SCRIPT], {
+    const result = spawnSync('npx', ['tsx', SCRIPT], {
       cwd: ROOT,
       encoding: 'utf8',
     });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
-    expect(result.stdout).toContain('[restore-rehearsal] ok - fixture backup restored into isolated temp root');
+    expect(result.stdout).toContain('[restore-rehearsal] ok - encrypted fixture backup restored into isolated temp root');
     expect(result.stdout).toContain('task=fixture-task-restore-rehearsal');
     expect(result.stdout).toContain('approval=approval-fixture-001');
     expect(result.stdout).toContain('workers=worker-fixture-001');
@@ -65,7 +75,7 @@ describe('restore rehearsal fixture', () => {
   });
 
   it('refuses to use the repository root as the rehearsal root', () => {
-    const result = spawnSync(process.execPath, [SCRIPT, '--root', ROOT], {
+    const result = spawnSync('npx', ['tsx', SCRIPT, '--root', ROOT], {
       cwd: ROOT,
       encoding: 'utf8',
     });

--- a/tests/unit/restore-rehearsal.test.ts
+++ b/tests/unit/restore-rehearsal.test.ts
@@ -74,13 +74,15 @@ describe('restore rehearsal fixture', () => {
     expect(result.stdout).toContain('corrupt-fixture ok - approval ledger is not valid JSON');
   });
 
-  it('refuses to use the repository root as the rehearsal root', () => {
-    const result = spawnSync('npx', ['tsx', SCRIPT, '--root', ROOT], {
-      cwd: ROOT,
-      encoding: 'utf8',
-    });
+  it('refuses to use repository paths as the rehearsal root', () => {
+    for (const unsafeRoot of [ROOT, resolve(ROOT, 'scripts')]) {
+      const result = spawnSync('npx', ['tsx', SCRIPT, '--root', unsafeRoot], {
+        cwd: tmpdir(),
+        encoding: 'utf8',
+      });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain('must be an isolated scratch directory');
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('must be an isolated scratch directory');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add an isolated restore rehearsal script that builds fixture Kanban, approval-ledger, and liveness config state
- verify backup/restore preserves the fixture task, comment, approval entry, and liveness values
- wire the rehearsal into CI and document the local/operator workflow

## Test Plan
- npm run dr:restore-rehearsal
- npx vitest run tests/unit/restore-rehearsal.test.ts tests/unit/ci-workflow.test.ts
- npm run typecheck
- npm run lint
- npx turbo run build typecheck
- npm run lint:security
- npm run test:root -- tests/unit/restore-rehearsal.test.ts tests/unit/ci-workflow.test.ts

Closes #1685
