### PR TITLE
fix(orchestrator): add crash-only worker restart contract

### DIFF
--- a/docs/guides/troubleshooting-stalled-workers.md
+++ b/docs/guides/troubleshooting-stalled-workers.md
@@ -39,6 +39,20 @@ gh pr view <pr-number> --repo djm204/frankenbeast --json number,state,mergeState
 gh pr checks <pr-number> --repo djm204/frankenbeast
 ```
 
+## Crash-only restart contract
+
+Every abnormal worker exit must produce one auditable restart contract row before a PM, doctor, or dispatcher starts another worker. The row records `exitReason`, `pid`, `heartbeatAgeMs`, and `nextAction`, then classifies the liveness state as terminal, retryable, or HITL:
+
+| Exit/state | Disposition | Next action |
+| --- | --- | --- |
+| Setup/spawn failure or protocol violation before the worker can own the task | HITL | `replace-with-doctor`; preserve spawn error, PID if known, stderr tail, and task context instead of blind respawn loops. |
+| Crash while the card is blocked or waiting on approval/provider/CI evidence | HITL | `defer-with-evidence`; keep the human/external gate visible and do not auto-respawn over it. |
+| Dead PID for an otherwise running card, with no sibling owner and no active PR/worktree owner | Retryable | `restart-once`; clear stale PID/current-run metadata only after evidence is recorded. |
+| Another live PID already owns the same worker card | HITL | `suppress-duplicate-respawn`; stop or park duplicates and record the surviving PID/run id. |
+| Completed/stopped/deleted card with no active crash evidence | Terminal | `no-op`; do not resurrect terminal work from stale liveness snapshots. |
+
+The contract is intentionally crash-only: recovery starts from the recorded evidence and either restarts exactly once, defers to a human/external gate, or replaces the card with a doctor lane. It must not churn stale `ready`/`running` states or keep stale active worker ids after a terminal decision.
+
 ## Recovery actions by outcome
 
 ### Active worker

--- a/docs/guides/troubleshooting-stalled-workers.md
+++ b/docs/guides/troubleshooting-stalled-workers.md
@@ -41,7 +41,7 @@ gh pr checks <pr-number> --repo djm204/frankenbeast
 
 ## Crash-only restart contract
 
-Every abnormal worker exit must produce one auditable restart contract row before a PM, doctor, or dispatcher starts another worker. The row records `exitReason`, `pid`, `heartbeatAgeMs`, and `nextAction`, then classifies the liveness state as terminal, retryable, or HITL:
+PM/liveness watchdog recovery of an abnormal worker exit must produce one auditable restart contract row before a PM, doctor, or dispatcher starts another worker from the stalled-card path. Manual/API restarts must still follow the fast triage checklist above, but this watchdog contract row specifically records `exitReason`, `pid`, `heartbeatAgeMs`, and `nextAction`, then classifies the liveness state as terminal, retryable, or HITL:
 
 | Exit/state | Disposition | Next action |
 | --- | --- | --- |

--- a/packages/franken-orchestrator/src/index.ts
+++ b/packages/franken-orchestrator/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from './types.js';
 
 // Issues
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, planKanbanStateMutation } from './issues/index.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, buildWorkerCrashOnlyRestartContract, planKanbanStateMutation } from './issues/index.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -73,6 +73,9 @@ export type {
   IssueStuckRunWatchdogFinding,
   IssueStuckRunWatchdogOptions,
   IssueWorkerCardProcessSnapshot,
+  IssueWorkerCrashOnlyRestartContract,
+  IssueWorkerRestartDisposition,
+  IssueWorkerRestartNextAction,
   KanbanStateMutationDecision,
   KanbanStateMutationDecisionAction,
   KanbanStateMutationOperation,

--- a/packages/franken-orchestrator/src/issues/index.ts
+++ b/packages/franken-orchestrator/src/issues/index.ts
@@ -11,7 +11,7 @@ export type {
 export { IssueFetcher } from './issue-fetcher.js';
 export { IssueTriage } from './issue-triage.js';
 export { IssueGraphBuilder } from './issue-graph-builder.js';
-export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, planKanbanStateMutation } from './issue-runner.js';
+export { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, buildWorkerCrashOnlyRestartContract, planKanbanStateMutation } from './issue-runner.js';
 export type {
   IssueRunnerConfig,
   IssueBackpressureConfig,
@@ -35,6 +35,9 @@ export type {
   IssueStuckRunWatchdogFinding,
   IssueStuckRunWatchdogOptions,
   IssueWorkerCardProcessSnapshot,
+  IssueWorkerCrashOnlyRestartContract,
+  IssueWorkerRestartDisposition,
+  IssueWorkerRestartNextAction,
   KanbanStateMutationDecision,
   KanbanStateMutationDecisionAction,
   KanbanStateMutationOperation,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -757,7 +757,8 @@ function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean
 
 function redactStuckRunEvidenceText(value: string): string {
   return redactSensitiveText(value)
-    .replace(/\b([A-Za-z0-9_]*(?:SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*|[A-Za-z0-9_]*API[_-]?KEY[A-Za-z0-9_]*)\s*[:=]\s*\S+/gi, '$1=<redacted>')
+    .replace(/\b([A-Za-z0-9_]*(?:SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*|[A-Za-z0-9_]*API[_-]?KEY[A-Za-z0-9_]*)\s*:\s*(?:"[^"]*"|'[^']*'|[^\r\n]*)/gi, '$1=<redacted>')
+    .replace(/\b([A-Za-z0-9_]*(?:SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*|[A-Za-z0-9_]*API[_-]?KEY[A-Za-z0-9_]*)\s*=\s*\S+/gi, '$1=<redacted>')
     .replace(/\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g, '[REDACTED_TOKEN]')
     .replace(/\b(sk|xox[baprs]?|hf|glpat)-[A-Za-z0-9._/-]+\b/g, '$1-[REDACTED]')
     .replace(/\b([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\b/g, '[REDACTED_JWT]')
@@ -940,7 +941,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (kanbanState === 'blocked' || kanbanState === 'pending-approval' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
+  if (kanbanState === 'blocked' || kanbanState === 'pending-approval' || input.category === 'approval-gate' || input.category === 'dispatcher-bug' || knownLongRunningWait(input.category)) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
@@ -1020,7 +1021,7 @@ export function detectStuckRunWatchdogFindings(
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
-  const emittedDeadRestartCards = new Set<string>();
+  const handledDeadRestartCards = new Set<string>();
 
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim()) continue;
@@ -1086,9 +1087,9 @@ export function detectStuckRunWatchdogFindings(
       kanbanState: status ?? 'unknown',
     });
     const normalizedCardId = snapshot.cardId.trim();
-    if (processStatus === 'dead' && restartContract.nextAction === 'restart-once') {
-      if (emittedDeadRestartCards.has(normalizedCardId)) continue;
-      emittedDeadRestartCards.add(normalizedCardId);
+    if (processStatus === 'dead') {
+      if (handledDeadRestartCards.has(normalizedCardId)) continue;
+      handledDeadRestartCards.add(normalizedCardId);
     }
     evidence.push(...restartContract.evidence);
 

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -763,13 +763,13 @@ function normalizeStuckRunBlockerCategory(
   snapshot: IssueWorkerCardProcessSnapshot,
 ): IssueStuckRunBlockerCategory {
   const status = snapshot.status?.trim().toLowerCase() ?? '';
-  if (snapshot.alive === false) return 'process-crash';
-  if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
+  if (snapshot.alive !== false && CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
+  if (snapshot.alive === false) return 'process-crash';
   if (/\b(crash(?:ed|ing)?|exit(?:ed|ing)?|dead|pid|fail(?:ed|ure|ing)?)\b/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
   return 'unknown';
@@ -823,6 +823,10 @@ function hasDuplicateRespawn(snapshot: IssueWorkerCardProcessSnapshot): boolean 
   return siblingPids.length > 0;
 }
 
+function terminalKanbanState(status: string): boolean {
+  return TERMINAL_WORKER_CARD_STATUSES.has(status.trim().toLowerCase());
+}
+
 export function buildWorkerCrashOnlyRestartContract(
   snapshot: IssueWorkerCardProcessSnapshot,
   input: {
@@ -832,7 +836,8 @@ export function buildWorkerCrashOnlyRestartContract(
     readonly kanbanState: string;
   },
 ): IssueWorkerCrashOnlyRestartContract {
-  const exitReason = normalizedExitReason(snapshot, input.category);
+  const rawExitReason = normalizedExitReason(snapshot, input.category);
+  const exitReason = redactStuckRunEvidenceText(rawExitReason);
   const evidence = [
     `exitReason=${exitReason}`,
     `pid=${snapshot.pid}`,
@@ -855,7 +860,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (exitReason === 'spawn_failed' || /spawn|setup|enoent|eacces|protocol[_ -]?violation/i.test(exitReason)) {
+  if (rawExitReason === 'spawn_failed' || /spawn|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
@@ -864,7 +869,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (input.kanbanState === 'blocked' || input.category === 'approval-gate') {
+  if (input.kanbanState === 'blocked' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
@@ -882,12 +887,40 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (terminalKanbanState(input.kanbanState)) {
+    return {
+      disposition: 'terminal',
+      nextAction: 'no-op',
+      ...base,
+      evidence,
+    };
+  }
+
   return {
-    disposition: 'terminal',
-    nextAction: 'no-op',
+    disposition: 'hitl',
+    nextAction: 'defer-with-evidence',
     ...base,
     evidence,
   };
+}
+
+function remediationForCrashOnlyRestartContract(
+  contract: IssueWorkerCrashOnlyRestartContract,
+  category: IssueStuckRunBlockerCategory,
+  processStatus: IssueStuckRunWatchdogFinding['processStatus'],
+): string {
+  switch (contract.nextAction) {
+    case 'replace-with-doctor':
+      return 'Open or route to a Doctor card with the preserved setup/protocol failure evidence; do not blind-respawn this worker.';
+    case 'defer-with-evidence':
+      return `${remediationForStuckRun(category, processStatus)} Preserve the wait/crash evidence and defer to the active HITL, CI, provider, or dispatcher investigation gate; do not auto-respawn over the blocker.`;
+    case 'suppress-duplicate-respawn':
+      return 'Suppress duplicate respawn, keep the surviving worker PID/run id as owner, and repair stale duplicate metadata before any restart.';
+    case 'restart-once':
+      return remediationForStuckRun(category, processStatus);
+    case 'no-op':
+      return 'No restart action is required for this terminal worker state; keep the evidence for audit only.';
+  }
 }
 
 export function detectStuckRunWatchdogFindings(
@@ -963,7 +996,7 @@ export function detectStuckRunWatchdogFindings(
     });
     evidence.push(...restartContract.evidence);
 
-    const recommendedAction = remediationForStuckRun(category, processStatus);
+    const recommendedAction = remediationForCrashOnlyRestartContract(restartContract, category, processStatus);
     const confidence = confidenceForStuckRun(category, staleCount, processStatus);
     findings.push({
       cardId: snapshot.cardId.trim(),

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -822,7 +822,12 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
   const byCard = new Map<string, Set<number>>();
   for (const snapshot of snapshots) {
     const cardId = snapshot.cardId.trim();
-    if (!cardId || snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) continue;
+    const status = snapshot.status?.trim().toLowerCase();
+    if (!cardId
+      || snapshot.alive === false
+      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
+      || !Number.isSafeInteger(snapshot.pid)
+      || snapshot.pid <= 0) continue;
     const pids = byCard.get(cardId) ?? new Set<number>();
     pids.add(snapshot.pid);
     byCard.set(cardId, pids);

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -763,8 +763,8 @@ function normalizeStuckRunBlockerCategory(
   snapshot: IssueWorkerCardProcessSnapshot,
 ): IssueStuckRunBlockerCategory {
   const status = snapshot.status?.trim().toLowerCase() ?? '';
+  if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
-  if (snapshot.alive !== false && CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
@@ -818,13 +818,35 @@ function normalizedExitReason(snapshot: IssueWorkerCardProcessSnapshot, category
   return 'unknown';
 }
 
-function hasDuplicateRespawn(snapshot: IssueWorkerCardProcessSnapshot): boolean {
-  const siblingPids = snapshot.siblingPids?.filter((pid) => Number.isSafeInteger(pid) && pid > 0 && pid !== snapshot.pid) ?? [];
-  return siblingPids.length > 0;
+function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnapshot[]): Map<string, number[]> {
+  const byCard = new Map<string, Set<number>>();
+  for (const snapshot of snapshots) {
+    const cardId = snapshot.cardId.trim();
+    if (!cardId || snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) continue;
+    const pids = byCard.get(cardId) ?? new Set<number>();
+    pids.add(snapshot.pid);
+    byCard.set(cardId, pids);
+  }
+  return new Map([...byCard].map(([cardId, pids]) => [cardId, [...pids].sort((a, b) => a - b)]));
+}
+
+function siblingPidsForSnapshot(
+  snapshot: IssueWorkerCardProcessSnapshot,
+  livePidsByCardId: ReadonlyMap<string, readonly number[]>,
+): number[] {
+  const explicit = snapshot.siblingPids ?? [];
+  const derived = livePidsByCardId.get(snapshot.cardId.trim()) ?? [];
+  return [...new Set([...explicit, ...derived]
+    .filter((pid) => Number.isSafeInteger(pid) && pid > 0 && pid !== snapshot.pid))]
+    .sort((a, b) => a - b);
+}
+
+function normalizeKanbanState(status: string): string {
+  return status.trim().toLowerCase();
 }
 
 function terminalKanbanState(status: string): boolean {
-  return TERMINAL_WORKER_CARD_STATUSES.has(status.trim().toLowerCase());
+  return TERMINAL_WORKER_CARD_STATUSES.has(normalizeKanbanState(status));
 }
 
 export function buildWorkerCrashOnlyRestartContract(
@@ -838,6 +860,8 @@ export function buildWorkerCrashOnlyRestartContract(
 ): IssueWorkerCrashOnlyRestartContract {
   const rawExitReason = normalizedExitReason(snapshot, input.category);
   const exitReason = redactStuckRunEvidenceText(rawExitReason);
+  const kanbanState = normalizeKanbanState(input.kanbanState) || 'unknown';
+  const siblingPids = siblingPidsForSnapshot(snapshot, new Map());
   const evidence = [
     `exitReason=${exitReason}`,
     `pid=${snapshot.pid}`,
@@ -848,15 +872,15 @@ export function buildWorkerCrashOnlyRestartContract(
     pid: snapshot.pid,
     ...(input.heartbeatAgeMs !== undefined ? { heartbeatAgeMs: input.heartbeatAgeMs } : {}),
     processStatus: input.processStatus,
-    kanbanState: input.kanbanState,
+    kanbanState,
   };
 
-  if (hasDuplicateRespawn(snapshot)) {
+  if (siblingPids.length > 0) {
     return {
       disposition: 'hitl',
       nextAction: 'suppress-duplicate-respawn',
       ...base,
-      evidence: [...evidence, `siblingPids=${snapshot.siblingPids?.join(',') ?? 'unknown'}`],
+      evidence: [...evidence, `siblingPids=${siblingPids.join(',')}`],
     };
   }
 
@@ -869,7 +893,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (input.kanbanState === 'blocked' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
+  if (kanbanState === 'blocked' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
@@ -904,6 +928,21 @@ export function buildWorkerCrashOnlyRestartContract(
   };
 }
 
+function deferRemediationForStuckRun(category: IssueStuckRunBlockerCategory): string {
+  switch (category) {
+    case 'approval-gate':
+      return 'Route the exact pending approval command/token to approval-cop or a human.';
+    case 'ci-wait':
+      return 'Check live CI/run status and merge queue state, rerun failed checks or unblock shared CI.';
+    case 'provider-wait':
+      return 'Check provider quota/rate-limit status and the latest model/bot response; retry later or switch provider only after preserving current work evidence.';
+    case 'dispatcher-bug':
+      return 'Audit Kanban current_run/status/heartbeat consistency and repair dispatcher metadata before unblocking the card.';
+    default:
+      return 'Open a Doctor card with heartbeat/output/tool/state evidence and verify process liveness.';
+  }
+}
+
 function remediationForCrashOnlyRestartContract(
   contract: IssueWorkerCrashOnlyRestartContract,
   category: IssueStuckRunBlockerCategory,
@@ -913,7 +952,7 @@ function remediationForCrashOnlyRestartContract(
     case 'replace-with-doctor':
       return 'Open or route to a Doctor card with the preserved setup/protocol failure evidence; do not blind-respawn this worker.';
     case 'defer-with-evidence':
-      return `${remediationForStuckRun(category, processStatus)} Preserve the wait/crash evidence and defer to the active HITL, CI, provider, or dispatcher investigation gate; do not auto-respawn over the blocker.`;
+      return `${deferRemediationForStuckRun(category)} Preserve the wait/crash evidence and defer to the active HITL, CI, provider, or dispatcher investigation gate; do not auto-respawn over the blocker.`;
     case 'suppress-duplicate-respawn':
       return 'Suppress duplicate respawn, keep the surviving worker PID/run id as owner, and repair stale duplicate metadata before any restart.';
     case 'restart-once':
@@ -934,6 +973,7 @@ export function detectStuckRunWatchdogFindings(
   const staleStateTransitionMs = options.staleStateTransitionMs ?? DEFAULT_STUCK_RUN_STALE_STATE_TRANSITION_MS;
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
+  const liveSiblings = liveSiblingPidsByCardId(snapshots);
 
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim()) continue;
@@ -988,7 +1028,11 @@ export function detectStuckRunWatchdogFindings(
       `blockerCategory=${category}`,
     ];
     if (snapshot.waitingOn) evidence.push(`waitingOn=${redactStuckRunEvidenceText(snapshot.waitingOn)}`);
-    const restartContract = buildWorkerCrashOnlyRestartContract(snapshot, {
+    const siblingPids = siblingPidsForSnapshot(snapshot, liveSiblings);
+    const restartSnapshot = siblingPids.length > 0
+      ? { ...snapshot, siblingPids }
+      : snapshot;
+    const restartContract = buildWorkerCrashOnlyRestartContract(restartSnapshot, {
       category,
       processStatus,
       ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -767,7 +767,7 @@ function normalizeStuckRunBlockerCategory(
   if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
   if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
-  if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
+  if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending[_ -]approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
   if (snapshot.alive === false) return 'process-crash';
@@ -863,6 +863,10 @@ function intentionalNonRetryExitReason(exitReason: string): boolean {
   return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill)$/i.test(exitReason.trim());
 }
 
+function externalSignalExitReason(exitReason: string): boolean {
+  return /^signal_[a-z0-9]+$/i.test(exitReason.trim());
+}
+
 export function buildWorkerCrashOnlyRestartContract(
   snapshot: IssueWorkerCardProcessSnapshot,
   input: {
@@ -907,6 +911,15 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (externalSignalExitReason(rawExitReason)) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      ...base,
+      evidence,
+    };
+  }
+
   if (intentionalNonRetryExitReason(rawExitReason) || (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState))) {
     return {
       disposition: 'terminal',
@@ -916,7 +929,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (kanbanState === 'blocked' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
+  if (kanbanState === 'blocked' || kanbanState === 'pending-approval' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -182,6 +182,10 @@ export interface IssueWorkerCardProcessSnapshot {
   readonly blockerCategory?: IssueStuckRunBlockerCategory | undefined;
   /** Human-readable wait reason, e.g. provider queue, CI checks, or approval token. */
   readonly waitingOn?: string | undefined;
+  /** Supervisor/dispatcher exit reason preserved from the last run/attempt. */
+  readonly exitReason?: string | undefined;
+  /** Other currently live PIDs observed for the same worker card. */
+  readonly siblingPids?: readonly number[] | undefined;
   /** Monotonic heartbeat sequence recorded by the heartbeat writer. */
   readonly heartbeatSequence?: number | undefined;
   /** Writer/reader source for diagnostics when heartbeat state is stale or regressive. */
@@ -220,9 +224,32 @@ export interface IssueStuckRunWatchdogFinding {
   readonly stateTransitionAgeMs?: number | undefined;
   readonly processStatus: 'alive' | 'dead' | 'unknown';
   readonly kanbanState: string;
+  readonly exitReason: string;
+  readonly restartDisposition: IssueWorkerRestartDisposition;
+  readonly nextAction: IssueWorkerRestartNextAction;
   readonly evidence: readonly string[];
   readonly recommendedAction: string;
   readonly message: string;
+}
+
+export type IssueWorkerRestartDisposition = 'terminal' | 'retryable' | 'hitl';
+
+export type IssueWorkerRestartNextAction =
+  | 'no-op'
+  | 'restart-once'
+  | 'defer-with-evidence'
+  | 'replace-with-doctor'
+  | 'suppress-duplicate-respawn';
+
+export interface IssueWorkerCrashOnlyRestartContract {
+  readonly disposition: IssueWorkerRestartDisposition;
+  readonly nextAction: IssueWorkerRestartNextAction;
+  readonly exitReason: string;
+  readonly pid: number;
+  readonly heartbeatAgeMs?: number | undefined;
+  readonly processStatus: IssueStuckRunWatchdogFinding['processStatus'];
+  readonly kanbanState: string;
+  readonly evidence: readonly string[];
 }
 
 export interface WorkerHeartbeatMonotonicityFinding {
@@ -781,6 +808,88 @@ function knownLongRunningWait(category: IssueStuckRunBlockerCategory): boolean {
   return category === 'ci-wait' || category === 'provider-wait';
 }
 
+function normalizedExitReason(snapshot: IssueWorkerCardProcessSnapshot, category: IssueStuckRunBlockerCategory): string {
+  const explicit = snapshot.exitReason?.trim();
+  if (explicit) return explicit;
+  if (snapshot.alive === false) return 'process_not_alive';
+  const status = snapshot.status?.trim().toLowerCase();
+  if (status && CRASH_WORKER_CARD_STATUSES.has(status)) return status;
+  if (category === 'process-crash') return 'process_crash';
+  return 'unknown';
+}
+
+function hasDuplicateRespawn(snapshot: IssueWorkerCardProcessSnapshot): boolean {
+  const siblingPids = snapshot.siblingPids?.filter((pid) => Number.isSafeInteger(pid) && pid > 0 && pid !== snapshot.pid) ?? [];
+  return siblingPids.length > 0;
+}
+
+export function buildWorkerCrashOnlyRestartContract(
+  snapshot: IssueWorkerCardProcessSnapshot,
+  input: {
+    readonly category: IssueStuckRunBlockerCategory;
+    readonly processStatus: IssueStuckRunWatchdogFinding['processStatus'];
+    readonly heartbeatAgeMs?: number | undefined;
+    readonly kanbanState: string;
+  },
+): IssueWorkerCrashOnlyRestartContract {
+  const exitReason = normalizedExitReason(snapshot, input.category);
+  const evidence = [
+    `exitReason=${exitReason}`,
+    `pid=${snapshot.pid}`,
+    `heartbeatAgeMs=${input.heartbeatAgeMs ?? 'unknown'}`,
+  ];
+  const base = {
+    exitReason,
+    pid: snapshot.pid,
+    ...(input.heartbeatAgeMs !== undefined ? { heartbeatAgeMs: input.heartbeatAgeMs } : {}),
+    processStatus: input.processStatus,
+    kanbanState: input.kanbanState,
+  };
+
+  if (hasDuplicateRespawn(snapshot)) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'suppress-duplicate-respawn',
+      ...base,
+      evidence: [...evidence, `siblingPids=${snapshot.siblingPids?.join(',') ?? 'unknown'}`],
+    };
+  }
+
+  if (exitReason === 'spawn_failed' || /spawn|setup|enoent|eacces|protocol[_ -]?violation/i.test(exitReason)) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+      ...base,
+      evidence,
+    };
+  }
+
+  if (input.kanbanState === 'blocked' || input.category === 'approval-gate') {
+    return {
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      ...base,
+      evidence,
+    };
+  }
+
+  if (input.processStatus === 'dead' || input.category === 'process-crash') {
+    return {
+      disposition: 'retryable',
+      nextAction: 'restart-once',
+      ...base,
+      evidence,
+    };
+  }
+
+  return {
+    disposition: 'terminal',
+    nextAction: 'no-op',
+    ...base,
+    evidence,
+  };
+}
+
 export function detectStuckRunWatchdogFindings(
   snapshots: readonly IssueWorkerCardProcessSnapshot[],
   options: IssueStuckRunWatchdogOptions = {},
@@ -846,6 +955,13 @@ export function detectStuckRunWatchdogFindings(
       `blockerCategory=${category}`,
     ];
     if (snapshot.waitingOn) evidence.push(`waitingOn=${redactStuckRunEvidenceText(snapshot.waitingOn)}`);
+    const restartContract = buildWorkerCrashOnlyRestartContract(snapshot, {
+      category,
+      processStatus,
+      ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),
+      kanbanState: status ?? 'unknown',
+    });
+    evidence.push(...restartContract.evidence);
 
     const recommendedAction = remediationForStuckRun(category, processStatus);
     const confidence = confidenceForStuckRun(category, staleCount, processStatus);
@@ -864,6 +980,9 @@ export function detectStuckRunWatchdogFindings(
       ...(stateTransitionAgeMs !== undefined ? { stateTransitionAgeMs } : {}),
       processStatus,
       kanbanState: status ?? 'unknown',
+      exitReason: restartContract.exitReason,
+      restartDisposition: restartContract.disposition,
+      nextAction: restartContract.nextAction,
       evidence,
       recommendedAction,
       message: `Worker card ${snapshot.cardId.trim()} appears stuck (${category}, ${confidence} confidence): ${recommendedAction}`,

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -22,6 +22,7 @@ import type { BeastResult } from '../types.js';
 import type { CliSkillExecutor } from '../skills/cli-skill-executor.js';
 import type { CliSkillConfig } from '../skills/cli-types.js';
 import type { PrCreator } from '../closure/pr-creator.js';
+import { redactSensitiveText } from '../logging/redaction.js';
 
 export interface IssueRuntimeArtifacts {
   readonly planName: string;
@@ -751,7 +752,7 @@ function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean
 }
 
 function redactStuckRunEvidenceText(value: string): string {
-  return value
+  return redactSensitiveText(value)
     .replace(/\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g, '[REDACTED_TOKEN]')
     .replace(/\b(sk|xox[baprs]?|hf|glpat)-[A-Za-z0-9._/-]+\b/g, '$1-[REDACTED]')
     .replace(/\b([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\b/g, '[REDACTED_JWT]')
@@ -764,11 +765,11 @@ function normalizeStuckRunBlockerCategory(
 ): IssueStuckRunBlockerCategory {
   const status = snapshot.status?.trim().toLowerCase() ?? '';
   if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
+  if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
-  if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   if (snapshot.alive === false) return 'process-crash';
   if (/\b(crash(?:ed|ing)?|exit(?:ed|ing)?|dead|pid|fail(?:ed|ure|ing)?)\b/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
@@ -859,7 +860,7 @@ function crashKanbanState(status: string): boolean {
 }
 
 function intentionalNonRetryExitReason(exitReason: string): boolean {
-  return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill|signal_sigterm|signal_sigint|signal_sighup|signal_sigquit)$/i.test(exitReason.trim());
+  return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill)$/i.test(exitReason.trim());
 }
 
 export function buildWorkerCrashOnlyRestartContract(

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -187,6 +187,10 @@ export interface IssueWorkerCardProcessSnapshot {
   readonly exitReason?: string | undefined;
   /** Other currently live PIDs observed for the same worker card. */
   readonly siblingPids?: readonly number[] | undefined;
+  /** Existing PR URL that already owns this worker's issue/branch, if observed. */
+  readonly activePrUrl?: string | undefined;
+  /** Existing worktree path that already owns this worker's issue/branch, if observed. */
+  readonly activeWorktreePath?: string | undefined;
   /** Monotonic heartbeat sequence recorded by the heartbeat writer. */
   readonly heartbeatSequence?: number | undefined;
   /** Writer/reader source for diagnostics when heartbeat state is stale or regressive. */
@@ -848,7 +852,7 @@ function siblingPidsForSnapshot(
 }
 
 function normalizeKanbanState(status: string): string {
-  return status.trim().toLowerCase().replace(/_/g, '-');
+  return status.trim().toLowerCase().replace(/[\s_]+/g, '-');
 }
 
 function terminalKanbanState(status: string): boolean {
@@ -880,10 +884,14 @@ export function buildWorkerCrashOnlyRestartContract(
   const exitReason = redactStuckRunEvidenceText(rawExitReason);
   const kanbanState = normalizeKanbanState(input.kanbanState) || 'unknown';
   const siblingPids = siblingPidsForSnapshot(snapshot, new Map());
+  const activePrUrl = snapshot.activePrUrl?.trim();
+  const activeWorktreePath = snapshot.activeWorktreePath?.trim();
   const evidence = [
     `exitReason=${exitReason}`,
     `pid=${snapshot.pid}`,
     `heartbeatAgeMs=${input.heartbeatAgeMs ?? 'unknown'}`,
+    ...(activePrUrl ? [`activePr=${activePrUrl}`] : []),
+    ...(activeWorktreePath ? [`activeWorktree=${activeWorktreePath}`] : []),
   ];
   const base = {
     exitReason,
@@ -930,6 +938,15 @@ export function buildWorkerCrashOnlyRestartContract(
   }
 
   if (kanbanState === 'blocked' || kanbanState === 'pending-approval' || input.category === 'approval-gate' || knownLongRunningWait(input.category)) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      ...base,
+      evidence,
+    };
+  }
+
+  if (activePrUrl || activeWorktreePath) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -854,6 +854,10 @@ function terminalKanbanState(status: string): boolean {
   return TERMINAL_WORKER_CARD_STATUSES.has(normalizeKanbanState(status));
 }
 
+function intentionalNonRetryExitReason(exitReason: string): boolean {
+  return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill)$/i.test(exitReason.trim());
+}
+
 export function buildWorkerCrashOnlyRestartContract(
   snapshot: IssueWorkerCardProcessSnapshot,
   input: {
@@ -889,10 +893,19 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (rawExitReason === 'spawn_failed' || /spawn|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
+  if (rawExitReason === 'spawn_failed' || /spawn|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
+      ...base,
+      evidence,
+    };
+  }
+
+  if (intentionalNonRetryExitReason(rawExitReason) || terminalKanbanState(kanbanState)) {
+    return {
+      disposition: 'terminal',
+      nextAction: 'no-op',
       ...base,
       evidence,
     };
@@ -911,15 +924,6 @@ export function buildWorkerCrashOnlyRestartContract(
     return {
       disposition: 'retryable',
       nextAction: 'restart-once',
-      ...base,
-      evidence,
-    };
-  }
-
-  if (terminalKanbanState(input.kanbanState)) {
-    return {
-      disposition: 'terminal',
-      nextAction: 'no-op',
       ...base,
       evidence,
     };

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -774,6 +774,7 @@ function normalizeStuckRunBlockerCategory(
   if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending[_ -]approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
+  if (snapshot.alive === false && /\b(crash(?:ed|ing)?|exit(?:ed|ing)?|dead|pid|fail(?:ed|ure|ing)?)\b/.test(text)) return 'process-crash';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
   if (snapshot.alive === false) return 'process-crash';
@@ -1004,9 +1005,8 @@ function deferRemediationForStuckRun(category: IssueStuckRunBlockerCategory): st
 function restartContractSafetyRank(contract: IssueWorkerCrashOnlyRestartContract): number {
   switch (contract.disposition) {
     case 'hitl':
-      return 3;
-    case 'terminal':
       return 2;
+    case 'terminal':
     case 'retryable':
       return 1;
   }
@@ -1023,7 +1023,8 @@ function snapshotRecencyMs(snapshot: IssueWorkerCardProcessSnapshot): number {
       snapshot.startedAt,
     ].map((value) => {
       if (value === undefined) return 0;
-      const parsed = Date.parse(String(value));
+      const date = value instanceof Date ? value : new Date(value);
+      const parsed = date.getTime();
       return Number.isFinite(parsed) ? parsed : 0;
     }),
   );

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -910,7 +910,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (rawExitReason === 'spawn_failed' || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation)$/i.test(rawExitReason.trim())) {
+  if (rawExitReason === 'spawn_failed' || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?\b|start[_ -]?failed\b|setup\b|enoent\b|eacces\b|protocol[_ -]?violation\b)/i.test(rawExitReason.trim())) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
@@ -1017,6 +1017,7 @@ export function detectStuckRunWatchdogFindings(
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
+  const emittedDeadRestartCards = new Set<string>();
 
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim()) continue;
@@ -1081,12 +1082,17 @@ export function detectStuckRunWatchdogFindings(
       ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),
       kanbanState: status ?? 'unknown',
     });
+    const normalizedCardId = snapshot.cardId.trim();
+    if (processStatus === 'dead' && restartContract.nextAction === 'restart-once') {
+      if (emittedDeadRestartCards.has(normalizedCardId)) continue;
+      emittedDeadRestartCards.add(normalizedCardId);
+    }
     evidence.push(...restartContract.evidence);
 
     const recommendedAction = remediationForCrashOnlyRestartContract(restartContract, category, processStatus);
     const confidence = confidenceForStuckRun(category, staleCount, processStatus);
     findings.push({
-      cardId: snapshot.cardId.trim(),
+      cardId: normalizedCardId,
       pid: snapshot.pid,
       ...(snapshot.runId ? { runId: snapshot.runId } : {}),
       ...(snapshot.issueNumber !== undefined ? { issueNumber: snapshot.issueNumber } : {}),

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -867,8 +867,8 @@ function intentionalNonRetryExitReason(exitReason: string): boolean {
   return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill)$/i.test(exitReason.trim());
 }
 
-function externalSignalExitReason(exitReason: string): boolean {
-  return /^signal_[a-z0-9]+$/i.test(exitReason.trim());
+function operatorControlledSignalExitReason(exitReason: string): boolean {
+  return /^signal_(?:sigterm|sigint|sighup)$/i.test(exitReason.trim());
 }
 
 export function buildWorkerCrashOnlyRestartContract(
@@ -919,7 +919,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (externalSignalExitReason(rawExitReason)) {
+  if (operatorControlledSignalExitReason(rawExitReason)) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -854,8 +854,12 @@ function terminalKanbanState(status: string): boolean {
   return TERMINAL_WORKER_CARD_STATUSES.has(normalizeKanbanState(status));
 }
 
+function crashKanbanState(status: string): boolean {
+  return CRASH_WORKER_CARD_STATUSES.has(normalizeKanbanState(status));
+}
+
 function intentionalNonRetryExitReason(exitReason: string): boolean {
-  return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill)$/i.test(exitReason.trim());
+  return /^(clean_exit|operator_stop|operator_kill|exit_code_0|completed|cancelled|canceled|stopped|manual_stop|manual_kill|signal_sigterm|signal_sigint|signal_sighup|signal_sigquit)$/i.test(exitReason.trim());
 }
 
 export function buildWorkerCrashOnlyRestartContract(
@@ -893,7 +897,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (rawExitReason === 'spawn_failed' || /spawn|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
+  if (rawExitReason === 'spawn_failed' || /spawn[_ -]?(?:fail(?:ed|ure)?|error)?|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
@@ -902,7 +906,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (intentionalNonRetryExitReason(rawExitReason) || terminalKanbanState(kanbanState)) {
+  if (intentionalNonRetryExitReason(rawExitReason) || (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState))) {
     return {
       disposition: 'terminal',
       nextAction: 'no-op',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -941,7 +941,13 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (kanbanState === 'blocked' || kanbanState === 'pending-approval' || input.category === 'approval-gate' || input.category === 'dispatcher-bug' || knownLongRunningWait(input.category)) {
+  if (
+    kanbanState === 'blocked'
+    || kanbanState === 'pending-approval'
+    || input.category === 'approval-gate'
+    || input.category === 'dispatcher-bug'
+    || knownLongRunningWait(input.category)
+  ) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -910,7 +910,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (rawExitReason === 'spawn_failed' || /spawn[_ -]?(?:fail(?:ed|ure)?|error)?|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation/i.test(rawExitReason)) {
+  if (rawExitReason === 'spawn_failed' || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?|start[_ -]?failed|setup|enoent|eacces|protocol[_ -]?violation)$/i.test(rawExitReason.trim())) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -764,11 +764,11 @@ function normalizeStuckRunBlockerCategory(
 ): IssueStuckRunBlockerCategory {
   const status = snapshot.status?.trim().toLowerCase() ?? '';
   if (CRASH_WORKER_CARD_STATUSES.has(status)) return 'process-crash';
-  if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   const text = `${snapshot.status ?? ''} ${snapshot.waitingOn ?? ''}`.toLowerCase();
   if (/\bapproval\b|\bhitl\b|\bhuman\b|approval[- ]?token|pending approval|operator approval|approval-cop|approve/.test(text)) return 'approval-gate';
   if (/provider|codex|rate limit|quota|llm|model/.test(text)) return 'provider-wait';
   if (/\bci\b|ci[- ]?check|status check|check run|workflow|merge queue|github actions?/.test(text)) return 'ci-wait';
+  if (snapshot.blockerCategory && snapshot.blockerCategory !== 'unknown') return snapshot.blockerCategory;
   if (snapshot.alive === false) return 'process-crash';
   if (/\b(crash(?:ed|ing)?|exit(?:ed|ing)?|dead|pid|fail(?:ed|ure|ing)?)\b/.test(text)) return 'process-crash';
   if (/dispatcher|kanban|current_run|current run|respawn|heartbeat/.test(text)) return 'dispatcher-bug';
@@ -847,7 +847,7 @@ function siblingPidsForSnapshot(
 }
 
 function normalizeKanbanState(status: string): string {
-  return status.trim().toLowerCase();
+  return status.trim().toLowerCase().replace(/_/g, '-');
 }
 
 function terminalKanbanState(status: string): boolean {
@@ -928,7 +928,6 @@ export function buildWorkerCrashOnlyRestartContract(
       evidence,
     };
   }
-
   return {
     disposition: 'hitl',
     nextAction: 'defer-with-evidence',

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -873,6 +873,10 @@ function operatorControlledSignalExitReason(exitReason: string): boolean {
   return /^signal_(?:sigterm|sigint|sighup)$/i.test(exitReason.trim());
 }
 
+function dispatcherRestartExitReason(exitReason: string): boolean {
+  return /^dispatcher_restart_/i.test(exitReason.trim());
+}
+
 export function buildWorkerCrashOnlyRestartContract(
   snapshot: IssueWorkerCardProcessSnapshot,
   input: {
@@ -946,6 +950,7 @@ export function buildWorkerCrashOnlyRestartContract(
     || kanbanState === 'pending-approval'
     || input.category === 'approval-gate'
     || input.category === 'dispatcher-bug'
+    || dispatcherRestartExitReason(rawExitReason)
     || knownLongRunningWait(input.category)
   ) {
     return {
@@ -996,6 +1001,34 @@ function deferRemediationForStuckRun(category: IssueStuckRunBlockerCategory): st
   }
 }
 
+function restartContractSafetyRank(contract: IssueWorkerCrashOnlyRestartContract): number {
+  switch (contract.disposition) {
+    case 'hitl':
+      return 3;
+    case 'terminal':
+      return 2;
+    case 'retryable':
+      return 1;
+  }
+}
+
+function snapshotRecencyMs(snapshot: IssueWorkerCardProcessSnapshot): number {
+  return Math.max(
+    0,
+    ...[
+      snapshot.lastHeartbeatAt,
+      snapshot.lastOutputAt,
+      snapshot.lastToolActivityAt,
+      snapshot.lastStateTransitionAt,
+      snapshot.startedAt,
+    ].map((value) => {
+      if (value === undefined) return 0;
+      const parsed = Date.parse(String(value));
+      return Number.isFinite(parsed) ? parsed : 0;
+    }),
+  );
+}
+
 function remediationForCrashOnlyRestartContract(
   contract: IssueWorkerCrashOnlyRestartContract,
   category: IssueStuckRunBlockerCategory,
@@ -1027,7 +1060,9 @@ export function detectStuckRunWatchdogFindings(
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
-  const handledDeadRestartCards = new Set<string>();
+  const deadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
+  const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
+  let findingIndex = 0;
 
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim()) continue;
@@ -1093,15 +1128,11 @@ export function detectStuckRunWatchdogFindings(
       kanbanState: status ?? 'unknown',
     });
     const normalizedCardId = snapshot.cardId.trim();
-    if (processStatus === 'dead') {
-      if (handledDeadRestartCards.has(normalizedCardId)) continue;
-      handledDeadRestartCards.add(normalizedCardId);
-    }
     evidence.push(...restartContract.evidence);
 
     const recommendedAction = remediationForCrashOnlyRestartContract(restartContract, category, processStatus);
     const confidence = confidenceForStuckRun(category, staleCount, processStatus);
-    findings.push({
+    const finding: IssueStuckRunWatchdogFinding = {
       cardId: normalizedCardId,
       pid: snapshot.pid,
       ...(snapshot.runId ? { runId: snapshot.runId } : {}),
@@ -1122,10 +1153,34 @@ export function detectStuckRunWatchdogFindings(
       evidence,
       recommendedAction,
       message: `Worker card ${snapshot.cardId.trim()} appears stuck (${category}, ${confidence} confidence): ${recommendedAction}`,
-    });
+    };
+
+    if (processStatus === 'dead') {
+      const candidateKey = {
+        safetyRank: restartContractSafetyRank(restartContract),
+        recencyMs: snapshotRecencyMs(snapshot),
+        index: findingIndex,
+      };
+      const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
+      const candidateIsSafer = existingKey === undefined
+        || candidateKey.safetyRank > existingKey.safetyRank
+        || (candidateKey.safetyRank === existingKey.safetyRank && candidateKey.recencyMs > existingKey.recencyMs)
+        || (
+          candidateKey.safetyRank === existingKey.safetyRank
+          && candidateKey.recencyMs === existingKey.recencyMs
+          && candidateKey.index > existingKey.index
+        );
+      if (candidateIsSafer) {
+        deadFindingKeysByCardId.set(normalizedCardId, candidateKey);
+        deadFindingsByCardId.set(normalizedCardId, finding);
+      }
+    } else {
+      findings.push(finding);
+    }
+    findingIndex += 1;
   }
 
-  return findings.sort((a, b) => a.cardId.localeCompare(b.cardId));
+  return [...findings, ...deadFindingsByCardId.values()].sort((a, b) => a.cardId.localeCompare(b.cardId));
 }
 
 function isoTimestamp(value: string | number | Date | undefined): string | undefined {

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -757,6 +757,7 @@ function explicitProcessCrash(snapshot: IssueWorkerCardProcessSnapshot): boolean
 
 function redactStuckRunEvidenceText(value: string): string {
   return redactSensitiveText(value)
+    .replace(/\b([A-Za-z0-9_]*(?:SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*|[A-Za-z0-9_]*API[_-]?KEY[A-Za-z0-9_]*)\s*[:=]\s*\S+/gi, '$1=<redacted>')
     .replace(/\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opusr]_[A-Za-z0-9_.-]{12,})\b/g, '[REDACTED_TOKEN]')
     .replace(/\b(sk|xox[baprs]?|hf|glpat)-[A-Za-z0-9._/-]+\b/g, '$1-[REDACTED]')
     .replace(/\b([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\.([A-Za-z0-9_-]{20,})\b/g, '[REDACTED_JWT]')
@@ -886,12 +887,14 @@ export function buildWorkerCrashOnlyRestartContract(
   const siblingPids = siblingPidsForSnapshot(snapshot, new Map());
   const activePrUrl = snapshot.activePrUrl?.trim();
   const activeWorktreePath = snapshot.activeWorktreePath?.trim();
+  const redactedActivePrUrl = activePrUrl ? redactStuckRunEvidenceText(activePrUrl) : undefined;
+  const redactedActiveWorktreePath = activeWorktreePath ? redactStuckRunEvidenceText(activeWorktreePath) : undefined;
   const evidence = [
     `exitReason=${exitReason}`,
     `pid=${snapshot.pid}`,
     `heartbeatAgeMs=${input.heartbeatAgeMs ?? 'unknown'}`,
-    ...(activePrUrl ? [`activePr=${activePrUrl}`] : []),
-    ...(activeWorktreePath ? [`activeWorktree=${activeWorktreePath}`] : []),
+    ...(redactedActivePrUrl ? [`activePr=${redactedActivePrUrl}`] : []),
+    ...(redactedActiveWorktreePath ? [`activeWorktree=${redactedActiveWorktreePath}`] : []),
   ];
   const base = {
     exitReason,
@@ -955,7 +958,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (input.processStatus === 'dead' || input.category === 'process-crash') {
+  if (input.processStatus === 'dead') {
     return {
       disposition: 'retryable',
       nextAction: 'restart-once',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -798,6 +798,36 @@ describe('stuck-run watchdog', () => {
     expect(findings[0].evidence).toContain('siblingPids=7413');
   });
 
+  it('does not derive duplicate siblings from terminal stale snapshots', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_terminal_sibling',
+        pid: 7412,
+        runId: 'run-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_terminal_sibling',
+        pid: 7413,
+        runId: 'run-old-done',
+        status: 'completed',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_terminal_sibling',
+      pid: 7412,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+    expect(findings[0].evidence).not.toContain('siblingPids=7413');
+  });
+
   it('normalizes exported restart-contract Kanban state before suppressing blocked respawns', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_direct_blocked',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -989,6 +989,87 @@ describe('stuck-run watchdog', () => {
     expect(finding.recommendedAction).toContain('do not auto-respawn over the blocker');
   });
 
+  it('uses numeric timestamp recency when coalescing dead attempts', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_numeric_recency',
+        pid: 7415,
+        runId: 'run-older',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: Date.parse('2026-07-16T11:30:00.000Z'),
+      },
+      {
+        cardId: 't_numeric_recency',
+        pid: 7416,
+        runId: 'run-newer',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: Date.parse('2026-07-16T11:31:00.000Z'),
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_numeric_recency',
+      pid: 7416,
+      runId: 'run-newer',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
+  it('prefers a newer retryable dead attempt over an older terminal stop', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_terminal_then_retryable',
+        pid: 7417,
+        runId: 'run-old-stop',
+        status: 'running',
+        alive: false,
+        exitReason: 'operator_stop',
+        lastHeartbeatAt: '2026-07-16T11:20:00.000Z',
+      },
+      {
+        cardId: 't_terminal_then_retryable',
+        pid: 7418,
+        runId: 'run-new-crash',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_terminal_then_retryable',
+      pid: 7418,
+      runId: 'run-new-crash',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
+  it('classifies dead workers as crashes before broad provider wait text', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_with_stale_provider_text',
+        pid: 7419,
+        status: 'running',
+        alive: false,
+        waitingOn: 'Codex process failed before the last heartbeat',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_dead_with_stale_provider_text',
+      blockerCategory: 'process-crash',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('does not emit restart advice after HITL evidence for the same dead card', () => {
     const findings = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -866,6 +866,35 @@ describe('stuck-run watchdog', () => {
     expect(findings[0].evidence).toContain('siblingPids=7413');
   });
 
+  it('coalesces multiple dead attempts into one restart recommendation', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_repeated_dead_attempts',
+        pid: 7412,
+        runId: 'run-dead-1',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_repeated_dead_attempts',
+        pid: 7413,
+        runId: 'run-dead-2',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_repeated_dead_attempts',
+      pid: 7412,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('does not derive duplicate siblings from terminal stale snapshots', () => {
     const findings = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -940,6 +940,7 @@ describe('stuck-run watchdog', () => {
       pid: 7418,
       status: 'running',
       alive: false,
+      exitReason: 'respawn_guarded(active_pr)',
       activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
       activeWorktreePath: '/tmp/frankenbeast/.worktrees/t_active_owner',
     }, {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, evaluateIssueSchedulingScore, planKanbanStateMutation } from '../../../src/issues/issue-runner.js';
+import { IssueRunner, evaluateIssueBackpressure, buildIssueSchedulerFairnessReport, routeIssueWorkerForDegradedMode, detectDuplicateWorkerCardProcesses, detectWorkerHeartbeatMonotonicityAnomalies, detectStuckRunWatchdogFindings, buildWorkerCrashOnlyRestartContract, evaluateIssueSchedulingScore, planKanbanStateMutation } from '../../../src/issues/issue-runner.js';
 import type { IssueBackpressureSignals, IssueBackpressureThresholds, IssueRunnerConfig } from '../../../src/issues/issue-runner.js';
 import type { GithubIssue, TriageResult } from '../../../src/issues/types.js';
 import type { PlanGraph, ICheckpointStore, ILogger, BeastLoopDeps } from '../../../src/deps.js';
@@ -766,6 +766,55 @@ describe('stuck-run watchdog', () => {
       recommendedAction: expect.stringContaining('Suppress duplicate respawn'),
     });
     expect(finding.evidence).toContain('siblingPids=7413');
+  });
+
+  it('derives duplicate respawn siblings from the watchdog snapshot set', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_derived_duplicate',
+        pid: 7412,
+        runId: 'run-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_derived_duplicate',
+        pid: 7413,
+        runId: 'run-live',
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_derived_duplicate',
+      pid: 7412,
+      restartDisposition: 'hitl',
+      nextAction: 'suppress-duplicate-respawn',
+    });
+    expect(findings[0].evidence).toContain('siblingPids=7413');
+  });
+
+  it('normalizes exported restart-contract Kanban state before suppressing blocked respawns', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_direct_blocked',
+      pid: 7418,
+      status: 'Blocked',
+      alive: false,
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'Blocked',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      kanbanState: 'blocked',
+    });
   });
 
   it('uses known blocker hints to report approval gates with concrete remediation', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -915,6 +915,25 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('defers pending approval Kanban states before dead-process retry', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_pending_approval',
+      pid: 7418,
+      status: 'pending_approval',
+      alive: false,
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'pending_approval',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      kanbanState: 'pending-approval',
+    });
+  });
+
   it('keeps direct terminal restart contracts as no-op before dead-process retry', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_direct_completed',
@@ -973,7 +992,7 @@ describe('stuck-run watchdog', () => {
     });
   });
 
-  it('treats external signal exits as retryable crashes in direct restart contracts', () => {
+  it('defers external signal exits for operator investigation in direct restart contracts', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_signal_stop',
       pid: 7423,
@@ -988,8 +1007,8 @@ describe('stuck-run watchdog', () => {
 
     expect(contract).toMatchObject({
       exitReason: 'signal_SIGTERM',
-      disposition: 'retryable',
-      nextAction: 'restart-once',
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -931,10 +931,62 @@ describe('stuck-run watchdog', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({
       cardId: 't_repeated_dead_attempts',
-      pid: 7412,
+      pid: 7413,
       restartDisposition: 'retryable',
       nextAction: 'restart-once',
     });
+  });
+
+  it('prefers safer HITL contracts over earlier retryable dead attempts for the same card', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_retry_then_hitl',
+        pid: 7412,
+        runId: 'run-dead-1',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_retry_then_hitl',
+        pid: 7413,
+        runId: 'run-spawn-failed-later',
+        status: 'failed',
+        alive: false,
+        exitReason: 'spawn_failed',
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_retry_then_hitl',
+      pid: 7413,
+      restartDisposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+    });
+  });
+
+  it('treats dispatcher restart stop reasons as HITL repair evidence before retrying', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dispatcher_restart_reason',
+        pid: 7414,
+        runId: 'run-dispatcher-stale-pid',
+        status: 'failed',
+        alive: false,
+        exitReason: 'dispatcher_restart_stale_pid',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_dispatcher_restart_reason',
+      exitReason: 'dispatcher_restart_stale_pid',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+    expect(finding.recommendedAction).toContain('do not auto-respawn over the blocker');
   });
 
   it('does not emit restart advice after HITL evidence for the same dead card', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -747,14 +747,14 @@ describe('stuck-run watchdog', () => {
     expect(finding.evidence.join('\n')).not.toContain('github_pat_');
   });
 
-  it('redacts key-value secrets in exit reasons before exposing restart evidence', () => {
+  it('redacts key-value and colon-form secrets in exit reasons before exposing restart evidence', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
         cardId: 't_key_secret_exit',
         pid: 7416,
         status: 'failed',
         alive: false,
-        exitReason: 'supervisor stderr AWS_SECRET_ACCESS_KEY=abc123 DB_PASSWORD=secret-value',
+        exitReason: 'supervisor stderr AWS_SECRET_ACCESS_KEY=abc123 DB_PASSWORD: secret-value',
         lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
       },
     ], { nowMs });
@@ -970,8 +970,8 @@ describe('stuck-run watchdog', () => {
       status: 'running',
       alive: false,
       exitReason: 'respawn_guarded(active_pr)',
-      activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
-      activeWorktreePath: '/tmp/frankenbeast/.worktrees/t_active_owner',
+      activePrUrl: `https://github.com/djm204/frankenbeast/pull/2560?token=${'github_pat_' + '12345678901234567890abcdef'}`,
+      activeWorktreePath: '/tmp/frankenbeast/.worktrees/t_active_owner/DB_PASSWORD:secret-value',
     }, {
       category: 'process-crash',
       processStatus: 'dead',
@@ -984,9 +984,11 @@ describe('stuck-run watchdog', () => {
       kanbanState: 'running',
     });
     expect(contract.evidence).toEqual(expect.arrayContaining([
-      'activePr=https://github.com/djm204/frankenbeast/pull/2560',
-      'activeWorktree=/tmp/frankenbeast/.worktrees/t_active_owner',
+      'activePr=https://github.com/djm204/frankenbeast/pull/2560?token=[REDACTED]',
+      'activeWorktree=/tmp/frankenbeast/.worktrees/t_active_owner/DB_PASSWORD=<redacted>',
     ]));
+    expect(contract.evidence.join('\n')).not.toContain('github_pat_');
+    expect(contract.evidence.join('\n')).not.toContain('secret-value');
   });
 
   it('keeps direct terminal restart contracts as no-op before dead-process retry', () => {
@@ -1023,6 +1025,26 @@ describe('stuck-run watchdog', () => {
     expect(contract).toMatchObject({
       disposition: 'retryable',
       nextAction: 'restart-once',
+      kanbanState: 'failed',
+    });
+  });
+
+  it('defers crash-like statuses while liveness still reports the process alive', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_failed_but_alive',
+      pid: 7426,
+      status: 'failed',
+      alive: true,
+    }, {
+      category: 'process-crash',
+      processStatus: 'alive',
+      kanbanState: 'failed',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      processStatus: 'alive',
       kanbanState: 'failed',
     });
   });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1037,6 +1037,26 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('restarts retryable signal-killed workers without active ownership', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_signal_kill',
+      pid: 7425,
+      status: 'running',
+      alive: false,
+      exitReason: 'signal_SIGKILL',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'signal_SIGKILL',
+      disposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('routes start_failed exit reasons to doctor replacement', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_start_failed',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -607,9 +607,83 @@ describe('stuck-run watchdog', () => {
         kanbanState: 'running',
         heartbeatAgeMs: 5 * 60 * 1000,
         outputAgeMs: 270_000,
+        exitReason: 'process_not_alive',
+        restartDisposition: 'retryable',
+        nextAction: 'restart-once',
         recommendedAction: expect.stringContaining('clear the stale PID/current-run pointer'),
       }),
     ]);
