### PR TITLE
feat(stability): add stuck-run watchdog hints

### DIFF
--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -95,6 +95,10 @@ npm test --workspace=@franken/orchestrator -- tests/unit/issues/issue-runner.tes
 
 Keep fixture snapshots narrow and deterministic: prefer structured `signals`, exact `expectedReasons`, and explicit `expectedRoute` values over wall-clock sleeps or prose-only assertions.
 
+## Stuck-run watchdog
+
+PM, Bob, and Doctor liveness tooling can import `detectStuckRunWatchdogFindings` from `@franken/orchestrator` to turn worker snapshots into compact remediation reports. Each snapshot may provide heartbeat, output, tool-activity, state-transition, process, Kanban-state, and known blocker fields; findings include the computed ages, a likely category (`process-crash`, `approval-gate`, `ci-wait`, `provider-wait`, `dispatcher-bug`, or `unknown`), one recommended action, and a confidence level. CI and provider waits have a grace guard so long-running but still-active checks/model calls do not become false stale-worker alarms before every activity signal is stale.
+
 ## Security limits
 
 Context snapshot imports are size-limited before JSON parsing to reduce resource-exhaustion risk from untrusted or corrupted resume/import files. `loadContext(filePath)` defaults to a 1 MiB cap, opens snapshots in nonblocking mode, rejects non-regular paths from the opened file descriptor, and enforces the same byte cap while reading so oversized content is rejected even if the file changes after metadata inspection. Trusted tooling that intentionally owns a larger snapshot must opt in per import with `loadContext(filePath, { maxBytes })`; invalid overrides such as `0`, negative, non-finite, or unsafe integer values fail closed.

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, planKanbanStateMutation } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, planKanbanStateMutation } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -69,6 +69,9 @@ export type {
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
+  IssueStuckRunBlockerCategory,
+  IssueStuckRunWatchdogFinding,
+  IssueStuckRunWatchdogOptions,
   IssueWorkerCardProcessSnapshot,
   KanbanStateMutationDecision,
   KanbanStateMutationDecisionAction,

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, planKanbanStateMutation } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, planKanbanStateMutation } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -31,6 +31,9 @@ export type {
   IssueSchedulerFairnessBucket,
   IssueSchedulerFairnessReport,
   IssueSchedulerFairnessReportOptions,
+  IssueStuckRunBlockerCategory,
+  IssueStuckRunWatchdogFinding,
+  IssueStuckRunWatchdogOptions,
   IssueWorkerCardProcessSnapshot,
   KanbanStateMutationDecision,
   KanbanStateMutationDecisionAction,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -707,7 +707,12 @@ function ageMs(value: string | number | Date | undefined, nowMs: number): number
 }
 
 function stale(age: number | undefined, threshold: number): boolean {
-  return age === undefined || age >= threshold;
+  return age !== undefined && age >= threshold;
+}
+
+function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean {
+  if (snapshot.blockerCategory === 'process-crash') return true;
+  return /crash|exit|dead|pid|process/.test(snapshot.waitingOn?.toLowerCase() ?? '');
 }
 
 function normalizeStuckRunBlockerCategory(
@@ -771,7 +776,7 @@ export function detectStuckRunWatchdogFindings(
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim() || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) continue;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && snapshot.alive !== false) continue;
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !explicitProcessCrash(snapshot)) continue;
 
     const category = normalizeStuckRunBlockerCategory(snapshot);
     const heartbeatAgeMs = ageMs(snapshot.lastHeartbeatAt, nowMs);
