### PR TITLE
test(observer): cover invalid traceparent version fields

### DIFF
--- a/packages/franken-observer/src/propagation/W3CTraceContext.test.ts
+++ b/packages/franken-observer/src/propagation/W3CTraceContext.test.ts
@@ -59,6 +59,10 @@ describe('parseTraceparent', () => {
     expect(parseTraceparent(`0g-${TRACE_ID}-${SPAN_ID}-01`)).toBeNull()
   })
 
+  it.each(['0', '000', '0G'])('returns null for invalid version field %s', version => {
+    expect(parseTraceparent(`${version}-${TRACE_ID}-${SPAN_ID}-01`)).toBeNull()
+  })
+
   it('returns null for null input', () => {
     expect(parseTraceparent(null)).toBeNull()
   })


### PR DESCRIPTION
## Summary
- Add explicit traceparent parser coverage for invalid version field lengths and uppercase bytes.
- Keep existing coverage for forbidden ff, malformed hex, and version 00 extra fields intact.

## Test Plan
- npm run build --workspace @franken/types
- npm run test --workspace @franken/observer -- W3CTraceContext.test.ts
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer (0 errors; existing warnings only)

Closes #2055