+  });
+
+  it('records crash-only setup failures as HITL doctor replacement instead of blind respawn', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_setup_crash',
+        pid: 7410,
+        runId: 'run-setup',
+        status: 'failed',
+        alive: false,
+        exitReason: 'spawn_failed',
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_setup_crash',
+      exitReason: 'spawn_failed',
+      pid: 7410,
+      heartbeatAgeMs: 60_000,
+      restartDisposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+    });
+    expect(finding.evidence).toEqual(expect.arrayContaining([
+      'exitReason=spawn_failed',
+      'pid=7410',
+      'heartbeatAgeMs=60000',
+    ]));
+  });
+
+  it('keeps blocked crash cards in HITL instead of auto-respawning them', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_blocked_crash',
+        pid: 7411,
+        runId: 'run-blocked',
+        status: 'blocked',
+        alive: false,
+        exitReason: 'exit_code_1',
+        lastHeartbeatAt: '2026-07-16T11:40:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_blocked_crash',
+      exitReason: 'exit_code_1',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('suppresses duplicate respawns when another PID already owns the worker card', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_duplicate_respawn',
+        pid: 7412,
+        runId: 'run-older',
+        status: 'running',
+        alive: false,
+        exitReason: 'unknown_exit',
+        siblingPids: [7413],
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_duplicate_respawn',
+      restartDisposition: 'hitl',
+      nextAction: 'suppress-duplicate-respawn',
+    });
+    expect(finding.evidence).toContain('siblingPids=7413');
   });
 
   it('uses known blocker hints to report approval gates with concrete remediation', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -847,6 +847,65 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('keeps direct terminal restart contracts as no-op before dead-process retry', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_direct_completed',
+      pid: 7419,
+      status: 'completed',
+      alive: false,
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'completed',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'terminal',
+      nextAction: 'no-op',
+      kanbanState: 'completed',
+    });
+  });
+
+  it('keeps intentional operator exits non-retryable in direct restart contracts', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_operator_stop',
+      pid: 7420,
+      status: 'running',
+      alive: false,
+      exitReason: 'operator_stop',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'operator_stop',
+      disposition: 'terminal',
+      nextAction: 'no-op',
+    });
+  });
+
+  it('routes start_failed exit reasons to doctor replacement', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_start_failed',
+      pid: 7421,
+      status: 'running',
+      alive: false,
+      exitReason: 'start_failed',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'start_failed',
+      disposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+    });
+  });
+
   it('uses known blocker hints to report approval gates with concrete remediation', () => {
     const findings = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -891,6 +891,25 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('treats crash-like terminal statuses as retryable process crashes', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_direct_failed',
+      pid: 7422,
+      status: 'failed',
+      alive: false,
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'failed',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'retryable',
+      nextAction: 'restart-once',
+      kanbanState: 'failed',
+    });
+  });
+
   it('keeps intentional operator exits non-retryable in direct restart contracts', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_operator_stop',
@@ -911,6 +930,26 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('keeps intentional signal exits non-retryable in direct restart contracts', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_signal_stop',
+      pid: 7423,
+      status: 'running',
+      alive: false,
+      exitReason: 'signal_SIGTERM',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'signal_SIGTERM',
+      disposition: 'terminal',
+      nextAction: 'no-op',
+    });
+  });
+
   it('routes start_failed exit reasons to doctor replacement', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_start_failed',
@@ -926,6 +965,26 @@ describe('stuck-run watchdog', () => {
 
     expect(contract).toMatchObject({
       exitReason: 'start_failed',
+      disposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+    });
+  });
+
+  it('routes spawn_failure exit reasons to doctor replacement', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_spawn_failure',
+      pid: 7424,
+      status: 'running',
+      alive: false,
+      exitReason: 'spawn_failure',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'spawn_failure',
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
     });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -747,6 +747,49 @@ describe('stuck-run watchdog', () => {
     expect(finding.evidence.join('\n')).not.toContain('github_pat_');
   });
 