@@ -783,6 +788,8 @@ export function detectStuckRunWatchdogFindings(
     const toolStale = stale(toolActivityAgeMs, staleToolActivityMs);
     const stateStale = stale(stateTransitionAgeMs, staleStateTransitionMs);
     const staleCount = [heartbeatStale, outputStale, toolStale, stateStale].filter(Boolean).length;
+    const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
+      .some((age) => age !== undefined && age < longRunningWaitGraceMs);
     const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
       ? 'dead'
       : snapshot.alive === true
@@ -792,9 +799,7 @@ export function detectStuckRunWatchdogFindings(
     if (
       knownLongRunningWait(category)
       && processStatus !== 'dead'
-      && staleCount < 4
-      && (heartbeatAgeMs === undefined || heartbeatAgeMs < longRunningWaitGraceMs)
-      && (outputAgeMs === undefined || outputAgeMs < longRunningWaitGraceMs)
+      && freshLongRunningWaitActivity
     ) {
       continue;
     }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -715,7 +715,16 @@ function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean
   const status = snapshot.status?.trim().toLowerCase() ?? '';
   const waitingOn = snapshot.waitingOn?.toLowerCase() ?? '';
   if (/crash|exit|dead|pid|process|fail/.test(waitingOn)) return true;
-  return snapshot.alive === false && /crash|exit|fail/.test(status);
+  return /crash|exit|fail/.test(status);
+}
+
+function redactStuckRunEvidenceText(value: string): string {
+  return value
+    .replace(/\b(gh[opsu]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b/g, '[REDACTED_TOKEN]')
+    .replace(/\b(sk|xox[baprs]?|hf|glpat)-[A-Za-z0-9._/-]+\b/g, '$1-[REDACTED]')
+    .replace(/\b([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\b/g, '[REDACTED_JWT]')
+    .replace(/\b((?:approval|session|access|refresh|api)[-_ ]?token)\s*[:=]\s*\S+/gi, '$1=[REDACTED]')
+    .replace(/\b(token)\s*[:=]\s*\S+/gi, '$1=[REDACTED]');
 }
 
 function normalizeStuckRunBlockerCategory(
@@ -726,7 +735,7 @@ function normalizeStuckRunBlockerCategory(
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
-  if (/crash|exit|dead|pid|process/.test(text) || snapshot.alive === false) return 'process-crash';
+  if (/crash|exit|dead|pid|process|fail/.test(text) || snapshot.alive === false) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
   return 'unknown';
 }
@@ -777,7 +786,8 @@ export function detectStuckRunWatchdogFindings(
   const findings: IssueStuckRunWatchdogFinding[] = [];
 
   for (const snapshot of snapshots) {
-    if (!snapshot.cardId.trim() || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) continue;
+    if (!snapshot.cardId.trim()) continue;
+    const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
     if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !explicitProcessCrash(snapshot)) continue;
 
@@ -791,15 +801,18 @@ export function detectStuckRunWatchdogFindings(
     const toolStale = stale(toolActivityAgeMs, staleToolActivityMs);
     const stateStale = stale(stateTransitionAgeMs, staleStateTransitionMs);
     const staleCount = [heartbeatStale, outputStale, toolStale, stateStale].filter(Boolean).length;
-    const optionalActivitySignalsProvided = outputAgeMs !== undefined || toolActivityAgeMs !== undefined;
-    const minimumStaleSignals = optionalActivitySignalsProvided ? 3 : 2;
+    const providedActivitySignalCount = [
+      heartbeatAgeMs,
+      outputAgeMs,
+      toolActivityAgeMs,
+      stateTransitionAgeMs,
+    ].filter((age) => age !== undefined).length;
+    const minimumStaleSignals = Math.max(2, Math.min(3, providedActivitySignalCount));
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || !hasPositivePid
       ? 'dead'
-      : snapshot.alive === true
-        ? 'alive'
-        : 'unknown';
+      : 'alive';
 
     if (
       knownLongRunningWait(category)
@@ -820,7 +833,7 @@ export function detectStuckRunWatchdogFindings(
       `kanbanState=${status ?? 'unknown'}`,
       `blockerCategory=${category}`,
     ];
-    if (snapshot.waitingOn) evidence.push(`waitingOn=${snapshot.waitingOn}`);
+    if (snapshot.waitingOn) evidence.push(`waitingOn=${redactStuckRunEvidenceText(snapshot.waitingOn)}`);
 
     const recommendedAction = remediationForStuckRun(category, processStatus);
     const confidence = confidenceForStuckRun(category, staleCount, processStatus);

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -729,10 +729,10 @@ function normalizeStuckRunBlockerCategory(
   snapshot: IssueWorkerCardProcessSnapshot,
 ): IssueStuckRunBlockerCategory {
   if (snapshot.alive === false) return 'process-crash';
-  if (snapshot.blockerCategory) return snapshot.blockerCategory;
+  if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
-  if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
+  if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
   if (/crash|exit|dead|pid|process|fail/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
@@ -806,7 +806,7 @@ export function detectStuckRunWatchdogFindings(
       toolActivityAgeMs,
       stateTransitionAgeMs,
     ].filter((age) => age !== undefined).length;
-    const minimumStaleSignals = Math.min(3, providedActivitySignalCount);
+    const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
     const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
@@ -815,7 +815,7 @@ export function detectStuckRunWatchdogFindings(
         ? 'alive'
         : 'unknown';
 
-    if (processStatus !== 'dead' && providedActivitySignalCount === 0) continue;
+    if (processStatus !== 'dead' && category !== 'process-crash' && providedActivitySignalCount === 0) continue;
 
     if (
       knownLongRunningWait(category)

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -172,10 +172,57 @@ export interface IssueWorkerCardProcessSnapshot {
   readonly alive?: boolean | undefined;
   readonly startedAt?: string | number | Date | undefined;
   readonly lastHeartbeatAt?: string | number | Date | undefined;
+  /** Last stdout/stderr/output event from the worker process. */
+  readonly lastOutputAt?: string | number | Date | undefined;
+  /** Last tool invocation or external side-effect recorded for the worker. */
+  readonly lastToolActivityAt?: string | number | Date | undefined;
+  /** Last Kanban/task state transition observed for this worker card. */
+  readonly lastStateTransitionAt?: string | number | Date | undefined;
+  /** PM/Doctor blocker hint already known before watchdog classification. */
+  readonly blockerCategory?: IssueStuckRunBlockerCategory | undefined;
+  /** Human-readable wait reason, e.g. provider queue, CI checks, or approval token. */
+  readonly waitingOn?: string | undefined;
   /** Monotonic heartbeat sequence recorded by the heartbeat writer. */
   readonly heartbeatSequence?: number | undefined;
   /** Writer/reader source for diagnostics when heartbeat state is stale or regressive. */
   readonly source?: string | undefined;
+}
+
+export type IssueStuckRunBlockerCategory =
+  | 'approval-gate'
+  | 'ci-wait'
+  | 'dispatcher-bug'
+  | 'process-crash'
+  | 'provider-wait'
+  | 'unknown';
+
+export interface IssueStuckRunWatchdogOptions {
+  readonly nowMs?: number | undefined;
+  readonly staleHeartbeatMs?: number | undefined;
+  readonly staleOutputMs?: number | undefined;
+  readonly staleToolActivityMs?: number | undefined;
+  readonly staleStateTransitionMs?: number | undefined;
+  readonly longRunningWaitGraceMs?: number | undefined;
+}
+
+export interface IssueStuckRunWatchdogFinding {
+  readonly cardId: string;
+  readonly pid: number;
+  readonly runId?: string | undefined;
+  readonly issueNumber?: number | undefined;
+  readonly owner?: string | undefined;
+  readonly status?: string | undefined;
+  readonly blockerCategory: IssueStuckRunBlockerCategory;
+  readonly confidence: 'low' | 'medium' | 'high';
+  readonly heartbeatAgeMs?: number | undefined;
+  readonly outputAgeMs?: number | undefined;
+  readonly toolActivityAgeMs?: number | undefined;
+  readonly stateTransitionAgeMs?: number | undefined;
+  readonly processStatus: 'alive' | 'dead' | 'unknown';
+  readonly kanbanState: string;
+  readonly evidence: readonly string[];
+  readonly recommendedAction: string;
+  readonly message: string;
 }
 
 export interface WorkerHeartbeatMonotonicityFinding {
@@ -338,6 +385,11 @@ const ONE_SHOT_MAX_ITERATIONS = 50;
 const ONE_SHOT_STALE_MATE_LIMIT = 3;
 const DEFAULT_SCHEDULER_FAIRNESS_ISSUE_NUMBER_LIMIT = 50;
 const DEFAULT_SCHEDULER_FAIRNESS_WARNING_LIMIT = 50;
+const DEFAULT_STUCK_RUN_STALE_HEARTBEAT_MS = 30 * 60 * 1000;
+const DEFAULT_STUCK_RUN_STALE_OUTPUT_MS = 45 * 60 * 1000;
+const DEFAULT_STUCK_RUN_STALE_TOOL_ACTIVITY_MS = 45 * 60 * 1000;
+const DEFAULT_STUCK_RUN_STALE_STATE_TRANSITION_MS = 60 * 60 * 1000;
+const DEFAULT_STUCK_RUN_WAIT_GRACE_MS = 2 * 60 * 60 * 1000;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const PRIORITY_AGING_DAYS_PER_RANK = 14;
 const MAX_PRIORITY_AGE_BOOST = 2;
@@ -644,6 +696,146 @@ function activeWorkerCardProcess(snapshot: IssueWorkerCardProcessSnapshot): bool
   if (!Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
   const status = snapshot.status?.trim().toLowerCase();
   return status === undefined || !TERMINAL_WORKER_CARD_STATUSES.has(status);
+}
+
+function ageMs(value: string | number | Date | undefined, nowMs: number): number | undefined {
+  if (value === undefined) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  const ms = date.getTime();
+  if (!Number.isFinite(ms) || ms > nowMs) return undefined;
+  return nowMs - ms;
+}
+
+function stale(age: number | undefined, threshold: number): boolean {
+  return age === undefined || age >= threshold;
+}
+
+function normalizeStuckRunBlockerCategory(
+  snapshot: IssueWorkerCardProcessSnapshot,
+): IssueStuckRunBlockerCategory {
+  if (snapshot.blockerCategory) return snapshot.blockerCategory;
+  const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
+  if (/approval|hitl|human|token/.test(text)) return 'approval-gate';
+  if (/\bci\b|check|workflow|merge queue/.test(text)) return 'ci-wait';
+  if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
+  if (/crash|exit|dead|pid|process/.test(text) || snapshot.alive === false) return 'process-crash';
+  if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
+  return 'unknown';
+}
+
+function remediationForStuckRun(category: IssueStuckRunBlockerCategory, processStatus: IssueStuckRunWatchdogFinding['processStatus']): string {
+  if (processStatus === 'dead' || category === 'process-crash') {
+    return 'Inspect the worker exit/crash logs, clear the stale PID/current-run pointer if no process is alive, then respawn one focused worker.';
+  }
+  switch (category) {
+    case 'approval-gate':
+      return 'Route the exact pending approval command/token to approval-cop or a human, and do not respawn duplicate workers while the gate is pending.';
+    case 'ci-wait':
+      return 'Check live CI/run status and merge queue state, rerun failed checks or unblock shared CI before touching issue code.';
+    case 'dispatcher-bug':
+      return 'Audit Kanban current_run/status/heartbeat consistency and repair dispatcher metadata before unblocking the card.';
+    case 'provider-wait':
+      return 'Check provider quota/rate-limit status and the latest model/bot response; retry later or switch provider only after preserving current work evidence.';
+    default:
+      return 'Open a Doctor card with heartbeat/output/tool/state evidence, verify process liveness, and choose between wait, repair, or single-worker respawn.';
+  }
+}
+
+function confidenceForStuckRun(
+  category: IssueStuckRunBlockerCategory,
+  staleCount: number,
+  processStatus: IssueStuckRunWatchdogFinding['processStatus'],
+): IssueStuckRunWatchdogFinding['confidence'] {
+  if (processStatus === 'dead') return 'high';
+  if (category !== 'unknown' && staleCount >= 3) return 'high';
+  if (category !== 'unknown' || staleCount >= 3) return 'medium';
+  return 'low';
+}
+
+function knownLongRunningWait(category: IssueStuckRunBlockerCategory): boolean {
+  return category === 'ci-wait' || category === 'provider-wait';
+}
+
+export function detectStuckRunWatchdogFindings(
+  snapshots: readonly IssueWorkerCardProcessSnapshot[],
+  options: IssueStuckRunWatchdogOptions = {},
+): IssueStuckRunWatchdogFinding[] {
+  const nowMs = options.nowMs ?? Date.now();
+  const staleHeartbeatMs = options.staleHeartbeatMs ?? DEFAULT_STUCK_RUN_STALE_HEARTBEAT_MS;
+  const staleOutputMs = options.staleOutputMs ?? DEFAULT_STUCK_RUN_STALE_OUTPUT_MS;
+  const staleToolActivityMs = options.staleToolActivityMs ?? DEFAULT_STUCK_RUN_STALE_TOOL_ACTIVITY_MS;
+  const staleStateTransitionMs = options.staleStateTransitionMs ?? DEFAULT_STUCK_RUN_STALE_STATE_TRANSITION_MS;
+  const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
+  const findings: IssueStuckRunWatchdogFinding[] = [];
+
+  for (const snapshot of snapshots) {
+    if (!snapshot.cardId.trim() || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) continue;
+    const status = snapshot.status?.trim().toLowerCase();
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && snapshot.alive !== false) continue;
+
+    const category = normalizeStuckRunBlockerCategory(snapshot);
+    const heartbeatAgeMs = ageMs(snapshot.lastHeartbeatAt, nowMs);
+    const outputAgeMs = ageMs(snapshot.lastOutputAt, nowMs);
+    const toolActivityAgeMs = ageMs(snapshot.lastToolActivityAt, nowMs);
+    const stateTransitionAgeMs = ageMs(snapshot.lastStateTransitionAt ?? snapshot.startedAt, nowMs);
+    const heartbeatStale = stale(heartbeatAgeMs, staleHeartbeatMs);
+    const outputStale = stale(outputAgeMs, staleOutputMs);
+    const toolStale = stale(toolActivityAgeMs, staleToolActivityMs);
+    const stateStale = stale(stateTransitionAgeMs, staleStateTransitionMs);
+    const staleCount = [heartbeatStale, outputStale, toolStale, stateStale].filter(Boolean).length;
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
+      ? 'dead'
+      : snapshot.alive === true
+        ? 'alive'
+        : 'unknown';
+
+    if (
+      knownLongRunningWait(category)
+      && processStatus !== 'dead'
+      && staleCount < 4
+      && (heartbeatAgeMs === undefined || heartbeatAgeMs < longRunningWaitGraceMs)
+      && (outputAgeMs === undefined || outputAgeMs < longRunningWaitGraceMs)
+    ) {
+      continue;
+    }
+
+    if (processStatus !== 'dead' && staleCount < 3) continue;
+
+    const evidence = [
+      `heartbeatAgeMs=${heartbeatAgeMs ?? 'unknown'}`,
+      `outputAgeMs=${outputAgeMs ?? 'unknown'}`,
+      `toolActivityAgeMs=${toolActivityAgeMs ?? 'unknown'}`,
+      `stateTransitionAgeMs=${stateTransitionAgeMs ?? 'unknown'}`,
+      `processStatus=${processStatus}`,
+      `kanbanState=${status ?? 'unknown'}`,
+      `blockerCategory=${category}`,
+    ];
+    if (snapshot.waitingOn) evidence.push(`waitingOn=${snapshot.waitingOn}`);
+
+    const recommendedAction = remediationForStuckRun(category, processStatus);
+    const confidence = confidenceForStuckRun(category, staleCount, processStatus);
+    findings.push({
+      cardId: snapshot.cardId.trim(),
+      pid: snapshot.pid,
+      ...(snapshot.runId ? { runId: snapshot.runId } : {}),
+      ...(snapshot.issueNumber !== undefined ? { issueNumber: snapshot.issueNumber } : {}),
+      ...(snapshot.owner ? { owner: snapshot.owner } : {}),
+      ...(snapshot.status ? { status: snapshot.status } : {}),
+      blockerCategory: category,
+      confidence,
+      ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),
+      ...(outputAgeMs !== undefined ? { outputAgeMs } : {}),
+      ...(toolActivityAgeMs !== undefined ? { toolActivityAgeMs } : {}),
+      ...(stateTransitionAgeMs !== undefined ? { stateTransitionAgeMs } : {}),
+      processStatus,
+      kanbanState: status ?? 'unknown',
+      evidence,
+      recommendedAction,
+      message: `Worker card ${snapshot.cardId.trim()} appears stuck (${category}, ${confidence} confidence): ${recommendedAction}`,
+    });
+  }
+
+  return findings.sort((a, b) => a.cardId.localeCompare(b.cardId));
 }
 
 function isoTimestamp(value: string | number | Date | undefined): string | undefined {

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -730,12 +730,13 @@ function redactStuckRunEvidenceText(value: string): string {
 function normalizeStuckRunBlockerCategory(
   snapshot: IssueWorkerCardProcessSnapshot,
 ): IssueStuckRunBlockerCategory {
+  if (snapshot.alive === false) return 'process-crash';
   if (snapshot.blockerCategory) return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
-  if (/crash|exit|dead|pid|process|fail/.test(text) || snapshot.alive === false) return 'process-crash';
+  if (/crash|exit|dead|pid|process|fail/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
   return 'unknown';
 }
@@ -807,12 +808,15 @@ export function detectStuckRunWatchdogFindings(
       toolActivityAgeMs,
       stateTransitionAgeMs,
     ].filter((age) => age !== undefined).length;
-    const minimumStaleSignals = Math.max(2, Math.min(3, providedActivitySignalCount));
+    if (providedActivitySignalCount === 0) continue;
+    const minimumStaleSignals = Math.min(3, providedActivitySignalCount);
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || !hasPositivePid
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
       ? 'dead'
-      : 'alive';
+      : hasPositivePid
+        ? 'alive'
+        : 'unknown';
 
     if (
       knownLongRunningWait(category)

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -690,6 +690,12 @@ const TERMINAL_WORKER_CARD_STATUSES = new Set([
   'stopped',
 ]);
 
+const CRASH_WORKER_CARD_STATUSES = new Set([
+  'crashed',
+  'exited',
+  'failed',
+]);
+
 function activeWorkerCardProcess(snapshot: IssueWorkerCardProcessSnapshot): boolean {
   if (snapshot.alive === false) return false;
   if (!snapshot.cardId.trim()) return false;
@@ -711,9 +717,10 @@ function stale(age: number | undefined, threshold: number): boolean {
 }
 
 function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean {
-  if (snapshot.blockerCategory === 'process-crash') return true;
   const status = snapshot.status?.trim().toLowerCase() ?? '';
-  return /crash|exit|fail/.test(status);
+  if (CRASH_WORKER_CARD_STATUSES.has(status)) return true;
+  return snapshot.blockerCategory === 'process-crash'
+    && (status === '' || !TERMINAL_WORKER_CARD_STATUSES.has(status));
 }
 
 function redactStuckRunEvidenceText(value: string): string {
@@ -728,13 +735,15 @@ function redactStuckRunEvidenceText(value: string): string {
 function normalizeStuckRunBlockerCategory(
   snapshot: IssueWorkerCardProcessSnapshot,
 ): IssueStuckRunBlockerCategory {
+  const status = snapshot.status?.trim().toLowerCase() ?? '';
   if (snapshot.alive === false) return 'process-crash';
+  if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
-  if (/crash|exit|dead|pid|process|fail/.test(text)) return 'process-crash';
+  if (/\b(crash(?:ed|ing)?|exit(?:ed|ing)?|dead|pid|fail(?:ed|ure|ing)?)\b/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
   return 'unknown';
 }
@@ -825,7 +834,7 @@ export function detectStuckRunWatchdogFindings(
       continue;
     }
 
-    if (processStatus !== 'dead' && staleCount < minimumStaleSignals) continue;
+    if (processStatus !== 'dead' && category !== 'process-crash' && staleCount < minimumStaleSignals) continue;
 
     const evidence = [
       `heartbeatAgeMs=${heartbeatAgeMs ?? 'unknown'}`,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -713,14 +713,12 @@ function stale(age: number | undefined, threshold: number): boolean {
 function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean {
   if (snapshot.blockerCategory === 'process-crash') return true;
   const status = snapshot.status?.trim().toLowerCase() ?? '';
-  const waitingOn = snapshot.waitingOn?.toLowerCase() ?? '';
-  if (/crash|exit|dead|pid|process|fail/.test(waitingOn)) return true;
   return /crash|exit|fail/.test(status);
 }
 
 function redactStuckRunEvidenceText(value: string): string {
   return value
-    .replace(/\b(gh[opsu]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b/g, '[REDACTED_TOKEN]')
+    .replace(/\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g, '[REDACTED_TOKEN]')
     .replace(/\b(sk|xox[baprs]?|hf|glpat)-[A-Za-z0-9._/-]+\b/g, '$1-[REDACTED]')
     .replace(/\b([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\b/g, '[REDACTED_JWT]')
     .replace(/\b((?:approval|session|access|refresh|api)[-_ ]?token)\s*[:=]\s*\S+/gi, '$1=[REDACTED]')
@@ -808,7 +806,6 @@ export function detectStuckRunWatchdogFindings(
       toolActivityAgeMs,
       stateTransitionAgeMs,
     ].filter((age) => age !== undefined).length;
-    if (providedActivitySignalCount === 0) continue;
     const minimumStaleSignals = Math.min(3, providedActivitySignalCount);
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
@@ -817,6 +814,8 @@ export function detectStuckRunWatchdogFindings(
       : hasPositivePid
         ? 'alive'
         : 'unknown';
+
+    if (processStatus !== 'dead' && providedActivitySignalCount === 0) continue;
 
     if (
       knownLongRunningWait(category)

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -712,7 +712,10 @@ function stale(age: number | undefined, threshold: number): boolean {
 
 function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean {
   if (snapshot.blockerCategory === 'process-crash') return true;
-  return /crash|exit|dead|pid|process/.test(snapshot.waitingOn?.toLowerCase() ?? '');
+  const status = snapshot.status?.trim().toLowerCase() ?? '';
+  const waitingOn = snapshot.waitingOn?.toLowerCase() ?? '';
+  if (/crash|exit|dead|pid|process|fail/.test(waitingOn)) return true;
+  return snapshot.alive === false && /crash|exit|fail/.test(status);
 }
 
 function normalizeStuckRunBlockerCategory(
@@ -720,9 +723,9 @@ function normalizeStuckRunBlockerCategory(
 ): IssueStuckRunBlockerCategory {
   if (snapshot.blockerCategory) return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
-  if (/approval|hitl|human|token/.test(text)) return 'approval-gate';
-  if (/\bci\b|check|workflow|merge queue/.test(text)) return 'ci-wait';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
+  if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
+  if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
   if (/crash|exit|dead|pid|process/.test(text) || snapshot.alive === false) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
   return 'unknown';
@@ -788,6 +791,8 @@ export function detectStuckRunWatchdogFindings(
     const toolStale = stale(toolActivityAgeMs, staleToolActivityMs);
     const stateStale = stale(stateTransitionAgeMs, staleStateTransitionMs);
     const staleCount = [heartbeatStale, outputStale, toolStale, stateStale].filter(Boolean).length;
+    const optionalActivitySignalsProvided = outputAgeMs !== undefined || toolActivityAgeMs !== undefined;
+    const minimumStaleSignals = optionalActivitySignalsProvided ? 3 : 2;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
     const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
@@ -804,7 +809,7 @@ export function detectStuckRunWatchdogFindings(
       continue;
     }
 
-    if (processStatus !== 'dead' && staleCount < 3) continue;
+    if (processStatus !== 'dead' && staleCount < minimumStaleSignals) continue;
 
     const evidence = [
       `heartbeatAgeMs=${heartbeatAgeMs ?? 'unknown'}`,

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -716,6 +716,28 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('classifies dead workers as crashes even when stale wait hints remain', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_ci_wait',
+        pid: 7407,
+        status: 'running',
+        alive: false,
+        blockerCategory: 'ci-wait',
+        waitingOn: 'CI checks were queued before the process exited',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_dead_ci_wait',
+      blockerCategory: 'process-crash',
+      confidence: 'high',
+      processStatus: 'dead',
+    });
+  });
+
   it('reports terminal crash statuses even when liveness probes are omitted', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -758,6 +780,26 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('reports stale heartbeat-only snapshots when heartbeat is the only provided activity signal', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_stale_heartbeat_only_no_start',
+        pid: 7408,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_stale_heartbeat_only_no_start',
+      blockerCategory: 'unknown',
+      confidence: 'low',
+      heartbeatAgeMs: 14_400_000,
+      processStatus: 'alive',
+    });
+  });
+
   it('reports partial stale snapshots when all provided activity signals are stale', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -793,9 +835,23 @@ describe('stuck-run watchdog', () => {
     expect(findings[0]).toMatchObject({
       cardId: 't_missing_pid',
       pid: 0,
-      processStatus: 'dead',
-      confidence: 'high',
+      processStatus: 'unknown',
+      confidence: 'low',
     });
+  });
+
+  it('does not treat fresh unreadable PID snapshots as dead crashes', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_fresh_missing_pid',
+        pid: 0,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
   });
 
   it('redacts token-like values from waitingOn evidence', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -711,6 +711,22 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('keeps successful terminal cards quiet even when stale blocker metadata mentions crashes', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_done_with_stale_crash_blocker',
+        pid: 7406,
+        status: 'done',
+        alive: true,
+        blockerCategory: 'process-crash',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('reports terminal crash statuses when alive is false without waitingOn hints', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -808,6 +824,39 @@ describe('stuck-run watchdog', () => {
       processStatus: 'alive',
       kanbanState: 'failed',
     });
+  });
+
+  it('lets explicit crash status override stale blocker hints', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_failed_stale_ci_wait',
+        pid: 7407,
+        status: 'failed',
+        blockerCategory: 'ci-wait',
+        lastStateTransitionAt: '2026-07-16T11:58:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_failed_stale_ci_wait',
+      blockerCategory: 'process-crash',
+      confidence: 'medium',
+      processStatus: 'alive',
+      kanbanState: 'failed',
+    });
+  });
+
+  it('does not infer crashes from ordinary process wait wording without stale evidence', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_waiting_on_child_process',
+        pid: 7407,
+        status: 'processing',
+        waitingOn: 'waiting on child process',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
   });
 
   it('reports stale heartbeat snapshots even when optional activity timestamps are absent', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -792,6 +792,24 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('reports crash-only snapshots even when activity timestamps are absent', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_crashed_without_activity',
+        pid: 7407,
+        status: 'failed',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_crashed_without_activity',
+      blockerCategory: 'process-crash',
+      confidence: 'medium',
+      processStatus: 'alive',
+      kanbanState: 'failed',
+    });
+  });
+
   it('reports stale heartbeat snapshots even when optional activity timestamps are absent', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -944,6 +962,66 @@ describe('stuck-run watchdog', () => {
         blockerCategory: 'unknown',
       }),
     ]));
+  });
+
+  it('prioritizes approval cues over broad provider wording', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_provider_approval',
+        pid: 7412,
+        status: 'running',
+        alive: true,
+        waitingOn: 'Codex model operation needs operator approval',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_provider_approval',
+      blockerCategory: 'approval-gate',
+    });
+  });
+
+  it('infers a specific blocker when callers provide unknown with useful waiting text', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_unknown_ci_wait',
+        pid: 7413,
+        status: 'running',
+        alive: true,
+        blockerCategory: 'unknown',
+        waitingOn: 'CI checks are queued',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_unknown_ci_wait',
+      blockerCategory: 'ci-wait',
+    });
+  });
+
+  it('suppresses watchdog findings when any provided activity signal is fresh', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_fresh_output',
+        pid: 7414,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T11:58:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
   });
 
   it('escalates stale provider waits after every activity signal exceeds grace', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, evaluateIssueSchedulingScore, planKanbanStateMutation } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, evaluateIssueSchedulingScore, planKanbanStateMutation } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -572,6 +572,119 @@ describe('duplicate worker-card process detector', () => {
     ]);
 
     expect(findings).toEqual([]);
+  });
+});
+
+describe('stuck-run watchdog', () => {
+  const nowMs = Date.parse('2026-07-16T12:00:00.000Z');
+
+  it('classifies crashed workers and recommends stale PID/current-run cleanup', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_crashed',
+        pid: 7401,
+        runId: 'run-crash',
+        issueNumber: 1678,
+        owner: 'doctor',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+        lastOutputAt: '2026-07-16T11:55:30.000Z',
+        lastToolActivityAt: '2026-07-16T11:54:00.000Z',
+        lastStateTransitionAt: '2026-07-16T11:50:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        cardId: 't_crashed',
+        pid: 7401,
+        runId: 'run-crash',
+        issueNumber: 1678,
+        blockerCategory: 'process-crash',
+        confidence: 'high',
+        processStatus: 'dead',
+        kanbanState: 'running',
+        heartbeatAgeMs: 5 * 60 * 1000,
+        outputAgeMs: 270_000,
+        recommendedAction: expect.stringContaining('clear the stale PID/current-run pointer'),
+      }),
+    ]);
+  });
+
+  it('uses known blocker hints to report approval gates with concrete remediation', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_approval',
+        pid: 7402,
+        runId: 'run-approval',
+        status: 'running',
+        alive: true,
+        blockerCategory: 'approval-gate',
+        waitingOn: 'approval token for git push --force-with-lease',
+        lastHeartbeatAt: '2026-07-16T10:00:00.000Z',
+        lastOutputAt: '2026-07-16T10:05:00.000Z',
+        lastToolActivityAt: '2026-07-16T10:05:00.000Z',
+        lastStateTransitionAt: '2026-07-16T09:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_approval',
+      blockerCategory: 'approval-gate',
+      confidence: 'high',
+      heartbeatAgeMs: 7_200_000,
+      toolActivityAgeMs: 6_900_000,
+      stateTransitionAgeMs: 9_000_000,
+      processStatus: 'alive',
+      recommendedAction: expect.stringContaining('approval-cop'),
+      evidence: expect.arrayContaining([
+        'waitingOn=approval token for git push --force-with-lease',
+        'blockerCategory=approval-gate',
+      ]),
+    });
+  });
+
+  it('guards against false positives for healthy long-running CI/provider waits', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_ci_wait',
+        pid: 7403,
+        status: 'running',
+        alive: true,
+        blockerCategory: 'ci-wait',
+        waitingOn: 'CI checks are still queued',
+        lastHeartbeatAt: '2026-07-16T11:45:00.000Z',
+        lastOutputAt: '2026-07-16T11:40:00.000Z',
+        lastToolActivityAt: '2026-07-16T10:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T10:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('escalates stale provider waits after every activity signal exceeds grace', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_provider',
+        pid: 7404,
+        status: 'running',
+        alive: true,
+        waitingOn: 'provider quota reset',
+        lastHeartbeatAt: '2026-07-16T08:30:00.000Z',
+        lastOutputAt: '2026-07-16T08:25:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:20:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:15:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_provider',
+      blockerCategory: 'provider-wait',
+      confidence: 'high',
+      recommendedAction: expect.stringContaining('provider quota'),
+    });
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -716,6 +716,26 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('reports terminal crash statuses even when liveness probes are omitted', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_crashed_without_probe',
+        pid: 7407,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_crashed_without_probe',
+      blockerCategory: 'process-crash',
+      confidence: 'medium',
+      processStatus: 'alive',
+      kanbanState: 'failed',
+    });
+  });
+
   it('reports stale heartbeat snapshots even when optional activity timestamps are absent', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -736,6 +756,66 @@ describe('stuck-run watchdog', () => {
       stateTransitionAgeMs: 16_200_000,
       processStatus: 'alive',
     });
+  });
+
+  it('reports partial stale snapshots when all provided activity signals are stale', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_heartbeat_output_only',
+        pid: 7408,
+        status: 'running',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:05:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_heartbeat_output_only',
+      blockerCategory: 'unknown',
+      confidence: 'low',
+      heartbeatAgeMs: 14_400_000,
+      outputAgeMs: 14_100_000,
+      processStatus: 'alive',
+    });
+  });
+
+  it('keeps stale cards visible when the PID is missing or unreadable', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_missing_pid',
+        pid: 0,
+        status: 'running',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_missing_pid',
+      pid: 0,
+      processStatus: 'dead',
+      confidence: 'high',
+    });
+  });
+
+  it('redacts token-like values from waitingOn evidence', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_secret_wait',
+        pid: 7411,
+        status: 'running',
+        alive: true,
+        waitingOn: 'approval token=ghp_abcdEFGHijklMNOPqrstUVWX1234567890 and api token: sk-testsecretvalue123',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0].evidence).toContain('waitingOn=approval token=[REDACTED] and api token=[REDACTED]');
+    expect(findings[0].evidence.join('\n')).not.toContain('ghp_abcd');
+    expect(findings[0].evidence.join('\n')).not.toContain('sk-testsecretvalue123');
   });
 
   it('keeps provider token and checkpoint text out of approval and CI buckets', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -664,6 +664,37 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('does not treat missing optional activity signals as stale', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_heartbeat_only',
+        pid: 7405,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('keeps normally completed dead workers quiet', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_done',
+        pid: 7406,
+        status: 'done',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('escalates stale provider waits after every activity signal exceeds grace', () => {
     const findings = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -695,6 +695,22 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('keeps terminal cards quiet even when stale waitingOn text mentions failures', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_done_with_stale_waiting_on',
+        pid: 7406,
+        status: 'done',
+        alive: true,
+        waitingOn: 'CI checks failed before the card completed',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('reports terminal crash statuses when alive is false without waitingOn hints', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -732,6 +748,24 @@ describe('stuck-run watchdog', () => {
 
     expect(findings[0]).toMatchObject({
       cardId: 't_dead_ci_wait',
+      blockerCategory: 'process-crash',
+      confidence: 'high',
+      processStatus: 'dead',
+    });
+  });
+
+  it('reports dead workers even when activity timestamps are absent', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_without_activity',
+        pid: 7407,
+        status: 'running',
+        alive: false,
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_dead_without_activity',
       blockerCategory: 'process-crash',
       confidence: 'high',
       processStatus: 'dead',
@@ -861,7 +895,7 @@ describe('stuck-run watchdog', () => {
         pid: 7411,
         status: 'running',
         alive: true,
-        waitingOn: 'approval token=ghp_abcdEFGHijklMNOPqrstUVWX1234567890 and api token: sk-testsecretvalue123',
+        waitingOn: 'approval token=ghr_abcdefghijklmnopqrstuvwx.yz-123456 and api token: sk-abcdefghijklmnopqrstuvwxyz123456',
         lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
         lastOutputAt: '2026-07-16T08:00:00.000Z',
         lastToolActivityAt: '2026-07-16T08:00:00.000Z',
@@ -870,8 +904,8 @@ describe('stuck-run watchdog', () => {
     ], { nowMs });
 
     expect(findings[0].evidence).toContain('waitingOn=approval token=[REDACTED] and api token=[REDACTED]');
-    expect(findings[0].evidence.join('\n')).not.toContain('ghp_abcd');
-    expect(findings[0].evidence.join('\n')).not.toContain('sk-testsecretvalue123');
+    expect(findings[0].evidence.join('\n')).not.toContain('ghr_');
+    expect(findings[0].evidence.join('\n')).not.toContain('sk-abcdefghijklmnopqrstuvwxyz123456');
   });
 
   it('keeps provider token and checkpoint text out of approval and CI buckets', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -695,6 +695,87 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('reports terminal crash statuses when alive is false without waitingOn hints', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_terminal_crash',
+        pid: 7407,
+        status: 'crashed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_terminal_crash',
+      blockerCategory: 'process-crash',
+      confidence: 'high',
+      processStatus: 'dead',
+      kanbanState: 'crashed',
+    });
+  });
+
+  it('reports stale heartbeat snapshots even when optional activity timestamps are absent', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_stale_heartbeat_only',
+        pid: 7408,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        startedAt: '2026-07-16T07:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings[0]).toMatchObject({
+      cardId: 't_stale_heartbeat_only',
+      blockerCategory: 'unknown',
+      confidence: 'low',
+      heartbeatAgeMs: 14_400_000,
+      stateTransitionAgeMs: 16_200_000,
+      processStatus: 'alive',
+    });
+  });
+
+  it('keeps provider token and checkpoint text out of approval and CI buckets', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_provider_tokens',
+        pid: 7409,
+        status: 'running',
+        alive: true,
+        waitingOn: 'provider budget remaining 0 tokens',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+      {
+        cardId: 't_checkpoint_wait',
+        pid: 7410,
+        status: 'running',
+        alive: true,
+        waitingOn: 'checkpoint handoff is pending',
+        lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
+        lastOutputAt: '2026-07-16T08:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T08:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T08:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        cardId: 't_provider_tokens',
+        blockerCategory: 'provider-wait',
+      }),
+      expect.objectContaining({
+        cardId: 't_checkpoint_wait',
+        blockerCategory: 'unknown',
+      }),
+    ]));
+  });
+
   it('escalates stale provider waits after every activity signal exceeds grace', () => {
     const findings = detectStuckRunWatchdogFindings([
       {


### PR DESCRIPTION
## Summary
- Add a focused stuck-run watchdog detector for issue worker snapshots with confidence, evidence, and remediation hints.
- Classify common blocker modes including process crashes, approval gates, CI waits, provider waits, dispatcher bugs, and unknown stuck states.
- Document the watchdog API and add targeted unit coverage for crash, approval, CI/provider wait false-positive, and stale provider scenarios.

## Test Plan
- npm test --workspace=@franken/orchestrator -- tests/unit/issues/issue-runner.test.ts
- npm run typecheck --workspace=@franken/orchestrator
- npm run build --workspace=@franken/orchestrator
- npm run lint --workspace=@franken/orchestrator

Closes #1678