### PR TITLE
fix(orchestrator): preserve comms transports in secret init

### DIFF
--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -53,6 +53,25 @@ function enabledTransportsFromConfig(config: OrchestratorConfig): SupportedComms
     .map((transport) => transport.id);
 }
 
+function answersFromConfig(config: OrchestratorConfig): Record<string, unknown> {
+  return {
+    'providers.default': config.providers.default,
+    'network.operatorTokenRef': config.network.operatorTokenRef,
+    'comms.slack.appId': config.comms.slack.appId,
+    'comms.slack.botTokenRef': config.comms.slack.botTokenRef,
+    'comms.slack.signingSecretRef': config.comms.slack.signingSecretRef,
+    'comms.discord.applicationId': config.comms.discord.applicationId,
+    'comms.discord.botTokenRef': config.comms.discord.botTokenRef,
+    'comms.discord.publicKeyRef': config.comms.discord.publicKeyRef,
+    'comms.telegram.botTokenRef': config.comms.telegram.botTokenRef,
+    'comms.telegram.webhookSecretTokenRef': config.comms.telegram.webhookSecretTokenRef,
+    'comms.whatsapp.accessTokenRef': config.comms.whatsapp.accessTokenRef,
+    'comms.whatsapp.phoneNumberIdRef': config.comms.whatsapp.phoneNumberIdRef,
+    'comms.whatsapp.appSecretRef': config.comms.whatsapp.appSecretRef,
+    'comms.whatsapp.verifyTokenRef': config.comms.whatsapp.verifyTokenRef,
+  };
+}
+
 function hasTransportOnlyScope(scope: readonly InitWizardScope[] | undefined): boolean {
   return scope !== undefined
     && scope.some((item) => item === 'slack' || item === 'discord' || item === 'telegram' || item === 'whatsapp')
@@ -230,7 +249,7 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
       selectedCommsTransports: preservedTransports,
       completedSteps: Array.from(completedSteps),
       securityMode,
-      answers: { ...options.initialState.answers },
+      answers: { ...answersFromConfig(config), ...options.initialState.answers },
     };
     return { config: buildConfig(config, nextState, {
       allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -47,6 +47,12 @@ function transportDefault(state: InitState, config: OrchestratorConfig, id: Supp
   return config.comms[id].enabled;
 }
 
+function enabledTransportsFromConfig(config: OrchestratorConfig): SupportedCommsTransportId[] {
+  return listSupportedCommsTransports()
+    .filter((transport) => config.comms[transport.id].enabled)
+    .map((transport) => transport.id);
+}
+
 function hasTransportOnlyScope(scope: readonly InitWizardScope[] | undefined): boolean {
   return scope !== undefined
     && scope.some((item) => item === 'slack' || item === 'discord' || item === 'telegram' || item === 'whatsapp')
@@ -217,7 +223,7 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
       : selectedModules;
     const preservedTransports = options.initialState.selectedCommsTransports.length > 0
       ? options.initialState.selectedCommsTransports
-      : options.initialState.selectedCommsTransports;
+      : enabledTransportsFromConfig(config);
     const nextState: InitState = {
       ...options.initialState,
       selectedModules: preservedModules,

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -302,4 +302,43 @@ describe('runInitWizard – scope: secret-backend only', () => {
     // io.ask should never have been called (no interactive prompts)
     expect(io.ask).not.toHaveBeenCalled();
   });
+
+  it('preserves base config comms transports when init state has none', async () => {
+    const io = makeIO([]);
+    const secretStore = makeSecretStore({ available: true });
+    const state = createEmptyInitState('/tmp/test-config.json');
+    const baseConfig = defaultConfig();
+    baseConfig.comms.enabled = true;
+    baseConfig.comms.slack = {
+      ...baseConfig.comms.slack,
+      enabled: true,
+      appId: 'existing-slack-app',
+      botTokenRef: 'secret://existing/slack-token',
+      signingSecretRef: 'secret://existing/slack-signing-secret',
+    };
+    baseConfig.comms.discord = {
+      ...baseConfig.comms.discord,
+      enabled: true,
+      applicationId: 'existing-discord-app',
+      botTokenRef: 'secret://existing/discord-token',
+      publicKeyRef: 'existing-discord-public-key',
+    };
+
+    const result = await runInitWizard({
+      io,
+      initialState: state,
+      baseConfig,
+      secretStore,
+      scope: ['secret-backend'],
+    });
+
+    expect(io.ask).not.toHaveBeenCalled();
+    expect(result.state.selectedModules).toEqual(['chat', 'dashboard', 'comms']);
+    expect(result.state.selectedCommsTransports).toEqual(['slack', 'discord']);
+    expect(result.config.comms.enabled).toBe(true);
+    expect(result.config.comms.slack.enabled).toBe(true);
+    expect(result.config.comms.discord.enabled).toBe(true);
+    expect(result.config.comms.telegram.enabled).toBe(false);
+    expect(result.config.comms.whatsapp.enabled).toBe(false);
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -340,5 +340,13 @@ describe('runInitWizard – scope: secret-backend only', () => {
     expect(result.config.comms.discord.enabled).toBe(true);
     expect(result.config.comms.telegram.enabled).toBe(false);
     expect(result.config.comms.whatsapp.enabled).toBe(false);
+    expect(result.state.answers).toMatchObject({
+      'comms.slack.appId': 'existing-slack-app',
+      'comms.slack.botTokenRef': 'secret://existing/slack-token',
+      'comms.slack.signingSecretRef': 'secret://existing/slack-signing-secret',
+      'comms.discord.applicationId': 'existing-discord-app',
+      'comms.discord.botTokenRef': 'secret://existing/discord-token',
+      'comms.discord.publicKeyRef': 'existing-discord-public-key',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- preserve enabled comms transports from base config during secret-backend-only init when init state has no transport selections
- add regression coverage for secret-backend-only init with config-backed Slack/Discord transports

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/init/init-wizard.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator

Closes #1893