+  it('redacts key-value secrets in exit reasons before exposing restart evidence', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_key_secret_exit',
+        pid: 7416,
+        status: 'failed',
+        alive: false,
+        exitReason: 'supervisor stderr AWS_SECRET_ACCESS_KEY=abc123 DB_PASSWORD=secret-value',
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding.exitReason).toBe('supervisor stderr AWS_SECRET_ACCESS_KEY=<redacted> DB_PASSWORD=<redacted>');
+    expect(finding.evidence).toContain('exitReason=supervisor stderr AWS_SECRET_ACCESS_KEY=<redacted> DB_PASSWORD=<redacted>');
+    expect(finding.evidence.join('\n')).not.toContain('abc123');
+    expect(finding.evidence.join('\n')).not.toContain('secret-value');
+  });
+
+  it('respects explicit blocker categories before stale waiting text', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_explicit_dispatcher_blocker',
+        pid: 7416,
+        status: 'running',
+        alive: true,
+        blockerCategory: 'dispatcher-bug',
+        waitingOn: 'old note: CI checks are still running',
+        lastHeartbeatAt: '2026-07-16T10:00:00.000Z',
+        lastOutputAt: '2026-07-16T10:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T10:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T10:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_explicit_dispatcher_blocker',
+      blockerCategory: 'dispatcher-bug',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+    expect(finding.recommendedAction).toContain('dispatcher metadata');
+  });
+
   it('keeps alive stale nonterminal workers in HITL instead of terminal no-op', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
@@ -930,7 +973,7 @@ describe('stuck-run watchdog', () => {
     });
   });
 
