### PR TITLE
test(observer): clean replay temp fixtures

### DIFF
--- a/packages/franken-observer/src/replay/deterministic-replayer.test.ts
+++ b/packages/franken-observer/src/replay/deterministic-replayer.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ReplayContentStore } from './replay-content-store.js';
 import { DeterministicReplayer } from './deterministic-replayer.js';
 import type { ReplayRecord } from './replay-record.js';
+
+const replayTempRoots: string[] = [];
+
+function createReplayTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'replay-'));
+  replayTempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of replayTempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+    expect(existsSync(root)).toBe(false);
+  }
+});
 
 function corruptReplayBlob(baseDir: string, ref: string, replacement: string): void {
   writeFileSync(join(baseDir, 'blobs', ref), replacement, 'utf8');
@@ -12,7 +27,7 @@ function corruptReplayBlob(baseDir: string, ref: string, replacement: string): v
 
 describe('DeterministicReplayer', () => {
   it('replays a saved llm.response without calling a live provider', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put(JSON.stringify({ text: 'cached answer' }));
     const replayer = new DeterministicReplayer(store);
@@ -24,7 +39,7 @@ describe('DeterministicReplayer', () => {
   });
 
   it('throws if a referenced blob fails hash verification', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put('x');
     corruptReplayBlob(root, ref, 'y');
@@ -38,7 +53,7 @@ describe('DeterministicReplayer', () => {
   });
 
   it('replays a saved tool.result by run and ordinal', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const first = store.put(JSON.stringify({ ok: true }));
     const second = store.put(JSON.stringify({ ok: false }));

--- a/packages/franken-observer/src/replay/replay-content-store.test.ts
+++ b/packages/franken-observer/src/replay/replay-content-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -9,9 +9,24 @@ function corruptReplayBlob(baseDir: string, ref: string, replacement: string): v
   writeFileSync(join(baseDir, 'blobs', ref), replacement, 'utf8');
 }
 
+const replayTempRoots: string[] = [];
+
+function createReplayTempRoot(prefix = 'replay-'): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  replayTempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of replayTempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+    expect(existsSync(root)).toBe(false);
+  }
+});
+
 describe('ReplayContentStore', () => {
   it('stores content by sha256 and reads it back without exposing test-only mutators', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put('hello world');
 
@@ -24,7 +39,7 @@ describe('ReplayContentStore', () => {
   });
 
   it('detects tampering on read by checking the content hash', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put('original');
 
@@ -34,7 +49,7 @@ describe('ReplayContentStore', () => {
   });
 
   it('repairs a corrupt existing blob before returning its content ref', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const content = 'original';
     const ref = store.put(content);
@@ -47,7 +62,7 @@ describe('ReplayContentStore', () => {
   });
 
   it('rejects refs that are not exact lowercase sha256 hex before reading', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put('legacy content');
 
@@ -68,7 +83,7 @@ describe('ReplayContentStore', () => {
   });
 
   it('rejects traversal refs before reading parent-directory files', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = store.put('secret');
     writeFileSync(join(root, ref), 'secret', 'utf8');
@@ -88,7 +103,7 @@ describe('ReplayContentStore', () => {
 
     try {
       const { ReplayContentStore: MockedReplayContentStore } = await import('./replay-content-store.js');
-      const root = mkdtempSync(join(tmpdir(), 'replay-'));
+      const root = createReplayTempRoot();
       const store = new MockedReplayContentStore(root);
 
       for (const invalidRef of ['../x', 'not-a-hash', 'a'.repeat(32) + '/' + 'b'.repeat(32)]) {
@@ -102,48 +117,34 @@ describe('ReplayContentStore', () => {
   });
 
   it('rejects a blobs directory symlink that escapes the replay base directory', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
-    const outside = mkdtempSync(join(tmpdir(), 'replay-outside-'));
+    const root = createReplayTempRoot();
+    const outside = createReplayTempRoot('replay-outside-');
     symlinkSync(outside, join(root, 'blobs'), 'dir');
 
-    try {
-      expect(() => new ReplayContentStore(root)).toThrow(/replayBlobsDir resolves outside base directory/i);
-      expect(existsSync(join(outside, hashContent('secret')))).toBe(false);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-      rmSync(outside, { recursive: true, force: true });
-    }
+    expect(() => new ReplayContentStore(root)).toThrow(/replayBlobsDir resolves outside base directory/i);
+    expect(existsSync(join(outside, hashContent('secret')))).toBe(false);
   });
 
   it('rejects dangling blob symlinks before writing content', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
+    const root = createReplayTempRoot();
     const store = new ReplayContentStore(root);
     const ref = hashContent('secret');
     const danglingTarget = join(tmpdir(), `missing-replay-target-${Date.now()}`);
     symlinkSync(danglingTarget, join(root, 'blobs', ref));
 
-    try {
-      expect(() => store.put('secret')).toThrow(/replayBlobPath must not be a symbolic link/i);
-      expect(existsSync(danglingTarget)).toBe(false);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    expect(() => store.put('secret')).toThrow(/replayBlobPath must not be a symbolic link/i);
+    expect(existsSync(danglingTarget)).toBe(false);
   });
 
   it('rejects existing blob symlinks before reading outside content', () => {
-    const root = mkdtempSync(join(tmpdir(), 'replay-'));
-    const outside = mkdtempSync(join(tmpdir(), 'replay-outside-'));
+    const root = createReplayTempRoot();
+    const outside = createReplayTempRoot('replay-outside-');
     const store = new ReplayContentStore(root);
     const ref = hashContent('secret');
     const outsideBlob = join(outside, ref);
     writeFileSync(outsideBlob, 'secret', 'utf8');
     symlinkSync(outsideBlob, join(root, 'blobs', ref));
 
-    try {
-      expect(() => store.get(ref)).toThrow(/replayBlobPath resolves outside base directory/i);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-      rmSync(outside, { recursive: true, force: true });
-    }
+    expect(() => store.get(ref)).toThrow(/replayBlobPath resolves outside base directory/i);
   });
 });


### PR DESCRIPTION
## Summary
- Add shared replay temp-root cleanup helpers to deterministic replayer and replay content store tests.
- Assert each registered replay temp root is removed after every test, including replay-outside symlink fixtures.

## Test Plan
- npm test --workspace @franken/observer -- src/replay/deterministic-replayer.test.ts src/replay/replay-content-store.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run lint --workspace @franken/observer
- npm test --workspace @franken/observer
- npm run build --workspace @franken/observer

Closes #2067