### PR TITLE
test(stability): add stream replay coverage

### DIFF
--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -129,6 +129,8 @@ Expected behavior:
 - opening the chat page creates or resumes a session over HTTP
 - the UI then opens a WebSocket connection to `/v1/chat/ws`
 - sending a message streams assistant output back into the transcript
+- WebSocket stream events include monotonic `eventId` values so reconnect/replay paths can ignore duplicate or stale events without duplicating transcript entries
+- dashboard SSE snapshots include monotonic `id: dashboard:<n>` fields; reconnecting clients pass their last processed id as `lastEventId` when minting the next short-lived stream, and client reducers must ignore duplicate event ids
 - approvals show up in the side rail when a turn requires them
 
 ## Security defaults

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -82,6 +82,10 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   const ticketStore = deps.ticketStore;
   const operatorToken = deps.operatorToken;
 
+  // Event ids are scoped to this route instance instead of each connection so
+  // reconnecting EventSource clients never drop fresh snapshots as stale replay.
+  let dashboardSnapshotSequence = 0;
+
   // GET /api/dashboard — aggregated snapshot of all dashboard state
   app.get('/', async (c) => {
     return c.json(await buildSnapshot(deps));
@@ -121,11 +125,11 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
 
     return streamSSE(c, async (stream) => {
       let lastSnapshot = JSON.stringify(await buildSnapshot(deps));
-      let snapshotSequence = 1;
 
       // Send initial snapshot
+      dashboardSnapshotSequence += 1;
       await stream.writeSSE({
-        id: `dashboard:${snapshotSequence}`,
+        id: `dashboard:${dashboardSnapshotSequence}`,
         event: 'snapshot',
         data: lastSnapshot,
       });
@@ -149,9 +153,9 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
           return;
         }
         lastSnapshot = nextSnapshot;
-        snapshotSequence += 1;
+        dashboardSnapshotSequence += 1;
         try {
-          await stream.writeSSE({ id: `dashboard:${snapshotSequence}`, event: 'snapshot', data: nextSnapshot });
+          await stream.writeSSE({ id: `dashboard:${dashboardSnapshotSequence}`, event: 'snapshot', data: nextSnapshot });
         } catch {
           clearAll();
         }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -121,9 +121,11 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
 
     return streamSSE(c, async (stream) => {
       let lastSnapshot = JSON.stringify(await buildSnapshot(deps));
+      let snapshotSequence = 1;
 
       // Send initial snapshot
       await stream.writeSSE({
+        id: `dashboard:${snapshotSequence}`,
         event: 'snapshot',
         data: lastSnapshot,
       });
@@ -147,8 +149,9 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
           return;
         }
         lastSnapshot = nextSnapshot;
+        snapshotSequence += 1;
         try {
-          await stream.writeSSE({ event: 'snapshot', data: nextSnapshot });
+          await stream.writeSSE({ id: `dashboard:${snapshotSequence}`, event: 'snapshot', data: nextSnapshot });
         } catch {
           clearAll();
         }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'node:crypto';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -82,8 +82,9 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   const ticketStore = deps.ticketStore;
   const operatorToken = deps.operatorToken;
 
-  // Event ids are scoped to this route instance instead of each connection so
-  // reconnecting EventSource clients never drop fresh snapshots as stale replay.
+  // Event ids are scoped to this route instance instead of each connection and
+  // include an epoch so a restarted dashboard route never reuses old ids.
+  const dashboardSnapshotEpoch = randomUUID();
   let dashboardSnapshotSequence = 0;
 
   // GET /api/dashboard — aggregated snapshot of all dashboard state
@@ -129,7 +130,7 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
       // Send initial snapshot
       dashboardSnapshotSequence += 1;
       await stream.writeSSE({
-        id: `dashboard:${dashboardSnapshotSequence}`,
+        id: `dashboard:${dashboardSnapshotEpoch}:${dashboardSnapshotSequence}`,
         event: 'snapshot',
         data: lastSnapshot,
       });
@@ -155,7 +156,7 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
         lastSnapshot = nextSnapshot;
         dashboardSnapshotSequence += 1;
         try {
-          await stream.writeSSE({ id: `dashboard:${dashboardSnapshotSequence}`, event: 'snapshot', data: nextSnapshot });
+          await stream.writeSSE({ id: `dashboard:${dashboardSnapshotEpoch}:${dashboardSnapshotSequence}`, event: 'snapshot', data: nextSnapshot });
         } catch {
           clearAll();
         }

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { WebSocketServer, type RawData, type WebSocket } from 'ws';
@@ -165,6 +166,7 @@ function createPeerState(
 
 export class ChatSocketController {
   readonly connections = new Map<ChatSocketPeer, ConnectionState>();
+  private readonly eventEpoch = randomUUID();
   private readonly eventSequences = new Map<string, number>();
   private readonly activeSessionTurns = new Set<string>();
   private readonly allowedOrigins: string[];
@@ -678,7 +680,7 @@ export class ChatSocketController {
     const nextSequence = (this.eventSequences.get(connection.sessionId) ?? 0) + 1;
     this.eventSequences.set(connection.sessionId, nextSequence);
     peer.send(JSON.stringify({
-      eventId: `${connection.sessionId}:${nextSequence}`,
+      eventId: `${connection.sessionId}:${this.eventEpoch}:${nextSequence}`,
       ...event,
     }));
   }

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -23,7 +23,6 @@ interface ConnectionState {
   sessionId: string;
   remoteAddress?: string | undefined;
   rateLimitKey: string;
-  eventSequence: number;
 }
 
 export interface ChatSocketMessageRateLimitOptions {
@@ -159,13 +158,14 @@ function createPeerState(
   rateLimitKey: string,
   controller: ChatSocketController,
 ): ConnectionState {
-  const state = { sessionId, remoteAddress, rateLimitKey, eventSequence: 0 };
+  const state = { sessionId, remoteAddress, rateLimitKey };
   controller.connections.set(peer, state);
   return state;
 }
 
 export class ChatSocketController {
   readonly connections = new Map<ChatSocketPeer, ConnectionState>();
+  private readonly eventSequences = new Map<string, number>();
   private readonly activeSessionTurns = new Set<string>();
   private readonly allowedOrigins: string[];
   private readonly messageRateLimiter: ChatSocketMessageRateLimiter;
@@ -675,9 +675,10 @@ export class ChatSocketController {
       return;
     }
 
-    connection.eventSequence += 1;
+    const nextSequence = (this.eventSequences.get(connection.sessionId) ?? 0) + 1;
+    this.eventSequences.set(connection.sessionId, nextSequence);
     peer.send(JSON.stringify({
-      eventId: `${connection.sessionId}:${connection.eventSequence}`,
+      eventId: `${connection.sessionId}:${nextSequence}`,
       ...event,
     }));
   }

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -23,6 +23,7 @@ interface ConnectionState {
   sessionId: string;
   remoteAddress?: string | undefined;
   rateLimitKey: string;
+  eventSequence: number;
 }
 
 export interface ChatSocketMessageRateLimitOptions {
@@ -158,7 +159,7 @@ function createPeerState(
   rateLimitKey: string,
   controller: ChatSocketController,
 ): ConnectionState {
-  const state = { sessionId, remoteAddress, rateLimitKey };
+  const state = { sessionId, remoteAddress, rateLimitKey, eventSequence: 0 };
   controller.connections.set(peer, state);
   return state;
 }
@@ -668,7 +669,17 @@ export class ChatSocketController {
   }
 
   private emit(peer: ChatSocketPeer, event: ServerSocketEvent): void {
-    peer.send(JSON.stringify(event));
+    const connection = this.connections.get(peer);
+    if (!connection || event.eventId) {
+      peer.send(JSON.stringify(event));
+      return;
+    }
+
+    connection.eventSequence += 1;
+    peer.send(JSON.stringify({
+      eventId: `${connection.sessionId}:${connection.eventSequence}`,
+      ...event,
+    }));
   }
 }
 

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -360,6 +360,16 @@ describe('ws chat server', () => {
     expect(events[0]).toMatchObject({ eventId: `${session.id}:1`, type: 'session.ready' });
     expect(events[1]).toMatchObject({ eventId: `${session.id}:2`, type: 'pong' });
 
+    const reconnectToken = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const { peer: reconnectPeer, sent: reconnectSent } = createPeer();
+    expect(controller.connect(reconnectPeer, {
+      origin: null,
+      sessionId: session.id,
+      token: reconnectToken,
+    }).ok).toBe(true);
+    const reconnectEvents = reconnectSent.map((raw) => JSON.parse(raw) as { eventId?: string; type: string });
+    expect(reconnectEvents[0]).toMatchObject({ eventId: `${session.id}:3`, type: 'session.ready' });
+
     rmSync(TMP, { recursive: true, force: true });
   });
 

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -335,7 +335,7 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
-  it('stamps outgoing websocket events with monotonic per-connection event ids', async () => {
+  it('stamps outgoing websocket events with a controller epoch and monotonic ids', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);
     const session = store.create('proj');
@@ -357,8 +357,12 @@ describe('ws chat server', () => {
     await controller.receive(peer, JSON.stringify({ type: 'ping' }));
 
     const events = sent.map((raw) => JSON.parse(raw) as { eventId?: string; type: string });
-    expect(events[0]).toMatchObject({ eventId: `${session.id}:1`, type: 'session.ready' });
-    expect(events[1]).toMatchObject({ eventId: `${session.id}:2`, type: 'pong' });
+    const [sessionId, controllerEpoch, firstSequence] = events[0]!.eventId!.split(':');
+    expect(sessionId).toBe(session.id);
+    expect(controllerEpoch).toMatch(/^[0-9a-f-]{36}$/);
+    expect(firstSequence).toBe('1');
+    expect(events[0]).toMatchObject({ type: 'session.ready' });
+    expect(events[1]).toMatchObject({ eventId: `${session.id}:${controllerEpoch}:2`, type: 'pong' });
 
     const reconnectToken = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const { peer: reconnectPeer, sent: reconnectSent } = createPeer();
@@ -368,7 +372,26 @@ describe('ws chat server', () => {
       token: reconnectToken,
     }).ok).toBe(true);
     const reconnectEvents = reconnectSent.map((raw) => JSON.parse(raw) as { eventId?: string; type: string });
-    expect(reconnectEvents[0]).toMatchObject({ eventId: `${session.id}:3`, type: 'session.ready' });
+    expect(reconnectEvents[0]).toMatchObject({ eventId: `${session.id}:${controllerEpoch}:3`, type: 'session.ready' });
+
+    const restartedController = new ChatSocketController({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const restartToken = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const { peer: restartPeer, sent: restartSent } = createPeer();
+    expect(restartedController.connect(restartPeer, {
+      origin: null,
+      sessionId: session.id,
+      token: restartToken,
+    }).ok).toBe(true);
+    const restartedReady = JSON.parse(restartSent[0]!) as { eventId?: string; type: string };
+    const [, restartedEpoch, restartedSequence] = restartedReady.eventId!.split(':');
+    expect(restartedReady.type).toBe('session.ready');
+    expect(restartedEpoch).toMatch(/^[0-9a-f-]{36}$/);
+    expect(restartedEpoch).not.toBe(controllerEpoch);
+    expect(restartedSequence).toBe('1');
 
     rmSync(TMP, { recursive: true, force: true });
   });

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -335,6 +335,34 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('stamps outgoing websocket events with monotonic per-connection event ids', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const controller = new ChatSocketController({
+      runtime: createTestRuntime(),
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({ type: 'ping' }));
+
+    const events = sent.map((raw) => JSON.parse(raw) as { eventId?: string; type: string });
+    expect(events[0]).toMatchObject({ eventId: `${session.id}:1`, type: 'session.ready' });
+    expect(events[1]).toMatchObject({ eventId: `${session.id}:2`, type: 'pong' });
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('emits typing, delta, and complete events for a reply turn', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -342,7 +342,8 @@ describe('dashboard routes', () => {
       }
       reader.cancel();
 
-      // SSE format: event: snapshot\ndata: ...\n\n
+      // SSE format: id: ...\nevent: snapshot\ndata: ...\n\n
+      expect(text).toContain('id: dashboard:1');
       expect(text).toContain('event: snapshot');
 
       // Extract the data line for the snapshot event

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -358,6 +358,30 @@ describe('dashboard routes', () => {
       expect(data.providers).toHaveLength(1);
     });
 
+    it('keeps snapshot ids monotonic across dashboard SSE reconnects', async () => {
+      const deps = createMockDeps();
+      const app = createDashboardRoutes(deps);
+      const readInitialStreamText = async (ticket: string) => {
+        const res = await app.request(`/events?ticket=${ticket}`);
+        const reader = res.body!.getReader();
+        const decoder = new TextDecoder();
+        let text = '';
+        for (let i = 0; i < 10; i++) {
+          const { value, done } = await reader.read();
+          if (value) text += decoder.decode(value, { stream: true });
+          if (done || text.includes('event: snapshot')) break;
+        }
+        await reader.cancel();
+        return text;
+      };
+
+      const firstText = await readInitialStreamText(await issueDashboardTicket(app));
+      const secondText = await readInitialStreamText(await issueDashboardTicket(app));
+
+      expect(firstText).toContain('id: dashboard:1');
+      expect(secondText).toContain('id: dashboard:2');
+    });
+
     it('streams a fresh snapshot when dashboard state changes after connect', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -343,7 +343,7 @@ describe('dashboard routes', () => {
       reader.cancel();
 
       // SSE format: id: ...\nevent: snapshot\ndata: ...\n\n
-      expect(text).toContain('id: dashboard:1');
+      expect(text).toMatch(/id: dashboard:[0-9a-f-]{36}:1/);
       expect(text).toContain('event: snapshot');
 
       // Extract the data line for the snapshot event
@@ -361,8 +361,11 @@ describe('dashboard routes', () => {
     it('keeps snapshot ids monotonic across dashboard SSE reconnects', async () => {
       const deps = createMockDeps();
       const app = createDashboardRoutes(deps);
-      const readInitialStreamText = async (ticket: string) => {
-        const res = await app.request(`/events?ticket=${ticket}`);
+      const readInitialStreamText = async (
+        ticket: string,
+        targetApp: ReturnType<typeof createDashboardRoutes> = app,
+      ) => {
+        const res = await targetApp.request(`/events?ticket=${ticket}`);
         const reader = res.body!.getReader();
         const decoder = new TextDecoder();
         let text = '';
@@ -378,8 +381,18 @@ describe('dashboard routes', () => {
       const firstText = await readInitialStreamText(await issueDashboardTicket(app));
       const secondText = await readInitialStreamText(await issueDashboardTicket(app));
 
-      expect(firstText).toContain('id: dashboard:1');
-      expect(secondText).toContain('id: dashboard:2');
+      const firstId = firstText.match(/^id: (dashboard:[0-9a-f-]{36}:1)$/m)?.[1];
+      const secondId = secondText.match(/^id: (dashboard:[0-9a-f-]{36}:2)$/m)?.[1];
+      expect(firstId).toBeDefined();
+      expect(secondId).toBeDefined();
+      const firstEpoch = firstId!.split(':')[1];
+      expect(secondId).toBe(`dashboard:${firstEpoch}:2`);
+
+      const restartedApp = createDashboardRoutes(createMockDeps());
+      const restartedText = await readInitialStreamText(await issueDashboardTicket(restartedApp), restartedApp);
+      const restartedId = restartedText.match(/^id: (dashboard:[0-9a-f-]{36}:1)$/m)?.[1];
+      expect(restartedId).toBeDefined();
+      expect(restartedId!.split(':')[1]).not.toBe(firstEpoch);
     });
 
     it('streams a fresh snapshot when dashboard state changes after connect', async () => {

--- a/packages/franken-types/src/comms.ts
+++ b/packages/franken-types/src/comms.ts
@@ -22,8 +22,13 @@ export const ClientSocketEventSchema = z.discriminatedUnion('type', [
 
 export type ClientSocketEvent = z.infer<typeof ClientSocketEventSchema>;
 
+const serverEventShape = <T extends z.ZodRawShape>(shape: T) => z.object({
+  eventId: z.string().min(1).optional(),
+  ...shape,
+}).strict();
+
 export const ServerSocketEventSchema = z.discriminatedUnion('type', [
-  z.object({
+  serverEventShape({
     type: z.literal('session.ready'),
     sessionId: z.string().min(1),
     projectId: z.string().min(1),
@@ -44,57 +49,57 @@ export const ServerSocketEventSchema = z.discriminatedUnion('type', [
       affectedFiles: z.array(z.string()).optional(),
       sessionId: z.string().optional(),
     }).nullable().optional(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('message.accepted'),
     clientMessageId: z.string().min(1),
     sessionId: z.string().min(1),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('message.delivered'),
     clientMessageId: z.string().min(1),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('message.read'),
     clientMessageId: z.string().min(1).optional(),
     messageId: z.string().min(1).optional(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('assistant.typing.start'),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('assistant.message.delta'),
     messageId: z.string().min(1),
     chunk: z.string(),
     modelTier: z.string().optional(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('assistant.message.complete'),
     messageId: z.string().min(1),
     content: z.string(),
     modelTier: z.string().optional(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.execution.start'),
     data: z.record(z.string(), z.unknown()).optional(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.execution.progress'),
     data: z.record(z.string(), z.unknown()).optional(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.execution.complete'),
     data: z.record(z.string(), z.unknown()).optional(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.approval.requested'),
     description: z.string().min(1),
     timestamp: z.string(),
@@ -103,22 +108,22 @@ export const ServerSocketEventSchema = z.discriminatedUnion('type', [
     risk: z.string().optional(),
     affectedFiles: z.array(z.string()).optional(),
     sessionId: z.string().optional(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.approval.resolved'),
     approved: z.boolean(),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('turn.error'),
     code: z.string().min(1),
     message: z.string().min(1),
     timestamp: z.string(),
-  }).strict(),
-  z.object({
+  }),
+  serverEventShape({
     type: z.literal('pong'),
     timestamp: z.string(),
-  }).strict(),
+  }),
 ]);
 
 export type ServerSocketEvent = z.infer<typeof ServerSocketEventSchema>;

--- a/packages/franken-web/src/hooks/chat-session-state.ts
+++ b/packages/franken-web/src/hooks/chat-session-state.ts
@@ -26,6 +26,40 @@ export interface PendingSend {
   reject: (error: Error) => void;
 }
 
+function parseReplayCursor(eventId: string): { stream: string; sequence: number } | null {
+  const match = /^(.*?)(?:[#:/-])(\d+)$/.exec(eventId);
+  if (!match) return null;
+  const sequence = Number(match[2]);
+  if (!Number.isSafeInteger(sequence)) return null;
+  return { stream: match[1] || 'default', sequence };
+}
+
+export function shouldApplySocketEvent(
+  payload: { eventId?: string },
+  processedEventIds: Set<string>,
+  replayCursors: Map<string, number>,
+): boolean {
+  if (!payload.eventId) return true;
+  if (processedEventIds.has(payload.eventId)) return false;
+
+  const cursor = parseReplayCursor(payload.eventId);
+  if (cursor) {
+    const previous = replayCursors.get(cursor.stream);
+    if (previous !== undefined && cursor.sequence <= previous) {
+      processedEventIds.add(payload.eventId);
+      return false;
+    }
+    replayCursors.set(cursor.stream, cursor.sequence);
+  }
+
+  processedEventIds.add(payload.eventId);
+  if (processedEventIds.size > 1_000) {
+    const oldest = processedEventIds.values().next().value;
+    if (oldest) processedEventIds.delete(oldest);
+  }
+  return true;
+}
+
 export class NonRetryableSendError extends Error {
   readonly retryableSend = false;
 }

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -25,6 +25,7 @@ import {
   preserveLocalRecoveryMessages,
   sessionHasCostTelemetry,
   sessionHasTokenTelemetry,
+  shouldApplySocketEvent,
   updateReceipt,
   type PendingSend,
 } from './chat-session-state';
@@ -136,41 +137,6 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const approvalResolvingRef = useRef(false);
   const processedSocketEventIdsRef = useRef<Set<string>>(new Set());
   const replayCursorsRef = useRef<Map<string, number>>(new Map());
-
-  function parseReplayCursor(eventId: string): { stream: string; sequence: number } | null {
-    const match = /^(.*?)(?:[#:/-])(\d+)$/.exec(eventId);
-    if (!match) return null;
-    const sequence = Number(match[2]);
-    if (!Number.isSafeInteger(sequence)) return null;
-    return { stream: match[1] || 'default', sequence };
-  }
-
-  function rememberSocketEventId(eventId: string): boolean {
-    if (processedSocketEventIdsRef.current.has(eventId)) {
-      return false;
-    }
-
-    const cursor = parseReplayCursor(eventId);
-    if (cursor) {
-      const previous = replayCursorsRef.current.get(cursor.stream);
-      if (previous !== undefined && cursor.sequence <= previous) {
-        processedSocketEventIdsRef.current.add(eventId);
-        return false;
-      }
-      replayCursorsRef.current.set(cursor.stream, cursor.sequence);
-    }
-
-    processedSocketEventIdsRef.current.add(eventId);
-    if (processedSocketEventIdsRef.current.size > 1_000) {
-      const oldest = processedSocketEventIdsRef.current.values().next().value;
-      if (oldest) processedSocketEventIdsRef.current.delete(oldest);
-    }
-    return true;
-  }
-
-  function shouldApplySocketEvent(payload: { eventId?: string }): boolean {
-    return !payload.eventId || rememberSocketEventId(payload.eventId);
-  }
 
   function addErrorBanner(banner: ChatErrorBanner) {
     errorActionRef.current.set(banner.id, banner.action);
@@ -454,7 +420,11 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       }
 
       const payload = parsed.data;
-      if (!shouldApplySocketEvent(payload)) {
+      if (!shouldApplySocketEvent(
+        payload,
+        processedSocketEventIdsRef.current,
+        replayCursorsRef.current,
+      )) {
         return;
       }
 

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -134,6 +134,43 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const lastMessageRef = useRef<{ clientMessageId: string; content: string } | null>(null);
   const errorActionRef = useRef(new Map<string, ChatErrorAction>());
   const approvalResolvingRef = useRef(false);
+  const processedSocketEventIdsRef = useRef<Set<string>>(new Set());
+  const replayCursorsRef = useRef<Map<string, number>>(new Map());
+
+  function parseReplayCursor(eventId: string): { stream: string; sequence: number } | null {
+    const match = /^(.*?)(?:[#:/-])(\d+)$/.exec(eventId);
+    if (!match) return null;
+    const sequence = Number(match[2]);
+    if (!Number.isSafeInteger(sequence)) return null;
+    return { stream: match[1] || 'default', sequence };
+  }
+
+  function rememberSocketEventId(eventId: string): boolean {
+    if (processedSocketEventIdsRef.current.has(eventId)) {
+      return false;
+    }
+
+    const cursor = parseReplayCursor(eventId);
+    if (cursor) {
+      const previous = replayCursorsRef.current.get(cursor.stream);
+      if (previous !== undefined && cursor.sequence <= previous) {
+        processedSocketEventIdsRef.current.add(eventId);
+        return false;
+      }
+      replayCursorsRef.current.set(cursor.stream, cursor.sequence);
+    }
+
+    processedSocketEventIdsRef.current.add(eventId);
+    if (processedSocketEventIdsRef.current.size > 1_000) {
+      const oldest = processedSocketEventIdsRef.current.values().next().value;
+      if (oldest) processedSocketEventIdsRef.current.delete(oldest);
+    }
+    return true;
+  }
+
+  function shouldApplySocketEvent(payload: { eventId?: string }): boolean {
+    return !payload.eventId || rememberSocketEventId(payload.eventId);
+  }
 
   function addErrorBanner(banner: ChatErrorBanner) {
     errorActionRef.current.set(banner.id, banner.action);
@@ -267,6 +304,8 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setTokenTelemetryStatus('unavailable');
     setErrorBanners([]);
     errorActionRef.current.clear();
+    processedSocketEventIdsRef.current.clear();
+    replayCursorsRef.current.clear();
     setStatus('connecting');
     setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'connecting');
 
@@ -415,6 +454,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       }
 
       const payload = parsed.data;
+      if (!shouldApplySocketEvent(payload)) {
+        return;
+      }
 
       switch (payload.type) {
         case 'session.ready':

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -341,6 +341,58 @@ describe('DashboardApiClient', () => {
       }
     });
 
+    it('deduplicates replayed EventSource snapshots and resumes from the last event id', async () => {
+      vi.useFakeTimers();
+      const closeFns = [vi.fn(), vi.fn()];
+      const listeners: Array<Record<string, (event: { data?: string; lastEventId?: string }) => void>> = [];
+
+      const MockEventSource = vi.fn(function (this: {
+        addEventListener?: (type: string, handler: (event: { data?: string; lastEventId?: string }) => void) => void;
+        close?: () => void;
+      }) {
+        const index = listeners.length;
+        listeners[index] = {};
+        this.addEventListener = vi.fn((type: string, handler: (event: { data?: string; lastEventId?: string }) => void) => {
+          listeners[index]![type] = handler;
+        });
+        this.close = closeFns[index];
+      });
+
+      const originalEventSource = globalThis.EventSource;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).EventSource = MockEventSource;
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-1' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ ticket: 'ticket-2' }) });
+
+      try {
+        const client = new DashboardApiClient(BASE_URL);
+        const onSnapshot = vi.fn();
+        const unsub = await client.subscribeToDashboard(onSnapshot);
+        const snapshot = makeMockSnapshot();
+
+        listeners[0]!.snapshot!({ data: JSON.stringify(snapshot), lastEventId: 'dash:1' });
+        listeners[0]!.snapshot!({ data: JSON.stringify({ ...snapshot, providers: [] }), lastEventId: 'dash:1' });
+        expect(onSnapshot).toHaveBeenCalledTimes(1);
+
+        listeners[0]!.error!({});
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(MockEventSource).toHaveBeenNthCalledWith(2, `${BASE_URL}/api/dashboard/events?ticket=ticket-2&lastEventId=dash%3A1`);
+
+        unsub();
+        expect(closeFns[1]).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        if (originalEventSource) {
+          globalThis.EventSource = originalEventSource;
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (globalThis as any).EventSource;
+        }
+      }
+    });
+
     it('mints a fresh one-shot ticket after EventSource errors', async () => {
       vi.useFakeTimers();
       const closeFns = [vi.fn(), vi.fn()];

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -92,6 +92,21 @@ export class DashboardApiClient {
     let eventSource: EventSource | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let closed = false;
+    let lastEventId: string | undefined;
+    const seenEventIds = new Set<string>();
+
+    const rememberEventId = (eventId: string): boolean => {
+      if (seenEventIds.has(eventId)) {
+        return false;
+      }
+      seenEventIds.add(eventId);
+      lastEventId = eventId;
+      if (seenEventIds.size > 1_000) {
+        const oldest = seenEventIds.values().next().value;
+        if (oldest) seenEventIds.delete(oldest);
+      }
+      return true;
+    };
 
     const closeActiveSource = () => {
       eventSource?.close();
@@ -122,8 +137,12 @@ export class DashboardApiClient {
       // EventSource may be mocked as a plain function in tests; prefer browser
       // constructor semantics, then fall back to callable test doubles.
       const EventSourceCtor: any = (globalThis as any).EventSource;
-      const url = ticket
-        ? `${this.baseUrl}/api/dashboard/events?${new URLSearchParams({ ticket }).toString()}`
+      const params = new URLSearchParams();
+      if (ticket) params.set('ticket', ticket);
+      if (lastEventId) params.set('lastEventId', lastEventId);
+      const query = params.toString();
+      const url = query
+        ? `${this.baseUrl}/api/dashboard/events?${query}`
         : `${this.baseUrl}/api/dashboard/events`;
       let nextEventSource: EventSource;
       try {
@@ -133,6 +152,13 @@ export class DashboardApiClient {
       }
       eventSource = nextEventSource;
       nextEventSource.addEventListener('snapshot', (event: any) => {
+        const eventId = typeof event.lastEventId === 'string' && event.lastEventId.length > 0
+          ? event.lastEventId
+          : undefined;
+        if (eventId && !rememberEventId(eventId)) {
+          return;
+        }
+
         let snapshot: DashboardSnapshot;
         try {
           snapshot = JSON.parse(event.data) as DashboardSnapshot;

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1451,6 +1451,53 @@ describe('useChatSession', () => {
     expect(result.current.connectionStatus).toBe('connecting');
   });
 
+  it('deduplicates replayed websocket events by event id and monotonic cursor', async () => {
+    const { result } = renderHook(() => useChatSession(opts));
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe('chat-1');
+    });
+
+    const socket = MockWebSocket.instances[0]!;
+    act(() => {
+      socket.open();
+      socket.message({
+        eventId: 'chat-1:1',
+        type: 'assistant.message.complete',
+        messageId: 'assistant-1',
+        content: 'First delivered answer',
+        timestamp: '2026-03-09T00:00:01Z',
+      });
+      socket.message({
+        eventId: 'chat-1:1',
+        type: 'assistant.message.complete',
+        messageId: 'assistant-duplicate',
+        content: 'Duplicate replay should not render',
+        timestamp: '2026-03-09T00:00:02Z',
+      });
+      socket.message({
+        eventId: 'chat-1:0',
+        type: 'assistant.message.complete',
+        messageId: 'assistant-stale',
+        content: 'Stale replay should not render',
+        timestamp: '2026-03-09T00:00:03Z',
+      });
+      socket.message({
+        eventId: 'chat-1:2',
+        type: 'assistant.message.complete',
+        messageId: 'assistant-2',
+        content: 'Second delivered answer',
+        timestamp: '2026-03-09T00:00:04Z',
+      });
+    });
+
+    expect(result.current.messages.map((message) => message.content)).toEqual([
+      'First delivered answer',
+      'Second delivered answer',
+    ]);
+    expect(result.current.errorBanners).toHaveLength(0);
+  });
+
   it('reconnects after the socket closes and falls back to HTTP send while reconnecting', async () => {
     const { result } = renderHook(() => useChatSession(opts));
 

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1489,11 +1489,19 @@ describe('useChatSession', () => {
         content: 'Second delivered answer',
         timestamp: '2026-03-09T00:00:04Z',
       });
+      socket.message({
+        eventId: 'chat-1:server-restart-epoch:1',
+        type: 'assistant.message.complete',
+        messageId: 'assistant-after-restart',
+        content: 'Restarted server answer',
+        timestamp: '2026-03-09T00:00:05Z',
+      });
     });
 
     expect(result.current.messages.map((message) => message.content)).toEqual([
       'First delivered answer',
       'Second delivered answer',
+      'Restarted server answer',
     ]);
     expect(result.current.errorBanners).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Add server-side event identifiers for chat WebSocket and dashboard SSE snapshot streams
- Add client-side replay/idempotency handling for chat socket and dashboard EventSource reconnects
- Add targeted web/orchestrator regression tests and document replay expectations

## Test Plan
- npm --workspace @franken/web test -- --run tests/hooks/use-chat-session.test.ts src/lib/dashboard-api.test.ts
- npm --workspace @franken/orchestrator test -- tests/integration/chat/ws-chat-server.test.ts tests/unit/http/dashboard-routes.test.ts
- npm --workspace @franken/types run build
- npm --workspace @franken/web run typecheck
- npm run build --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor --workspace @franken/planner
- npm --workspace @franken/orchestrator run typecheck
- npm --workspace @franken/web run lint
- npm --workspace @franken/orchestrator run lint

Closes #1714