-  it('keeps intentional signal exits non-retryable in direct restart contracts', () => {
+  it('treats external signal exits as retryable crashes in direct restart contracts', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_signal_stop',
       pid: 7423,
@@ -945,8 +988,8 @@ describe('stuck-run watchdog', () => {
 
     expect(contract).toMatchObject({
       exitReason: 'signal_SIGTERM',
-      disposition: 'terminal',
-      nextAction: 'no-op',
+      disposition: 'retryable',
+      nextAction: 'restart-once',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -765,6 +765,24 @@ describe('stuck-run watchdog', () => {
     expect(finding.evidence.join('\n')).not.toContain('secret value');
   });
 
+  it('redacts quoted and space-containing colon-form secret values before exposing restart evidence', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_key_secret_phrase_exit',
+        pid: 7416,
+        status: 'failed',
+        alive: false,
+        exitReason: 'supervisor stderr DB_PASSWORD: "correct horse battery staple" AWS_SECRET_ACCESS_KEY: alpha beta gamma',
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding.exitReason).toBe('supervisor stderr DB_PASSWORD=<redacted> AWS_SECRET_ACCESS_KEY=<redacted>');
+    expect(finding.evidence).toContain('exitReason=supervisor stderr DB_PASSWORD=<redacted> AWS_SECRET_ACCESS_KEY=<redacted>');
+    expect(finding.evidence.join('\n')).not.toContain('correct horse');
+    expect(finding.evidence.join('\n')).not.toContain('alpha beta gamma');
+  });
+
   it('respects explicit blocker categories before stale waiting text', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
@@ -788,6 +806,30 @@ describe('stuck-run watchdog', () => {
       nextAction: 'defer-with-evidence',
     });
     expect(finding.recommendedAction).toContain('dispatcher metadata');
+  });
+
+  it('defers dead dispatcher-bug snapshots instead of restarting over repair evidence', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_dispatcher_blocker',
+        pid: 7416,
+        status: 'running',
+        alive: false,
+        blockerCategory: 'dispatcher-bug',
+        exitReason: 'current_run mismatch after dispatcher crash',
+        lastHeartbeatAt: '2026-07-16T10:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_dead_dispatcher_blocker',
+      blockerCategory: 'dispatcher-bug',
+      processStatus: 'dead',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+    expect(finding.recommendedAction).toContain('dispatcher metadata');
+    expect(finding.recommendedAction).not.toContain('respawn one focused worker');
   });
 
   it('keeps alive stale nonterminal workers in HITL instead of terminal no-op', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -919,12 +919,12 @@ describe('stuck-run watchdog', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_pending_approval',
       pid: 7418,
-      status: 'pending_approval',
+      status: 'pending approval',
       alive: false,
     }, {
       category: 'process-crash',
       processStatus: 'dead',
-      kanbanState: 'pending_approval',
+      kanbanState: 'pending approval',
     });
 
     expect(contract).toMatchObject({
@@ -932,6 +932,31 @@ describe('stuck-run watchdog', () => {
       nextAction: 'defer-with-evidence',
       kanbanState: 'pending-approval',
     });
+  });
+
+  it('defers dead workers with active PR/worktree ownership before restart-once', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_active_owner',
+      pid: 7418,
+      status: 'running',
+      alive: false,
+      activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
+      activeWorktreePath: '/tmp/frankenbeast/.worktrees/t_active_owner',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      kanbanState: 'running',
+    });
+    expect(contract.evidence).toEqual(expect.arrayContaining([
+      'activePr=https://github.com/djm204/frankenbeast/pull/2560',
+      'activeWorktree=/tmp/frankenbeast/.worktrees/t_active_owner',
+    ]));
   });
 
   it('keeps direct terminal restart contracts as no-op before dead-process retry', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -754,7 +754,7 @@ describe('stuck-run watchdog', () => {
         pid: 7416,
         status: 'failed',
         alive: false,
-        exitReason: 'supervisor stderr AWS_SECRET_ACCESS_KEY=abc123 DB_PASSWORD: secret-value',
+        exitReason: 'supervisor stderr AWS_SECRET_ACCESS_KEY=abc123 DB_PASSWORD: "secret value with spaces"',
         lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
       },
     ], { nowMs });
