### PR TITLE
fix(orchestrator): validate beast rate limiter options

### DIFF
--- a/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
+++ b/packages/franken-orchestrator/src/beasts/http/beast-rate-limit.ts
@@ -15,10 +15,27 @@ interface CounterState {
 
 const DEFAULT_CLEANUP_BATCH_SIZE = 128;
 
+function assertPositiveSafeInteger(optionName: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`Beast rate limiter option ${optionName} must be a positive safe integer`);
+  }
+}
+
+function normalizeOptions(options: BeastRateLimitOptions): Required<BeastRateLimitOptions> {
+  assertPositiveSafeInteger('max', options.max);
+  assertPositiveSafeInteger('windowMs', options.windowMs);
+  const cleanupBatchSize = options.cleanupBatchSize ?? DEFAULT_CLEANUP_BATCH_SIZE;
+  assertPositiveSafeInteger('cleanupBatchSize', cleanupBatchSize);
+  return { ...options, cleanupBatchSize };
+}
+
 export class InMemoryRateLimiter {
   private readonly counters = new Map<string, CounterState>();
+  private readonly options: Required<BeastRateLimitOptions>;
 
-  constructor(private readonly options: BeastRateLimitOptions) {}
+  constructor(options: BeastRateLimitOptions) {
+    this.options = normalizeOptions(options);
+  }
 
   take(key: string): { allowed: boolean; remaining: number } {
     if (this.options.max <= 0) {

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-rate-limit.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-rate-limit.test.ts
@@ -10,6 +10,38 @@ describe('InMemoryRateLimiter', () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    ['max', { max: 0, windowMs: 1_000 }],
+    ['max', { max: -1, windowMs: 1_000 }],
+    ['max', { max: Number.NaN, windowMs: 1_000 }],
+    ['max', { max: Number.POSITIVE_INFINITY, windowMs: 1_000 }],
+    ['max', { max: 1.5, windowMs: 1_000 }],
+    ['max', { max: Number.MAX_SAFE_INTEGER + 1, windowMs: 1_000 }],
+    ['windowMs', { max: 1, windowMs: 0 }],
+    ['windowMs', { max: 1, windowMs: -1 }],
+    ['windowMs', { max: 1, windowMs: Number.NaN }],
+    ['windowMs', { max: 1, windowMs: Number.POSITIVE_INFINITY }],
+    ['windowMs', { max: 1, windowMs: 1.5 }],
+    ['windowMs', { max: 1, windowMs: Number.MAX_SAFE_INTEGER + 1 }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: 0 }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: -1 }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: Number.NaN }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: Number.POSITIVE_INFINITY }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: 1.5 }],
+    ['cleanupBatchSize', { max: 1, windowMs: 1_000, cleanupBatchSize: Number.MAX_SAFE_INTEGER + 1 }],
+  ])('rejects invalid numeric option %s', (optionName, options) => {
+    expect(() => new InMemoryRateLimiter(options)).toThrow(RangeError);
+    expect(() => new InMemoryRateLimiter(options)).toThrow(optionName);
+  });
+
+  it('accepts omitted cleanup batch size', () => {
+    expect(() => new InMemoryRateLimiter({ max: 1, windowMs: 1 })).not.toThrow();
+  });
+
+  it('accepts positive safe integer cleanup batch size', () => {
+    expect(() => new InMemoryRateLimiter({ max: 1, windowMs: 1, cleanupBatchSize: 1 })).not.toThrow();
+  });
+
   it('evicts expired one-shot counters when a different key is used later', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-11T00:00:00.000Z'));


### PR DESCRIPTION
## Summary
- Validate beast in-memory rate limiter numeric options at construction time
- Reject non-positive, non-integer, unsafe, NaN, and infinite max/windowMs/cleanupBatchSize values with RangeError
- Add focused unit coverage for invalid and valid rate limiter option configurations

## Test Plan
- npm test -- --run tests/unit/beasts/beast-rate-limit.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #2065