### PR TITLE
test(web): cover ticketed dashboard SSE auth

### DIFF
--- a/packages/franken-orchestrator/tests/unit/http/dashboard-chat-app-auth.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-chat-app-auth.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import { createChatApp } from '../../../src/http/chat-app.js';
+import type { DashboardRouteDeps } from '../../../src/http/routes/dashboard-routes.js';
+import type { SkillManager } from '../../../src/skills/skill-manager.js';
+import { testCredential } from '../../support/test-credentials.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const TMP = join(__dirname, '__fixtures__/dashboard-chat-app-auth');
+const TEST_OPERATOR_TOKEN = testCredential('TEST_DASHBOARD_CHAT_APP_OPERATOR_TOKEN');
+let ticketStore: SseConnectionTicketStore | undefined;
+
+function createDashboardDeps(): DashboardRouteDeps {
+  return {
+    skillManager: {
+      listInstalled: vi.fn().mockReturnValue([]),
+      getEnabledSkills: vi.fn().mockReturnValue([]),
+    } as unknown as SkillManager,
+    getSecurityConfig: vi.fn().mockReturnValue({
+      profile: 'standard',
+      injectionDetection: true,
+      piiMasking: true,
+      outputValidation: true,
+    }),
+    getProviders: vi.fn().mockReturnValue([]),
+    ticketStore: ticketStore = new SseConnectionTicketStore(),
+  };
+}
+
+function createProtectedDashboardApp() {
+  mkdirSync(TMP, { recursive: true });
+  return createChatApp({
+    sessionStoreDir: join(TMP, 'chat'),
+    llm: { complete: vi.fn().mockResolvedValue('hello') },
+    projectName: 'dashboard-auth-test-project',
+    operatorToken: TEST_OPERATOR_TOKEN,
+    dashboardDeps: createDashboardDeps(),
+  });
+}
+
+describe('dashboard SSE auth through createChatApp', () => {
+  afterEach(() => {
+    ticketStore?.destroy();
+    ticketStore = undefined;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('rejects a bare protected EventSource request and accepts a one-shot ticketed stream', async () => {
+    const app = createProtectedDashboardApp();
+
+    const bareStream = await app.request('/api/dashboard/events');
+    expect(bareStream.status).toBe(401);
+
+    const unauthenticatedTicket = await app.request('/api/dashboard/events/ticket', { method: 'POST' });
+    expect(unauthenticatedTicket.status).toBe(401);
+
+    const ticketResponse = await app.request('/api/dashboard/events/ticket', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TEST_OPERATOR_TOKEN}` },
+    });
+    expect(ticketResponse.status).toBe(200);
+    const { ticket } = await ticketResponse.json() as { ticket?: string };
+    expect(ticket).toBeTruthy();
+
+    const ticketedStream = await app.request(`/api/dashboard/events?ticket=${ticket}`);
+    expect(ticketedStream.status).toBe(200);
+    expect(ticketedStream.headers.get('content-type')).toContain('text/event-stream');
+    await ticketedStream.body?.cancel();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds createChatApp-level regression coverage for secured dashboard SSE subscriptions.
- Verifies bare `/api/dashboard/events` requests fail under operator-token auth while authenticated `/events/ticket` minting plus one-shot ticketed streams succeed.

## Test Plan
- npm test --workspace @franken/orchestrator -- tests/unit/http/dashboard-chat-app-auth.test.ts tests/unit/http/dashboard-routes.test.ts
- npm test --workspace @franken/web -- src/lib/dashboard-api.test.ts
- npm run build --workspace @franken/types
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run build --workspace @franken/planner
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run typecheck --workspace @franken/web
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/web

Closes #2096