@@ -762,7 +762,7 @@ describe('stuck-run watchdog', () => {
     expect(finding.exitReason).toBe('supervisor stderr AWS_SECRET_ACCESS_KEY=<redacted> DB_PASSWORD=<redacted>');
     expect(finding.evidence).toContain('exitReason=supervisor stderr AWS_SECRET_ACCESS_KEY=<redacted> DB_PASSWORD=<redacted>');
     expect(finding.evidence.join('\n')).not.toContain('abc123');
-    expect(finding.evidence.join('\n')).not.toContain('secret-value');
+    expect(finding.evidence.join('\n')).not.toContain('secret value');
   });
 
   it('respects explicit blocker categories before stale waiting text', () => {
@@ -892,6 +892,36 @@ describe('stuck-run watchdog', () => {
       pid: 7412,
       restartDisposition: 'retryable',
       nextAction: 'restart-once',
+    });
+  });
+
+  it('does not emit restart advice after HITL evidence for the same dead card', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_hitl_then_dead',
+        pid: 7412,
+        runId: 'run-spawn-failed',
+        status: 'failed',
+        alive: false,
+        exitReason: 'spawn_failed',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_hitl_then_dead',
+        pid: 7413,
+        runId: 'run-dead-later',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_hitl_then_dead',
+      pid: 7412,
+      restartDisposition: 'hitl',
+      nextAction: 'replace-with-doctor',
     });
   });
 
