### PR TITLE
fix(orchestrator): reject invalid numeric config env vars

### DIFF
--- a/packages/franken-orchestrator/src/cli/config-loader.ts
+++ b/packages/franken-orchestrator/src/cli/config-loader.ts
@@ -22,18 +22,34 @@ function parseBooleanEnv(name: string): boolean | undefined {
   );
 }
 
+function parseNumericEnv(name: string, options: { integer?: boolean } = {}): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+
+  const normalized = raw.trim();
+  const value = Number(normalized);
+  if (normalized.length === 0 || !Number.isFinite(value) || (options.integer === true && !Number.isInteger(value))) {
+    const expected = options.integer === true ? 'a finite integer' : 'a finite number';
+    throw new Error(
+      `Invalid numeric value for ${name}: ${JSON.stringify(raw)}. Expected ${expected}.`,
+    );
+  }
+
+  return value;
+}
+
 /** Extract config values from environment variables. */
 function fromEnv(shadowedFields: ReadonlySet<keyof OrchestratorConfig> = new Set()): Partial<OrchestratorConfig> {
   const env: Partial<OrchestratorConfig> = {};
 
-  const maxTokens = process.env[`${ENV_PREFIX}MAX_TOTAL_TOKENS`];
-  if (maxTokens) env.maxTotalTokens = Number(maxTokens);
+  const maxTokens = parseNumericEnv(`${ENV_PREFIX}MAX_TOTAL_TOKENS`, { integer: true });
+  if (maxTokens !== undefined) env.maxTotalTokens = maxTokens;
 
-  const maxDuration = process.env[`${ENV_PREFIX}MAX_DURATION_MS`];
-  if (maxDuration) env.maxDurationMs = Number(maxDuration);
+  const maxDuration = parseNumericEnv(`${ENV_PREFIX}MAX_DURATION_MS`, { integer: true });
+  if (maxDuration !== undefined) env.maxDurationMs = maxDuration;
 
-  const maxCritique = process.env[`${ENV_PREFIX}MAX_CRITIQUE_ITERATIONS`];
-  if (maxCritique) env.maxCritiqueIterations = Number(maxCritique);
+  const maxCritique = parseNumericEnv(`${ENV_PREFIX}MAX_CRITIQUE_ITERATIONS`, { integer: true });
+  if (maxCritique !== undefined) env.maxCritiqueIterations = maxCritique;
 
   if (!shadowedFields.has('enableHeartbeat')) {
     const heartbeat = parseBooleanEnv(`${ENV_PREFIX}ENABLE_HEARTBEAT`);
@@ -50,8 +66,8 @@ function fromEnv(shadowedFields: ReadonlySet<keyof OrchestratorConfig> = new Set
     if (reflection !== undefined) env.enableReflection = reflection;
   }
 
-  const minScore = process.env[`${ENV_PREFIX}MIN_CRITIQUE_SCORE`];
-  if (minScore) env.minCritiqueScore = Number(minScore);
+  const minScore = parseNumericEnv(`${ENV_PREFIX}MIN_CRITIQUE_SCORE`);
+  if (minScore !== undefined) env.minCritiqueScore = minScore;
 
   return env;
 }

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -15,6 +15,8 @@ describe('Config loader', () => {
     tmpFiles.length = 0;
     // Clean env vars
     delete process.env['FRANKEN_MAX_TOTAL_TOKENS'];
+    delete process.env['FRANKEN_MAX_DURATION_MS'];
+    delete process.env['FRANKEN_MAX_CRITIQUE_ITERATIONS'];
     delete process.env['FRANKEN_ENABLE_HEARTBEAT'];
     delete process.env['FRANKEN_ENABLE_TRACING'];
     delete process.env['FRANKEN_ENABLE_REFLECTION'];
@@ -222,8 +224,44 @@ describe('Config loader', () => {
   );
 
   it('reads numeric env vars', async () => {
+    process.env['FRANKEN_MAX_TOTAL_TOKENS'] = '125000';
+    process.env['FRANKEN_MAX_DURATION_MS'] = '450000';
+    process.env['FRANKEN_MAX_CRITIQUE_ITERATIONS'] = '4';
     process.env['FRANKEN_MIN_CRITIQUE_SCORE'] = '0.9';
+
     const config = await loadConfig(makeArgs());
+
+    expect(config.maxTotalTokens).toBe(125_000);
+    expect(config.maxDurationMs).toBe(450_000);
+    expect(config.maxCritiqueIterations).toBe(4);
     expect(config.minCritiqueScore).toBe(0.9);
+  });
+
+  it.each([
+    ['FRANKEN_MAX_TOTAL_TOKENS', ''],
+    ['FRANKEN_MAX_TOTAL_TOKENS', 'abc'],
+    ['FRANKEN_MAX_TOTAL_TOKENS', 'NaN'],
+    ['FRANKEN_MAX_TOTAL_TOKENS', 'Infinity'],
+    ['FRANKEN_MIN_CRITIQUE_SCORE', ''],
+    ['FRANKEN_MIN_CRITIQUE_SCORE', 'abc'],
+    ['FRANKEN_MIN_CRITIQUE_SCORE', 'NaN'],
+    ['FRANKEN_MIN_CRITIQUE_SCORE', 'Infinity'],
+  ])('rejects invalid numeric env var %s=%j with a clear error', async (name, value) => {
+    process.env[name] = value;
+
+    await expect(loadConfig(makeArgs())).rejects.toThrow(
+      `Invalid numeric value for ${name}`,
+    );
+  });
+
+  it('does not silently ignore blank numeric env vars over file config', async () => {
+    const filePath = join(tmpdir(), `beast-config-${Date.now()}.json`);
+    tmpFiles.push(filePath);
+    await writeFile(filePath, JSON.stringify({ maxTotalTokens: 50_000 }));
+    process.env['FRANKEN_MAX_TOTAL_TOKENS'] = '';
+
+    await expect(loadConfig(makeArgs({ config: filePath }))).rejects.toThrow(
+      'Invalid numeric value for FRANKEN_MAX_TOTAL_TOKENS',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a shared strict numeric env parser for orchestrator config overrides.
- Rejects blank, non-numeric, NaN, and Infinity values before generic schema validation while preserving valid numeric overrides.
- Expands config-loader tests for integer and score env vars plus blank env override behavior.

## Test Plan
- npm test -- --run tests/unit/cli/config-loader.test.ts
- npm test -- --run tests/unit/cli/config-loader.test.ts test/cli/config-loading.test.ts
- npm run build --workspace @franken/types --workspace @franken/brain --workspace @franken/planner --workspace @franken/observer --workspace @franken/critique --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)
- npm run build --workspace @franken/orchestrator

Closes #2063
