### PR TITLE
test(orchestrator): add LLM chaos stability coverage

### DIFF
--- a/packages/franken-orchestrator/docs/testing/chaos-fixtures.md
+++ b/packages/franken-orchestrator/docs/testing/chaos-fixtures.md
@@ -1,0 +1,18 @@
+# LLM and Tool Chaos Fixtures
+
+The orchestrator stability tests use deterministic fake adapters instead of live model or tool calls. Keep new chaos coverage small and clock-controlled so CI cannot hang.
+
+## Covered failure modes
+
+- Dropped LLM response: return a never-settling promise and configure a short planner timeout. Advance Vitest fake timers and assert the fallback or explicit failure plus `vi.getTimerCount() === 0`.
+- Malformed LLM response: return non-JSON text and assert the caller takes its documented fallback/error path.
+- Empty LLM response: return whitespace and assert the same recoverable fallback/error path as malformed output.
+- Duplicate LLM completion: return duplicated task IDs or duplicated completion markers and assert the runtime rejects the ambiguous result before downstream dependency mapping proceeds.
+- Tool exception: make the fake tool/Martin loop reject, then assert the operator-visible error, terminal error span, replay/audit behavior, and lack of leaked polling timers.
+
+## Adding a new fixture
+
+1. Put provider-response fixtures beside the unit that consumes them; prefer inline `vi.fn()` fakes for single-case tests.
+2. Use `vi.useFakeTimers()` for dropped or delayed responses; always restore real timers in `finally`.
+3. Assert three things for every chaos case: final state, user/operator-visible error or fallback, and cleanup of timers/listeners/process handles.
+4. Do not call live providers, CLIs, GitHub, or network services from chaos tests.

