### PR TITLE
fix(cli): reject zero port values

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -762,7 +762,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     ? parseFiniteDecimalOption('--budget', values.budget, { minExclusive: 0 })
     : 10;
   const port = values.port !== undefined
-    ? parseIntegerOption('--port', values.port, { min: 0, max: 65535 })
+    ? parseIntegerOption('--port', values.port, { min: 1, max: 65535 })
     : (subcommand === 'chat-server' ? 3737 : subcommand === 'beasts-daemon' ? 4050 : undefined);
 
   const hasModuleFlags = values['no-firewall'] || values['no-skills'] || values['no-memory']

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -615,14 +615,11 @@ describe('parseArgs', () => {
       expect(chatArgs.budget).toBe(12.5);
       expect(chatArgs.port).toBe(4242);
 
-      const ephemeralPortArgs = parseArgs(['chat-server', '--port', '0']);
-      expect(ephemeralPortArgs.port).toBe(0);
-
       const issueArgs = parseArgs(['issues', '--limit', '50']);
       expect(issueArgs.issueLimit).toBe(50);
     });
 
-    it.each(['abc', 'NaN', 'Infinity', '12abc'])('rejects invalid budget value %s', (value) => {
+    it.each(['abc', 'NaN', 'Infinity', '12abc', '0.01usd'])('rejects invalid budget value %s', (value) => {
       expect(() => parseArgs(['--budget', value])).toThrow(/Invalid --budget/);
     });
 
@@ -631,7 +628,7 @@ describe('parseArgs', () => {
       expect(() => parseArgs(['--budget=-0.01'])).toThrow(/Invalid --budget/);
     });
 
-    it.each(['abc', 'NaN', '3737abc', '8080abc', '3.5', '', '65536'])('rejects invalid port value %s', (value) => {
+    it.each(['abc', 'NaN', '3737abc', '8080abc', '3.5', '', '0', '65536'])('rejects invalid port value %s', (value) => {
       expect(() => parseArgs(['chat-server', '--port', value])).toThrow(/Invalid --port/);
     });
 


### PR DESCRIPTION
## Summary
- Tighten CLI `--port` validation to require ports 1-65535.
- Extend numeric option regression coverage for suffixed budgets and zero ports.

## Test Plan
- `npm --prefix packages/franken-orchestrator test -- tests/unit/cli/args.test.ts`
- `npm run build`
- `npm --prefix packages/franken-orchestrator run typecheck`
- `npm --prefix packages/franken-orchestrator run lint` (passes with pre-existing warnings)

Closes #2106
