### PR TITLE
fix(mcp): harden observer cost validation typing

### DIFF
--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.test.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { parseObserverCostArgs, validateObserverCostNumbers } from './observer-cost-validation.js';
+
+describe('observer cost validation', () => {
+  it('parses valid zero and positive token/cost inputs', () => {
+    expect(parseObserverCostArgs({
+      sessionId: 'sess-1',
+      model: 'gpt-4o',
+      promptTokens: 0,
+      completionTokens: '25',
+      costUsd: '0.001',
+    })).toEqual({
+      ok: true,
+      value: {
+        sessionId: 'sess-1',
+        model: 'gpt-4o',
+        promptTokens: 0,
+        completionTokens: 25,
+        costUsd: 0.001,
+      },
+    });
+  });
+
+  it('rejects invalid token and cost inputs before adapter persistence', () => {
+    const cases = [
+      { field: 'promptTokens', args: { promptTokens: 'NaN', completionTokens: 0 } },
+      { field: 'promptTokens', args: { promptTokens: 'Infinity', completionTokens: 0 } },
+      { field: 'promptTokens', args: { promptTokens: -1, completionTokens: 0 } },
+      { field: 'promptTokens', args: { promptTokens: 1.5, completionTokens: 0 } },
+      { field: 'promptTokens', args: { promptTokens: Number.MAX_SAFE_INTEGER + 1, completionTokens: 0 } },
+      { field: 'completionTokens', args: { promptTokens: 0, completionTokens: 'NaN' } },
+      { field: 'completionTokens', args: { promptTokens: 0, completionTokens: 'Infinity' } },
+      { field: 'completionTokens', args: { promptTokens: 0, completionTokens: -1 } },
+      { field: 'completionTokens', args: { promptTokens: 0, completionTokens: 1.5 } },
+      { field: 'completionTokens', args: { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 } },
+      { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: 'NaN' } },
+      { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: 'Infinity' } },
+      { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: -0.01 } },
+    ];
+
+    for (const { field, args } of cases) {
+      const result = parseObserverCostArgs({
+        sessionId: 'sess-1',
+        model: 'gpt-4o',
+        ...args,
+      });
+
+      if (result.ok) {
+        throw new Error(`Expected ${field} case to be rejected`);
+      }
+      expect(result).toMatchObject({ ok: false, message: expect.stringContaining(field) });
+    }
+  });
+
+  it('defends ObserverAdapter.logCost callers with runtime validation too', () => {
+    expect(() => validateObserverCostNumbers({
+      promptTokens: Number.NaN,
+      completionTokens: 0,
+    })).toThrow('promptTokens must be a finite safe non-negative integer');
+
+    expect(() => validateObserverCostNumbers({
+      promptTokens: 0,
+      completionTokens: Number.POSITIVE_INFINITY,
+    })).toThrow('completionTokens must be a finite safe non-negative integer');
+
+    expect(() => validateObserverCostNumbers({
+      promptTokens: 0,
+      completionTokens: 0,
+      costUsd: -0.01,
+    })).toThrow('costUsd must be a finite non-negative number');
+  });
+});

--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
@@ -59,15 +59,15 @@ export function validateObserverCostNumbers(input: ObserverCostNumbers): void {
 export function parseObserverCostArgs(args: Record<string, unknown>): ParseResult<ParsedObserverCostArgs> {
   const promptTokensArg = parseNonNegativeIntegerArg('promptTokens', args['promptTokens']);
   if (!promptTokensArg.ok) {
-    return promptTokensArg;
+    return { ok: false, message: 'promptTokens must be a finite safe non-negative integer' };
   }
   const completionTokensArg = parseNonNegativeIntegerArg('completionTokens', args['completionTokens']);
   if (!completionTokensArg.ok) {
-    return completionTokensArg;
+    return { ok: false, message: 'completionTokens must be a finite safe non-negative integer' };
   }
   const costUsdArg = parseOptionalNonNegativeNumberArg('costUsd', args['costUsd']);
   if (!costUsdArg.ok) {
-    return costUsdArg;
+    return { ok: false, message: 'costUsd must be a finite non-negative number' };
   }
 
   const parsed = {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -873,7 +873,7 @@ const TOOLS: ToolFull[] = [
       if (!parsedArgs.ok) {
         return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${parsedArgs.message}` }], isError: true };
       }
-      const { sessionId, model, promptTokens, completionTokens } = parsedArgs.value;
+      const { model, promptTokens, completionTokens } = parsedArgs.value;
       const result = await observer.logCost(parsedArgs.value);
       const pricingNote = result.unknownModel ? ' (unknown model — not priced)' : '';
       return { content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}` }] };


### PR DESCRIPTION
## Summary
- Keeps observer cost validation failures typed as `ParsedObserverCostArgs` failures instead of returning narrower helper parse results.
- Adds focused validation regression coverage for valid zero/positive values and invalid `NaN`, `Infinity`, negative, fractional, and unsafe token/cost inputs.
- Removes an unused observer cost handler destructuring while preserving behavior.

## Test Plan
- npm run test --workspace @franken/mcp-suite -- --run src/shared/observer-cost-validation.test.ts src/servers/observer.test.ts src/shared/tool-registry.test.ts src/adapters/observer-adapter.test.ts
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite
- npm run lint --workspace @franken/mcp-suite (passes with existing warnings outside this change)

Closes #2180