@@ -1026,6 +1056,25 @@ describe('stuck-run watchdog', () => {
       disposition: 'retryable',
       nextAction: 'restart-once',
       kanbanState: 'failed',
+    });
+  });
+
+  it('defers dispatcher-bug crashes before considering dead-process restart', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_dispatcher_bug_dead',
+      pid: 7425,
+      status: 'running',
+      alive: false,
+    }, {
+      category: 'dispatcher-bug',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      processStatus: 'dead',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -665,6 +665,7 @@ describe('stuck-run watchdog', () => {
       nextAction: 'defer-with-evidence',
       recommendedAction: expect.stringContaining('do not auto-respawn over the blocker'),
     });
+    expect(finding.recommendedAction).not.toContain('respawn one focused worker');
   });
 
   it('defers dead workers when waiting evidence names CI or provider gates', () => {
@@ -695,14 +696,38 @@ describe('stuck-run watchdog', () => {
         blockerCategory: 'ci-wait',
         restartDisposition: 'hitl',
         nextAction: 'defer-with-evidence',
+        recommendedAction: expect.not.stringContaining('respawn one focused worker'),
       }),
       expect.objectContaining({
         cardId: 't_provider_dead',
         blockerCategory: 'provider-wait',
         restartDisposition: 'hitl',
         nextAction: 'defer-with-evidence',
+        recommendedAction: expect.not.stringContaining('respawn one focused worker'),
       }),
     ]);
