### PR TITLE
fix(observer): unref BatchAdapter flush interval timers

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -105,6 +105,38 @@ describe('BatchAdapter — options', () => {
 
     expect(timer.unref).toHaveBeenCalledOnce()
   })
+
+  it('refs flush interval timers while traces are buffered and unrefs them after draining', async () => {
+    let intervalCallback!: () => void
+    const timer = {
+      ref: vi.fn(),
+      unref: vi.fn(),
+    } as unknown as ReturnType<typeof globalThis.setInterval> & {
+      ref: () => void
+      unref: () => void
+    }
+    const setIntervalFn = vi.fn((callback: () => void) => {
+      intervalCallback = callback
+      return timer
+    })
+    const inner = new InMemoryAdapter()
+    const batch = new BatchAdapter({
+      adapter: inner,
+      maxBatchSize: 100,
+      flushIntervalMs: 1000,
+      setInterval: setIntervalFn,
+    })
+
+    await batch.flush(makeTrace('timer-drained'))
+    expect(timer.ref).toHaveBeenCalledOnce()
+
+    intervalCallback()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(await inner.listTraceIds()).toEqual(['timer-drained'])
+    expect(timer.unref).toHaveBeenCalledTimes(2)
+  })
 })
 
 // ── buffering ─────────────────────────────────────────────────────────────────

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -90,6 +90,21 @@ describe('BatchAdapter — options', () => {
     await batch.stop()
     expect(clearIntervalFn).toHaveBeenCalledWith(42)
   })
+
+  it('unrefs Node-compatible flush interval timers', () => {
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof globalThis.setInterval> & {
+      unref: () => void
+    }
+    const setIntervalFn = vi.fn().mockReturnValue(timer)
+
+    new BatchAdapter({
+      adapter: new InMemoryAdapter(),
+      flushIntervalMs: 1000,
+      setInterval: setIntervalFn,
+    })
+
+    expect(timer.unref).toHaveBeenCalledOnce()
+  })
 })
 
 // ── buffering ─────────────────────────────────────────────────────────────────

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -30,6 +30,10 @@ function validatePositiveSafeInteger(value: number, optionName: string): number 
   return value
 }
 
+function unrefTimerIfSupported(timer: ReturnType<typeof globalThis.setInterval>): void {
+  ;(timer as { unref?: () => void }).unref?.()
+}
+
 /**
  * Buffers `flush()` calls and forwards them to the underlying adapter in bulk,
  * reducing HTTP round-trips on high-throughput deployments.
@@ -70,6 +74,7 @@ export class BatchAdapter implements ExportAdapter {
       const flushIntervalMs = validatePositiveSafeInteger(options.flushIntervalMs, 'flushIntervalMs')
       const si = options.setInterval ?? globalThis.setInterval
       this.timer = si(() => { void this.drain().catch(() => undefined) }, flushIntervalMs)
+      unrefTimerIfSupported(this.timer)
     }
   }
 

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -30,8 +30,13 @@ function validatePositiveSafeInteger(value: number, optionName: string): number 
   return value
 }
 
-function unrefTimerIfSupported(timer: ReturnType<typeof globalThis.setInterval>): void {
-  ;(timer as { unref?: () => void }).unref?.()
+function setTimerRefState(
+  timer: ReturnType<typeof globalThis.setInterval>,
+  shouldRef: boolean,
+): void {
+  const refableTimer = timer as { ref?: () => void, unref?: () => void }
+  if (shouldRef) refableTimer.ref?.()
+  else refableTimer.unref?.()
 }
 
 /**
@@ -74,14 +79,16 @@ export class BatchAdapter implements ExportAdapter {
       const flushIntervalMs = validatePositiveSafeInteger(options.flushIntervalMs, 'flushIntervalMs')
       const si = options.setInterval ?? globalThis.setInterval
       this.timer = si(() => { void this.drain().catch(() => undefined) }, flushIntervalMs)
-      unrefTimerIfSupported(this.timer)
+      setTimerRefState(this.timer, false)
     }
   }
 
   /** Add a trace to the buffer. Drains immediately if `maxBatchSize` is reached. */
   async flush(trace: Trace): Promise<void> {
     warnIfTraceHasActiveSpans(trace, 'BatchAdapter')
+    const wasEmpty = this.buffer.length === 0
     this.buffer.push(trace)
+    if (wasEmpty && this.timer !== null) setTimerRefState(this.timer, true)
     if (this.buffer.length >= this.maxBatchSize) {
       await this.drainForSizeTriggeredFlush(trace)
     }
@@ -173,6 +180,8 @@ export class BatchAdapter implements ExportAdapter {
         failures.push(result.reason)
       }
     }
+
+    if (this.buffer.length === 0 && this.timer !== null) setTimerRefState(this.timer, false)
 
     if (failures.length > 0) {
       const firstFailure = failures[0]


### PR DESCRIPTION
## Summary
- unrefs BatchAdapter flush interval handles when Node-compatible timers expose unref()
- adds regression coverage for the flushIntervalMs timer lifecycle

## Test Plan
- npm run test --workspace @franken/observer -- src/adapters/batch/BatchAdapter.test.ts -t 'unrefs Node-compatible flush interval timers'
- npm run test --workspace @franken/observer -- src/adapters/batch/BatchAdapter.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run lint --workspace @franken/observer (passes with existing warnings)
- npm run build --workspace @franken/observer
- git diff --check

Closes #2030