### PR TITLE
test(governor): make integration script config-only

### DIFF
--- a/packages/franken-governor/package.json
+++ b/packages/franken-governor/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "INTEGRATION=true vitest run --config vitest.integration.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "prepublishOnly": "npm --prefix ../.. run build"
   },
   "keywords": [

--- a/packages/franken-governor/tests/unit/vitest-selection.test.ts
+++ b/packages/franken-governor/tests/unit/vitest-selection.test.ts
@@ -15,19 +15,21 @@ describe('governor Vitest suite selection', () => {
   it('keeps default and coverage runs scoped to unit tests', () => {
     const unitConfig = readFileSync(unitConfigPath, 'utf8');
 
-    expect(unitConfig).toContain("['tests/unit/**/*.test.ts']");
-    expect(unitConfig).toContain("exclude: isIntegration ? [] : ['tests/integration/**/*.test.ts', 'tests/**/*.integration.test.ts']");
+    expect(unitConfig).toContain("include: ['tests/unit/**/*.test.ts']");
+    expect(unitConfig).toContain("exclude: ['tests/integration/**/*.test.ts', 'tests/**/*.integration.test.ts']");
+    expect(unitConfig).not.toContain('INTEGRATION');
   });
 
-  it('exposes a dedicated integration test script, config, and suite', () => {
+  it('exposes a dedicated integration-only test script, config, and suite', () => {
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string>;
     };
     const integrationConfig = readFileSync(integrationConfigPath, 'utf8');
 
     expect(pkg.scripts['test:integration']).toBe(
-      'INTEGRATION=true vitest run --config vitest.integration.config.ts',
+      'vitest run --config vitest.integration.config.ts',
     );
+    expect(pkg.scripts['test:integration']).not.toContain('INTEGRATION=true');
     expect(integrationConfig).toContain("include: ['tests/integration/**/*.test.ts']");
     expect(existsSync(integrationTestPath)).toBe(true);
   });

--- a/packages/franken-governor/vitest.config.ts
+++ b/packages/franken-governor/vitest.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { createFrankenSourceAliases } from '../../scripts/vitest-source-aliases.js';
-import { readVitestFlags } from '../../scripts/vitest-env.js';
 import { fileURLToPath } from 'node:url';
-
-const vitestFlags = readVitestFlags(['INTEGRATION']);
-const isIntegration = vitestFlags.INTEGRATION;
 
 export default defineConfig({
   resolve: {
@@ -14,8 +10,8 @@ export default defineConfig({
     pool: 'threads',
     setupFiles: [fileURLToPath(new URL('../../scripts/vitest-deterministic-setup.ts', import.meta.url))],
     globals: false,
-    include: isIntegration ? ['tests/integration/**/*.test.ts', 'tests/**/*.integration.test.ts'] : ['tests/unit/**/*.test.ts'],
-    exclude: isIntegration ? [] : ['tests/integration/**/*.test.ts', 'tests/**/*.integration.test.ts'],
+    include: ['tests/unit/**/*.test.ts'],
+    exclude: ['tests/integration/**/*.test.ts', 'tests/**/*.integration.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- removes the redundant `INTEGRATION=true` path from the governor `test:integration` script
- makes the default governor Vitest config unit-only while leaving `vitest.integration.config.ts` as the dedicated integration-only suite
- strengthens the suite-selection regression test so the default and integration entrypoints stay disjoint

## Test Plan
- `npm test --workspace @franken/governor -- tests/unit/vitest-selection.test.ts` (red first, then green)
- `npm run test:integration --workspace @franken/governor`
- `npm test --workspace @franken/governor`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/governor`
- `npm run lint --workspace @franken/governor` (passes with existing warnings in `tests/integration/full-approval-flow.test.ts`)
- `npm run build --workspace @franken/governor`

Closes #2022
