### PR TITLE
fix(critique): validate rate limit configuration

### DIFF
--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -12,6 +12,7 @@ const ReviewRequestSchema = z.object({
 
 export interface CritiqueAppOptions {
   bearerToken?: string;
+  /** Positive finite integer request quota per minute. Use 0 or undefined to disable. */
   rateLimitPerMinute?: number;
   pipeline?: CritiquePipeline;
 }
@@ -54,10 +55,29 @@ export function evictOldestRateLimitBucket(
   }
 }
 
+function resolveRateLimitPerMinute(
+  rateLimitPerMinute: number | undefined,
+): number | undefined {
+  if (rateLimitPerMinute === undefined || rateLimitPerMinute === 0) {
+    return undefined;
+  }
+
+  if (!Number.isSafeInteger(rateLimitPerMinute) || rateLimitPerMinute < 1) {
+    throw new Error(
+      'rateLimitPerMinute must be a positive finite integer, or 0/undefined to disable rate limiting',
+    );
+  }
+
+  return rateLimitPerMinute;
+}
+
 export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
   const app = new Hono();
   const requestCounts = new Map<string, RateLimitBucket>();
   let nextRateLimitCleanupAt = 0;
+  const rateLimitPerMinute = resolveRateLimitPerMinute(
+    options.rateLimitPerMinute,
+  );
 
   // Bearer auth middleware
   const bearerToken = options.bearerToken;
@@ -77,8 +97,8 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
   // Rate limiting middleware. Expired buckets are swept at a fixed cadence and
   // the active bucket map has a hard cap so high-cardinality forwarded-address
   // traffic cannot force an O(bucket count) scan on every request.
-  if (options.rateLimitPerMinute) {
-    const limit = options.rateLimitPerMinute;
+  if (rateLimitPerMinute !== undefined) {
+    const limit = rateLimitPerMinute;
     app.use('/v1/*', async (c, next) => {
       const ip = c.req.header('x-forwarded-for') ?? 'unknown';
       const now = wallClockNow();

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -95,9 +95,7 @@ describe('Critique Hono Server', () => {
       const body = await res.json();
       expect(body.error.message).toBe('Invalid request');
       expect(body.error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ path: ['code'] }),
-        ]),
+        expect.arrayContaining([expect.objectContaining({ path: ['code'] })]),
       );
     });
 
@@ -205,6 +203,39 @@ describe('Critique Hono Server', () => {
       evictOldestRateLimitBucket(requestCounts);
 
       expect([...requestCounts.keys()]).toEqual(['newest', 'middle']);
+    });
+
+    it.each([
+      ['negative', -1],
+      ['fractional', 1.5],
+      ['NaN', Number.NaN],
+      ['Infinity', Infinity],
+    ])(
+      'rejects invalid %s rate-limit configuration',
+      (_name, rateLimitPerMinute) => {
+        expect(() =>
+          createCritiqueApp({
+            rateLimitPerMinute,
+            pipeline: makePipeline(),
+          }),
+        ).toThrow('rateLimitPerMinute must be a positive finite integer');
+      },
+    );
+
+    it('treats 0 as an explicit disabled rate-limit value', async () => {
+      const app = createCritiqueApp({
+        rateLimitPerMinute: 0,
+        pipeline: makePipeline(),
+      });
+
+      for (let i = 0; i < 3; i++) {
+        const res = await app.request('/v1/review', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: 'x' }),
+        });
+        expect(res.status).toBe(200);
+      }
     });
 
     it('returns 429 after exceeding limit', async () => {


### PR DESCRIPTION
## Summary
- validate rateLimitPerMinute before installing franken-critique rate limiting middleware
- document 0/undefined as disabled and reject negative, fractional, NaN, and infinite values
- add regression coverage for invalid and disabled rate-limit configuration

## Test Plan
- npm ci
- npm test -- tests/unit/server/app.test.ts (red: invalid config tests failed before fix)
- npm test -- tests/unit/server/app.test.ts
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- npm test --workspace @franken/critique
- npm run build --workspace @franken/critique
- npx prettier --check packages/franken-critique/src/server/app.ts packages/franken-critique/tests/unit/server/app.test.ts

Note: package-wide npm run format:check --workspace @franken/critique still reports pre-existing formatting drift in 36 files outside this PR's scope; changed files pass Prettier.

Closes #2042