### PR TITLE
test(security): add secret redaction regression suite

### DIFF
--- a/docs/security-secret-redaction.md
+++ b/docs/security-secret-redaction.md
@@ -1,0 +1,20 @@
+# Secret redaction regression fixtures
+
+Frankenbeast keeps a shared regression harness in `tests/security-secret-redaction-regression.test.ts`. It pushes representative credential shapes through logs, memory writes, trace persistence, and HTTP error responses, then asserts each surface identifies the leaking surface without printing the raw credential.
+
+## Covered fixture families
+
+- GitHub-style tokens.
+- Discord webhook URLs.
+- npm automation tokens.
+- Database URLs with user/password authority sections.
+- Cookie and Set-Cookie headers.
+- Generic Bearer/token authorization strings.
+
+## Adding a new secret pattern safely
+
+1. Add the smallest redaction rule in the surface implementation that owns the leak.
+2. Add a fixture to the shared harness by constructing the sample from string fragments, not by pasting a real-looking credential literal.
+3. Assert with `assertNoFixtureLeak(surface, value)` so failures report only the fixture name and surface, not the secret bytes.
+4. Run the targeted harness and the owning package tests before widening to package-level checks.
+5. Never use production credentials in fixtures; use deterministic fake fragments with enough shape to exercise the matcher.

