### PR TITLE
fix(critique): harden lesson scope metadata validation

### DIFF
--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1915,7 +1915,7 @@ function isLessonScopeAllowed(
   if (isEmptyLessonInjectionContext(context)) {
     return false;
   }
-  const nowMs = parseScopeTimestamp(context.now ?? new Date().toISOString());
+  const nowMs = parseContextTimestamp(context.now ?? new Date().toISOString());
   if (nowMs === undefined) {
     return false;
   }
@@ -1985,7 +1985,18 @@ function hasValidScopeAuditTrail(
   const validEntries = scope.auditTrail.filter(
     (entry): entry is LessonScopeAuditEntry => isValidScopeAuditEntry(entry),
   );
-  const latestEntry = validEntries.at(-1);
+  const latestEntry = validEntries.reduce<LessonScopeAuditEntry | undefined>(
+    (latest, entry) => {
+      if (latest === undefined) {
+        return entry;
+      }
+      return parseScopeTimestamp(entry.changedAt)! >
+        parseScopeTimestamp(latest.changedAt)!
+        ? entry
+        : latest;
+    },
+    undefined,
+  );
   return latestEntry?.toScope === currentScope;
 }
 
@@ -2015,6 +2026,11 @@ function parseScopeTimestamp(timestamp: string): number | undefined {
     return undefined;
   }
   return new Date(parsed).toISOString() === timestamp ? parsed : undefined;
+}
+
+function parseContextTimestamp(timestamp: string): number | undefined {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function isKnownLessonScopeKind(

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1990,7 +1990,7 @@ function hasValidScopeAuditTrail(
       if (latest === undefined) {
         return entry;
       }
-      return parseScopeTimestamp(entry.changedAt)! >
+      return parseScopeTimestamp(entry.changedAt)! >=
         parseScopeTimestamp(latest.changedAt)!
         ? entry
         : latest;

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -1982,26 +1982,51 @@ function hasValidScopeAuditTrail(
   if (!Array.isArray(scope.auditTrail)) {
     return false;
   }
-  return scope.auditTrail.some((entry) => {
-    if (entry === null || typeof entry !== 'object') {
-      return false;
-    }
-    const candidate = entry as Partial<LessonScopeAuditEntry>;
-    return (
-      typeof candidate.changedAt === 'string' &&
-      parseScopeTimestamp(candidate.changedAt) !== undefined &&
-      candidate.toScope === currentScope &&
-      typeof candidate.actor === 'string' &&
-      candidate.actor.trim().length > 0 &&
-      typeof candidate.reason === 'string' &&
-      candidate.reason.trim().length > 0
-    );
-  });
+  const validEntries = scope.auditTrail.filter(
+    (entry): entry is LessonScopeAuditEntry => isValidScopeAuditEntry(entry),
+  );
+  const latestEntry = validEntries.at(-1);
+  return latestEntry?.toScope === currentScope;
+}
+
+function isValidScopeAuditEntry(
+  entry: unknown,
+): entry is LessonScopeAuditEntry {
+  if (entry === null || typeof entry !== 'object') {
+    return false;
+  }
+  const candidate = entry as Partial<LessonScopeAuditEntry>;
+  return (
+    typeof candidate.changedAt === 'string' &&
+    parseScopeTimestamp(candidate.changedAt) !== undefined &&
+    isKnownLessonScopeKind(candidate.toScope) &&
+    (candidate.fromScope === undefined ||
+      isKnownLessonScopeKind(candidate.fromScope)) &&
+    typeof candidate.actor === 'string' &&
+    candidate.actor.trim().length > 0 &&
+    typeof candidate.reason === 'string' &&
+    candidate.reason.trim().length > 0
+  );
 }
 
 function parseScopeTimestamp(timestamp: string): number | undefined {
   const parsed = Date.parse(timestamp);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  return new Date(parsed).toISOString() === timestamp ? parsed : undefined;
+}
+
+function isKnownLessonScopeKind(
+  scope: unknown,
+): scope is LessonScopeKind {
+  return (
+    scope === 'global' ||
+    scope === 'repo' ||
+    scope === 'role' ||
+    scope === 'profile' ||
+    scope === 'task'
+  );
 }
 
 function isEmptyLessonInjectionContext(
@@ -2027,7 +2052,12 @@ function matchesRequiredAllowlist(
   allowed: readonly string[] | undefined,
   actual: string | undefined,
 ): boolean {
-  return actual !== undefined && allowed?.includes(actual) === true;
+  return (
+    actual !== undefined &&
+    Array.isArray(allowed) &&
+    allowed.every((value) => typeof value === 'string') &&
+    allowed.includes(actual)
+  );
 }
 
 export function detectLessonContradictions(

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1778,6 +1778,36 @@ describe('LessonRecorder', () => {
       }),
     ).toBe(false);
 
+    const importedRepoWithSameTimestampDemotion = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+        auditTrail: [
+          {
+            changedAt: reviewedAt,
+            actor: 'pm-reviewer',
+            toScope: 'repo',
+            reason: 'Initial review attested repo scope.',
+          },
+          {
+            changedAt: reviewedAt,
+            actor: 'pm-reviewer',
+            fromScope: 'repo',
+            toScope: 'task',
+            reason: 'Same-timestamp demotion was appended later.',
+          },
+        ],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithSameTimestampDemotion, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const importedRepoWithMalformedAllowlist = {
       ...repoScoped,
       lessonScope: {
@@ -1802,6 +1832,7 @@ describe('LessonRecorder', () => {
     expect(
       isLessonApplicable(importedRepoWithNormalizedExpiry, {
         repo: 'djm204/frankenbeast',
+        now: '2026-02-01T00:00:00.000Z',
       }),
     ).toBe(false);
 

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1732,6 +1732,63 @@ describe('LessonRecorder', () => {
       }),
     ).toBe(false);
 
+    const importedRepoWithStaleAuditScope = {
+      ...baseLesson,
+      lessonScope: {
+        schemaVersion: 'lesson-scope-v1',
+        scope: 'repo',
+        allowedRepos: ['djm204/frankenbeast'],
+        provenance: { source: 'recorded', taskId: 'scope-task' },
+        auditTrail: [
+          {
+            changedAt: reviewedAt,
+            actor: 'pm-reviewer',
+            toScope: 'repo',
+            reason: 'Previously attested repo scope.',
+          },
+          {
+            changedAt: '2026-07-13T01:30:00.000Z',
+            actor: 'pm-reviewer',
+            fromScope: 'repo',
+            toScope: 'task',
+            reason: 'Latest review demoted the lesson.',
+          },
+        ],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithStaleAuditScope, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
+    const importedRepoWithMalformedAllowlist = {
+      ...repoScoped,
+      lessonScope: {
+        ...repoScoped.lessonScope!,
+        allowedRepos:
+          'djm204/frankenbeast-archive' as unknown as readonly string[],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithMalformedAllowlist, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
+    const importedRepoWithNormalizedExpiry = {
+      ...repoScoped,
+      lessonScope: {
+        ...repoScoped.lessonScope!,
+        expiresAt: '2026-02-30T00:00:00.000Z',
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithNormalizedExpiry, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const importedRepoWithMalformedAudit = {
       ...baseLesson,
       lessonScope: {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -1762,6 +1762,22 @@ describe('LessonRecorder', () => {
       }),
     ).toBe(false);
 
+    const importedRepoWithUnorderedStaleAuditScope = {
+      ...importedRepoWithStaleAuditScope,
+      lessonScope: {
+        ...importedRepoWithStaleAuditScope.lessonScope,
+        auditTrail: [
+          importedRepoWithStaleAuditScope.lessonScope.auditTrail[1]!,
+          importedRepoWithStaleAuditScope.lessonScope.auditTrail[0]!,
+        ],
+      },
+    } satisfies CritiqueLesson;
+    expect(
+      isLessonApplicable(importedRepoWithUnorderedStaleAuditScope, {
+        repo: 'djm204/frankenbeast',
+      }),
+    ).toBe(false);
+
     const importedRepoWithMalformedAllowlist = {
       ...repoScoped,
       lessonScope: {
@@ -1846,6 +1862,12 @@ describe('LessonRecorder', () => {
       isLessonApplicable(expired, {
         role: 'worker',
         now: '2026-07-13T01:30:00.000Z',
+      }),
+    ).toBe(true);
+    expect(
+      isLessonApplicable(expired, {
+        role: 'worker',
+        now: '2026-07-13T01:30:00Z',
       }),
     ).toBe(true);
     expect(


### PR DESCRIPTION
## Summary
- Requires the latest valid scope audit entry to attest the persisted scope.
- Fails closed for malformed persisted allowlists instead of using string substring matches.
- Requires scope timestamps to round-trip as canonical ISO instants.
- Adds regressions for the late Codex findings on PR #2357.

## Test Plan
- npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/critique
- npm run lint --workspace @franken/critique
- npm run build --workspace @franken/critique

Follow-up for #2357 / issue #1731 post-merge Codex findings.

Closes #1731