+  });
+
+  it('normalizes direct restart-contract Kanban state before choosing HITL defer', () => {
+    const contract = buildWorkerCrashOnlyRestartContract(
+      {
+        cardId: 't_direct_blocked',
+        pid: 7418,
+        status: 'running',
+        alive: false,
+      },
+      {
+        category: 'process-crash',
+        processStatus: 'dead',
+        kanbanState: 'Blocked',
+      },
+    );
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      kanbanState: 'blocked',
+    });
   });
 
   it('redacts sensitive exit reasons before exposing restart evidence', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -641,6 +641,8 @@ describe('stuck-run watchdog', () => {
       'pid=7410',
       'heartbeatAgeMs=60000',
     ]));
+    expect(finding.recommendedAction).toContain('Doctor card');
+    expect(finding.recommendedAction).not.toContain('respawn one focused worker');
   });
 
   it('keeps blocked crash cards in HITL instead of auto-respawning them', () => {
@@ -659,6 +661,85 @@ describe('stuck-run watchdog', () => {
     expect(finding).toMatchObject({
       cardId: 't_blocked_crash',
       exitReason: 'exit_code_1',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      recommendedAction: expect.stringContaining('do not auto-respawn over the blocker'),
+    });
+  });
+
+  it('defers dead workers when waiting evidence names CI or provider gates', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_ci_dead',
+        pid: 7414,
+        runId: 'run-ci',
+        status: 'running',
+        alive: false,
+        waitingOn: 'CI checks are still queued',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_provider_dead',
+        pid: 7415,
+        runId: 'run-provider',
+        status: 'running',
+        alive: false,
+        waitingOn: 'Codex rate limit reset',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        cardId: 't_ci_dead',
+        blockerCategory: 'ci-wait',
+        restartDisposition: 'hitl',
+        nextAction: 'defer-with-evidence',
+      }),
+      expect.objectContaining({
+        cardId: 't_provider_dead',
+        blockerCategory: 'provider-wait',
+        restartDisposition: 'hitl',
+        nextAction: 'defer-with-evidence',
+      }),
+    ]);
+  });
+
+  it('redacts sensitive exit reasons before exposing restart evidence', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_secret_exit',
+        pid: 7416,
+        status: 'failed',
+        alive: false,
+        exitReason: `spawn failed with token=${'github_pat_' + '12345678901234567890abcdef'}`,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding.exitReason).toBe('spawn failed with token=[REDACTED]');
+    expect(finding.evidence).toContain('exitReason=spawn failed with token=[REDACTED]');
+    expect(finding.evidence.join('\n')).not.toContain('github_pat_');
+  });
+
+  it('keeps alive stale nonterminal workers in HITL instead of terminal no-op', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_alive_unknown',
+        pid: 7417,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T10:00:00.000Z',
+        lastOutputAt: '2026-07-16T10:00:00.000Z',
+        lastToolActivityAt: '2026-07-16T10:00:00.000Z',
+        lastStateTransitionAt: '2026-07-16T10:00:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_alive_unknown',
+      processStatus: 'alive',
+      kanbanState: 'running',
       restartDisposition: 'hitl',
       nextAction: 'defer-with-evidence',
     });
