### PR TITLE
fix(critique): return structured 400 for malformed review JSON

### DIFF
--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -121,7 +121,21 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
 
   // POST /v1/review — submit code for critique
   app.post('/v1/review', async (c) => {
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        {
+          error: {
+            message: 'Invalid JSON request body',
+            type: 'invalid_json',
+          },
+        },
+        400,
+      );
+    }
+
     const parsed = ReviewRequestSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -92,6 +92,31 @@ describe('Critique Hono Server', () => {
       });
 
       expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.message).toBe('Invalid request');
+      expect(body.error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: ['code'] }),
+        ]),
+      );
+    });
+
+    it('returns a structured 400 for malformed JSON', async () => {
+      const app = createCritiqueApp({ pipeline: makePipeline() });
+      const res = await app.request('/v1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{ "code":',
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({
+        error: {
+          message: 'Invalid JSON request body',
+          type: 'invalid_json',
+        },
+      });
     });
 
     it('passes context through to pipeline', async () => {


### PR DESCRIPTION
## Summary
- catches malformed JSON in `POST /v1/review` before schema validation
- returns a structured `400` `invalid_json` error envelope instead of bubbling parser exceptions
- adds regression coverage for malformed JSON while strengthening invalid-shape assertions

## Test Plan
- `npm run test --workspace @franken/critique -- --run tests/unit/server/app.test.ts`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/critique`
- `npm run lint --workspace @franken/critique`
- `npm run build --workspace @franken/critique`

Closes #2046
