### PR TITLE
fix(orchestrator): validate beast interview options

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
@@ -7,7 +7,7 @@ const promptConfigSchema = z.object({
   files: z.array(z.string()).optional(),
 }).strict();
 
-const martinLoopProviderSchema = z.enum(['claude', 'codex', 'gemini', 'aider']);
+const martinLoopProviderSchema = z.string().min(1);
 
 export const martinLoopDefinition: BeastDefinition = {
   id: 'martin-loop',

--- a/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/martin-loop-definition.ts
@@ -7,6 +7,8 @@ const promptConfigSchema = z.object({
   files: z.array(z.string()).optional(),
 }).strict();
 
+const martinLoopProviderSchema = z.enum(['claude', 'codex', 'gemini', 'aider']);
+
 export const martinLoopDefinition: BeastDefinition = {
   id: 'martin-loop',
   version: 1,
@@ -14,7 +16,7 @@ export const martinLoopDefinition: BeastDefinition = {
   description: 'Create a tracked agent for MartinLoop, validate the chunk directory, then dispatch execution.',
   executionModeDefault: 'process',
   configSchema: z.object({
-    provider: z.string().min(1),
+    provider: martinLoopProviderSchema,
     objective: z.string().min(1),
     chunkDirectory: z.string().min(1),
     projectRoot: z.string().optional(),

--- a/packages/franken-orchestrator/src/beasts/interview-answers.ts
+++ b/packages/franken-orchestrator/src/beasts/interview-answers.ts
@@ -1,0 +1,26 @@
+import type { BeastInterviewPrompt } from './types.js';
+
+export class InvalidBeastInterviewAnswerError extends Error {
+  constructor(
+    public readonly prompt: BeastInterviewPrompt,
+    public readonly answer: string,
+  ) {
+    const allowed = prompt.options?.join(', ') ?? 'none';
+    super(`Invalid answer for '${prompt.key}': expected one of ${allowed}`);
+    this.name = 'InvalidBeastInterviewAnswerError';
+  }
+}
+
+export function coerceInterviewAnswer(prompt: BeastInterviewPrompt, answer: string): unknown {
+  const normalizedOptionAnswer = answer.trim();
+  if (prompt.options && !prompt.options.includes(normalizedOptionAnswer)) {
+    throw new InvalidBeastInterviewAnswerError(prompt, answer);
+  }
+
+  if (prompt.kind === 'boolean') {
+    const normalized = normalizedOptionAnswer.toLowerCase();
+    return normalized === 'true' || normalized === 'yes' || normalized === 'y';
+  }
+
+  return prompt.options ? normalizedOptionAnswer : answer;
+}

--- a/packages/franken-orchestrator/src/beasts/services/beast-interview-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-interview-service.ts
@@ -6,6 +6,7 @@ import type {
 import { isoNow } from '@franken/types';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './beast-catalog-service.js';
+import { coerceInterviewAnswer } from '../interview-answers.js';
 
 export interface BeastInterviewProgress {
   readonly session: BeastInterviewSession;
@@ -83,7 +84,7 @@ export class BeastInterviewService {
 
     const nextAnswers = {
       ...session.answers,
-      [prompt.key]: coerceAnswer(prompt, answer),
+      [prompt.key]: coerceInterviewAnswer(prompt, answer),
     };
     const now = isoNow();
     const nextPrompt = currentPrompt(definition, nextAnswers);
@@ -134,12 +135,4 @@ function currentPrompt(
   answers: Readonly<Record<string, unknown>>,
 ): BeastInterviewPrompt | undefined {
   return definition.interviewPrompts.find((prompt) => answers[prompt.key] === undefined);
-}
-
-function coerceAnswer(prompt: BeastInterviewPrompt, answer: string): unknown {
-  if (prompt.kind === 'boolean') {
-    const normalized = answer.trim().toLowerCase();
-    return normalized === 'true' || normalized === 'yes' || normalized === 'y';
-  }
-  return answer;
 }

--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -71,8 +71,15 @@ export class BeastDaemonDispatchAdapter {
       ? { ...state.beastContext, executionMode: state.executionMode }
       : state.beastContext;
     if (activeContext?.status === 'interviewing' && activeContext.interviewSessionId) {
-      const progress = await this.answerInterview(activeContext.interviewSessionId, input);
-      return this.resultFromProgress(progress, activeContext, state.sessionId);
+      try {
+        const progress = await this.answerInterview(activeContext.interviewSessionId, input);
+        return this.resultFromProgress(progress, activeContext, state.sessionId);
+      } catch (error) {
+        if (error instanceof BeastDaemonRequestError && error.status === 400 && error.code === 'INVALID_INTERVIEW_ANSWER') {
+          return this.invalidAnswerResult(error, activeContext);
+        }
+        throw error;
+      }
     }
 
     if (!this.isLaunchRequest(input)) {
@@ -283,6 +290,38 @@ export class BeastDaemonDispatchAdapter {
     }
 
     return [...aliases];
+  }
+
+  private async invalidAnswerResult(
+    error: BeastDaemonRequestError,
+    context: ChatBeastContext,
+  ): Promise<ChatBeastDispatchResult> {
+    const definitionId = context.definitionId;
+    const definition = (await this.listDefinitions()).find((entry) => entry.id === definitionId);
+    if (!definition) {
+      throw new Error(`Unknown Beast definition: ${definitionId}`);
+    }
+
+    const details = error.details && typeof error.details === 'object'
+      ? error.details as Record<string, unknown>
+      : {};
+    const prompt = typeof details.prompt === 'string' ? details.prompt : String(details.promptKey ?? 'Please choose a valid option.');
+    const options = Array.isArray(details.options)
+      ? details.options.filter((option): option is string => typeof option === 'string')
+      : undefined;
+
+    return {
+      kind: 'interview',
+      definitionId,
+      assistantMessage: this.formatPrompt(definition.label, prompt, options),
+      beastContext: {
+        ...(context.agentId ? { agentId: context.agentId } : {}),
+        definitionId,
+        interviewSessionId: context.interviewSessionId,
+        ...(context.executionMode ? { executionMode: context.executionMode } : {}),
+        status: 'interviewing',
+      },
+    };
   }
 
   private formatPrompt(label: string, prompt: string, options?: readonly string[] | undefined): string {

--- a/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-daemon-dispatch-adapter.ts
@@ -54,8 +54,9 @@ export class BeastDaemonRequestError extends Error {
     public readonly statusText: string,
     public readonly code?: string | undefined,
     public readonly details?: unknown,
+    public readonly daemonMessage?: string | undefined,
   ) {
-    super(code ? `Beast daemon request failed: ${status} ${statusText} (${code})` : `Beast daemon request failed: ${status} ${statusText}`);
+    super(daemonMessage ?? (code ? `Beast daemon request failed: ${status} ${statusText} (${code})` : `Beast daemon request failed: ${status} ${statusText}`));
     this.name = 'BeastDaemonRequestError';
   }
 }
@@ -253,6 +254,7 @@ export class BeastDaemonDispatchAdapter {
         response.statusText,
         envelope?.error?.code,
         envelope?.error?.details,
+        envelope?.error?.message,
       );
     }
     return response.json() as Promise<T>;
@@ -313,7 +315,7 @@ export class BeastDaemonDispatchAdapter {
     return {
       kind: 'interview',
       definitionId,
-      assistantMessage: this.formatPrompt(definition.label, prompt, options),
+      assistantMessage: `${error.message}. ${this.formatPrompt(definition.label, prompt, options)}`,
       beastContext: {
         ...(context.agentId ? { agentId: context.agentId } : {}),
         definitionId,

--- a/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
+++ b/packages/franken-orchestrator/src/chat/beast-dispatch-adapter.ts
@@ -1,6 +1,7 @@
 import type { BeastCatalogService } from '../beasts/services/beast-catalog-service.js';
 import type { BeastDispatchService } from '../beasts/services/beast-dispatch-service.js';
 import type { BeastInterviewService, BeastInterviewProgress } from '../beasts/services/beast-interview-service.js';
+import { InvalidBeastInterviewAnswerError } from '../beasts/interview-answers.js';
 import type { AgentInitService } from '../beasts/services/agent-init-service.js';
 import { MaintenanceModeError } from '../beasts/services/maintenance-mode-service.js';
 import type { BeastExecutionMode } from '../beasts/types.js';
@@ -45,7 +46,15 @@ export class ChatBeastDispatchAdapter {
       ? { ...state.beastContext, executionMode: state.executionMode }
       : state.beastContext;
     if (activeContext?.status === 'interviewing' && activeContext.interviewSessionId) {
-      const progress = this.options.interviews.answer(activeContext.interviewSessionId, input);
+      let progress: BeastInterviewProgress;
+      try {
+        progress = this.options.interviews.answer(activeContext.interviewSessionId, input);
+      } catch (error) {
+        if (error instanceof InvalidBeastInterviewAnswerError) {
+          return this.invalidAnswerResult(error, activeContext);
+        }
+        throw error;
+      }
       return this.resultFromProgress(progress, activeContext, state.sessionId);
     }
 
@@ -188,6 +197,25 @@ export class ChatBeastDispatchAdapter {
       throw new Error(`Unknown Beast definition: ${definitionId}`);
     }
     return definition;
+  }
+
+  private invalidAnswerResult(
+    error: InvalidBeastInterviewAnswerError,
+    context: ChatBeastContext,
+  ): ChatBeastDispatchResult {
+    const definition = this.getDefinitionOrThrow(context.definitionId);
+    return {
+      kind: 'interview',
+      definitionId: context.definitionId,
+      assistantMessage: `${error.message}. ${this.formatPrompt(definition.label, error.prompt.prompt, error.prompt.options)}`,
+      beastContext: {
+        ...(context.agentId ? { agentId: context.agentId } : {}),
+        definitionId: context.definitionId,
+        interviewSessionId: context.interviewSessionId,
+        ...(context.executionMode ? { executionMode: context.executionMode } : {}),
+        status: 'interviewing',
+      },
+    };
   }
 
   private formatPrompt(label: string, prompt: string, options?: readonly string[] | undefined): string {

--- a/packages/franken-orchestrator/src/cli/beast-prompts.ts
+++ b/packages/franken-orchestrator/src/cli/beast-prompts.ts
@@ -1,5 +1,6 @@
 import type { InterviewIO } from '../planning/interview-loop.js';
 import type { BeastDefinition } from '../beasts/types.js';
+import { coerceInterviewAnswer } from '../beasts/interview-answers.js';
 
 export async function collectBeastConfig(
   io: InterviewIO,
@@ -9,9 +10,7 @@ export async function collectBeastConfig(
 
   for (const prompt of definition.interviewPrompts) {
     const answer = await io.ask(prompt.prompt);
-    answers[prompt.key] = prompt.kind === 'boolean'
-      ? ['true', 'yes', 'y'].includes(answer.trim().toLowerCase())
-      : answer;
+    answers[prompt.key] = coerceInterviewAnswer(prompt, answer);
   }
 
   return definition.configSchema.parse(answers);

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
 import { InMemoryRateLimiter, requireBeastRateLimit, type BeastRateLimitOptions } from '../../beasts/http/beast-rate-limit.js';
 import { UnknownBeastDefinitionError, UnknownTrackedAgentError } from '../../beasts/errors.js';
+import { InvalidBeastInterviewAnswerError } from '../../beasts/interview-answers.js';
 import { BeastCatalogService } from '../../beasts/services/beast-catalog-service.js';
 import { BeastDispatchService } from '../../beasts/services/beast-dispatch-service.js';
 import {
@@ -357,6 +358,12 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     } catch (error) {
       if (error instanceof UnknownBeastInterviewSessionError) {
         throw new InterviewSessionNotFoundHttpError(sessionId);
+      }
+      if (error instanceof InvalidBeastInterviewAnswerError) {
+        throw new HttpError(400, 'INVALID_INTERVIEW_ANSWER', error.message, {
+          promptKey: error.prompt.key,
+          options: error.prompt.options,
+        });
       }
       throw error;
     }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -370,6 +370,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       if (error instanceof InvalidBeastInterviewAnswerError) {
         throw new HttpError(400, 'INVALID_INTERVIEW_ANSWER', error.message, {
           promptKey: error.prompt.key,
+          prompt: error.prompt.prompt,
           options: error.prompt.options,
         });
       }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { requireBeastOperatorAuth } from '../../beasts/http/beast-auth.js';
@@ -262,6 +262,14 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
           404,
           'TRACKED_AGENT_NOT_FOUND',
           `Tracked agent '${body.trackedAgentId}' was not found`,
+        );
+      }
+      if (error instanceof ZodError) {
+        throw new HttpError(
+          422,
+          'BEAST_CONFIG_VALIDATION_ERROR',
+          'Beast run config validation failed',
+          error.issues,
         );
       }
       throwCapacityReservationError(error);

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -527,6 +527,37 @@ describe('beast routes', () => {
     expect(answered.data.session.currentPrompt.key).toBe('objective');
   });
 
+  it('returns a structured 400 for invalid option-backed interview answers', async () => {
+    const { app, operatorToken } = createBeastApp();
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+    const startResponse = await app.request('/v1/beasts/interviews/martin-loop/start', {
+      method: 'POST',
+      headers,
+    });
+    const started = await startResponse.json() as { data: { id: string } };
+
+    const response = await app.request(`/v1/beasts/interviews/${started.data.id}/answer`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ answer: 'not-a-provider' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'INVALID_INTERVIEW_ANSWER',
+        message: "Invalid answer for 'provider': expected one of claude, codex, gemini, aider",
+        details: {
+          promptKey: 'provider',
+          options: ['claude', 'codex', 'gemini', 'aider'],
+        },
+      },
+    });
+  });
+
   it('returns a structured 404 when answering an unknown interview session', async () => {
     const { app, operatorToken } = createBeastApp();
 

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -552,6 +552,7 @@ describe('beast routes', () => {
         message: "Invalid answer for 'provider': expected one of claude, codex, gemini, aider",
         details: {
           promptKey: 'provider',
+          prompt: 'Which provider should run the martin loop?',
           options: ['claude', 'codex', 'gemini', 'aider'],
         },
       },
@@ -651,7 +652,7 @@ describe('beast routes', () => {
     expect(runsBody.data.runs).toEqual([]);
   });
 
-  it('returns 422 and does not persist a direct run when config provider is invalid', async () => {
+  it('returns 422 and does not persist a direct run when required config is invalid', async () => {
     const { app, operatorToken } = createBeastApp();
     const headers = {
       authorization: `Bearer ${operatorToken}`,
@@ -664,8 +665,8 @@ describe('beast routes', () => {
       body: JSON.stringify({
         definitionId: 'martin-loop',
         config: {
-          provider: 'not-a-provider',
-          objective: 'Reject invalid direct providers',
+          provider: 'prod-claude',
+          objective: '',
           chunkDirectory: 'docs/chunks',
         },
         startNow: true,
@@ -679,7 +680,7 @@ describe('beast routes', () => {
     expect(body.error.code).toBe('BEAST_CONFIG_VALIDATION_ERROR');
     expect(body.error.message).toBe('Beast run config validation failed');
     expect(body.error.details).toEqual(expect.arrayContaining([
-      expect.objectContaining({ path: ['provider'] }),
+      expect.objectContaining({ path: ['objective'] }),
     ]));
 
     const runsResponse = await app.request('/v1/beasts/runs', {

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -651,6 +651,46 @@ describe('beast routes', () => {
     expect(runsBody.data.runs).toEqual([]);
   });
 
+  it('returns 422 and does not persist a direct run when config provider is invalid', async () => {
+    const { app, operatorToken } = createBeastApp();
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+
+    const createResponse = await app.request('/v1/beasts/runs', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        definitionId: 'martin-loop',
+        config: {
+          provider: 'not-a-provider',
+          objective: 'Reject invalid direct providers',
+          chunkDirectory: 'docs/chunks',
+        },
+        startNow: true,
+      }),
+    });
+
+    expect(createResponse.status).toBe(422);
+    const body = await createResponse.json() as {
+      error: { code: string; message: string; details: Array<{ path: string[]; message: string }> };
+    };
+    expect(body.error.code).toBe('BEAST_CONFIG_VALIDATION_ERROR');
+    expect(body.error.message).toBe('Beast run config validation failed');
+    expect(body.error.details).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: ['provider'] }),
+    ]));
+
+    const runsResponse = await app.request('/v1/beasts/runs', {
+      headers: {
+        authorization: `Bearer ${operatorToken}`,
+      },
+    });
+    const runsBody = await runsResponse.json() as { data: { runs: Array<unknown> } };
+    expect(runsBody.data.runs).toEqual([]);
+  });
+
   it('persists a failed run instead of returning 500 when startNow startup fails', async () => {
     const { app, operatorToken } = createBeastApp({ failStart: true });
     const headers = {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -58,7 +58,7 @@ describe('BeastDispatchService', () => {
     expect(repo.listRuns()).toHaveLength(0);
   });
 
-  it('rejects direct Martin Loop runs with providers outside the advertised prompt options', async () => {
+  it('preserves configured Martin Loop provider aliases for direct runs', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -77,19 +77,20 @@ describe('BeastDispatchService', () => {
     };
     const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
 
-    await expect(dispatch.createRun({
+    const run = await dispatch.createRun({
       definitionId: 'martin-loop',
       config: {
-        provider: 'not-a-provider',
+        provider: 'prod-claude',
         objective: 'Implement the dispatch panel',
         chunkDirectory: 'docs/chunks',
       },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'pfk',
       executionMode: 'process',
-    })).rejects.toThrow();
+    });
+    expect(run.configSnapshot.provider).toBe('prod-claude');
     expect(executors.process.start).not.toHaveBeenCalled();
-    expect(repo.listRuns()).toHaveLength(0);
+    expect(repo.listRuns()).toHaveLength(1);
   });
 
   it('fails closed when a persisted maintenance state file is not an object', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -58,6 +58,40 @@ describe('BeastDispatchService', () => {
     expect(repo.listRuns()).toHaveLength(0);
   });
 
+  it('rejects direct Martin Loop runs with providers outside the advertised prompt options', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logs = new BeastLogStore(join(workDir, 'logs'));
+    const metrics = new PrometheusBeastMetrics();
+    const executors = {
+      process: {
+        start: vi.fn(async () => repo.createAttempt('placeholder', { status: 'running' })),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+      container: {
+        start: vi.fn(),
+        stop: vi.fn(),
+        kill: vi.fn(),
+      },
+    };
+    const dispatch = new BeastDispatchService(repo, new BeastCatalogService(), executors, metrics, logs);
+
+    await expect(dispatch.createRun({
+      definitionId: 'martin-loop',
+      config: {
+        provider: 'not-a-provider',
+        objective: 'Implement the dispatch panel',
+        chunkDirectory: 'docs/chunks',
+      },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      executionMode: 'process',
+    })).rejects.toThrow();
+    expect(executors.process.start).not.toHaveBeenCalled();
+    expect(repo.listRuns()).toHaveLength(0);
+  });
+
   it('fails closed when a persisted maintenance state file is not an object', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beast-dispatch-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/interview-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/interview-service.test.ts
@@ -82,4 +82,30 @@ describe('BeastInterviewService', () => {
       prompt: 'What should the martin loop accomplish?',
     });
   });
+
+  it('accepts valid option-backed Martin Loop provider answers', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-interview-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const service = new BeastInterviewService(repo, new BeastCatalogService());
+    const started = service.start('martin-loop');
+
+    const progressed = service.answer(started.id, 'codex');
+
+    expect(progressed.complete).toBe(false);
+    expect(progressed.session.answers).toEqual({ provider: 'codex' });
+    expect(progressed.currentPrompt).toMatchObject({ key: 'objective' });
+  });
+
+  it('rejects invalid option-backed Martin Loop provider answers before persisting them', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-interview-'));
+    const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const service = new BeastInterviewService(repo, new BeastCatalogService());
+    const started = service.start('martin-loop');
+
+    expect(() => service.answer(started.id, 'not-a-provider')).toThrow(
+      "Invalid answer for 'provider': expected one of claude, codex, gemini, aider",
+    );
+    expect(service.resume(started.id).session.answers).toEqual({});
+  });
+
 });

--- a/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
@@ -221,6 +221,7 @@ describe('BeastDaemonDispatchAdapter', () => {
         status: 'interviewing',
       }),
     });
+    expect(result?.assistantMessage).toContain("Invalid answer for 'provider'");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-daemon-dispatch-adapter.test.ts
@@ -171,6 +171,59 @@ describe('BeastDaemonDispatchAdapter', () => {
     expect(result?.assistantMessage).toContain('beasts maintenance off');
   });
 
+  it('keeps daemon-backed interviews active after invalid option answers', async () => {
+    const context = {
+      agentId: 'agent-1',
+      definitionId: 'martin-loop',
+      interviewSessionId: 'interview-1',
+      status: 'interviewing' as const,
+    };
+    const fetchMock = vi.fn(async (url: URL | RequestInfo) => {
+      const target = url.toString();
+      if (target.endsWith('/v1/beasts/interviews/interview-1/answer')) {
+        return Response.json({
+          error: {
+            code: 'INVALID_INTERVIEW_ANSWER',
+            message: "Invalid answer for 'provider': expected one of claude, codex, gemini, aider",
+            details: {
+              promptKey: 'provider',
+              prompt: 'Which provider should run the martin loop?',
+              options: ['claude', 'codex', 'gemini', 'aider'],
+            },
+          },
+        }, { status: 400, statusText: 'Bad Request' });
+      }
+      if (target.endsWith('/v1/beasts/catalog')) {
+        return Response.json({ data: definitions });
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new BeastDaemonDispatchAdapter({
+      baseUrl: 'http://127.0.0.1:4050',
+      operatorToken: TEST_DAEMON_TOKEN,
+    });
+
+    const result = await adapter.handle('not-a-provider', {
+      projectId: 'project',
+      sessionId: 'session-1',
+      transcript: [],
+      beastContext: context,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'interview',
+      definitionId: 'martin-loop',
+      assistantMessage: expect.stringContaining('Options: claude, codex, gemini, aider'),
+      beastContext: expect.objectContaining({
+        agentId: 'agent-1',
+        interviewSessionId: 'interview-1',
+        status: 'interviewing',
+      }),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('propagates daemon catalog failures for launch requests', async () => {
     const fetchMock = vi.fn(async () => Response.json({ error: 'unauthorized' }, { status: 401, statusText: 'Unauthorized' }));
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/beast-dispatch-adapter.test.ts
@@ -5,6 +5,7 @@ import type { BeastDispatchService } from '../../../src/beasts/services/beast-di
 import type { BeastInterviewService } from '../../../src/beasts/services/beast-interview-service.js';
 import type { AgentInitService } from '../../../src/beasts/services/agent-init-service.js';
 import { MaintenanceModeError } from '../../../src/beasts/services/maintenance-mode-service.js';
+import { InvalidBeastInterviewAnswerError } from '../../../src/beasts/interview-answers.js';
 import type { BeastInterviewPrompt } from '../../../src/beasts/types.js';
 
 const providerPrompt: BeastInterviewPrompt = {
@@ -75,6 +76,48 @@ describe('ChatBeastDispatchAdapter', () => {
       config: {},
     });
     expect(result?.assistantMessage).toContain('Which provider should run the martin loop?');
+  });
+
+  it('keeps chat beast interviews active after invalid option-backed answers', async () => {
+    const answer = vi.fn(() => {
+      throw new InvalidBeastInterviewAnswerError(providerPrompt, 'not-a-provider');
+    });
+    const adapter = new ChatBeastDispatchAdapter({
+      catalog: {
+        listDefinitions: () => [
+          { id: 'martin-loop', label: 'Martin Loop' },
+        ],
+      } as unknown as BeastCatalogService,
+      interviews: { answer } as unknown as BeastInterviewService,
+      dispatch: {} as BeastDispatchService,
+      agentInit: {} as AgentInitService,
+    });
+
+    const result = await adapter.handle('not-a-provider', {
+      projectId: 'proj',
+      sessionId: 'chat-1',
+      transcript: [],
+      beastContext: {
+        agentId: 'agent-1',
+        definitionId: 'martin-loop',
+        interviewSessionId: 'interview-1',
+        status: 'interviewing',
+      },
+    });
+
+    expect(answer).toHaveBeenCalledWith('interview-1', 'not-a-provider');
+    expect(result).toMatchObject({
+      kind: 'interview',
+      definitionId: 'martin-loop',
+      beastContext: {
+        agentId: 'agent-1',
+        definitionId: 'martin-loop',
+        interviewSessionId: 'interview-1',
+        status: 'interviewing',
+      },
+    });
+    expect(result?.assistantMessage).toContain("Invalid answer for 'provider'");
+    expect(result?.assistantMessage).toContain('Options: claude, codex');
   });
 
   it('answers interview prompts and dispatches a Beast run when the interview completes', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/beast-prompts.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-prompts.test.ts
@@ -21,4 +21,17 @@ describe('collectBeastConfig', () => {
       chunkDirectory: 'docs/chunks',
     });
   });
+
+  it('rejects answers outside prompt options before schema parsing', async () => {
+    const io = {
+      ask: vi.fn().mockResolvedValue('not-a-provider'),
+      display: vi.fn(),
+    };
+
+    await expect(collectBeastConfig(io, martinLoopDefinition)).rejects.toThrow(
+      "Invalid answer for 'provider': expected one of claude, codex, gemini, aider",
+    );
+    expect(io.ask).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
## Summary
- add shared Beast interview answer validation for prompt option lists
- reject invalid option-backed answers in HTTP interview and CLI collection paths
- tighten Martin Loop direct-run provider config to the advertised provider enum

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/beasts/interview-service.test.ts tests/unit/cli/beast-prompts.test.ts tests/unit/beasts/beast-dispatch-service.test.ts tests/integration/beasts/beast-routes.test.ts
- npm run build --workspace @franken/types --workspace @franken/planner --workspace @franken/brain --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor && npm run typecheck --workspace @franken/orchestrator && npm run lint --workspace @franken/orchestrator && npm run build --workspace @franken/orchestrator

Closes #2123