--- a/packages/franken-mcp-suite/src/servers/memory.test.ts
+++ b/packages/franken-mcp-suite/src/servers/memory.test.ts
@@ -277,7 +277,7 @@ describe("Memory Server", () => {
     expect(brain.store).not.toHaveBeenCalled();
     expect(brain.proposeMemory).toHaveBeenCalledWith({
       key: "OPENAI_API_KEY",
-      value: sensitiveValue,
+      value: "<redacted>",
       source: "fbeast_memory_store:quarantine",
       evidenceId: "quarantine:OPENAI_API_KEY",
       confidence: 1,

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -120,8 +120,8 @@ function parseStringArg(name: string, value: unknown): { ok: true; value: string
 
 const SENSITIVE_MEMORY_KEY_PATTERNS = [
   /(^|[._:-])(api[-_]?key|apikey)([._:-]|$)/i,
-  /(^|[._:-])(access[-_]?token|refresh[-_]?token|auth[-_]?token|bearer[-_]?token)([._:-]|$)/i,
-  /(^|[._:-])(password|passphrase|secret|credential|credentials)([._:-]|$)/i,
+  /(^|[._:-])(access[-_]?token|refresh[-_]?token|auth[-_]?token|bearer[-_]?token|authorization|proxy[-_]?authorization)([._:-]|$)/i,
+  /(^|[._:-])(password|passphrase|secret|credential|credentials|cookie|session)([._:-]|$)/i,
   /(^|[._:-])private[-_]?key([._:-]|$)/i,
 ];
 
@@ -130,7 +130,7 @@ const SENSITIVE_MEMORY_VALUE_PATTERNS = [
   /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/,
   /\bnpm_[A-Za-z0-9_\-]{12,}\b/,
   /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/i,
-  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/i,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/i,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/i,
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/i,
 ];

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -127,8 +127,12 @@ const SENSITIVE_MEMORY_KEY_PATTERNS = [
 
 const SENSITIVE_MEMORY_VALUE_PATTERNS = [
   /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
-  /\b(?:sk|gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_\-]{12,}\b/,
+  /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/,
+  /\bnpm_[A-Za-z0-9_\-]{12,}\b/,
+  /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/i,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/i,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/i,
+  /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/i,
 ];
 
 function sensitiveMemoryQuarantineReason(key: string, value: string): string | undefined {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -135,8 +135,18 @@ const SENSITIVE_MEMORY_VALUE_PATTERNS = [
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/i,
 ];
 
+const SENSITIVE_MEMORY_REDACTION = '<redacted>';
+
+function normalizeSensitiveMemoryKey(key: string): string {
+  return key
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-z0-9]+/giu, '_');
+}
+
 function sensitiveMemoryQuarantineReason(key: string, value: string): string | undefined {
-  const normalizedKey = key.trim();
+  const normalizedKey = normalizeSensitiveMemoryKey(key);
   if (SENSITIVE_MEMORY_KEY_PATTERNS.some((pattern) => pattern.test(normalizedKey))) {
     return 'key-name-indicates-secret';
   }
@@ -235,7 +245,7 @@ const TOOLS: ToolFull[] = [
         }
         const candidate = await brain.proposeMemory({
           key,
-          value,
+          value: SENSITIVE_MEMORY_REDACTION,
           source: 'fbeast_memory_store:quarantine',
           evidenceId: `quarantine:${key}`,
           confidence: 1,

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -200,6 +200,17 @@ function redactSensitiveText(text: string): string {
   return redacted
 }
 
+function normalizeSensitiveKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-z0-9]+/giu, '_')
+}
+
+function isSensitiveMetadataKey(key: string): boolean {
+  return SENSITIVE_METADATA_KEY_RE.test(normalizeSensitiveKey(key))
+}
+
 function redactMetadata(value: unknown): unknown {
   if (typeof value === 'string') return redactSensitiveText(value)
   if (value === null || typeof value !== 'object') return value
@@ -212,7 +223,7 @@ function redactMetadata(value: unknown): unknown {
 }
 
 function redactMetadataEntry(key: string, value: unknown): unknown {
-  if (!SENSITIVE_METADATA_KEY_RE.test(key)) return redactMetadata(value)
+  if (!isSensitiveMetadataKey(key)) return redactMetadata(value)
   if (typeof value === 'string' && REDACTION_MARKERS.has(value)) return value
   return REDACTED
 }

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -180,6 +180,7 @@ function snapshotTrace(trace: Trace): Trace {
 }
 
 const REDACTED = '<redacted>'
+const REDACTION_MARKERS = new Set(['[REDACTED]', '<redacted>', '***'])
 const SENSITIVE_METADATA_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu
 const SENSITIVE_TEXT_PATTERNS = [
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
@@ -205,9 +206,15 @@ function redactMetadata(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(redactMetadata)
   const redacted: Record<string, unknown> = {}
   for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
-    redacted[key] = SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : redactMetadata(nestedValue)
+    redacted[key] = redactMetadataEntry(key, nestedValue)
   }
   return redacted
+}
+
+function redactMetadataEntry(key: string, value: unknown): unknown {
+  if (!SENSITIVE_METADATA_KEY_RE.test(key)) return redactMetadata(value)
+  if (typeof value === 'string' && REDACTION_MARKERS.has(value)) return value
+  return REDACTED
 }
 
 /**

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -187,13 +187,21 @@ const SENSITIVE_TEXT_PATTERNS = [
   /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
   /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
   /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
-  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+  /\b(?:Proxy-)?Authorization:\s*[^\r\n]+/giu,
 ]
+const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
+const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
 
 function redactSensitiveText(text: string): string {
-  let redacted = text
+  let redacted = text.replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string) => {
+    return isSensitiveMetadataKey(key) ? `${key}=${REDACTED}` : match
+  })
+  redacted = redacted.replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) => {
+    return isSensitiveMetadataKey(key) ? `${prefix}"${REDACTED}"` : match
+  })
   for (const pattern of SENSITIVE_TEXT_PATTERNS) {
     redacted = redacted.replace(pattern, REDACTED)
   }

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -159,7 +159,7 @@ function isSqliteLockError(error: unknown): boolean {
 function snapshotTrace(trace: Trace): Trace {
   return {
     id: trace.id,
-    goal: trace.goal,
+    goal: redactSensitiveText(trace.goal),
     status: trace.status,
     startedAt: trace.startedAt,
     endedAt: trace.endedAt,
@@ -172,11 +172,42 @@ function snapshotTrace(trace: Trace): Trace {
       startedAt: span.startedAt,
       endedAt: span.endedAt,
       durationMs: span.durationMs,
-      errorMessage: span.errorMessage,
-      metadata: JSON.parse(JSON.stringify(span.metadata)) as Record<string, unknown>,
-      thoughtBlocks: [...span.thoughtBlocks],
+      errorMessage: span.errorMessage === undefined ? undefined : redactSensitiveText(span.errorMessage),
+      metadata: redactMetadata(JSON.parse(JSON.stringify(span.metadata)) as Record<string, unknown>) as Record<string, unknown>,
+      thoughtBlocks: span.thoughtBlocks.map(redactSensitiveText),
     })),
   }
+}
+
+const REDACTED = '<redacted>'
+const SENSITIVE_METADATA_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu
+const SENSITIVE_TEXT_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
+  /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
+  /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
+  /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
+  /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+]
+
+function redactSensitiveText(text: string): string {
+  let redacted = text
+  for (const pattern of SENSITIVE_TEXT_PATTERNS) {
+    redacted = redacted.replace(pattern, REDACTED)
+  }
+  return redacted
+}
+
+function redactMetadata(value: unknown): unknown {
+  if (typeof value === 'string') return redactSensitiveText(value)
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(redactMetadata)
+  const redacted: Record<string, unknown> = {}
+  for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+    redacted[key] = SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : redactMetadata(nestedValue)
+  }
+  return redacted
 }
 
 /**

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -90,6 +90,7 @@ function cloneTrace(trace: Trace): Trace {
 }
 
 const REDACTED = '<redacted>'
+const REDACTION_MARKERS = new Set(['[REDACTED]', '<redacted>', '***'])
 const SENSITIVE_METADATA_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu
 const SENSITIVE_TEXT_PATTERNS = [
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
@@ -185,7 +186,7 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
       cloned['errors'] = cloneMetadataValue(value.errors, seen)
     }
     for (const [key, nestedValue] of Object.entries(value)) {
-      defineMetadataProperty(cloned, key, SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : cloneMetadataValue(nestedValue, seen))
+      defineMetadataProperty(cloned, key, redactMetadataEntry(key, nestedValue, seen))
     }
     return cloned
   }
@@ -193,9 +194,19 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
   const cloned: Record<string, unknown> = {}
   seen.set(value, cloned)
   for (const [key, nestedValue] of Object.entries(value)) {
-    defineMetadataProperty(cloned, key, SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : cloneMetadataValue(nestedValue, seen))
+    defineMetadataProperty(cloned, key, redactMetadataEntry(key, nestedValue, seen))
   }
   return cloned
+}
+
+function redactMetadataEntry(key: string, value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (!SENSITIVE_METADATA_KEY_RE.test(key)) {
+    return cloneMetadataValue(value, seen)
+  }
+  if (typeof value === 'string' && REDACTION_MARKERS.has(value)) {
+    return value
+  }
+  return REDACTED
 }
 
 function cloneArrayBufferView(value: ArrayBufferView): ArrayBufferView {

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -114,6 +114,17 @@ function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknow
   return cloneMetadataValue(metadata) as Record<string, unknown>
 }
 
+function normalizeSensitiveKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-z0-9]+/giu, '_')
+}
+
+function isSensitiveMetadataKey(key: string): boolean {
+  return SENSITIVE_METADATA_KEY_RE.test(normalizeSensitiveKey(key))
+}
+
 function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
   if (typeof value === 'function' || typeof value === 'symbol') {
     return String(value)
@@ -200,7 +211,7 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
 }
 
 function redactMetadataEntry(key: string, value: unknown, seen: WeakMap<object, unknown>): unknown {
-  if (!SENSITIVE_METADATA_KEY_RE.test(key)) {
+  if (!isSensitiveMetadataKey(key)) {
     return cloneMetadataValue(value, seen)
   }
   if (typeof value === 'string' && REDACTION_MARKERS.has(value)) {

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -97,13 +97,21 @@ const SENSITIVE_TEXT_PATTERNS = [
   /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
   /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
   /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
-  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+  /\b(?:Proxy-)?Authorization:\s*[^\r\n]+/giu,
 ]
+const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
+const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
 
 function redactSensitiveText(text: string): string {
-  let redacted = text
+  let redacted = text.replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string) => {
+    return isSensitiveMetadataKey(key) ? `${key}=${REDACTED}` : match
+  })
+  redacted = redacted.replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) => {
+    return isSensitiveMetadataKey(key) ? `${prefix}"${REDACTED}"` : match
+  })
   for (const pattern of SENSITIVE_TEXT_PATTERNS) {
     redacted = redacted.replace(pattern, REDACTED)
   }
@@ -164,7 +172,10 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
     const cloned = new Map<unknown, unknown>()
     seen.set(value, cloned)
     for (const [key, nestedValue] of value.entries()) {
-      cloned.set(cloneMetadataValue(key, seen), cloneMetadataValue(nestedValue, seen))
+      cloned.set(
+        cloneMetadataValue(key, seen),
+        typeof key === 'string' ? redactMetadataEntry(key, nestedValue, seen) : cloneMetadataValue(nestedValue, seen),
+      )
     }
     return cloned
   }

--- a/packages/franken-observer/src/export/InMemoryAdapter.ts
+++ b/packages/franken-observer/src/export/InMemoryAdapter.ts
@@ -69,7 +69,7 @@ export class InMemoryAdapter implements ExportAdapter {
 function cloneTrace(trace: Trace): Trace {
   return {
     id: trace.id,
-    goal: trace.goal,
+    goal: redactSensitiveText(trace.goal),
     status: trace.status,
     startedAt: trace.startedAt,
     ...(trace.endedAt !== undefined ? { endedAt: trace.endedAt } : {}),
@@ -82,11 +82,31 @@ function cloneTrace(trace: Trace): Trace {
       startedAt: span.startedAt,
       ...(span.endedAt !== undefined ? { endedAt: span.endedAt } : {}),
       ...(span.durationMs !== undefined ? { durationMs: span.durationMs } : {}),
-      ...(span.errorMessage !== undefined ? { errorMessage: span.errorMessage } : {}),
+      ...(span.errorMessage !== undefined ? { errorMessage: redactSensitiveText(span.errorMessage) } : {}),
       metadata: cloneMetadata(span.metadata),
-      thoughtBlocks: [...span.thoughtBlocks],
+      thoughtBlocks: span.thoughtBlocks.map(redactSensitiveText),
     })),
   }
+}
+
+const REDACTED = '<redacted>'
+const SENSITIVE_METADATA_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu
+const SENSITIVE_TEXT_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
+  /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
+  /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
+  /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
+  /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+]
+
+function redactSensitiveText(text: string): string {
+  let redacted = text
+  for (const pattern of SENSITIVE_TEXT_PATTERNS) {
+    redacted = redacted.replace(pattern, REDACTED)
+  }
+  return redacted
 }
 
 function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
@@ -96,6 +116,10 @@ function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknow
 function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
   if (typeof value === 'function' || typeof value === 'symbol') {
     return String(value)
+  }
+
+  if (typeof value === 'string') {
+    return redactSensitiveText(value)
   }
 
   if (value === null || typeof value !== 'object') {
@@ -152,16 +176,16 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
   if (value instanceof Error) {
     const cloned: Record<string, unknown> = {
       name: value.name,
-      message: value.message,
+      message: redactSensitiveText(value.message),
     }
     seen.set(value, cloned)
-    if (value.stack !== undefined) cloned['stack'] = value.stack
+    if (value.stack !== undefined) cloned['stack'] = redactSensitiveText(value.stack)
     if ('cause' in value) cloned['cause'] = cloneMetadataValue(value.cause, seen)
     if (value instanceof AggregateError) {
       cloned['errors'] = cloneMetadataValue(value.errors, seen)
     }
     for (const [key, nestedValue] of Object.entries(value)) {
-      defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
+      defineMetadataProperty(cloned, key, SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : cloneMetadataValue(nestedValue, seen))
     }
     return cloned
   }
@@ -169,7 +193,7 @@ function cloneMetadataValue(value: unknown, seen = new WeakMap<object, unknown>(
   const cloned: Record<string, unknown> = {}
   seen.set(value, cloned)
   for (const [key, nestedValue] of Object.entries(value)) {
-    defineMetadataProperty(cloned, key, cloneMetadataValue(nestedValue, seen))
+    defineMetadataProperty(cloned, key, SENSITIVE_METADATA_KEY_RE.test(key) ? REDACTED : cloneMetadataValue(nestedValue, seen))
   }
   return cloned
 }

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -3,6 +3,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { createMiddleware } from 'hono/factory';
 import type { ZodSchema } from 'zod';
 import { deterministicUuid } from '@franken/types';
+import { redactLogData, redactSensitiveText } from '../logging/redaction.js';
 
 export interface ApiError {
   error: {
@@ -188,17 +189,19 @@ export function requestSizeLimit(maxSize: number) {
 
 export const errorHandler: ErrorHandler = (err, c) => {
   if (err instanceof HttpError) {
+    const safeMessage = redactSensitiveText(err.message);
+    const safeDetails = err.details === undefined ? undefined : redactLogData(err.details);
     if (err.statusCode >= 500) {
-      console.error(`[HTTP ${err.statusCode}] ${err.code}: ${err.message}`, err.details ?? '');
+      console.error(`[HTTP ${err.statusCode}] ${err.code}: ${safeMessage}`, safeDetails ?? '');
     } else {
-      console.warn(`[HTTP ${err.statusCode}] ${err.code}: ${err.message}`, err.details ?? '');
+      console.warn(`[HTTP ${err.statusCode}] ${err.code}: ${safeMessage}`, safeDetails ?? '');
     }
     return c.json(
       {
         error: {
           code: err.code,
-          message: err.message,
-          ...(err.details !== undefined ? { details: err.details } : {}),
+          message: safeMessage,
+          ...(safeDetails !== undefined ? { details: safeDetails } : {}),
         },
       } satisfies ApiError,
       err.statusCode as 400,

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -3,12 +3,12 @@ const REDACTED = '<redacted>';
 const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|PROXY[_-]?AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu;
 const ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu;
 const JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu;
+const CREDENTIAL_URL_RE = /\b((?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/(?:[^:\s"'/@]+)?):[^@\s"']+(@[^\s"']+)/giu;
 const SENSITIVE_VALUE_PATTERNS = [
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
   /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
   /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
   /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
-  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
   /\b(?:Proxy-)?Authorization:\s*[^\r\n]+/giu,
@@ -64,7 +64,7 @@ export function redactSensitiveTextWithProvenance(text: string, path = '$'): Red
     return `${prefix}"${REDACTED}"`;
   });
 
-  let value = withJsonFieldsRedacted;
+  let value = withJsonFieldsRedacted.replace(CREDENTIAL_URL_RE, `$1:${REDACTED}$2`);
   for (const pattern of SENSITIVE_VALUE_PATTERNS) {
     value = value.replace(pattern, () => REDACTED);
   }

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -3,6 +3,15 @@ const REDACTED = '<redacted>';
 const SENSITIVE_KEY_RE = /(?:^|[_-])(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|CREDENTIAL|COOKIE|BEARER|AUTH|AUTHORIZATION|PROXY[_-]?AUTHORIZATION|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLAUDE[_-]?SESSION)(?:$|[_-])/iu;
 const ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu;
 const JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu;
+const SENSITIVE_VALUE_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
+  /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
+  /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
+  /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
+  /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+];
 
 export type RedactionDecisionSource = 'text-assignment' | 'text-json-field' | 'object-key';
 
@@ -46,13 +55,18 @@ export function redactSensitiveTextWithProvenance(text: string, path = '$'): Red
     return `${key}=${REDACTED}`;
   });
 
-  const value = withAssignmentsRedacted.replace(JSON_FIELD_RE, (match, prefix: string, key: string) => {
+  const withJsonFieldsRedacted = withAssignmentsRedacted.replace(JSON_FIELD_RE, (match, prefix: string, key: string) => {
     if (!isSensitiveLogKey(key)) {
       return match;
     }
     decisions.push(createDecision(path, key, 'text-json-field'));
     return `${prefix}"${REDACTED}"`;
   });
+
+  let value = withJsonFieldsRedacted;
+  for (const pattern of SENSITIVE_VALUE_PATTERNS) {
+    value = value.replace(pattern, () => REDACTED);
+  }
 
   return { value, decisions };
 }

--- a/packages/franken-orchestrator/src/logging/redaction.ts
+++ b/packages/franken-orchestrator/src/logging/redaction.ts
@@ -8,9 +8,10 @@ const SENSITIVE_VALUE_PATTERNS = [
   /\b(?:sk|gho|ghp|glpat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b/gu,
   /\bnpm_[A-Za-z0-9_\-]{12,}\b/gu,
   /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_\-]+/giu,
-  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/giu,
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu,
   /\b(?:Bearer|token)\s+[A-Za-z0-9._~+/=-]{20,}\b/giu,
   /\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/giu,
+  /\b(?:Proxy-)?Authorization:\s*[^\r\n]+/giu,
 ];
 
 export type RedactionDecisionSource = 'text-assignment' | 'text-json-field' | 'object-key';

--- a/tasks/issue-1670-secret-redaction-regression-progress.md
+++ b/tasks/issue-1670-secret-redaction-regression-progress.md
@@ -1,0 +1,22 @@
+# Issue 1670 Secret Redaction Regression Progress
+
+- [x] Read shared lessons and live issue state.
+- [x] Create isolated worktree on `resolve/issue-1670-security-add-secret-redaction-regression-suite-f`.
+- [x] Add fixture-driven tests for log, memory, trace, and error-response redaction surfaces.
+- [x] Implement minimal redaction gaps exposed by the tests.
+- [x] Document safe addition of future secret patterns.
+- [x] Run targeted package tests/checks.
+- [ ] Commit, push, open PR, run Codex gate, merge.
+
+Verification completed:
+- `npx vitest run tests/security-secret-redaction-regression.test.ts`
+- `npm run test --workspace @franken/orchestrator -- tests/unit/logger.test.ts`
+- `npm run test --workspace @franken/mcp-suite -- src/servers/memory.test.ts`
+- `npm run test --workspace @franken/observer -- src/adapters/sqlite/SQLiteAdapter.test.ts`
+- `npm run typecheck --workspace @franken/orchestrator`
+- `npm run typecheck --workspace @franken/mcp-suite`
+- `npm run typecheck --workspace @franken/observer`
+- `npm run build`
+- `npm run lint --workspace @franken/orchestrator` (0 errors, pre-existing warnings)
+- `npm run lint --workspace @franken/mcp-suite` (0 errors, pre-existing warnings)
+- `npm run lint --workspace @franken/observer` (0 errors, pre-existing warnings)

--- a/tests/security-secret-redaction-regression.test.ts
+++ b/tests/security-secret-redaction-regression.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConsoleLogger } from '../packages/franken-orchestrator/src/logger.js';
+import { HttpError, errorHandler } from '../packages/franken-orchestrator/src/http/middleware.js';
+import { createMemoryServer } from '../packages/franken-mcp-suite/src/servers/memory.js';
+import type { BrainAdapter } from '../packages/franken-mcp-suite/src/adapters/brain-adapter.js';
+import { TraceContext } from '../packages/franken-observer/src/core/TraceContext.js';
+import { SpanLifecycle } from '../packages/franken-observer/src/core/SpanLifecycle.js';
+import { InMemoryAdapter } from '../packages/franken-observer/src/export/InMemoryAdapter.js';
+
+const githubToken = ['ghp', '_', 'A'.repeat(36)].join('');
+const discordWebhook = [
+  'https://',
+  'discord.com',
+  '/api/webhooks/',
+  '1'.repeat(18),
+  '/',
+  'a'.repeat(68),
+].join('');
+const npmToken = ['npm', '_', 'b'.repeat(36)].join('');
+const databaseUrl = ['postgres://agent:', 'c'.repeat(24), '@db.internal:5432/app'].join('');
+const cookieHeader = ['Cookie: session=', 'd'.repeat(32), '; csrf=', 'e'.repeat(32)].join('');
+const bearerToken = ['Bearer ', 'f'.repeat(48)].join('');
+
+const fixtures = [
+  { name: 'github-token', value: githubToken },
+  { name: 'discord-webhook', value: discordWebhook },
+  { name: 'npm-token', value: npmToken },
+  { name: 'database-url', value: databaseUrl },
+  { name: 'cookie-header', value: cookieHeader },
+  { name: 'bearer-token', value: bearerToken },
+] as const;
+
+function assertNoFixtureLeak(surface: string, value: unknown): void {
+  const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+  for (const fixture of fixtures) {
+    if (rendered.includes(fixture.value)) {
+      throw new Error(`${surface} leaked ${fixture.name}`);
+    }
+  }
+}
+
+function createBrainStub(overrides: Partial<BrainAdapter> = {}): BrainAdapter {
+  return {
+    query: vi.fn().mockResolvedValue([]),
+    store: vi.fn().mockResolvedValue(undefined),
+    frontload: vi.fn().mockResolvedValue([]),
+    exportProjectMemory: vi.fn().mockResolvedValue({
+      version: 1,
+      exportedAt: '2026-07-17T00:00:00.000Z',
+      scope: { readScope: 'all' },
+      redaction: 'safe',
+      counts: { working: 0, episodic: 0 },
+      working: [],
+      episodic: [],
+    }),
+    forget: vi.fn().mockResolvedValue(false),
+    rightToForget: vi.fn().mockResolvedValue({
+      selectorHash: 'selector-hash',
+      dryRun: false,
+      deleted: { working: 0, episodic: 0, derived: 0 },
+      remainingReferences: 0,
+    }),
+    proposeMemory: vi.fn().mockResolvedValue({
+      id: 'memcand_secret_fixture',
+      targetStore: 'working',
+      key: 'fixture-redaction-check',
+      value: 'redacted by test helper',
+      source: 'fbeast_memory_store:quarantine',
+      confidence: 1,
+      reason: 'Sensitive memory quarantined for operator review (value-shape-indicates-secret).',
+      status: 'pending',
+      createdAt: '2026-07-17T00:00:00.000Z',
+      updatedAt: '2026-07-17T00:00:00.000Z',
+    }),
+    listMemoryReview: vi.fn().mockResolvedValue([]),
+    memoryAttribution: vi.fn().mockResolvedValue([]),
+    conflictsForMemoryReview: vi.fn().mockResolvedValue([]),
+    decideMemoryReview: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('secret redaction regression harness', () => {
+  it('redacts representative secret fixtures from structured and text logs', () => {
+    const logSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const logger = new ConsoleLogger({ verbose: true });
+
+    logger.debug(`runtime credentials ${cookieHeader} ${bearerToken}`, {
+      githubToken,
+      discordWebhook,
+      npmToken,
+      databaseUrl,
+    });
+
+    const output = logSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('<redacted>');
+    assertNoFixtureLeak('logger', output);
+  });
+
+  it('quarantines representative secret fixtures before memory persistence or display', async () => {
+    for (const fixture of fixtures) {
+      const brain = createBrainStub();
+      const server = createMemoryServer({ brain });
+
+      const result = await server.callTool('fbeast_memory_store', {
+        key: `redaction-fixture-${fixture.name}`,
+        value: fixture.value,
+        type: 'working',
+      });
+
+      expect(brain.store, fixture.name).not.toHaveBeenCalled();
+      expect(brain.proposeMemory, fixture.name).toHaveBeenCalled();
+      assertNoFixtureLeak(`memory ${fixture.name}`, result.content[0]?.text ?? '');
+    }
+  });
+
+  it('redacts representative secret fixtures before trace persistence and query display', async () => {
+    const adapter = new InMemoryAdapter();
+    const trace = TraceContext.createTrace(`goal ${databaseUrl}`);
+    const span = TraceContext.startSpan(trace, { name: 'redaction-check' });
+    SpanLifecycle.setMetadata(span, {
+      githubToken,
+      discordWebhook,
+      npmToken,
+      databaseUrl,
+      cookieHeader,
+      bearerToken,
+    });
+    SpanLifecycle.addThoughtBlock(span, `thought ${discordWebhook} ${bearerToken}`);
+    TraceContext.endSpan(span, { status: 'error', errorMessage: `failed with ${databaseUrl}` });
+    TraceContext.endTrace(trace);
+
+    await adapter.flush(trace);
+    const persisted = await adapter.queryByTraceId(trace.id);
+
+    expect(JSON.stringify(persisted)).toContain('<redacted>');
+    assertNoFixtureLeak('trace persistence', persisted);
+  });
+
+  it('redacts representative secret fixtures from HTTP error responses and logs', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const response = vi.fn((payload: unknown, status: number) => ({ payload, status }));
+    const context = { json: response };
+
+    errorHandler(
+      new HttpError(400, 'BAD_REQUEST', `bad input ${bearerToken}`, {
+        callback: discordWebhook,
+        databaseUrl,
+        cookieHeader,
+        githubToken,
+        npmToken,
+      }),
+      context as never,
+    );
+
+    expect(response).toHaveBeenCalledTimes(1);
+    const payload = response.mock.calls[0]?.[0];
+    const logOutput = warnSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    assertNoFixtureLeak('http error response', payload);
+    assertNoFixtureLeak('http error log', logOutput);
+  });
+});

--- a/tests/security-secret-redaction-regression.test.ts
+++ b/tests/security-secret-redaction-regression.test.ts
@@ -31,6 +31,15 @@ const fixtures = [
   { name: 'bearer-token', value: bearerToken },
 ] as const;
 
+const camelCaseSecretMetadata = {
+  accessToken: 'opaque-access-token-value',
+  authToken: 'opaque-auth-token-value',
+  passwordValue: 'opaque-password-value',
+  cookieHeader: 'opaque-cookie-header-value',
+  privateKey: 'opaque-private-key-value',
+  APIKey: 'opaque-api-key-value',
+};
+
 function assertNoFixtureLeak(surface: string, value: unknown): void {
   const rendered = typeof value === 'string' ? value : JSON.stringify(value);
   for (const fixture of fixtures) {
@@ -111,6 +120,8 @@ describe('secret redaction regression harness', () => {
 
       expect(brain.store, fixture.name).not.toHaveBeenCalled();
       expect(brain.proposeMemory, fixture.name).toHaveBeenCalled();
+      expect(brain.proposeMemory, fixture.name).not.toHaveBeenCalledWith(expect.objectContaining({ value: fixture.value }));
+      expect(brain.proposeMemory, fixture.name).toHaveBeenCalledWith(expect.objectContaining({ value: '<redacted>' }));
       assertNoFixtureLeak(`memory ${fixture.name}`, result.content[0]?.text ?? '');
     }
   });
@@ -126,6 +137,7 @@ describe('secret redaction regression harness', () => {
       databaseUrl,
       cookieHeader,
       bearerToken,
+      ...camelCaseSecretMetadata,
     });
     SpanLifecycle.addThoughtBlock(span, `thought ${discordWebhook} ${bearerToken}`);
     TraceContext.endSpan(span, { status: 'error', errorMessage: `failed with ${databaseUrl}` });
@@ -136,6 +148,9 @@ describe('secret redaction regression harness', () => {
 
     expect(JSON.stringify(persisted)).toContain('<redacted>');
     assertNoFixtureLeak('trace persistence', persisted);
+    for (const value of Object.values(camelCaseSecretMetadata)) {
+      expect(JSON.stringify(persisted)).not.toContain(value);
+    }
   });
 
   it('redacts representative secret fixtures from HTTP error responses and logs', () => {

--- a/tests/security-secret-redaction-regression.test.ts
+++ b/tests/security-secret-redaction-regression.test.ts
@@ -21,21 +21,27 @@ const npmToken = ['npm', '_', 'b'.repeat(36)].join('');
 const databaseUrl = ['postgres://agent:', 'c'.repeat(24), '@db.internal:5432/app'].join('');
 const cookieHeader = ['Cookie: session=', 'd'.repeat(32), '; csrf=', 'e'.repeat(32)].join('');
 const bearerToken = ['Bearer ', 'f'.repeat(48)].join('');
+const passwordOnlyRedisUrl = ['redis://:', 'g'.repeat(24), '@cache.internal:6379/0'].join('');
+const bareCookieValue = ['session=', 'h'.repeat(32), '; csrf=', 'i'.repeat(32)].join('');
+const authorizationHeader = ['Authorization: Basic ', 'j'.repeat(32)].join('');
 
 const fixtures = [
   { name: 'github-token', value: githubToken },
   { name: 'discord-webhook', value: discordWebhook },
   { name: 'npm-token', value: npmToken },
   { name: 'database-url', value: databaseUrl },
+  { name: 'password-only-redis-url', value: passwordOnlyRedisUrl },
   { name: 'cookie-header', value: cookieHeader },
+  { name: 'bare-cookie-value', value: bareCookieValue },
   { name: 'bearer-token', value: bearerToken },
+  { name: 'authorization-header', value: authorizationHeader },
 ] as const;
 
 const camelCaseSecretMetadata = {
   accessToken: 'opaque-access-token-value',
   authToken: 'opaque-auth-token-value',
   passwordValue: 'opaque-password-value',
-  cookieHeader: 'opaque-cookie-header-value',
+  sessionCookie: 'opaque-cookie-header-value',
   privateKey: 'opaque-private-key-value',
   APIKey: 'opaque-api-key-value',
 };
@@ -95,11 +101,12 @@ describe('secret redaction regression harness', () => {
     const logSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const logger = new ConsoleLogger({ verbose: true });
 
-    logger.debug(`runtime credentials ${cookieHeader} ${bearerToken}`, {
+    logger.debug(`runtime credentials ${cookieHeader} ${bearerToken} ${authorizationHeader}`, {
       githubToken,
       discordWebhook,
       npmToken,
       databaseUrl,
+      passwordOnlyRedisUrl,
     });
 
     const output = logSpy.mock.calls.map(call => call.join(' ')).join('\n');
@@ -135,12 +142,17 @@ describe('secret redaction regression harness', () => {
       discordWebhook,
       npmToken,
       databaseUrl,
+      passwordOnlyRedisUrl,
       cookieHeader,
+      authorizationHeader,
       bearerToken,
+      keyAssignment: `OPENAI_API_KEY=${githubToken}`,
+      jsonAssignment: `{"password":"${bearerToken}"}`,
+      sensitiveMap: new Map([['apiKey', 'short-secret-value']]),
       ...camelCaseSecretMetadata,
     });
-    SpanLifecycle.addThoughtBlock(span, `thought ${discordWebhook} ${bearerToken}`);
-    TraceContext.endSpan(span, { status: 'error', errorMessage: `failed with ${databaseUrl}` });
+    SpanLifecycle.addThoughtBlock(span, `thought ${discordWebhook} ${bearerToken} password=short-value`);
+    TraceContext.endSpan(span, { status: 'error', errorMessage: `failed with ${databaseUrl} ${authorizationHeader}` });
     TraceContext.endTrace(trace);
 
     await adapter.flush(trace);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -110,6 +110,7 @@ export default defineConfig({
       '@franken/critique': resolve(__dirname, 'packages/franken-critique/src/index.ts'),
       '@franken/governor': resolve(__dirname, 'packages/franken-governor/src/index.ts'),
       '@franken/types/json-pointer': resolve(__dirname, 'packages/franken-types/src/json-pointer.ts'),
+      '@franken/types/path-containment': resolve(__dirname, 'packages/franken-types/src/path-containment.ts'),
       '@franken/types/utils': resolve(__dirname, 'packages/franken-types/src/utils/index.ts'),
       '@franken/types': resolve(__dirname, 'packages/franken-types/src/index.ts'),
       '@franken/orchestrator': resolve(__dirname, 'packages/franken-orchestrator/src/index.ts'),


### PR DESCRIPTION
## Summary
- add a shared secret-redaction regression harness for logs, memory storage, trace persistence, and HTTP error responses
- extend redaction coverage for token/webhook/database/cookie credential shapes across logging, memory quarantine, and observer trace adapters
- document safe addition of future secret fixture patterns

## Test Plan
- npx vitest run tests/security-secret-redaction-regression.test.ts
- npm run test --workspace @franken/orchestrator -- tests/unit/logger.test.ts
- npm run test --workspace @franken/mcp-suite -- src/servers/memory.test.ts
- npm run test --workspace @franken/observer -- src/adapters/sqlite/SQLiteAdapter.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/mcp-suite
- npm run typecheck --workspace @franken/observer
- npm run build
- npm run lint --workspace @franken/orchestrator (0 errors; existing warnings)
- npm run lint --workspace @franken/mcp-suite (0 errors; existing warnings)
- npm run lint --workspace @franken/observer (0 errors; existing warnings)

Closes #1670