--- a/packages/franken-orchestrator/src/skills/llm-planner.ts
+++ b/packages/franken-orchestrator/src/skills/llm-planner.ts
@@ -13,17 +13,48 @@ type RawTask = {
 
 class PlanStructureError extends Error {}
 
+export interface LlmPlannerOptions {
+  readonly timeoutMs?: number | undefined;
+}
+
 export class LlmPlanner implements IPlannerModule {
   private readonly llmClient: ILlmClient;
+  private readonly timeoutMs: number | undefined;
 
-  constructor(llmClient: ILlmClient) {
+  constructor(llmClient: ILlmClient, options: LlmPlannerOptions = {}) {
     this.llmClient = llmClient;
+    this.timeoutMs = options.timeoutMs;
   }
 
   async createPlan(intent: PlanIntent): Promise<PlanGraph> {
     const prompt = this.buildPrompt(intent);
-    const response = await this.llmClient.complete(prompt);
+    const response = await this.completeWithTimeout(prompt);
     return this.parsePlan(response, intent);
+  }
+
+  private async completeWithTimeout(prompt: string): Promise<string> {
+    if (this.timeoutMs === undefined) {
+      return this.llmClient.complete(prompt);
+    }
+
+    if (!Number.isFinite(this.timeoutMs) || this.timeoutMs <= 0) {
+      throw new Error(`LlmPlanner timeoutMs must be a positive finite number; received ${this.timeoutMs}`);
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        this.llmClient.complete(prompt),
+        new Promise<string>((resolve) => {
+          timeout = setTimeout(() => resolve(''), this.timeoutMs);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   private buildPrompt(intent: PlanIntent): string {
@@ -81,11 +112,18 @@ export class LlmPlanner implements IPlannerModule {
 
   private buildIdMap(rawTasks: RawTask[]): Map<string, string> {
     const idMap = new Map<string, string>();
+    const seenRawIds = new Set<string>();
 
     rawTasks.forEach((task, index) => {
       const rawId = typeof task?.id === 'string' && task.id.trim().length > 0
         ? task.id.trim()
         : `t${index + 1}`;
+      if (seenRawIds.has(rawId)) {
+        throw new PlanStructureError(
+          `Invalid plan structure: duplicate task id '${rawId}'`,
+        );
+      }
+      seenRawIds.add(rawId);
       idMap.set(rawId, `t${index + 1}`);
     });
 

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -467,6 +467,34 @@ describe('CliSkillExecutor', () => {
       );
     });
 
+    it('surfaces tool exceptions, records a terminal error span, and leaves no budget polling timer behind', async () => {
+      vi.useFakeTimers();
+      try {
+        martin.run.mockRejectedValue(new Error('tool adapter exploded'));
+
+        await expect(createAndExecute('cli:01_types')).rejects.toThrow(
+          'MartinLoop failed for chunk "01_types": tool adapter exploded',
+        );
+
+        expect(observer.endSpan).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            status: 'error',
+            errorMessage: 'Error: tool adapter exploded',
+          }),
+        );
+        expect(observer.recordReplay).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'tool.call',
+          runId: 'session-1',
+          toolName: 'cli:01_types',
+        }));
+        expect(observer.recordReplay.mock.calls.some(([record]) => record.kind === 'tool.result')).toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('mentions emitted mismatched promise tags in the failure message', async () => {
       martin.run.mockResolvedValue({
         completed: false,

--- a/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/llm-planner.test.ts
@@ -45,8 +45,11 @@ describe('LlmPlanner', () => {
     expect(prompt).toContain('| {"repo":"frankenbeast"}');
   });
 
-  it('falls back to a single task plan on malformed LLM output', async () => {
-    const llmClient = { complete: vi.fn().mockResolvedValue('not-json') };
+  it.each([
+    ['malformed JSON', 'not-json'],
+    ['empty response', '   '],
+  ])('falls back to a single task plan on %s LLM output', async (_name, response) => {
+    const llmClient = { complete: vi.fn().mockResolvedValue(response) };
     const planner = new LlmPlanner(llmClient);
 
     const plan = await planner.createPlan(intent);
@@ -61,6 +64,32 @@ describe('LlmPlanner', () => {
         },
       ],
     });
+  });
+
+  it('falls back to a single task plan when a dropped LLM response times out without leaking timers', async () => {
+    vi.useFakeTimers();
+    try {
+      const llmClient = { complete: vi.fn(() => new Promise<string>(() => {})) };
+      const planner = new LlmPlanner(llmClient, { timeoutMs: 25 });
+
+      const pendingPlan = planner.createPlan(intent);
+      await vi.advanceTimersByTimeAsync(25);
+      const plan = await pendingPlan;
+
+      expect(plan).toEqual({
+        tasks: [
+          {
+            id: 't1',
+            objective: 'Ship the release',
+            requiredSkills: ['llm-generate'],
+            dependsOn: [],
+          },
+        ],
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('fails plan creation when a task depends on an unknown task id', async () => {
@@ -78,6 +107,24 @@ describe('LlmPlanner', () => {
 
     await expect(planner.createPlan(intent)).rejects.toThrow(
       "Invalid plan structure: task 'ship' depends on unknown task 'missing'",
+    );
+  });
+
+  it('fails plan creation on duplicate LLM task ids before ambiguous dependency mapping can proceed', async () => {
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          tasks: [
+            { id: 'repeat', objective: 'First completion', dependsOn: [] },
+            { id: 'repeat', objective: 'Duplicate completion', dependsOn: [] },
+          ],
+        }),
+      ),
+    };
+    const planner = new LlmPlanner(llmClient);
+
+    await expect(planner.createPlan(intent)).rejects.toThrow(
+      "Invalid plan structure: duplicate task id 'repeat'",
     );
   });
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -309,3 +309,6 @@
 
 ## 2026-07-16 — DR process cleanup closeout
 - DR process cleanup planners should ignore terminal attempts before PID counting and orphan scans, treat missing-PID live attempts as possible owners of matching processes, and include process-start tokens on executable orphan actions so signal-time consumers can revalidate PID identity before termination.
+
+## 2026-07-17 — Orchestrator chaos-test closeout
+- For orchestrator chaos/stability regressions, keep dropped-provider and thrown-tool cases deterministic: use fake timers around never-settling promises, assert cleanup with zero leaked timers, and build dependent workspaces before package typecheck when source-only workspace packages make bare orchestrator `tsc --noEmit` report missing `@franken/*` declarations.


### PR DESCRIPTION
## Summary
- add deterministic LLM planner chaos coverage for malformed, empty, dropped, and duplicate responses
- add CLI skill executor coverage for thrown tool/Martin-loop failures and timer cleanup
- document chaos-fixture patterns and capture a reusable shared lesson

## Test Plan
- npm ci
- npm test -- --run tests/unit/skills/llm-planner.test.ts tests/unit/skills/cli-skill-executor.test.ts (from packages/franken-orchestrator)
- npm run build --workspace @franken/types --workspace @franken/observer --workspace @franken/brain --workspace @franken/planner --workspace @franken/critique --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1676