### PR TITLE
fix(memory): document memory query limit bounds

### DIFF
--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -106,6 +106,10 @@ describe("Memory Server", () => {
       enum: ["working", "episodic"],
       description: "Filter by type: working or episodic",
     });
+    expect(queryTool.inputSchema.properties?.limit).toMatchObject({
+      type: "string",
+      description: "Max results as a positive integer from 1 to 1000 (default 20)",
+    });
   });
 
   it("delegates memory store/query/frontload/forget to the brain adapter", async () => {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -275,7 +275,7 @@ const TOOLS: ToolFull[] = [
       properties: {
         query: { type: 'string', description: 'Search query (substring match on key and value)' },
         type: { type: 'string', description: 'Filter by type: working or episodic', enum: ['working', 'episodic'] },
-        limit: { type: 'string', description: 'Max results (default 20)' },
+        limit: { type: 'string', description: 'Max results as a positive integer from 1 to 1000 (default 20)' },
         readScope: { type: 'string', description: 'Read scope: all (legacy), shared (hide agent-scoped entries), or agent (shared plus entries for agentId)', enum: ['all', 'shared', 'agent'] },
         agentId: { type: 'string', description: 'Agent id required when readScope is agent' },
       },


### PR DESCRIPTION
## Summary
- Documents `fbeast_memory_query` limit bounds in the public MCP tool schema.
- Adds regression coverage so the schema stays aligned with the existing positive-integer validation.

## Test Plan
- npm ci
- npm test -- --run src/servers/memory.test.ts -t "limits memory type enums" (observed failing before the schema description update)
- npm test -- --run src/servers/memory.test.ts
- npm run build
- cd packages/franken-mcp-suite && npm run typecheck
- cd packages/franken-mcp-suite && npm run lint
- cd packages/franken-mcp-suite && npm run build

Closes #2127
