### PR TITLE
fix(dr): close restore backup codex followups

### DIFF
--- a/packages/franken-orchestrator/src/dr/state-backup.ts
+++ b/packages/franken-orchestrator/src/dr/state-backup.ts
@@ -94,12 +94,12 @@ async function deriveKey(keyFilePath: string): Promise<Buffer> {
 }
 
 function classifyBackupPath(path: string): BackupCategory {
-  const normalized = path.toLowerCase();
+  const normalized = path.toLowerCase().replace(/\\/g, '/');
   const base = basename(normalized);
-  if (base === 'kanban.db' || base.startsWith('kanban.db-') || normalized.includes(`${sep}kanban${sep}`)) return 'kanban';
+  if (base === 'kanban.db' || base.startsWith('kanban.db-') || normalized.includes('/kanban/')) return 'kanban';
   if (normalized.includes('approval') || normalized.includes('ledger')) return 'approvals';
   if (normalized.includes('liveness') || normalized.includes('heartbeat')) return 'liveness';
-  if (normalized.startsWith('runs/') || normalized.includes(`${sep}runs${sep}`) || normalized.includes('run-metadata') || normalized.includes('attempt')) return 'runs';
+  if (normalized.startsWith('runs/') || normalized.includes('/runs/') || normalized.includes('run-metadata') || normalized.includes('attempt')) return 'runs';
   return 'other';
 }
 
@@ -108,7 +108,7 @@ function emptyCategoryCounts(): Record<BackupCategory, number> {
 }
 
 function assertSafeRelativePath(filePath: string): void {
-  if (!filePath || filePath.startsWith('/') || filePath.includes('..') || filePath.split(/[\\/]+/).some((part) => part === '..' || part === '')) {
+  if (!filePath || filePath.startsWith('/') || filePath.split(/[\\/]+/).some((part) => part === '..' || part === '')) {
     throw new Error(`Unsafe backup entry path: ${filePath}`);
   }
 }
@@ -392,6 +392,22 @@ async function ensureRealDirectory(path: string): Promise<void> {
   }
 }
 
+async function assertRealAncestorChain(path: string): Promise<void> {
+  const parent = dirname(path);
+  if (parent !== path) {
+    await assertRealAncestorChain(parent);
+  }
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error(`DR restore target parent must be a real directory: ${path}`);
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return;
+    throw error;
+  }
+}
+
 async function assertRestoreTargetReady(targetDir: string, createIfMissing: boolean): Promise<void> {
   try {
     const stats = await lstat(targetDir);
@@ -404,6 +420,7 @@ async function assertRestoreTargetReady(targetDir: string, createIfMissing: bool
     }
   } catch (error: unknown) {
     if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      await assertRealAncestorChain(dirname(targetDir));
       if (createIfMissing) await ensureRealDirectory(targetDir);
       return;
     }

--- a/packages/franken-orchestrator/tests/unit/dr/state-backup.test.ts
+++ b/packages/franken-orchestrator/tests/unit/dr/state-backup.test.ts
@@ -20,6 +20,7 @@ async function makeFixtureState(): Promise<{ dir: string; keyFile: string }> {
   await writeFile(join(stateDir, 'approvals', 'ledger.json'), JSON.stringify({ token: 'secret-approval-token' }), 'utf8');
   await writeFile(join(stateDir, 'liveness', 'worker.json'), JSON.stringify({ heartbeat: 'ok' }), 'utf8');
   await writeFile(join(stateDir, 'runs', 'run-1', 'metadata.json'), JSON.stringify({ taskId: 'task-1' }), 'utf8');
+  await writeFile(join(stateDir, 'runs', 'run-1', 'retry..metadata.json'), JSON.stringify({ taskId: 'task-1', retry: true }), 'utf8');
   await writeFile(join(stateDir, 'profile-memory.json'), JSON.stringify({ user: 'private memory' }), 'utf8');
   const keyFile = join(dir, 'backup.key');
   await writeFile(keyFile, 'test key material', 'utf8');
@@ -45,7 +46,7 @@ describe('encrypted DR state backups', () => {
         kanban: 1,
         approvals: 1,
         liveness: 1,
-        runs: 1,
+        runs: 2,
       }));
       expect(envelope.manifest.files.map((file) => file.path)).toEqual([
         'approvals/ledger.json',
@@ -53,6 +54,7 @@ describe('encrypted DR state backups', () => {
         'liveness/worker.json',
         'profile-memory.json',
         'runs/run-1/metadata.json',
+        'runs/run-1/retry..metadata.json',
       ]);
       expect(raw).not.toContain('secret-approval-token');
       expect(raw).not.toContain('private memory');
@@ -69,7 +71,7 @@ describe('encrypted DR state backups', () => {
     try {
       await createEncryptedStateBackup({ stateDir: join(dir, 'state'), outputPath: backupPath, keyFilePath: keyFile });
       const report = await verifyEncryptedStateBackup(backupPath, keyFile);
-      expect(report.verifiedFiles).toBe(5);
+      expect(report.verifiedFiles).toBe(6);
       expect(report.manifest.categories.approvals).toBe(1);
 
       const parsed = JSON.parse(await readFile(backupPath, 'utf8')) as { ciphertext: string };
@@ -177,6 +179,12 @@ describe('encrypted DR state backups', () => {
       await createEncryptedStateBackup({ stateDir: join(dir, 'state'), outputPath: backupPath, keyFilePath: keyFile });
       await mkdir(outsideDir, { recursive: true });
       await symlink(outsideDir, linkedParent);
+      await expect(restoreEncryptedStateBackup({
+        backupPath,
+        targetDir: join(linkedParent, 'new-target'),
+        keyFilePath: keyFile,
+        dryRun: true,
+      })).rejects.toThrow(/real directory/);
       await expect(restoreEncryptedStateBackup({
         backupPath,
         targetDir: join(linkedParent, 'new-target'),


### PR DESCRIPTION
## Summary
- fixes post-merge Codex findings from PR #2308 around dry-run restore target validation, portable manifest run classification, and valid filenames containing `..`
- validates missing dry-run restore targets under symlinked ancestors without mutating the filesystem
- keeps traversal rejection segment-based while allowing legitimate filenames such as `retry..metadata.json`

## Test Plan
- npm --prefix packages/franken-orchestrator test -- tests/unit/dr/state-backup.test.ts
- npm --prefix packages/franken-orchestrator run typecheck
- npm --prefix packages/franken-orchestrator run build

Follow-up to #2308 / issue #1683. Does not close a new issue.