### PR TITLE
fix(orchestrator): quarantine malformed init config fallback

### DIFF
--- a/packages/franken-orchestrator/src/init/init-engine.ts
+++ b/packages/franken-orchestrator/src/init/init-engine.ts
@@ -38,10 +38,20 @@ async function loadExistingConfig(
   });
 }
 
+async function quarantineMalformedConfigIfPresent(configFile: string): Promise<void> {
+  await readJsonFileOrDefault<unknown | undefined>(configFile, () => undefined, {
+    description: 'orchestrator config',
+    onCorrupt: warnJsonQuarantined,
+  });
+}
+
 async function resolveBaseConfig(options: RunInteractiveInitOptions): Promise<OrchestratorConfig> {
   const baseConfig = options.baseConfig ?? await loadExistingConfig(options.configFile, {
     allowTrustedProviderCommandOverrides: options.allowTrustedProviderCommandOverrides,
   });
+  if (options.baseConfig) {
+    await quarantineMalformedConfigIfPresent(options.configFile);
+  }
   if (!options.initBackend) {
     return baseConfig;
   }

--- a/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { handleInitCommand } from '../../../src/cli/init-command.js';
@@ -157,6 +157,33 @@ describe('handleInitCommand', () => {
     expect(initState.selectedModules).toEqual(['chat']);
   });
 
+  function makeInitIo(overrides: Record<string, string> = {}) {
+    return {
+      ask: vi.fn(async (prompt: string) => {
+        if (prompt in overrides) return overrides[prompt]!;
+        switch (prompt) {
+          case 'Enter passphrase for local encrypted store:':
+            return 'test-passphrase';
+          case 'Enable Chat? [y/N]':
+            return '';
+          case 'Enable Dashboard? [Y/n]':
+            return 'n';
+          case 'Enable Comms? [y/N]':
+            return 'n';
+          case 'Default provider [claude]':
+            return '';
+          case 'Security mode [secure/insecure] (default: secure)':
+            return '';
+          case 'Enter operator token (leave blank to auto-generate):':
+            return '';
+          default:
+            return '';
+        }
+      }),
+      display: () => undefined,
+    };
+  }
+
   it('uses resolved fallback config for interactive init when existing config is not an object', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
     const frankenbeastDir = join(tempDir, '.fbeast');
@@ -165,35 +192,43 @@ describe('handleInitCommand', () => {
     await writeFile(configFile, 'null\n', 'utf-8');
     const resolvedConfig = defaultConfig();
     resolvedConfig.chat.enabled = false;
-    const ask = vi.fn(async (prompt: string) => {
-      switch (prompt) {
-        case 'Enter passphrase for local encrypted store:':
-          return 'test-passphrase';
-        case 'Enable Chat? [y/N]':
-          return '';
-        case 'Enable Dashboard? [Y/n]':
-          return 'n';
-        case 'Enable Comms? [y/N]':
-          return 'n';
-        case 'Default provider [claude]':
-          return '';
-        case 'Security mode [secure/insecure] (default: secure)':
-          return '';
-        case 'Enter operator token (leave blank to auto-generate):':
-          return '';
-        default:
-          return '';
-      }
-    });
+    const io = makeInitIo();
 
     await handleInitCommand({
       args: makeArgs(),
       config: resolvedConfig,
       configLoadFallback: true,
-      io: { ask, display: () => undefined },
+      io,
       paths: makePaths(tempDir, configFile),
       print: () => undefined,
     });
+
+    const config = JSON.parse(await readFile(configFile, 'utf-8')) as { chat: { enabled: boolean } };
+    expect(config.chat.enabled).toBe(false);
+  });
+
+  it('quarantines malformed config JSON before interactive init overwrites it', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
+    const frankenbeastDir = join(tempDir, '.fbeast');
+    const configFile = join(frankenbeastDir, 'config.json');
+    await mkdir(frankenbeastDir, { recursive: true });
+    await writeFile(configFile, '{bad json\n', 'utf-8');
+    const resolvedConfig = defaultConfig();
+    resolvedConfig.chat.enabled = false;
+
+    await handleInitCommand({
+      args: makeArgs(),
+      config: resolvedConfig,
+      configLoadFallback: true,
+      io: makeInitIo(),
+      paths: makePaths(tempDir, configFile),
+      print: () => undefined,
+    });
+
+    const files = await readdir(frankenbeastDir);
+    const corruptFile = files.find((file) => file.startsWith('config.json.corrupt-'));
+    expect(corruptFile).toBeDefined();
+    expect(await readFile(join(frankenbeastDir, corruptFile!), 'utf-8')).toBe('{bad json\n');
 
     const config = JSON.parse(await readFile(configFile, 'utf-8')) as { chat: { enabled: boolean } };
     expect(config.chat.enabled).toBe(false);


### PR DESCRIPTION
## Summary
- Preserve malformed explicit init config files by running the JSON quarantine path even when CLI fallback config is supplied.
- Add regression coverage for interactive init overwriting malformed config JSON.

## Test Plan
- npm run test --workspace @franken/orchestrator -- --run tests/unit/cli/init-command.test.ts tests/unit/init/init-engine.test.ts tests/unit/init/init-json-file.test.ts
- npm run typecheck --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)

Follow-up for late Codex finding on merged PR #1621.