@@ -682,6 +763,7 @@ describe('stuck-run watchdog', () => {
       cardId: 't_duplicate_respawn',
       restartDisposition: 'hitl',
       nextAction: 'suppress-duplicate-respawn',
+      recommendedAction: expect.stringContaining('Suppress duplicate respawn'),
     });
     expect(finding.evidence).toContain('siblingPids=7413');
   });
@@ -822,7 +904,7 @@ describe('stuck-run watchdog', () => {
     });
   });
 
-  it('classifies dead workers as crashes even when stale wait hints remain', () => {
+  it('defers dead workers when explicit wait hints remain', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
         cardId: 't_dead_ci_wait',
@@ -838,9 +920,11 @@ describe('stuck-run watchdog', () => {
 
     expect(findings[0]).toMatchObject({
       cardId: 't_dead_ci_wait',
-      blockerCategory: 'process-crash',
+      blockerCategory: 'ci-wait',
       confidence: 'high',
       processStatus: 'dead',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
     });
   });
 
@@ -906,7 +990,7 @@ describe('stuck-run watchdog', () => {
         cardId: 't_failed_stale_ci_wait',
         pid: 7407,
         status: 'failed',
-        blockerCategory: 'ci-wait',
+        waitingOn: 'CI checks were queued before the process exited',
         lastStateTransitionAt: '2026-07-16T11:58:00.000Z',
       },
     ], { nowMs });

--- a/tasks/pr-2560-closeout-progress.md
+++ b/tasks/pr-2560-closeout-progress.md
@@ -4,7 +4,7 @@
 - [x] Confirmed live PR #2560 is open, CI green, current head `5606135247640fcf683cd4b3fa20082374010614`, Codex reported current-head findings.
 - [x] Aligned local isolated worktree with PR #2560 head and resolved the local conflict in `issue-runner.ts`.
 - [x] Inspected the restart contract implementation and tests.
-- [x] Fixed actionable current-head Codex findings in the restart-contract logic/tests.
+- [x] Fixed actionable current-head Codex findings in the restart-contract logic/tests, including the second Codex round on crash-like statuses, SIGTERM stops, and `spawn_failure` setup failures.
 - [x] Ran targeted unit tests; workspace typecheck remains blocked by pre-existing `@franken/types`/zod/API drift unrelated to this diff.
 - [ ] Commit and push fixes through approval discipline.
 - [ ] Reply/resolve Codex threads and run a fresh Codex review loop.

--- a/tasks/pr-2560-closeout-progress.md
+++ b/tasks/pr-2560-closeout-progress.md
@@ -1,0 +1,11 @@
+# PR #2560 closeout progress
+
+- [x] Loaded Kanban task context and closeout requirements.
+- [x] Confirmed live PR #2560 is open, CI green, current head `5606135247640fcf683cd4b3fa20082374010614`, Codex reported current-head findings.
+- [x] Aligned local isolated worktree with PR #2560 head and resolved the local conflict in `issue-runner.ts`.
+- [x] Inspected the restart contract implementation and tests.
+- [x] Fixed actionable current-head Codex findings in the restart-contract logic/tests.
+- [x] Ran targeted unit tests; workspace typecheck remains blocked by pre-existing `@franken/types`/zod/API drift unrelated to this diff.
+- [ ] Commit and push fixes through approval discipline.
+- [ ] Reply/resolve Codex threads and run a fresh Codex review loop.
+- [ ] Merge or block with exact remaining gate evidence.


### PR DESCRIPTION
## Summary
- add a structured crash-only restart contract to stuck-run watchdog findings
- classify dead workers as retryable, setup/protocol failures as doctor replacement, blocked crashes as HITL, and duplicate respawns as suppressed
- document the restart contract and add focused regression tests

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts tests/unit/beasts/execution/worker-crash-classification.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Closes #1675