### PR TITLE
test(ci): guard Docker sandbox smoke skip in CI

### DIFF
--- a/scripts/run-docker-sandbox-smoke.mjs
+++ b/scripts/run-docker-sandbox-smoke.mjs
@@ -6,11 +6,18 @@ const dockerVersion = spawnSync('docker', ['version', '--format', '{{.Server.Ver
   stdio: 'pipe',
 });
 
+const ciRequiresDocker = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+
 if (dockerVersion.error || dockerVersion.status !== 0) {
   const reason = dockerVersion.error?.message
     ?? dockerVersion.stderr?.trim()
     ?? `docker version exited with status ${dockerVersion.status}`;
-  console.warn(`Docker sandbox build smoke test skipped: Docker daemon unavailable (${reason}).`);
+  const message = `Docker sandbox build smoke test ${ciRequiresDocker ? 'failed' : 'skipped'}: Docker daemon unavailable (${reason}).`;
+  if (ciRequiresDocker) {
+    console.error(message);
+    process.exit(1);
+  }
+  console.warn(message);
   process.exit(0);
 }
 

--- a/scripts/run-docker-sandbox-smoke.mjs
+++ b/scripts/run-docker-sandbox-smoke.mjs
@@ -6,7 +6,9 @@ const dockerVersion = spawnSync('docker', ['version', '--format', '{{.Server.Ver
   stdio: 'pipe',
 });
 
-const ciRequiresDocker = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+const trueLikeCiValues = new Set(['1', 'true', 'yes', 'on']);
+const ciRequiresDocker = trueLikeCiValues.has((process.env.CI ?? '').trim().toLowerCase())
+  || trueLikeCiValues.has((process.env.GITHUB_ACTIONS ?? '').trim().toLowerCase());
 
 if (dockerVersion.error || dockerVersion.status !== 0) {
   const reason = dockerVersion.error?.message

--- a/tests/vitest-env.test.ts
+++ b/tests/vitest-env.test.ts
@@ -74,8 +74,9 @@ describe('Vitest environment flag helper', () => {
     expect(ci).toContain('npm run test:docker:sandbox');
     expect(smokeScript).toContain('DOCKER_BUILD');
     expect(smokeScript).toContain("${ciRequiresDocker ? 'failed' : 'skipped'}: Docker daemon unavailable");
-    expect(smokeScript).toContain("process.env.CI === 'true'");
-    expect(smokeScript).toContain("process.env.GITHUB_ACTIONS === 'true'");
+    expect(smokeScript).toContain("const trueLikeCiValues = new Set(['1', 'true', 'yes', 'on'])");
+    expect(smokeScript).toContain("process.env.CI ?? ''");
+    expect(smokeScript).toContain("process.env.GITHUB_ACTIONS ?? ''");
     expect(smokeScript).toContain('Docker sandbox build smoke test passed');
   });
 
@@ -98,16 +99,23 @@ describe('Vitest environment flag helper', () => {
         encoding: 'utf-8',
         env: { ...baseEnv, CI: undefined },
       });
-      const ciResult = spawnSync(process.execPath, [script], {
+      const ciTrueResult = spawnSync(process.execPath, [script], {
         cwd: ROOT,
         encoding: 'utf-8',
         env: { ...baseEnv, CI: 'true' },
       });
+      const ciOneResult = spawnSync(process.execPath, [script], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        env: { ...baseEnv, CI: '1' },
+      });
 
       expect(localResult.status).toBe(0);
       expect(localResult.stderr).toContain('Docker sandbox build smoke test skipped');
-      expect(ciResult.status).toBe(1);
-      expect(ciResult.stderr).toContain('Docker sandbox build smoke test failed');
+      expect(ciTrueResult.status).toBe(1);
+      expect(ciTrueResult.stderr).toContain('Docker sandbox build smoke test failed');
+      expect(ciOneResult.status).toBe(1);
+      expect(ciOneResult.stderr).toContain('Docker sandbox build smoke test failed');
     } finally {
       rmSync(binDir, { force: true, recursive: true });
     }

--- a/tests/vitest-env.test.ts
+++ b/tests/vitest-env.test.ts
@@ -1,5 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
 import { readVitestFlag, readVitestFlags } from '../scripts/vitest-env.js';
@@ -71,7 +73,43 @@ describe('Vitest environment flag helper', () => {
     expect(ci).toContain('Run Docker sandbox build smoke test');
     expect(ci).toContain('npm run test:docker:sandbox');
     expect(smokeScript).toContain('DOCKER_BUILD');
-    expect(smokeScript).toContain('Docker sandbox build smoke test skipped: Docker daemon unavailable');
+    expect(smokeScript).toContain("${ciRequiresDocker ? 'failed' : 'skipped'}: Docker daemon unavailable");
+    expect(smokeScript).toContain("process.env.CI === 'true'");
+    expect(smokeScript).toContain("process.env.GITHUB_ACTIONS === 'true'");
     expect(smokeScript).toContain('Docker sandbox build smoke test passed');
+  });
+
+  it('fails the Docker sandbox smoke script in CI when Docker is unavailable', () => {
+    const binDir = mkdtempSync(join(tmpdir(), 'frankenbeast-no-docker-'));
+    const dockerShim = join(binDir, process.platform === 'win32' ? 'docker.cmd' : 'docker');
+    writeFileSync(dockerShim, '#!/usr/bin/env sh\necho "Docker daemon is unavailable" >&2\nexit 1\n', {
+      mode: 0o755,
+    });
+
+    try {
+      const baseEnv = {
+        ...process.env,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+        GITHUB_ACTIONS: undefined,
+      };
+      const script = resolve(ROOT, 'scripts/run-docker-sandbox-smoke.mjs');
+      const localResult = spawnSync(process.execPath, [script], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        env: { ...baseEnv, CI: undefined },
+      });
+      const ciResult = spawnSync(process.execPath, [script], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        env: { ...baseEnv, CI: 'true' },
+      });
+
+      expect(localResult.status).toBe(0);
+      expect(localResult.stderr).toContain('Docker sandbox build smoke test skipped');
+      expect(ciResult.status).toBe(1);
+      expect(ciResult.stderr).toContain('Docker sandbox build smoke test failed');
+    } finally {
+      rmSync(binDir, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Make the Docker sandbox smoke script fail in CI/GitHub Actions when Docker is unavailable instead of silently skipping.
- Add a deterministic regression test with a fake Docker shim that proves local runs still skip while CI runs fail.

## Test Plan
- npm run test:root -- tests/vitest-env.test.ts tests/sandbox-dockerfile.test.ts --reporter=verbose
- npm run typecheck
- npm run test:docker:sandbox
- npm run lint

Closes #2056
