### PR TITLE
fix(orchestrator): write cache JSON atomically

### DIFF
--- a/packages/franken-orchestrator/src/cache/llm-cache-store.ts
+++ b/packages/franken-orchestrator/src/cache/llm-cache-store.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from '../init/init-json-file.js';
 import type { CacheEntry, CacheStoreOptions, StoredCacheEntry } from './llm-cache-types.js';
 import { encodeCachePathSegment } from './llm-cache-types.js';
 
@@ -55,26 +55,20 @@ export class LlmCacheStore {
   }
 
   private async write(filePath: string, entry: StoredCacheEntry): Promise<void> {
-    await mkdir(dirname(filePath), { recursive: true });
-    await writeFile(filePath, JSON.stringify(entry, null, 2) + '\n', 'utf8');
+    await writeJsonFileAtomic(filePath, entry);
   }
 
   private async read(filePath: string): Promise<StoredCacheEntry | undefined> {
-    try {
-      const raw = await readFile(filePath, 'utf8');
-      const stored = JSON.parse(raw) as unknown;
+    const stored = await readJsonFileOrDefault<unknown>(filePath, () => undefined, {
+      description: 'LLM cache entry',
+      onCorrupt: warnJsonQuarantined,
+    });
 
-      if (!this.isValidStoredCacheEntry(stored)) {
-        return undefined;
-      }
-
-      return stored;
-    } catch (error) {
-      if ((error as { code?: string }).code === 'ENOENT' || error instanceof SyntaxError) {
-        return undefined;
-      }
-      throw error;
+    if (!this.isValidStoredCacheEntry(stored)) {
+      return undefined;
     }
+
+    return stored;
   }
 
   private isValidStoredCacheEntry(value: unknown): value is StoredCacheEntry {

--- a/packages/franken-orchestrator/src/cache/provider-session-store.ts
+++ b/packages/franken-orchestrator/src/cache/provider-session-store.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from '../init/init-json-file.js';
 import type {
   CacheStoreOptions,
   ProviderSessionLookup,
@@ -20,8 +20,7 @@ export class ProviderSessionStore {
       ...record,
       schemaVersion: this.options.schemaVersion,
     };
-    await mkdir(dirname(filePath), { recursive: true });
-    await writeFile(filePath, JSON.stringify(stored, null, 2) + '\n', 'utf8');
+    await writeJsonFileAtomic(filePath, stored);
   }
 
   async load(criteria: ProviderSessionLookup): Promise<StoredProviderSessionRecord | undefined> {
@@ -60,14 +59,9 @@ export class ProviderSessionStore {
   }
 
   private async read(filePath: string): Promise<StoredProviderSessionRecord | undefined> {
-    try {
-      const raw = await readFile(filePath, 'utf8');
-      return JSON.parse(raw) as StoredProviderSessionRecord;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) {
-        return undefined;
-      }
-      throw error;
-    }
+    return readJsonFileOrDefault<StoredProviderSessionRecord | undefined>(filePath, () => undefined, {
+      description: 'provider session',
+      onCorrupt: warnJsonQuarantined,
+    });
   }
 }

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -72,7 +72,14 @@ export async function readJsonFileOrDefault<T>(
     const targetPath = await resolveExistingOrSymlinkTarget(filePath);
     const quarantinePath = quarantinePathFor(targetPath);
     const targetMode = await stat(targetPath).then((info) => info.mode & 0o777).catch(() => undefined);
-    await rename(targetPath, quarantinePath);
+    try {
+      await rename(targetPath, quarantinePath);
+    } catch (renameError) {
+      if ((renameError as NodeJS.ErrnoException).code === 'ENOENT') {
+        return fallback();
+      }
+      throw renameError;
+    }
     if (targetMode !== undefined) {
       recoveredFileModes.set(filePath, targetMode);
       recoveredFileModes.set(targetPath, targetMode);

--- a/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LlmCacheStore } from '../../../src/cache/llm-cache-store.js';
@@ -141,5 +141,60 @@ describe('LlmCacheStore', () => {
     await expect(store.loadWorkEntry('frankenbeast', 'issue:99', 'shared-key')).resolves.toMatchObject({
       content: 'work shared',
     });
+  });
+
+  it('uses atomic writes that replace valid cache JSON only after the replacement is complete', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-llm-cache-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const store = new LlmCacheStore(rootDir, { schemaVersion: 1 });
+    const path = join(
+      rootDir,
+      'project',
+      encodeCachePathSegment('frankenbeast'),
+      'stable',
+      `${encodeCachePathSegment('atomic:key')}.json`,
+    );
+
+    await store.saveProjectEntry('frankenbeast', 'atomic:key', {
+      content: 'initial valid cache entry',
+      fingerprint: 'fp-initial',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      metadata: { kind: 'project' },
+    });
+
+    await store.saveProjectEntry('frankenbeast', 'atomic:key', {
+      content: 'replacement cache entry',
+      fingerprint: 'fp-replacement',
+      createdAt: '2026-03-13T00:00:01.000Z',
+      metadata: { kind: 'project' },
+    });
+
+    await expect(readFile(path, 'utf8')).resolves.toContain('replacement cache entry');
+    await expect(store.loadProjectEntry('frankenbeast', 'atomic:key')).resolves.toMatchObject({
+      content: 'replacement cache entry',
+      fingerprint: 'fp-replacement',
+      schemaVersion: 1,
+    });
+  });
+
+  it('quarantines malformed cache JSON and treats corruption as an explicit miss', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-llm-cache-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const path = join(
+      rootDir,
+      'project',
+      encodeCachePathSegment('frankenbeast'),
+      'stable',
+      `${encodeCachePathSegment('corrupt:key')}.json`,
+    );
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, '{"content": "truncated"', 'utf8');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new LlmCacheStore(rootDir, { schemaVersion: 1 });
+    await expect(store.loadProjectEntry('frankenbeast', 'corrupt:key')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed LLM cache entry JSON'));
+    await expect(readFile(path, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    warn.mockRestore();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/llm-cache-store.test.ts
@@ -197,4 +197,27 @@ describe('LlmCacheStore', () => {
     await expect(readFile(path, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     warn.mockRestore();
   });
+
+  it('tolerates concurrent readers racing to quarantine the same malformed cache JSON', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-llm-cache-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const path = join(
+      rootDir,
+      'project',
+      encodeCachePathSegment('frankenbeast'),
+      'stable',
+      `${encodeCachePathSegment('racy-corrupt:key')}.json`,
+    );
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, '{"content": "truncated"', 'utf8');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new LlmCacheStore(rootDir, { schemaVersion: 1 });
+    await expect(Promise.all([
+      store.loadProjectEntry('frankenbeast', 'racy-corrupt:key'),
+      store.loadProjectEntry('frankenbeast', 'racy-corrupt:key'),
+    ])).resolves.toEqual([undefined, undefined]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed LLM cache entry JSON'));
+    warn.mockRestore();
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ProviderSessionStore } from '../../../src/cache/provider-session-store.js';
 
@@ -133,5 +133,67 @@ describe('ProviderSessionStore', () => {
       model: 'claude-sonnet-4-6',
       promptFingerprint: 'fp-110',
     })).resolves.toBeUndefined();
+  });
+
+  it('uses atomic writes that replace valid provider-session JSON only after the replacement is complete', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-provider-session-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const sessionPath = join(rootDir, 'work', 'frankenbeast', 'issue%3A99', 'provider-session.json');
+    const store = new ProviderSessionStore(rootDir, { schemaVersion: 3 });
+
+    await store.save({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: 'sess-99',
+      promptFingerprint: 'fp-99',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      updatedAt: '2026-03-13T00:00:00.000Z',
+    });
+
+    await store.save({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: 'sess-99-replacement',
+      promptFingerprint: 'fp-99',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      updatedAt: '2026-03-13T00:00:01.000Z',
+    });
+
+    await expect(readFile(sessionPath, 'utf8')).resolves.toContain('sess-99-replacement');
+    await expect(store.load({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      promptFingerprint: 'fp-99',
+    })).resolves.toMatchObject({
+      sessionId: 'sess-99-replacement',
+      schemaVersion: 3,
+    });
+  });
+
+  it('quarantines malformed provider-session JSON and treats corruption as an explicit miss', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-provider-session-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const sessionPath = join(rootDir, 'work', 'frankenbeast', 'issue%3A99', 'provider-session.json');
+    await mkdir(dirname(sessionPath), { recursive: true });
+    await writeFile(sessionPath, '{"sessionId": "truncated"', 'utf8');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new ProviderSessionStore(rootDir, { schemaVersion: 3 });
+    await expect(store.load({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      promptFingerprint: 'fp-99',
+    })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Malformed provider session JSON'));
+    await expect(readFile(sessionPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Route LLM cache and provider-session writes through the orchestrator atomic JSON helper.
- Use shared corrupt-JSON quarantine behavior for cache/session reads.
- Add targeted regression coverage for replacement writes and malformed JSON quarantine.

## Test Plan
- npm ci
- npm run test --workspace @franken/orchestrator -- tests/unit/cache/llm-cache-store.test.ts tests/unit/cache/provider-session-store.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #2031