### PR TITLE
fix(orchestrator): make kanban updates idempotent

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -168,6 +168,12 @@ await evaluateIssueBackpressure({
 
 PM and liveness callers that inventory worker-card processes can call `detectDuplicateWorkerCardProcesses(snapshots)` before starting or refilling issue work. Provide one snapshot per observed worker process with `cardId`, `pid`, optional string `runId`, `issueNumber`, `owner`, `status`, `alive`, `startedAt`, and `lastHeartbeatAt`. The detector ignores terminal/dead/invalid snapshots while preserving live blocked workers and reports only cards with two or more distinct live PIDs. Each finding is structured for automation: `cardId`, `processCount`, sorted `pids`, `runIds`, `owners`, `statuses`, timestamps, a `message`, and operator `guidance` telling the PM to keep one live owner, stop or park the duplicate, and record the survivor in liveness output.
 
+## Idempotent Kanban state mutation planning
+
+Retrying PM, doctor, or watchdog updates should first call `planKanbanStateMutation(snapshot, request)` with a deterministic `idempotencyKey` and, when available, an `expectedRevision`. The planner returns `apply`, `skip`, or `conflict` with machine-readable evidence so repeated comment/block/unblock/complete attempts converge without duplicate noise while stale concurrent writes surface an explicit compare-and-set conflict.
+
+Use stable keys derived from the business intent, not random attempts, for example `comment:<card-id>:liveness:<head-sha>`, `block:<card-id>:codex-usage-limit`, `unblock:<card-id>:doctor-treatment`, or `complete:<card-id>:merged:<pr-number>`. Treat `skip` as success, `conflict` as a re-read-and-decide signal, and only execute the underlying Kanban mutation on `apply`.
+
 ## Scheduler fairness report
 
 Before execution starts, `IssueRunner` emits `[issues] Scheduler fairness report` with structured data that PM/liveness tooling can consume without parsing prose. The report includes:

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, planKanbanStateMutation } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -70,6 +70,13 @@ export type {
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
+  KanbanStateMutationDecision,
+  KanbanStateMutationDecisionAction,
+  KanbanStateMutationOperation,
+  KanbanStateMutationRecord,
+  KanbanStateMutationRequest,
+  KanbanTaskCommentSnapshot,
+  KanbanTaskStateSnapshot,
   WorkerHeartbeatMonotonicityFinding,
   DuplicateWorkerCardProcessFinding,
 } from './issues/index.js';

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, planKanbanStateMutation } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -32,6 +32,13 @@ export type {
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
   IssueWorkerCardProcessSnapshot,
+  KanbanStateMutationDecision,
+  KanbanStateMutationDecisionAction,
+  KanbanStateMutationOperation,
+  KanbanStateMutationRecord,
+  KanbanStateMutationRequest,
+  KanbanTaskCommentSnapshot,
+  KanbanTaskStateSnapshot,
   WorkerHeartbeatMonotonicityFinding,
   DuplicateWorkerCardProcessFinding,
 } from './issue-runner.js';

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { appendFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { loadavg } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
@@ -791,23 +792,39 @@ function normalizedMutationStatus(status: string): string {
   return status.trim().toLowerCase().replace(/_/g, '-');
 }
 
-function mutationContentHash(request: KanbanStateMutationRequest): string | undefined {
-  return request.contentHash?.trim() || (request.body !== undefined ? request.body.trim() : undefined);
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function mutationContentTokens(request: KanbanStateMutationRequest): readonly string[] {
+  const tokens = new Set<string>();
+  const explicitHash = request.contentHash?.trim();
+  if (explicitHash) tokens.add(explicitHash);
+  if (request.body !== undefined) {
+    const body = request.body.trim();
+    tokens.add(body);
+    const digest = sha256Hex(body);
+    tokens.add(digest);
+    tokens.add(`sha256:${digest}`);
+  }
+  return [...tokens];
 }
 
 function mutationRecordMatches(record: KanbanStateMutationRecord, request: KanbanStateMutationRequest): boolean {
   if (record.idempotencyKey.trim() !== request.idempotencyKey.trim()) return false;
   if (record.operation !== request.operation) return false;
-  const requestedHash = mutationContentHash(request);
-  return requestedHash === undefined || record.contentHash === undefined || record.contentHash === requestedHash;
+  const requestedTokens = mutationContentTokens(request);
+  if (requestedTokens.length === 0 || record.contentHash === undefined) return true;
+  return requestedTokens.includes(record.contentHash.trim());
 }
 
 function matchingComment(snapshot: KanbanTaskStateSnapshot, request: KanbanStateMutationRequest): KanbanTaskCommentSnapshot | undefined {
+  if (request.operation !== 'comment') return undefined;
   const requestedKey = request.idempotencyKey.trim();
   const requestedBody = request.body?.trim();
   return snapshot.comments?.find((comment) => {
     if (comment.idempotencyKey?.trim() === requestedKey) return true;
-    return request.operation === 'comment' && requestedBody !== undefined && comment.body.trim() === requestedBody;
+    return requestedBody !== undefined && comment.body.trim() === requestedBody;
   });
 }
 
@@ -825,6 +842,10 @@ function statusConverged(snapshot: KanbanTaskStateSnapshot, request: KanbanState
     return `task ${snapshot.taskId} is already complete with the requested summary`;
   }
   return undefined;
+}
+
+function revisionsMatch(actual: string | number | undefined, expected: string | number | undefined): boolean {
+  return actual !== undefined && expected !== undefined && String(actual) === String(expected);
 }
 
 export function planKanbanStateMutation(
@@ -885,7 +906,7 @@ export function planKanbanStateMutation(
     };
   }
 
-  if (request.expectedRevision !== undefined && snapshot.revision !== request.expectedRevision) {
+  if (request.expectedRevision !== undefined && !revisionsMatch(snapshot.revision, request.expectedRevision)) {
     return {
       action: 'conflict',
       operation: request.operation,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -801,9 +801,10 @@ function mutationContentTokens(request: KanbanStateMutationRequest): readonly st
   const explicitHash = request.contentHash?.trim();
   if (explicitHash) tokens.add(explicitHash);
   if (request.body !== undefined) {
-    const body = request.body.trim();
+    const rawBody = request.body;
+    const body = rawBody.trim();
     tokens.add(body);
-    const digest = sha256Hex(body);
+    const digest = sha256Hex(rawBody);
     tokens.add(digest);
     tokens.add(`sha256:${digest}`);
   }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -205,6 +205,50 @@ export interface DuplicateWorkerCardProcessFinding {
   readonly guidance: string;
 }
 
+
+export type KanbanStateMutationOperation = 'comment' | 'block' | 'unblock' | 'complete';
+export type KanbanStateMutationDecisionAction = 'apply' | 'skip' | 'conflict';
+
+export interface KanbanStateMutationRecord {
+  readonly idempotencyKey: string;
+  readonly operation: KanbanStateMutationOperation;
+  readonly contentHash?: string | undefined;
+  readonly appliedAt?: string | number | Date | undefined;
+}
+
+export interface KanbanTaskCommentSnapshot {
+  readonly body: string;
+  readonly idempotencyKey?: string | undefined;
+  readonly author?: string | undefined;
+  readonly createdAt?: string | number | Date | undefined;
+}
+
+export interface KanbanTaskStateSnapshot {
+  readonly taskId: string;
+  readonly status: string;
+  readonly revision?: string | number | undefined;
+  readonly blockReason?: string | undefined;
+  readonly completionSummary?: string | undefined;
+  readonly comments?: readonly KanbanTaskCommentSnapshot[] | undefined;
+  readonly appliedMutations?: readonly KanbanStateMutationRecord[] | undefined;
+}
+
+export interface KanbanStateMutationRequest {
+  readonly operation: KanbanStateMutationOperation;
+  readonly idempotencyKey: string;
+  readonly expectedRevision?: string | number | undefined;
+  readonly body?: string | undefined;
+  readonly contentHash?: string | undefined;
+}
+
+export interface KanbanStateMutationDecision {
+  readonly action: KanbanStateMutationDecisionAction;
+  readonly operation: KanbanStateMutationOperation;
+  readonly idempotencyKey: string;
+  readonly reason: string;
+  readonly evidence: readonly string[];
+}
+
 export interface IssueSchedulerFairnessBucket {
   readonly severity: 'critical' | 'high' | 'medium' | 'low' | 'unprioritized';
   /** Sampled issue numbers for PM/liveness output; `count` is authoritative when this list is truncated. */
@@ -740,6 +784,133 @@ export function detectDuplicateWorkerCardProcesses(
   }
 
   return findings.sort((a, b) => a.cardId.localeCompare(b.cardId));
+}
+
+
+function normalizedMutationStatus(status: string): string {
+  return status.trim().toLowerCase().replace(/_/g, '-');
+}
+
+function mutationContentHash(request: KanbanStateMutationRequest): string | undefined {
+  return request.contentHash?.trim() || (request.body !== undefined ? request.body.trim() : undefined);
+}
+
+function mutationRecordMatches(record: KanbanStateMutationRecord, request: KanbanStateMutationRequest): boolean {
+  if (record.idempotencyKey.trim() !== request.idempotencyKey.trim()) return false;
+  if (record.operation !== request.operation) return false;
+  const requestedHash = mutationContentHash(request);
+  return requestedHash === undefined || record.contentHash === undefined || record.contentHash === requestedHash;
+}
+
+function matchingComment(snapshot: KanbanTaskStateSnapshot, request: KanbanStateMutationRequest): KanbanTaskCommentSnapshot | undefined {
+  const requestedKey = request.idempotencyKey.trim();
+  const requestedBody = request.body?.trim();
+  return snapshot.comments?.find((comment) => {
+    if (comment.idempotencyKey?.trim() === requestedKey) return true;
+    return request.operation === 'comment' && requestedBody !== undefined && comment.body.trim() === requestedBody;
+  });
+}
+
+function statusConverged(snapshot: KanbanTaskStateSnapshot, request: KanbanStateMutationRequest): string | undefined {
+  const status = normalizedMutationStatus(snapshot.status);
+  const body = request.body?.trim();
+  if (request.operation === 'block' && status === 'blocked' && (!body || snapshot.blockReason?.trim() === body)) {
+    return `task ${snapshot.taskId} is already blocked with the requested reason`;
+  }
+  if (request.operation === 'unblock' && status !== 'blocked') {
+    return `task ${snapshot.taskId} is already not blocked`;
+  }
+  if (request.operation === 'complete' && ['done', 'complete', 'completed', 'merged', 'closed'].includes(status)
+    && (!body || snapshot.completionSummary?.trim() === body)) {
+    return `task ${snapshot.taskId} is already complete with the requested summary`;
+  }
+  return undefined;
+}
+
+export function planKanbanStateMutation(
+  snapshot: KanbanTaskStateSnapshot,
+  request: KanbanStateMutationRequest,
+): KanbanStateMutationDecision {
+  const key = request.idempotencyKey.trim();
+  const evidence: string[] = [`task=${snapshot.taskId}`, `operation=${request.operation}`];
+  if (!key) {
+    return {
+      action: 'conflict',
+      operation: request.operation,
+      idempotencyKey: request.idempotencyKey,
+      reason: 'kanban state mutation requires a non-empty idempotency key',
+      evidence,
+    };
+  }
+  evidence.push(`idempotencyKey=${key}`);
+
+  const priorMutation = snapshot.appliedMutations?.find((record) => mutationRecordMatches(record, request));
+  if (priorMutation) {
+    return {
+      action: 'skip',
+      operation: request.operation,
+      idempotencyKey: key,
+      reason: 'mutation idempotency key was already applied with matching operation/content',
+      evidence: [
+        ...evidence,
+        ...(priorMutation.appliedAt !== undefined ? [`appliedAt=${isoTimestamp(priorMutation.appliedAt) ?? String(priorMutation.appliedAt)}`] : []),
+      ],
+    };
+  }
+
+  const comment = matchingComment(snapshot, request);
+  if (comment) {
+    return {
+      action: 'skip',
+      operation: request.operation,
+      idempotencyKey: key,
+      reason: request.operation === 'comment'
+        ? 'comment mutation already converged on an existing matching comment'
+        : 'mutation idempotency key is already present on an existing comment',
+      evidence: [
+        ...evidence,
+        ...(comment.createdAt !== undefined ? [`commentCreatedAt=${isoTimestamp(comment.createdAt) ?? String(comment.createdAt)}`] : []),
+      ],
+    };
+  }
+
+  const converged = statusConverged(snapshot, request);
+  if (converged) {
+    return {
+      action: 'skip',
+      operation: request.operation,
+      idempotencyKey: key,
+      reason: converged,
+      evidence: [...evidence, `status=${snapshot.status}`],
+    };
+  }
+
+  if (request.expectedRevision !== undefined && snapshot.revision !== request.expectedRevision) {
+    return {
+      action: 'conflict',
+      operation: request.operation,
+      idempotencyKey: key,
+      reason: 'kanban state revision changed before mutation could be applied',
+      evidence: [
+        ...evidence,
+        `expectedRevision=${request.expectedRevision}`,
+        `actualRevision=${snapshot.revision ?? 'unknown'}`,
+        `status=${snapshot.status}`,
+      ],
+    };
+  }
+
+  return {
+    action: 'apply',
+    operation: request.operation,
+    idempotencyKey: key,
+    reason: 'mutation is new for the current task state and compare-and-set guard passed',
+    evidence: [
+      ...evidence,
+      ...(snapshot.revision !== undefined ? [`revision=${snapshot.revision}`] : []),
+      `status=${snapshot.status}`,
+    ],
+  };
 }
 
 function extractSeverity(labels: readonly string[]): number {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -335,6 +336,43 @@ describe('kanban state mutation idempotency planning', () => {
       reason: 'mutation idempotency key was already applied with matching operation/content',
       evidence: expect.arrayContaining(['appliedAt=2026-07-16T10:00:00.000Z']),
     });
+  });
+
+  it('recognizes retries that provide the body when the stored content hash is a digest', () => {
+    const body = 'doctor note';
+    const digest = createHash('sha256').update(body).digest('hex');
+
+    expect(planKanbanStateMutation(
+      {
+        taskId: 't_retry',
+        status: 'running',
+        appliedMutations: [{
+          operation: 'comment',
+          idempotencyKey: 'comment:t_retry:liveness',
+          contentHash: digest,
+        }],
+      },
+      { operation: 'comment', idempotencyKey: 'comment:t_retry:liveness', body },
+    )).toMatchObject({ action: 'skip' });
+  });
+
+  it('does not let audit comments prove non-comment state mutations', () => {
+    expect(planKanbanStateMutation(
+      {
+        taskId: 't_retry',
+        status: 'running',
+        revision: 7,
+        comments: [{ body: 'blocked: usage limit', idempotencyKey: 'block:t_retry:usage-limit' }],
+      },
+      { operation: 'block', idempotencyKey: 'block:t_retry:usage-limit', expectedRevision: 7, body: 'usage limit' },
+    )).toMatchObject({ action: 'apply' });
+  });
+
+  it('applies new mutations when numeric and serialized revisions match', () => {
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'running', revision: '7' },
+      { operation: 'block', idempotencyKey: 'block:t_retry:new', expectedRevision: 7, body: 'fresh blocker' },
+    )).toMatchObject({ action: 'apply' });
   });
 
   it('applies new mutations only when the compare-and-set revision matches', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -339,7 +339,7 @@ describe('kanban state mutation idempotency planning', () => {
   });
 
   it('recognizes retries that provide the body when the stored content hash is a digest', () => {
-    const body = 'doctor note';
+    const body = 'doctor note\n';
     const digest = createHash('sha256').update(body).digest('hex');
 
     expect(planKanbanStateMutation(

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, evaluateIssueSchedulingScore } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, evaluateIssueSchedulingScore, planKanbanStateMutation } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -292,6 +292,69 @@ function makeIssueRuntimeSupport(): IssueRuntimeSupport {
   };
 }
 
+
+
+describe('kanban state mutation idempotency planning', () => {
+  it('skips repeated comment, block, unblock, and complete mutations when state already converged', () => {
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'running', comments: [{ body: 'doctor note', idempotencyKey: 'comment:t_retry:doctor', createdAt: '2026-07-16T10:00:00Z' }] },
+      { operation: 'comment', idempotencyKey: 'comment:t_retry:doctor', body: 'doctor note' },
+    )).toMatchObject({ action: 'skip', reason: 'comment mutation already converged on an existing matching comment' });
+
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'blocked', blockReason: 'usage limit' },
+      { operation: 'block', idempotencyKey: 'block:t_retry:usage-limit', body: 'usage limit' },
+    )).toMatchObject({ action: 'skip', reason: 'task t_retry is already blocked with the requested reason' });
+
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'running' },
+      { operation: 'unblock', idempotencyKey: 'unblock:t_retry:doctor' },
+    )).toMatchObject({ action: 'skip', reason: 'task t_retry is already not blocked' });
+
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'completed', completionSummary: 'merged PR' },
+      { operation: 'complete', idempotencyKey: 'complete:t_retry:merged', body: 'merged PR' },
+    )).toMatchObject({ action: 'skip', reason: 'task t_retry is already complete with the requested summary' });
+  });
+
+  it('uses idempotency records before comments so retrying a reserved mutation is quiet', () => {
+    expect(planKanbanStateMutation(
+      {
+        taskId: 't_retry',
+        status: 'running',
+        appliedMutations: [{
+          operation: 'comment',
+          idempotencyKey: 'comment:t_retry:liveness',
+          contentHash: 'same-body',
+          appliedAt: '2026-07-16T10:00:00Z',
+        }],
+      },
+      { operation: 'comment', idempotencyKey: 'comment:t_retry:liveness', contentHash: 'same-body' },
+    )).toMatchObject({
+      action: 'skip',
+      reason: 'mutation idempotency key was already applied with matching operation/content',
+      evidence: expect.arrayContaining(['appliedAt=2026-07-16T10:00:00.000Z']),
+    });
+  });
+
+  it('applies new mutations only when the compare-and-set revision matches', () => {
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'running', revision: 7 },
+      { operation: 'block', idempotencyKey: 'block:t_retry:new', expectedRevision: 7, body: 'fresh blocker' },
+    )).toMatchObject({ action: 'apply' });
+  });
+
+  it('returns explicit conflict evidence for stale concurrent updates', () => {
+    expect(planKanbanStateMutation(
+      { taskId: 't_retry', status: 'running', revision: 8 },
+      { operation: 'block', idempotencyKey: 'block:t_retry:stale', expectedRevision: 7, body: 'fresh blocker' },
+    )).toMatchObject({
+      action: 'conflict',
+      reason: 'kanban state revision changed before mutation could be applied',
+      evidence: expect.arrayContaining(['expectedRevision=7', 'actualRevision=8', 'status=running']),
+    });
+  });
+});
 
 describe('duplicate worker-card process detector', () => {
   it('detects duplicate and regressive heartbeat writes with worker diagnostics', () => {

--- a/tasks/issue-1677-kanban-idempotency-progress.md
+++ b/tasks/issue-1677-kanban-idempotency-progress.md
@@ -1,0 +1,12 @@
+# Issue 1677 Kanban Idempotency Progress
+
+- [x] Read Kanban task, GitHub issue #1677, shared lessons, and repo lessons.
+- [x] Confirm no existing open PR owns issue #1677 and create isolated worktree/branch.
+- [x] Locate PM/liveness Kanban-adjacent state update helpers in `IssueRunner`.
+- [x] Add deterministic idempotency/compare-and-set planning for comment/block/unblock/complete mutations.
+- [x] Add regression tests for repeated comment/block/unblock/complete and stale concurrent revision conflicts.
+- [x] Document how PM/doctor/watchdog callers should derive stable idempotency keys and handle `apply`/`skip`/`conflict`.
+- [x] Run targeted tests and package checks after final export/docs changes.
+- [ ] Commit, push, open PR closing only #1677.
+- [ ] Run real GitHub `@codex review` loop until current-head clean, then merge if CI is green.
+- [ ] Append reusable shared lessons if useful and complete/block the Kanban card.


### PR DESCRIPTION
## Summary
- Add `planKanbanStateMutation` for deterministic Kanban comment/block/unblock/complete retry planning.
- Return explicit `apply`, `skip`, or `conflict` decisions using idempotency keys, converged task state, and optional revision guards.
- Export the helper/types and document stable-key usage for PM/doctor/watchdog callers.

## Test Plan
- `npm --workspace @franken/orchestrator test -- tests/unit/issues/issue-runner.test.ts`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run build`
- `npm --workspace @franken/orchestrator run lint` (passes with existing warnings)
- `git diff --check`

Closes #1677
