### PR TITLE
test(security): avoid gitleaks fixture secrets

### DIFF
--- a/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dr-restore.test.ts
@@ -399,7 +399,13 @@ describe('dr restore-dry-run CLI', () => {
           status: 'open',
           payload: {
             command: 'curl --password notasecret -H "Authorization: Bearer ***" https://api.github.com/repos/djm204/frankenbeast',
-            argv: ['gh', 'api', '--token', 'abcdefghijklmnopqrstuvwxyz123456', '--password=abcd1234secret5678'],
+            argv: [
+              'gh',
+              'api',
+              '--token',
+              ['abcdefghijklmnop', 'qrstuvwxyz123456'].join(''),
+              `--password=${['abcd1234', 'secret5678'].join('')}`,
+            ],
             databaseUrl: 'postgres://beast:anotherSecret456@db.example/franken',
           },
         }],

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1725,7 +1725,7 @@ describe('stuck-run watchdog', () => {
         pid: 7411,
         status: 'running',
         alive: true,
-        waitingOn: 'approval token=ghr_abcdefghijklmnopqrstuvwx.yz-123456 and api token: sk-abcdefghijklmnopqrstuvwxyz123456',
+        waitingOn: `approval token=${'ghr_'}abcdefghijklmnopqrstuvwx.yz-123456 and api token: ${'sk-'}abcdefghijklmnopqrstuvwxyz123456`,
         lastHeartbeatAt: '2026-07-16T08:00:00.000Z',
         lastOutputAt: '2026-07-16T08:00:00.000Z',
         lastToolActivityAt: '2026-07-16T08:00:00.000Z',

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-17 — Gitleaks fixture secret hygiene
+- Secret-redaction tests that spawn child commands must avoid putting full fixture secrets in the command argv source itself; split PEM headers/footers and token-like values inside the generated command text as well as in test source so Gitleaks does not flag the fixture while runtime output still exercises full secret redaction.
+
+
 ## 2026-07-16 — Synthetic availability probe review fixes
 - Availability probes should fail closed for real dependencies: do not default provider checks to `node --version` or dashboard checks to a static UI health URL, require explicit provider/backend health targets, and cover missing-target behavior in tests so cron copies cannot produce false-green uptime.
 - For cron/CI probe JSON logs, redact both `key=value` and whitespace-separated secret forms, including split `Authorization: Bearer *** argv sequences, before serializing command details or error messages.

--- a/tests/unit/cron-script-error-envelope.test.ts
+++ b/tests/unit/cron-script-error-envelope.test.ts
@@ -166,7 +166,7 @@ describe('cron script error envelope runner', () => {
       '--',
       process.execPath,
       '-e',
-      "const fs = require('node:fs'); fs.writeSync(2, '-----BEGIN PRIVATE KEY-----\\nsecret-line-one\\n'); fs.writeSync(2, 'secret-line-two\\n-----END PRIVATE KEY-----\\nreal diagnostic'); process.exit(4)",
+      "const fs = require('node:fs'); fs.writeSync(2, '-----BEGIN PRIVATE ' + 'KEY-----\\nsecret-line-' + 'one\\n'); fs.writeSync(2, 'secret-line-' + 'two\\n-----END PRIVATE ' + 'KEY-----\\nreal diagnostic'); process.exit(4)",
     ], { CRON_SCRIPT_EXIT_STDERR_DRAIN_MS: '2000' });
 
     expect(result.status).toBe(4);
@@ -449,7 +449,7 @@ describe('cron script error envelope runner', () => {
       '--',
       process.execPath,
       '-e',
-      `const fs = require('node:fs'); fs.writeSync(2, '-----BEGIN PRIVATE KEY-----\\n'); fs.writeSync(2, ${JSON.stringify(keyBody)}); fs.writeSync(2, '\\n-----END PRIVATE KEY-----\\nafter-key'); process.exit(9)`,
+      `const fs = require('node:fs'); const keyBody = 'split-private-' + 'key-material-'; fs.writeSync(2, '-----BEGIN PRIVATE ' + 'KEY-----\\n'); fs.writeSync(2, keyBody.repeat(256)); fs.writeSync(2, '\\n-----END PRIVATE ' + 'KEY-----\\nafter-key'); process.exit(9)`,
     ], { CRON_SCRIPT_EXIT_STDERR_DRAIN_MS: '2000' });
 
     expect(result.status).toBe(9);
@@ -520,7 +520,7 @@ describe('cron script error envelope runner', () => {
       '--',
       process.execPath,
       '-e',
-      "process.stderr.write('PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\\nkey-body-line\\n-----END PRIVATE KEY-----\\nreal diagnostic'); process.exit(9)",
+      "process.stderr.write('PRIVATE_KEY=-----BEGIN PRIVATE ' + 'KEY-----\\nkey-body-line\\n-----END PRIVATE ' + 'KEY-----\\nreal diagnostic'); process.exit(9)",
     ], { CRON_SCRIPT_EXIT_STDERR_DRAIN_MS: '2000' });
 
     expect(result.status).toBe(9);


### PR DESCRIPTION
## Summary
- split token-like and PEM fixture strings so Gitleaks no longer flags test fixtures
- preserve the full runtime secret-redaction behavior in the spawned test commands
- add a shared lesson for future gitleaks fixture work

Closes #2399

## Test Plan
- gitleaks 8.21.2 detect --source . --no-git --report-format sarif --redact --exit-code 0 (0 findings)
- npx vitest run tests/unit/cron-script-error-envelope.test.ts
- cd packages/franken-orchestrator && npx vitest run tests/unit/cli/dr-restore.test.ts tests/unit/issues/issue-runner.test.ts
- npm run lint:security
- npm run build
- npm run typecheck --workspace @franken/orchestrator