### PR TITLE
fix(orchestrator): resolve late restart contract review

### DIFF
--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -886,8 +886,9 @@ function hasSamePidLiveProbe(
   const liveProbe = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
   const snapshotRecency = snapshotRecencyMs(snapshot);
   return liveProbe !== undefined && (
-    liveProbe.recencyMs > snapshotRecency
-    || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
+    snapshotRecency === 0
+      ? liveProbe.index > snapshotIndex
+      : liveProbe.recencyMs > snapshotRecency || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
   );
 }
 

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -843,6 +843,21 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
   return new Map([...byCard].map(([cardId, pids]) => [cardId, [...pids].sort((a, b) => a - b)]));
 }
 
+function samePidLiveProbeRecencyByCardId(snapshots: readonly IssueWorkerCardProcessSnapshot[]): Map<string, Map<number, number>> {
+  const byCard = new Map<string, Map<number, number>>();
+  for (const snapshot of snapshots) {
+    const cardId = snapshot.cardId.trim();
+    if (!cardId
+      || snapshot.alive !== true
+      || !Number.isSafeInteger(snapshot.pid)
+      || snapshot.pid <= 0) continue;
+    const byPid = byCard.get(cardId) ?? new Map<number, number>();
+    byPid.set(snapshot.pid, Math.max(byPid.get(snapshot.pid) ?? 0, snapshotRecencyMs(snapshot)));
+    byCard.set(cardId, byPid);
+  }
+  return byCard;
+}
+
 function siblingPidsForSnapshot(
   snapshot: IssueWorkerCardProcessSnapshot,
   livePidsByCardId: ReadonlyMap<string, readonly number[]>,
@@ -856,12 +871,11 @@ function siblingPidsForSnapshot(
 
 function hasSamePidLiveProbe(
   snapshot: IssueWorkerCardProcessSnapshot,
-  livePidsByCardId: ReadonlyMap<string, readonly number[]>,
+  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, number>>,
 ): boolean {
-  return snapshot.alive !== false
-    && Number.isSafeInteger(snapshot.pid)
-    && snapshot.pid > 0
-    && (livePidsByCardId.get(snapshot.cardId.trim()) ?? []).includes(snapshot.pid);
+  if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
+  const liveProbeRecencyMs = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
+  return liveProbeRecencyMs !== undefined && liveProbeRecencyMs > snapshotRecencyMs(snapshot);
 }
 
 function normalizeKanbanState(status: string): string {
@@ -1071,6 +1085,7 @@ export function detectStuckRunWatchdogFindings(
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
+  const samePidLiveProbes = samePidLiveProbeRecencyByCardId(snapshots);
   const deadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
   const terminalRecencyByCardId = new Map<string, number>();
@@ -1084,14 +1099,16 @@ export function detectStuckRunWatchdogFindings(
       const normalizedCardId = snapshot.cardId.trim();
       if (snapshot.alive === false) {
         const terminalRecencyMs = snapshotRecencyMs(snapshot);
-        terminalRecencyByCardId.set(
-          normalizedCardId,
-          Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
-        );
-        const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
-        if (existingKey && terminalRecencyMs >= existingKey.recencyMs) {
-          deadFindingKeysByCardId.delete(normalizedCardId);
-          deadFindingsByCardId.delete(normalizedCardId);
+        if (terminalRecencyMs > 0) {
+          terminalRecencyByCardId.set(
+            normalizedCardId,
+            Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
+          );
+          const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
+          if (existingKey && terminalRecencyMs >= existingKey.recencyMs) {
+            deadFindingKeysByCardId.delete(normalizedCardId);
+            deadFindingsByCardId.delete(normalizedCardId);
+          }
         }
       }
       continue;
@@ -1116,7 +1133,7 @@ export function detectStuckRunWatchdogFindings(
     const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, liveSiblings);
+    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes);
     const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && status !== undefined && crashKanbanState(status))
       ? 'dead'
       : hasPositivePid

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1121,16 +1121,44 @@ export function detectStuckRunWatchdogFindings(
   const newestDeadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const newestDeadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
   const terminalRecencyByCardId = new Map<string, { readonly recencyMs: number; readonly index: number }>();
+  snapshots.forEach((snapshot, index) => {
+    const status = snapshot.status?.trim().toLowerCase();
+    const isTerminalCleanup = status !== undefined
+      && TERMINAL_WORKER_CARD_STATUSES.has(status)
+      && !crashKanbanState(status)
+      && !explicitProcessCrash(snapshot)
+      && !setupFailureExitReason(snapshot.exitReason ?? '')
+      && !operatorControlledSignalExitReason(snapshot.exitReason ?? '');
+    if (!isTerminalCleanup || snapshot.alive !== false) return;
+    const recencyMs = snapshotRecencyMs(snapshot);
+    if (recencyMs > nowMs) return;
+    const cardId = snapshot.cardId.trim();
+    const existing = terminalRecencyByCardId.get(cardId);
+    if (existing === undefined || recencyMs > existing.recencyMs || (recencyMs === existing.recencyMs && index > existing.index)) {
+      terminalRecencyByCardId.set(cardId, { recencyMs, index });
+    }
+  });
   let findingIndex = 0;
 
   for (const [snapshotIndex, snapshot] of snapshots.entries()) {
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot) && !setupFailureExitReason(snapshot.exitReason ?? '') && !operatorControlledSignalExitReason(snapshot.exitReason ?? '')) {
-      const normalizedCardId = snapshot.cardId.trim();
+    const normalizedCardId = snapshot.cardId.trim();
+    const isTerminalCleanup = status !== undefined
+      && TERMINAL_WORKER_CARD_STATUSES.has(status)
+      && !crashKanbanState(status)
+      && !explicitProcessCrash(snapshot)
+      && !setupFailureExitReason(snapshot.exitReason ?? '')
+      && !operatorControlledSignalExitReason(snapshot.exitReason ?? '');
+    const terminalWatermark = terminalRecencyByCardId.get(normalizedCardId);
+    const snapshotRecency = snapshotRecencyMs(snapshot);
+    if (!isTerminalCleanup && terminalWatermark !== undefined
+      && (terminalWatermark.recencyMs > snapshotRecency
+        || (terminalWatermark.recencyMs === snapshotRecency && terminalWatermark.index > snapshotIndex))) continue;
+    if (isTerminalCleanup) {
       if (snapshot.alive === false) {
-        const terminalRecencyMs = snapshotRecencyMs(snapshot);
+        const terminalRecencyMs = snapshotRecency;
         if (terminalRecencyMs > nowMs) continue;
         const terminalKey = { recencyMs: terminalRecencyMs, index: snapshotIndex };
         const existingTerminalKey = terminalRecencyByCardId.get(normalizedCardId);
@@ -1215,7 +1243,6 @@ export function detectStuckRunWatchdogFindings(
       ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),
       kanbanState: status ?? 'unknown',
     });
-    const normalizedCardId = snapshot.cardId.trim();
     evidence.push(...restartContract.evidence);
 
     const recommendedAction = remediationForCrashOnlyRestartContract(restartContract, category, processStatus);

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -854,6 +854,16 @@ function siblingPidsForSnapshot(
     .sort((a, b) => a - b);
 }
 
+function hasSamePidLiveProbe(
+  snapshot: IssueWorkerCardProcessSnapshot,
+  livePidsByCardId: ReadonlyMap<string, readonly number[]>,
+): boolean {
+  return snapshot.alive !== false
+    && Number.isSafeInteger(snapshot.pid)
+    && snapshot.pid > 0
+    && (livePidsByCardId.get(snapshot.cardId.trim()) ?? []).includes(snapshot.pid);
+}
+
 function normalizeKanbanState(status: string): string {
   return status.trim().toLowerCase().replace(/[\s_]+/g, '-');
 }
@@ -919,6 +929,15 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (intentionalNonRetryExitReason(rawExitReason) || (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState))) {
+    return {
+      disposition: 'terminal',
+      nextAction: 'no-op',
+      ...base,
+      evidence,
+    };
+  }
+
   if (activePrUrl || activeWorktreePath) {
     return {
       disposition: 'hitl',
@@ -941,15 +960,6 @@ export function buildWorkerCrashOnlyRestartContract(
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
-      ...base,
-      evidence,
-    };
-  }
-
-  if (intentionalNonRetryExitReason(rawExitReason) || (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState))) {
-    return {
-      disposition: 'terminal',
-      nextAction: 'no-op',
       ...base,
       evidence,
     };
@@ -1063,15 +1073,20 @@ export function detectStuckRunWatchdogFindings(
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
   const deadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
+  const terminalRecencyByCardId = new Map<string, number>();
   let findingIndex = 0;
 
   for (const snapshot of snapshots) {
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !explicitProcessCrash(snapshot)) {
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot)) {
       const normalizedCardId = snapshot.cardId.trim();
       const terminalRecencyMs = snapshotRecencyMs(snapshot);
+      terminalRecencyByCardId.set(
+        normalizedCardId,
+        Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
+      );
       const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
       if (existingKey && snapshot.alive !== true && terminalRecencyMs >= existingKey.recencyMs) {
         deadFindingKeysByCardId.delete(normalizedCardId);
@@ -1099,7 +1114,8 @@ export function detectStuckRunWatchdogFindings(
     const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && status !== undefined && crashKanbanState(status))
+    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, liveSiblings);
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && status !== undefined && crashKanbanState(status))
       ? 'dead'
       : hasPositivePid
         ? 'alive'
@@ -1171,6 +1187,11 @@ export function detectStuckRunWatchdogFindings(
         recencyMs: snapshotRecencyMs(snapshot),
         index: findingIndex,
       };
+      const terminalRecencyMs = terminalRecencyByCardId.get(normalizedCardId);
+      if (terminalRecencyMs !== undefined && terminalRecencyMs >= candidateKey.recencyMs) {
+        findingIndex += 1;
+        continue;
+      }
       const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
       const candidateIsSafer = existingKey === undefined
         || candidateKey.safetyRank > existingKey.safetyRank

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1172,8 +1172,8 @@ export function detectStuckRunWatchdogFindings(
     const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes, findingIndex);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && status !== undefined && crashKanbanState(status))
+    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes, snapshotIndex);
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && ((status !== undefined && crashKanbanState(status)) || setupFailureExitReason(snapshot.exitReason ?? '')))
       ? 'dead'
       : hasPositivePid
         ? 'alive'
@@ -1243,7 +1243,7 @@ export function detectStuckRunWatchdogFindings(
       const candidateKey = {
         safetyRank: restartContractSafetyRank(restartContract),
         recencyMs: snapshotRecencyMs(snapshot),
-        index: findingIndex,
+        index: snapshotIndex,
       };
       const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
       if (newestKey === undefined || candidateKey.recencyMs > newestKey.recencyMs || (candidateKey.recencyMs === newestKey.recencyMs && candidateKey.index > newestKey.index)) {

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -843,20 +843,26 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
   return new Map([...byCard].map(([cardId, pids]) => [cardId, [...pids].sort((a, b) => a - b)]));
 }
 
-function samePidLiveProbeRecencyByCardId(snapshots: readonly IssueWorkerCardProcessSnapshot[]): Map<string, Map<number, number>> {
-  const byCard = new Map<string, Map<number, number>>();
-  for (const snapshot of snapshots) {
+function samePidLiveProbeRecencyByCardId(
+  snapshots: readonly IssueWorkerCardProcessSnapshot[],
+): Map<string, Map<number, { readonly recencyMs: number; readonly index: number }>> {
+  const byCard = new Map<string, Map<number, { readonly recencyMs: number; readonly index: number }>>();
+  snapshots.forEach((snapshot, index) => {
     const cardId = snapshot.cardId.trim();
     const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
       || snapshot.alive === false
       || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
       || !Number.isSafeInteger(snapshot.pid)
-      || snapshot.pid <= 0) continue;
-    const byPid = byCard.get(cardId) ?? new Map<number, number>();
-    byPid.set(snapshot.pid, Math.max(byPid.get(snapshot.pid) ?? 0, snapshotRecencyMs(snapshot)));
+      || snapshot.pid <= 0) return;
+    const byPid = byCard.get(cardId) ?? new Map<number, { readonly recencyMs: number; readonly index: number }>();
+    const recencyMs = snapshotRecencyMs(snapshot);
+    const existingProbe = byPid.get(snapshot.pid);
+    if (existingProbe === undefined || recencyMs > existingProbe.recencyMs || (recencyMs === existingProbe.recencyMs && index > existingProbe.index)) {
+      byPid.set(snapshot.pid, { recencyMs, index });
+    }
     byCard.set(cardId, byPid);
-  }
+  });
   return byCard;
 }
 
@@ -873,12 +879,17 @@ function siblingPidsForSnapshot(
 
 function hasSamePidLiveProbe(
   snapshot: IssueWorkerCardProcessSnapshot,
-  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, number>>,
+  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, { readonly recencyMs: number; readonly index: number }>>,
+  snapshotIndex: number,
 ): boolean {
   if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
-  const liveProbeRecencyMs = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
+  const liveProbe = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
   const snapshotRecency = snapshotRecencyMs(snapshot);
-  return liveProbeRecencyMs !== undefined && liveProbeRecencyMs >= snapshotRecency;
+  return liveProbe !== undefined && (
+    liveProbe.recencyMs > snapshotRecency
+    || (liveProbe.recencyMs === 0 && snapshotRecency === 0)
+    || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
+  );
 }
 
 function normalizeKanbanState(status: string): string {
@@ -1124,7 +1135,7 @@ export function detectStuckRunWatchdogFindings(
             Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
           );
           const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
-          if (existingKey && terminalRecencyMs >= existingKey.recencyMs) {
+          if (existingKey && terminalRecencyMs > existingKey.recencyMs) {
             const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
             const newestFinding = newestDeadFindingsByCardId.get(normalizedCardId);
             if (newestKey && newestFinding && newestKey.recencyMs > terminalRecencyMs) {
@@ -1159,7 +1170,7 @@ export function detectStuckRunWatchdogFindings(
     const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes);
+    const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes, findingIndex);
     const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && status !== undefined && crashKanbanState(status))
       ? 'dead'
       : hasPositivePid

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -919,6 +919,15 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (activePrUrl || activeWorktreePath) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      ...base,
+      evidence,
+    };
+  }
+
   if (rawExitReason === 'spawn_failed' || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?\b|start[_ -]?failed\b|setup\b|enoent\b|eacces\b|protocol[_ -]?violation\b)/i.test(rawExitReason.trim())) {
     return {
       disposition: 'hitl',
@@ -954,15 +963,6 @@ export function buildWorkerCrashOnlyRestartContract(
     || dispatcherRestartExitReason(rawExitReason)
     || knownLongRunningWait(input.category)
   ) {
-    return {
-      disposition: 'hitl',
-      nextAction: 'defer-with-evidence',
-      ...base,
-      evidence,
-    };
-  }
-
-  if (activePrUrl || activeWorktreePath) {
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
@@ -1069,7 +1069,16 @@ export function detectStuckRunWatchdogFindings(
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !explicitProcessCrash(snapshot)) continue;
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !explicitProcessCrash(snapshot)) {
+      const normalizedCardId = snapshot.cardId.trim();
+      const terminalRecencyMs = snapshotRecencyMs(snapshot);
+      const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
+      if (existingKey && snapshot.alive !== true && terminalRecencyMs >= existingKey.recencyMs) {
+        deadFindingKeysByCardId.delete(normalizedCardId);
+        deadFindingsByCardId.delete(normalizedCardId);
+      }
+      continue;
+    }
 
     const category = normalizeStuckRunBlockerCategory(snapshot);
     const heartbeatAgeMs = ageMs(snapshot.lastHeartbeatAt, nowMs);
@@ -1090,7 +1099,7 @@ export function detectStuckRunWatchdogFindings(
     const minimumStaleSignals = providedActivitySignalCount;
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && status !== undefined && crashKanbanState(status))
       ? 'dead'
       : hasPositivePid
         ? 'alive'

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -878,7 +878,7 @@ function hasSamePidLiveProbe(
   if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
   const liveProbeRecencyMs = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
   const snapshotRecency = snapshotRecencyMs(snapshot);
-  return liveProbeRecencyMs !== undefined && (liveProbeRecencyMs > snapshotRecency || (liveProbeRecencyMs === 0 && snapshotRecency === 0));
+  return liveProbeRecencyMs !== undefined && liveProbeRecencyMs >= snapshotRecency;
 }
 
 function normalizeKanbanState(status: string): string {
@@ -978,19 +978,19 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState)) {
+  if (operatorControlledSignalExitReason(rawExitReason)) {
     return {
-      disposition: 'terminal',
-      nextAction: 'no-op',
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
       ...base,
       evidence,
     };
   }
 
-  if (operatorControlledSignalExitReason(rawExitReason)) {
+  if (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState)) {
     return {
-      disposition: 'hitl',
-      nextAction: 'defer-with-evidence',
+      disposition: 'terminal',
+      nextAction: 'no-op',
       ...base,
       evidence,
     };
@@ -1238,7 +1238,7 @@ export function detectStuckRunWatchdogFindings(
         newestDeadFindingsByCardId.set(normalizedCardId, finding);
       }
       const terminalRecencyMs = terminalRecencyByCardId.get(normalizedCardId);
-      if (terminalRecencyMs !== undefined && terminalRecencyMs >= candidateKey.recencyMs) {
+      if (terminalRecencyMs !== undefined && terminalRecencyMs > candidateKey.recencyMs) {
         findingIndex += 1;
         continue;
       }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -845,8 +845,8 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
 
 function samePidLiveProbeRecencyByCardId(
   snapshots: readonly IssueWorkerCardProcessSnapshot[],
-): Map<string, Map<number, { readonly recencyMs: number; readonly index: number }>> {
-  const byCard = new Map<string, Map<number, { readonly recencyMs: number; readonly index: number }>>();
+): Map<string, Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>> {
+  const byCard = new Map<string, Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>>();
   snapshots.forEach((snapshot, index) => {
     const cardId = snapshot.cardId.trim();
     const status = snapshot.status?.trim().toLowerCase();
@@ -855,11 +855,13 @@ function samePidLiveProbeRecencyByCardId(
       || (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !(snapshot.alive === true && CRASH_WORKER_CARD_STATUSES.has(status)))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) return;
-    const byPid = byCard.get(cardId) ?? new Map<number, { readonly recencyMs: number; readonly index: number }>();
+    const byPid = byCard.get(cardId) ?? new Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>();
     const recencyMs = snapshotRecencyMs(snapshot);
     const existingProbe = byPid.get(snapshot.pid);
     if (existingProbe === undefined || recencyMs > existingProbe.recencyMs || (recencyMs === existingProbe.recencyMs && index > existingProbe.index)) {
-      byPid.set(snapshot.pid, { recencyMs, index });
+      byPid.set(snapshot.pid, { recencyMs, index, latestIndex: Math.max(existingProbe?.latestIndex ?? -1, index) });
+    } else if (index > existingProbe.latestIndex) {
+      byPid.set(snapshot.pid, { ...existingProbe, latestIndex: index });
     }
     byCard.set(cardId, byPid);
   });
@@ -879,7 +881,7 @@ function siblingPidsForSnapshot(
 
 function hasSamePidLiveProbe(
   snapshot: IssueWorkerCardProcessSnapshot,
-  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, { readonly recencyMs: number; readonly index: number }>>,
+  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>>,
   snapshotIndex: number,
 ): boolean {
   if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
@@ -887,7 +889,7 @@ function hasSamePidLiveProbe(
   const snapshotRecency = snapshotRecencyMs(snapshot);
   return liveProbe !== undefined && (
     snapshotRecency === 0
-      ? liveProbe.index > snapshotIndex
+      ? liveProbe.latestIndex > snapshotIndex
       : liveProbe.recencyMs > snapshotRecency || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
   );
 }
@@ -1129,10 +1131,12 @@ export function detectStuckRunWatchdogFindings(
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot) && !setupFailureExitReason(snapshot.exitReason ?? '')) {
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot) && !setupFailureExitReason(snapshot.exitReason ?? '') && !operatorControlledSignalExitReason(snapshot.exitReason ?? '')) {
       const normalizedCardId = snapshot.cardId.trim();
       if (snapshot.alive === false) {
-        const terminalKey = { recencyMs: snapshotRecencyMs(snapshot), index: snapshotIndex };
+        const terminalRecencyMs = snapshotRecencyMs(snapshot);
+        if (terminalRecencyMs > nowMs) continue;
+        const terminalKey = { recencyMs: terminalRecencyMs, index: snapshotIndex };
         const existingTerminalKey = terminalRecencyByCardId.get(normalizedCardId);
         if (existingTerminalKey === undefined
           || terminalKey.recencyMs > existingTerminalKey.recencyMs

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -887,7 +887,7 @@ function hasSamePidLiveProbe(
   const snapshotRecency = snapshotRecencyMs(snapshot);
   return liveProbe !== undefined && (
     snapshotRecency === 0
-      ? liveProbe.recencyMs > 0 || liveProbe.index > snapshotIndex
+      ? liveProbe.index > snapshotIndex
       : liveProbe.recencyMs > snapshotRecency || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
   );
 }
@@ -971,6 +971,15 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (operatorControlledSignalExitReason(rawExitReason)) {
+    return {
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      ...base,
+      evidence,
+    };
+  }
+
   if (
     terminalKanbanState(kanbanState)
     && !crashKanbanState(kanbanState)
@@ -997,15 +1006,6 @@ export function buildWorkerCrashOnlyRestartContract(
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
-      ...base,
-      evidence,
-    };
-  }
-
-  if (operatorControlledSignalExitReason(rawExitReason)) {
-    return {
-      disposition: 'hitl',
-      nextAction: 'defer-with-evidence',
       ...base,
       evidence,
     };

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -887,7 +887,6 @@ function hasSamePidLiveProbe(
   const snapshotRecency = snapshotRecencyMs(snapshot);
   return liveProbe !== undefined && (
     liveProbe.recencyMs > snapshotRecency
-    || (liveProbe.recencyMs === 0 && snapshotRecency === 0)
     || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
   );
 }
@@ -1118,33 +1117,36 @@ export function detectStuckRunWatchdogFindings(
   const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
   const newestDeadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const newestDeadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
-  const terminalRecencyByCardId = new Map<string, number>();
+  const terminalRecencyByCardId = new Map<string, { readonly recencyMs: number; readonly index: number }>();
   let findingIndex = 0;
 
-  for (const snapshot of snapshots) {
+  for (const [snapshotIndex, snapshot] of snapshots.entries()) {
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
     if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot) && !setupFailureExitReason(snapshot.exitReason ?? '')) {
       const normalizedCardId = snapshot.cardId.trim();
       if (snapshot.alive === false) {
-        const terminalRecencyMs = snapshotRecencyMs(snapshot);
-        if (terminalRecencyMs > 0) {
-          terminalRecencyByCardId.set(
-            normalizedCardId,
-            Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
-          );
-          const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
-          if (existingKey && terminalRecencyMs > existingKey.recencyMs) {
-            const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
-            const newestFinding = newestDeadFindingsByCardId.get(normalizedCardId);
-            if (newestKey && newestFinding && newestKey.recencyMs > terminalRecencyMs) {
-              deadFindingKeysByCardId.set(normalizedCardId, newestKey);
-              deadFindingsByCardId.set(normalizedCardId, newestFinding);
-            } else {
-              deadFindingKeysByCardId.delete(normalizedCardId);
-              deadFindingsByCardId.delete(normalizedCardId);
-            }
+        const terminalKey = { recencyMs: snapshotRecencyMs(snapshot), index: snapshotIndex };
+        const existingTerminalKey = terminalRecencyByCardId.get(normalizedCardId);
+        if (existingTerminalKey === undefined
+          || terminalKey.recencyMs > existingTerminalKey.recencyMs
+          || (terminalKey.recencyMs === existingTerminalKey.recencyMs && terminalKey.index > existingTerminalKey.index)) {
+          terminalRecencyByCardId.set(normalizedCardId, terminalKey);
+        }
+        const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
+        const terminalClearsExisting = existingKey !== undefined
+          && terminalKey.recencyMs > 0
+          && (terminalKey.recencyMs > existingKey.recencyMs || (terminalKey.recencyMs === existingKey.recencyMs && terminalKey.index > existingKey.index));
+        if (existingKey && terminalClearsExisting) {
+          const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
+          const newestFinding = newestDeadFindingsByCardId.get(normalizedCardId);
+          if (newestKey && newestFinding && (newestKey.recencyMs > terminalKey.recencyMs || (newestKey.recencyMs === terminalKey.recencyMs && newestKey.index > terminalKey.index))) {
+            deadFindingKeysByCardId.set(normalizedCardId, newestKey);
+            deadFindingsByCardId.set(normalizedCardId, newestFinding);
+          } else {
+            deadFindingKeysByCardId.delete(normalizedCardId);
+            deadFindingsByCardId.delete(normalizedCardId);
           }
         }
       }
@@ -1248,8 +1250,11 @@ export function detectStuckRunWatchdogFindings(
         newestDeadFindingKeysByCardId.set(normalizedCardId, candidateKey);
         newestDeadFindingsByCardId.set(normalizedCardId, finding);
       }
-      const terminalRecencyMs = terminalRecencyByCardId.get(normalizedCardId);
-      if (terminalRecencyMs !== undefined && terminalRecencyMs > candidateKey.recencyMs) {
+      const terminalKey = terminalRecencyByCardId.get(normalizedCardId);
+      const terminalSuppressesCandidate = terminalKey !== undefined
+        && candidateKey.recencyMs > 0
+        && (terminalKey.recencyMs > candidateKey.recencyMs || (terminalKey.recencyMs === candidateKey.recencyMs && terminalKey.index > candidateKey.index));
+      if (terminalSuppressesCandidate) {
         findingIndex += 1;
         continue;
       }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -833,7 +833,7 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
     const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
       || snapshot.alive === false
-      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !(snapshot.alive === true && CRASH_WORKER_CARD_STATUSES.has(status)))
+      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) continue;
     const pids = byCard.get(cardId) ?? new Set<number>();
@@ -843,10 +843,10 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
   return new Map([...byCard].map(([cardId, pids]) => [cardId, [...pids].sort((a, b) => a - b)]));
 }
 
-function samePidLiveProbeRecencyByCardId(
+function samePidLiveProbesByCardId(
   snapshots: readonly IssueWorkerCardProcessSnapshot[],
-): Map<string, Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>> {
-  const byCard = new Map<string, Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>>();
+): Map<string, Map<number, Array<{ readonly recencyMs: number; readonly index: number }>>> {
+  const byCard = new Map<string, Map<number, Array<{ readonly recencyMs: number; readonly index: number }>>>();
   snapshots.forEach((snapshot, index) => {
     const cardId = snapshot.cardId.trim();
     const status = snapshot.status?.trim().toLowerCase();
@@ -855,14 +855,10 @@ function samePidLiveProbeRecencyByCardId(
       || (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !(snapshot.alive === true && CRASH_WORKER_CARD_STATUSES.has(status)))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) return;
-    const byPid = byCard.get(cardId) ?? new Map<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>();
-    const recencyMs = snapshotRecencyMs(snapshot);
-    const existingProbe = byPid.get(snapshot.pid);
-    if (existingProbe === undefined || recencyMs > existingProbe.recencyMs || (recencyMs === existingProbe.recencyMs && index > existingProbe.index)) {
-      byPid.set(snapshot.pid, { recencyMs, index, latestIndex: Math.max(existingProbe?.latestIndex ?? -1, index) });
-    } else if (index > existingProbe.latestIndex) {
-      byPid.set(snapshot.pid, { ...existingProbe, latestIndex: index });
-    }
+    const byPid = byCard.get(cardId) ?? new Map<number, Array<{ readonly recencyMs: number; readonly index: number }>>();
+    const probes = byPid.get(snapshot.pid) ?? [];
+    probes.push({ recencyMs: snapshotRecencyMs(snapshot), index });
+    byPid.set(snapshot.pid, probes);
     byCard.set(cardId, byPid);
   });
   return byCard;
@@ -881,17 +877,17 @@ function siblingPidsForSnapshot(
 
 function hasSamePidLiveProbe(
   snapshot: IssueWorkerCardProcessSnapshot,
-  liveProbeRecencyByCardId: ReadonlyMap<string, ReadonlyMap<number, { readonly recencyMs: number; readonly index: number; readonly latestIndex: number }>>,
+  liveProbesByCardId: ReadonlyMap<string, ReadonlyMap<number, readonly { readonly recencyMs: number; readonly index: number }[]>>,
   snapshotIndex: number,
 ): boolean {
   if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
-  const liveProbe = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
+  const liveProbes = liveProbesByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid) ?? [];
   const snapshotRecency = snapshotRecencyMs(snapshot);
-  return liveProbe !== undefined && (
-    snapshotRecency === 0
-      ? liveProbe.latestIndex > snapshotIndex
-      : liveProbe.recencyMs > snapshotRecency || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
-  );
+  return liveProbes.some(liveProbe => snapshotRecency === 0
+    ? liveProbe.index > snapshotIndex
+    : liveProbe.recencyMs > snapshotRecency
+      || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
+      || (liveProbe.recencyMs === 0 && liveProbe.index > snapshotIndex));
 }
 
 function normalizeKanbanState(status: string): string {
@@ -1119,7 +1115,7 @@ export function detectStuckRunWatchdogFindings(
   const longRunningWaitGraceMs = options.longRunningWaitGraceMs ?? DEFAULT_STUCK_RUN_WAIT_GRACE_MS;
   const findings: IssueStuckRunWatchdogFinding[] = [];
   const liveSiblings = liveSiblingPidsByCardId(snapshots);
-  const samePidLiveProbes = samePidLiveProbeRecencyByCardId(snapshots);
+  const samePidLiveProbes = samePidLiveProbesByCardId(snapshots);
   const deadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
   const newestDeadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
@@ -1145,7 +1141,6 @@ export function detectStuckRunWatchdogFindings(
         }
         const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
         const terminalClearsExisting = existingKey !== undefined
-          && terminalKey.recencyMs > 0
           && (terminalKey.recencyMs > existingKey.recencyMs || (terminalKey.recencyMs === existingKey.recencyMs && terminalKey.index > existingKey.index));
         if (existingKey && terminalClearsExisting) {
           const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
@@ -1182,7 +1177,7 @@ export function detectStuckRunWatchdogFindings(
     const freshLongRunningWaitActivity = [heartbeatAgeMs, outputAgeMs, toolActivityAgeMs, stateTransitionAgeMs]
       .some((age) => age !== undefined && age < longRunningWaitGraceMs);
     const samePidLiveProbe = hasSamePidLiveProbe(snapshot, samePidLiveProbes, snapshotIndex);
-    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && ((status !== undefined && crashKanbanState(status)) || setupFailureExitReason(snapshot.exitReason ?? '')))
+    const processStatus: IssueStuckRunWatchdogFinding['processStatus'] = snapshot.alive === false || (snapshot.alive !== true && !samePidLiveProbe && (operatorControlledSignalExitReason(snapshot.exitReason ?? '') || (status !== undefined && crashKanbanState(status)) || setupFailureExitReason(snapshot.exitReason ?? '')))
       ? 'dead'
       : hasPositivePid
         ? 'alive'

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -1082,15 +1082,17 @@ export function detectStuckRunWatchdogFindings(
     const status = snapshot.status?.trim().toLowerCase();
     if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot)) {
       const normalizedCardId = snapshot.cardId.trim();
-      const terminalRecencyMs = snapshotRecencyMs(snapshot);
-      terminalRecencyByCardId.set(
-        normalizedCardId,
-        Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
-      );
-      const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
-      if (existingKey && snapshot.alive !== true && terminalRecencyMs >= existingKey.recencyMs) {
-        deadFindingKeysByCardId.delete(normalizedCardId);
-        deadFindingsByCardId.delete(normalizedCardId);
+      if (snapshot.alive === false) {
+        const terminalRecencyMs = snapshotRecencyMs(snapshot);
+        terminalRecencyByCardId.set(
+          normalizedCardId,
+          Math.max(terminalRecencyByCardId.get(normalizedCardId) ?? 0, terminalRecencyMs),
+        );
+        const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
+        if (existingKey && terminalRecencyMs >= existingKey.recencyMs) {
+          deadFindingKeysByCardId.delete(normalizedCardId);
+          deadFindingsByCardId.delete(normalizedCardId);
+        }
       }
       continue;
     }

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -847,8 +847,10 @@ function samePidLiveProbeRecencyByCardId(snapshots: readonly IssueWorkerCardProc
   const byCard = new Map<string, Map<number, number>>();
   for (const snapshot of snapshots) {
     const cardId = snapshot.cardId.trim();
+    const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
       || snapshot.alive !== true
+      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) continue;
     const byPid = byCard.get(cardId) ?? new Map<number, number>();
@@ -875,7 +877,8 @@ function hasSamePidLiveProbe(
 ): boolean {
   if (snapshot.alive === false || !Number.isSafeInteger(snapshot.pid) || snapshot.pid <= 0) return false;
   const liveProbeRecencyMs = liveProbeRecencyByCardId.get(snapshot.cardId.trim())?.get(snapshot.pid);
-  return liveProbeRecencyMs !== undefined && liveProbeRecencyMs > snapshotRecencyMs(snapshot);
+  const snapshotRecency = snapshotRecencyMs(snapshot);
+  return liveProbeRecencyMs !== undefined && (liveProbeRecencyMs > snapshotRecency || (liveProbeRecencyMs === 0 && snapshotRecency === 0));
 }
 
 function normalizeKanbanState(status: string): string {
@@ -900,6 +903,11 @@ function operatorControlledSignalExitReason(exitReason: string): boolean {
 
 function dispatcherRestartExitReason(exitReason: string): boolean {
   return /^dispatcher_restart_/i.test(exitReason.trim());
+}
+
+function setupFailureExitReason(exitReason: string): boolean {
+  return exitReason === 'spawn_failed'
+    || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?\b|start[_ -]?failed\b|setup\b|enoent\b|eacces\b|protocol[_ -]?violation\b)/i.test(exitReason.trim());
 }
 
 export function buildWorkerCrashOnlyRestartContract(
@@ -943,7 +951,7 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (intentionalNonRetryExitReason(rawExitReason) || (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState))) {
+  if (intentionalNonRetryExitReason(rawExitReason)) {
     return {
       disposition: 'terminal',
       nextAction: 'no-op',
@@ -961,10 +969,19 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
-  if (rawExitReason === 'spawn_failed' || /^(?:spawn(?:[_ -]?(?:fail(?:ed|ure)?|error))?\b|start[_ -]?failed\b|setup\b|enoent\b|eacces\b|protocol[_ -]?violation\b)/i.test(rawExitReason.trim())) {
+  if (setupFailureExitReason(rawExitReason)) {
     return {
       disposition: 'hitl',
       nextAction: 'replace-with-doctor',
+      ...base,
+      evidence,
+    };
+  }
+
+  if (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState)) {
+    return {
+      disposition: 'terminal',
+      nextAction: 'no-op',
       ...base,
       evidence,
     };

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -833,7 +833,7 @@ function liveSiblingPidsByCardId(snapshots: readonly IssueWorkerCardProcessSnaps
     const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
       || snapshot.alive === false
-      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
+      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !(snapshot.alive === true && CRASH_WORKER_CARD_STATUSES.has(status)))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) continue;
     const pids = byCard.get(cardId) ?? new Set<number>();
@@ -852,7 +852,7 @@ function samePidLiveProbeRecencyByCardId(
     const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
       || snapshot.alive === false
-      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
+      || (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !(snapshot.alive === true && CRASH_WORKER_CARD_STATUSES.has(status)))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) return;
     const byPid = byCard.get(cardId) ?? new Map<number, { readonly recencyMs: number; readonly index: number }>();
@@ -887,7 +887,7 @@ function hasSamePidLiveProbe(
   const snapshotRecency = snapshotRecencyMs(snapshot);
   return liveProbe !== undefined && (
     snapshotRecency === 0
-      ? liveProbe.index > snapshotIndex
+      ? liveProbe.recencyMs > 0 || liveProbe.index > snapshotIndex
       : liveProbe.recencyMs > snapshotRecency || (liveProbe.recencyMs === snapshotRecency && liveProbe.index > snapshotIndex)
   );
 }
@@ -971,6 +971,19 @@ export function buildWorkerCrashOnlyRestartContract(
     };
   }
 
+  if (
+    terminalKanbanState(kanbanState)
+    && !crashKanbanState(kanbanState)
+    && !setupFailureExitReason(rawExitReason)
+  ) {
+    return {
+      disposition: 'terminal',
+      nextAction: 'no-op',
+      ...base,
+      evidence,
+    };
+  }
+
   if (activePrUrl || activeWorktreePath) {
     return {
       disposition: 'hitl',
@@ -993,15 +1006,6 @@ export function buildWorkerCrashOnlyRestartContract(
     return {
       disposition: 'hitl',
       nextAction: 'defer-with-evidence',
-      ...base,
-      evidence,
-    };
-  }
-
-  if (terminalKanbanState(kanbanState) && !crashKanbanState(kanbanState)) {
-    return {
-      disposition: 'terminal',
-      nextAction: 'no-op',
       ...base,
       evidence,
     };
@@ -1253,7 +1257,6 @@ export function detectStuckRunWatchdogFindings(
       }
       const terminalKey = terminalRecencyByCardId.get(normalizedCardId);
       const terminalSuppressesCandidate = terminalKey !== undefined
-        && candidateKey.recencyMs > 0
         && (terminalKey.recencyMs > candidateKey.recencyMs || (terminalKey.recencyMs === candidateKey.recencyMs && terminalKey.index > candidateKey.index));
       if (terminalSuppressesCandidate) {
         findingIndex += 1;

--- a/packages/franken-orchestrator/src/issues/issue-runner.ts
+++ b/packages/franken-orchestrator/src/issues/issue-runner.ts
@@ -849,7 +849,7 @@ function samePidLiveProbeRecencyByCardId(snapshots: readonly IssueWorkerCardProc
     const cardId = snapshot.cardId.trim();
     const status = snapshot.status?.trim().toLowerCase();
     if (!cardId
-      || snapshot.alive !== true
+      || snapshot.alive === false
       || (status && TERMINAL_WORKER_CARD_STATUSES.has(status))
       || !Number.isSafeInteger(snapshot.pid)
       || snapshot.pid <= 0) continue;
@@ -1105,6 +1105,8 @@ export function detectStuckRunWatchdogFindings(
   const samePidLiveProbes = samePidLiveProbeRecencyByCardId(snapshots);
   const deadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
   const deadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
+  const newestDeadFindingsByCardId = new Map<string, IssueStuckRunWatchdogFinding>();
+  const newestDeadFindingKeysByCardId = new Map<string, { readonly safetyRank: number; readonly recencyMs: number; readonly index: number }>();
   const terminalRecencyByCardId = new Map<string, number>();
   let findingIndex = 0;
 
@@ -1112,7 +1114,7 @@ export function detectStuckRunWatchdogFindings(
     if (!snapshot.cardId.trim()) continue;
     const hasPositivePid = Number.isSafeInteger(snapshot.pid) && snapshot.pid > 0;
     const status = snapshot.status?.trim().toLowerCase();
-    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot)) {
+    if (status && TERMINAL_WORKER_CARD_STATUSES.has(status) && !crashKanbanState(status) && !explicitProcessCrash(snapshot) && !setupFailureExitReason(snapshot.exitReason ?? '')) {
       const normalizedCardId = snapshot.cardId.trim();
       if (snapshot.alive === false) {
         const terminalRecencyMs = snapshotRecencyMs(snapshot);
@@ -1123,8 +1125,15 @@ export function detectStuckRunWatchdogFindings(
           );
           const existingKey = deadFindingKeysByCardId.get(normalizedCardId);
           if (existingKey && terminalRecencyMs >= existingKey.recencyMs) {
-            deadFindingKeysByCardId.delete(normalizedCardId);
-            deadFindingsByCardId.delete(normalizedCardId);
+            const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
+            const newestFinding = newestDeadFindingsByCardId.get(normalizedCardId);
+            if (newestKey && newestFinding && newestKey.recencyMs > terminalRecencyMs) {
+              deadFindingKeysByCardId.set(normalizedCardId, newestKey);
+              deadFindingsByCardId.set(normalizedCardId, newestFinding);
+            } else {
+              deadFindingKeysByCardId.delete(normalizedCardId);
+              deadFindingsByCardId.delete(normalizedCardId);
+            }
           }
         }
       }
@@ -1223,6 +1232,11 @@ export function detectStuckRunWatchdogFindings(
         recencyMs: snapshotRecencyMs(snapshot),
         index: findingIndex,
       };
+      const newestKey = newestDeadFindingKeysByCardId.get(normalizedCardId);
+      if (newestKey === undefined || candidateKey.recencyMs > newestKey.recencyMs || (candidateKey.recencyMs === newestKey.recencyMs && candidateKey.index > newestKey.index)) {
+        newestDeadFindingKeysByCardId.set(normalizedCardId, candidateKey);
+        newestDeadFindingsByCardId.set(normalizedCardId, finding);
+      }
       const terminalRecencyMs = terminalRecencyByCardId.get(normalizedCardId);
       if (terminalRecencyMs !== undefined && terminalRecencyMs >= candidateKey.recencyMs) {
         findingIndex += 1;

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1048,6 +1048,35 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('ignores future-dated terminal watermarks when evaluating real dead attempts', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_future_terminal_before_dead',
+        pid: 7413,
+        runId: 'run-future-complete',
+        status: 'completed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T13:00:00.000Z',
+      },
+      {
+        cardId: 't_future_terminal_before_dead',
+        pid: 7412,
+        runId: 'run-real-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_future_terminal_before_dead',
+      pid: 7412,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('does not let omitted-liveness terminal snapshots clear dead restart candidates', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -1543,6 +1572,31 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('lets a later undated same-PID live probe override an undated crash despite an older dated probe', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dated_live_then_undated_crash_then_live',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+      {
+        cardId: 't_dated_live_then_undated_crash_then_live',
+        pid: 7426,
+        status: 'failed',
+      },
+      {
+        cardId: 't_dated_live_then_undated_crash_then_live',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+      },
+    ], { nowMs });
+
+    expect(findings.some(finding => finding.processStatus === 'dead')).toBe(false);
+  });
+
   it('counts live crash-status probes as live evidence', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -1766,6 +1820,26 @@ describe('stuck-run watchdog', () => {
     expect(contract).toMatchObject({
       exitReason: 'signal_SIGTERM',
       disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('reports terminal operator signals through the watchdog detector', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_signal_stop_completed_watchdog',
+        pid: 7423,
+        status: 'completed',
+        alive: false,
+        exitReason: 'signal_SIGTERM',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_signal_stop_completed_watchdog',
+      exitReason: 'signal_SIGTERM',
+      processStatus: 'dead',
+      restartDisposition: 'hitl',
       nextAction: 'defer-with-evidence',
     });
   });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -990,6 +990,41 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('preserves newer retryable dead attempts when older HITL evidence is cleared by terminal cleanup', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_terminal_between_dead_attempts',
+        pid: 7426,
+        status: 'failed',
+        alive: false,
+        exitReason: 'spawn_failed',
+        lastHeartbeatAt: '2026-07-16T11:50:00.000Z',
+      },
+      {
+        cardId: 't_terminal_between_dead_attempts',
+        pid: 7427,
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+      {
+        cardId: 't_terminal_between_dead_attempts',
+        pid: 7428,
+        status: 'completed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_terminal_between_dead_attempts',
+      pid: 7427,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('uses terminal recency watermarks when terminal snapshots arrive before older dead attempts', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -1332,6 +1367,26 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('reports terminal setup failures through watchdog contract evaluation', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_watchdog_completed_spawn_failed',
+        pid: 7422,
+        status: 'completed',
+        alive: false,
+        exitReason: 'spawn_failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_watchdog_completed_spawn_failed',
+      exitReason: 'spawn_failed',
+      restartDisposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+    });
+  });
+
   it('treats crash-like terminal statuses as retryable process crashes', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_direct_failed',
@@ -1505,6 +1560,31 @@ describe('stuck-run watchdog', () => {
 
     expect(finding).toMatchObject({
       cardId: 't_undated_same_pid_probe',
+      pid: 7426,
+      processStatus: 'alive',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('honors omitted-liveness same-PID live snapshots', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_omitted_liveness_same_pid_probe',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+      {
+        cardId: 't_omitted_liveness_same_pid_probe',
+        pid: 7426,
+        status: 'running',
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_omitted_liveness_same_pid_probe',
       pid: 7426,
       processStatus: 'alive',
       restartDisposition: 'hitl',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -990,6 +990,29 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('uses terminal recency watermarks when terminal snapshots arrive before older dead attempts', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_terminal_before_old_dead',
+        pid: 7413,
+        runId: 'run-new-complete',
+        status: 'completed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+      {
+        cardId: 't_terminal_before_old_dead',
+        pid: 7412,
+        runId: 'run-old-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('treats dispatcher restart stop reasons as HITL repair evidence before retrying', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
@@ -1336,6 +1359,35 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('honors same-PID live probes before inferring status-only crash snapshots are dead', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_same_pid_probe',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+      {
+        cardId: 't_same_pid_probe',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        cardId: 't_same_pid_probe',
+        pid: 7426,
+        processStatus: 'alive',
+        restartDisposition: 'hitl',
+        nextAction: 'defer-with-evidence',
+      }),
+    ]);
+    expect(findings[0]!.recommendedAction).not.toContain('respawn one focused worker');
+  });
+
   it('keeps intentional operator exits non-retryable in direct restart contracts', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_operator_stop',
@@ -1354,6 +1406,32 @@ describe('stuck-run watchdog', () => {
       disposition: 'terminal',
       nextAction: 'no-op',
     });
+  });
+
+  it('keeps intentional exits terminal even when active ownership evidence is present', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_operator_stop_owned',
+      pid: 7420,
+      status: 'running',
+      alive: false,
+      exitReason: 'operator_stop',
+      activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
+      activeWorktreePath: '/tmp/frankenbeast/.worktrees/t_operator_stop_owned',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'operator_stop',
+      disposition: 'terminal',
+      nextAction: 'no-op',
+    });
+    expect(contract.evidence).toEqual(expect.arrayContaining([
+      'activePr=https://github.com/djm204/frankenbeast/pull/2560',
+      'activeWorktree=/tmp/frankenbeast/.worktrees/t_operator_stop_owned',
+    ]));
   });
 
   it('defers external signal exits for operator investigation in direct restart contracts', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1416,6 +1416,58 @@ describe('stuck-run watchdog', () => {
     expect(findings[0]!.recommendedAction).not.toContain('respawn one focused worker');
   });
 
+  it('prefers newer same-PID crash snapshots over older live probes', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_same_pid_probe_newer_crash',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:50:00.000Z',
+      },
+      {
+        cardId: 't_same_pid_probe_newer_crash',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_same_pid_probe_newer_crash',
+      pid: 7426,
+      processStatus: 'dead',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
+  it('does not let undated terminal records clear undated dead restart candidates', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_undated_terminal_then_dead',
+        pid: 7427,
+        status: 'completed',
+        alive: false,
+      },
+      {
+        cardId: 't_undated_terminal_then_dead',
+        pid: 7428,
+        status: 'running',
+        alive: false,
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_undated_terminal_then_dead',
+      pid: 7428,
+      processStatus: 'dead',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('keeps intentional operator exits non-retryable in direct restart contracts', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_operator_stop',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1663,6 +1663,33 @@ describe('stuck-run watchdog', () => {
     expect(findings.some(finding => finding.processStatus === 'dead')).toBe(false);
   });
 
+  it('suppresses same-PID crash warnings after newer terminal cleanup', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_crash_probe_then_terminal_cleanup',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_crash_probe_then_terminal_cleanup',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+      {
+        cardId: 't_crash_probe_then_terminal_cleanup',
+        pid: 7426,
+        status: 'completed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:59:30.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('counts live crash-status probes as live evidence', () => {
     const findings = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -908,6 +908,34 @@ describe('stuck-run watchdog', () => {
     expect(findings[0].evidence).toContain('siblingPids=7413');
   });
 
+  it('does not derive live siblings from older crash-status probes', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_old_crash_probe_not_sibling',
+        pid: 7412,
+        status: 'failed',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_old_crash_probe_not_sibling',
+        pid: 7413,
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    const finding = findings.find(candidate => candidate.pid === 7413);
+    expect(finding).toMatchObject({
+      cardId: 't_old_crash_probe_not_sibling',
+      pid: 7413,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+    expect(finding.evidence).not.toContain('siblingPids=7412');
+  });
+
   it('coalesces multiple dead attempts into one restart recommendation', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -1075,6 +1103,25 @@ describe('stuck-run watchdog', () => {
       restartDisposition: 'retryable',
       nextAction: 'restart-once',
     });
+  });
+
+  it('lets later undated terminal cleanup clear an earlier undated dead attempt', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_undated_dead_then_terminal',
+        pid: 7412,
+        status: 'running',
+        alive: false,
+      },
+      {
+        cardId: 't_undated_dead_then_terminal',
+        pid: 7413,
+        status: 'completed',
+        alive: false,
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
   });
 
   it('does not let omitted-liveness terminal snapshots clear dead restart candidates', () => {
@@ -1597,6 +1644,25 @@ describe('stuck-run watchdog', () => {
     expect(findings.some(finding => finding.processStatus === 'dead')).toBe(false);
   });
 
+  it('lets a later undated same-PID live probe override an earlier dated crash', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dated_crash_then_undated_live',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+      {
+        cardId: 't_dated_crash_then_undated_live',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+      },
+    ], { nowMs });
+
+    expect(findings.some(finding => finding.processStatus === 'dead')).toBe(false);
+  });
+
   it('counts live crash-status probes as live evidence', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
@@ -1837,6 +1903,25 @@ describe('stuck-run watchdog', () => {
 
     expect(finding).toMatchObject({
       cardId: 't_signal_stop_completed_watchdog',
+      exitReason: 'signal_SIGTERM',
+      processStatus: 'dead',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('reports terminal operator signals when liveness is omitted', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_signal_stop_without_liveness',
+        pid: 7423,
+        status: 'completed',
+        exitReason: 'signal_SIGTERM',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_signal_stop_without_liveness',
       exitReason: 'signal_SIGTERM',
       processStatus: 'dead',
       restartDisposition: 'hitl',

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1311,6 +1311,27 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('routes setup failures to doctor even after terminal Kanban cleanup', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_completed_spawn_failed',
+      pid: 7422,
+      status: 'completed',
+      alive: false,
+      exitReason: 'spawn_failed',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'completed',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'spawn_failed',
+      disposition: 'hitl',
+      nextAction: 'replace-with-doctor',
+      kanbanState: 'completed',
+    });
+  });
+
   it('treats crash-like terminal statuses as retryable process crashes', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_direct_failed',
@@ -1439,6 +1460,55 @@ describe('stuck-run watchdog', () => {
       processStatus: 'dead',
       restartDisposition: 'retryable',
       nextAction: 'restart-once',
+    });
+  });
+
+  it('does not treat terminal same-PID records as live crash probes', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_same_pid_terminal_probe',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+      {
+        cardId: 't_same_pid_terminal_probe',
+        pid: 7426,
+        status: 'completed',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_same_pid_terminal_probe',
+      processStatus: 'dead',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
+  it('honors undated same-PID live probes as ambiguous live evidence', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_undated_same_pid_probe',
+        pid: 7426,
+        status: 'failed',
+      },
+      {
+        cardId: 't_undated_same_pid_probe',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_undated_same_pid_probe',
+      pid: 7426,
+      processStatus: 'alive',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1518,6 +1518,59 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('honors dated same-PID live probes before undated crash snapshots', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dated_live_then_undated_crash',
+        pid: 7426,
+        status: 'running',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+      {
+        cardId: 't_dated_live_then_undated_crash',
+        pid: 7426,
+        status: 'failed',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_dated_live_then_undated_crash',
+      pid: 7426,
+      processStatus: 'alive',
+      restartDisposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('counts live crash-status probes as live evidence', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_live_failed_status_probe',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+      {
+        cardId: 't_live_failed_status_probe',
+        pid: 7426,
+        status: 'failed',
+        alive: true,
+        lastHeartbeatAt: '2026-07-16T11:59:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        cardId: 't_live_failed_status_probe',
+        processStatus: 'alive',
+        restartDisposition: 'hitl',
+        nextAction: 'defer-with-evidence',
+      }),
+    ]));
+    expect(findings.some(finding => finding.processStatus === 'dead')).toBe(false);
+  });
+
   it('does not treat terminal same-PID records as live crash probes', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
@@ -1592,13 +1645,14 @@ describe('stuck-run watchdog', () => {
     });
   });
 
-  it('does not let undated terminal records clear undated dead restart candidates', () => {
+  it('lets dated terminal records clear later undated dead restart candidates', () => {
     const findings = detectStuckRunWatchdogFindings([
       {
         cardId: 't_undated_terminal_then_dead',
         pid: 7427,
         status: 'completed',
         alive: false,
+        lastStateTransitionAt: '2026-07-16T11:59:00.000Z',
       },
       {
         cardId: 't_undated_terminal_then_dead',
@@ -1608,14 +1662,7 @@ describe('stuck-run watchdog', () => {
       },
     ], { nowMs });
 
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({
-      cardId: 't_undated_terminal_then_dead',
-      pid: 7428,
-      processStatus: 'dead',
-      restartDisposition: 'retryable',
-      nextAction: 'restart-once',
-    });
+    expect(findings).toHaveLength(0);
   });
 
   it('keeps intentional operator exits non-retryable in direct restart contracts', () => {
@@ -1662,6 +1709,25 @@ describe('stuck-run watchdog', () => {
       'activePr=https://github.com/djm204/frankenbeast/pull/2560',
       'activeWorktree=/tmp/frankenbeast/.worktrees/t_operator_stop_owned',
     ]));
+  });
+
+  it('keeps terminal card states ahead of active ownership deferral', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_completed_with_pr',
+      pid: 7420,
+      status: 'completed',
+      alive: false,
+      activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'completed',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'terminal',
+      nextAction: 'no-op',
+    });
   });
 
   it('defers external signal exits for operator investigation in direct restart contracts', () => {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -967,6 +967,29 @@ describe('stuck-run watchdog', () => {
     });
   });
 
+  it('lets newer terminal snapshots clear stale dead restart candidates', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_then_terminal',
+        pid: 7412,
+        runId: 'run-old-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_dead_then_terminal',
+        pid: 7413,
+        runId: 'run-new-complete',
+        status: 'completed',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toEqual([]);
+  });
+
   it('treats dispatcher restart stop reasons as HITL repair evidence before retrying', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
@@ -1196,6 +1219,28 @@ describe('stuck-run watchdog', () => {
     expect(contract.evidence.join('\n')).not.toContain('secret-value');
   });
 
+  it('defers spawn failures with active ownership before routing to doctor replacement', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_spawn_failed_owned',
+      pid: 7418,
+      status: 'running',
+      alive: false,
+      exitReason: 'spawn_failed',
+      activePrUrl: 'https://github.com/djm204/frankenbeast/pull/2560',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+      kanbanState: 'running',
+    });
+    expect(contract.evidence).toContain('activePr=https://github.com/djm204/frankenbeast/pull/2560');
+  });
+
   it('keeps direct terminal restart contracts as no-op before dead-process retry', () => {
     const contract = buildWorkerCrashOnlyRestartContract({
       cardId: 't_direct_completed',
@@ -1270,6 +1315,24 @@ describe('stuck-run watchdog', () => {
       nextAction: 'defer-with-evidence',
       processStatus: 'alive',
       kanbanState: 'failed',
+    });
+  });
+
+  it('treats status-only crash snapshots as dead when no live probe contradicts them', () => {
+    const [finding] = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_status_only_failed',
+        pid: 7426,
+        status: 'failed',
+        lastHeartbeatAt: '2026-07-16T11:55:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(finding).toMatchObject({
+      cardId: 't_status_only_failed',
+      processStatus: 'dead',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
     });
   });
 
@@ -1565,8 +1628,8 @@ describe('stuck-run watchdog', () => {
     expect(findings[0]).toMatchObject({
       cardId: 't_crashed_without_probe',
       blockerCategory: 'process-crash',
-      confidence: 'medium',
-      processStatus: 'alive',
+      confidence: 'high',
+      processStatus: 'dead',
       kanbanState: 'failed',
     });
   });
@@ -1583,8 +1646,8 @@ describe('stuck-run watchdog', () => {
     expect(findings[0]).toMatchObject({
       cardId: 't_crashed_without_activity',
       blockerCategory: 'process-crash',
-      confidence: 'medium',
-      processStatus: 'alive',
+      confidence: 'high',
+      processStatus: 'dead',
       kanbanState: 'failed',
     });
   });
@@ -1603,8 +1666,8 @@ describe('stuck-run watchdog', () => {
     expect(findings[0]).toMatchObject({
       cardId: 't_failed_stale_ci_wait',
       blockerCategory: 'process-crash',
-      confidence: 'medium',
-      processStatus: 'alive',
+      confidence: 'high',
+      processStatus: 'dead',
       kanbanState: 'failed',
     });
   });

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1013,6 +1013,34 @@ describe('stuck-run watchdog', () => {
     expect(findings).toEqual([]);
   });
 
+  it('does not let omitted-liveness terminal snapshots clear dead restart candidates', () => {
+    const findings = detectStuckRunWatchdogFindings([
+      {
+        cardId: 't_dead_then_terminal_without_probe',
+        pid: 7412,
+        runId: 'run-old-dead',
+        status: 'running',
+        alive: false,
+        lastHeartbeatAt: '2026-07-16T11:30:00.000Z',
+      },
+      {
+        cardId: 't_dead_then_terminal_without_probe',
+        pid: 7413,
+        runId: 'run-new-complete-no-probe',
+        status: 'completed',
+        lastHeartbeatAt: '2026-07-16T11:31:00.000Z',
+      },
+    ], { nowMs });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      cardId: 't_dead_then_terminal_without_probe',
+      pid: 7412,
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
+    });
+  });
+
   it('treats dispatcher restart stop reasons as HITL repair evidence before retrying', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {

--- a/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
+++ b/packages/franken-orchestrator/tests/unit/issues/issue-runner.test.ts
@@ -1518,7 +1518,7 @@ describe('stuck-run watchdog', () => {
     });
   });
 
-  it('honors dated same-PID live probes before undated crash snapshots', () => {
+  it('does not let an older dated same-PID live probe mask a later undated crash snapshot', () => {
     const [finding] = detectStuckRunWatchdogFindings([
       {
         cardId: 't_dated_live_then_undated_crash',
@@ -1537,9 +1537,9 @@ describe('stuck-run watchdog', () => {
     expect(finding).toMatchObject({
       cardId: 't_dated_live_then_undated_crash',
       pid: 7426,
-      processStatus: 'alive',
-      restartDisposition: 'hitl',
-      nextAction: 'defer-with-evidence',
+      processStatus: 'dead',
+      restartDisposition: 'retryable',
+      nextAction: 'restart-once',
     });
   });
 
@@ -1741,6 +1741,26 @@ describe('stuck-run watchdog', () => {
       category: 'process-crash',
       processStatus: 'dead',
       kanbanState: 'running',
+    });
+
+    expect(contract).toMatchObject({
+      exitReason: 'signal_SIGTERM',
+      disposition: 'hitl',
+      nextAction: 'defer-with-evidence',
+    });
+  });
+
+  it('preserves operator signal investigation after the Kanban card becomes terminal', () => {
+    const contract = buildWorkerCrashOnlyRestartContract({
+      cardId: 't_signal_stop_completed',
+      pid: 7423,
+      status: 'completed',
+      alive: false,
+      exitReason: 'signal_SIGTERM',
+    }, {
+      category: 'process-crash',
+      processStatus: 'dead',
+      kanbanState: 'completed',
     });
 
     expect(contract).toMatchObject({

--- a/tasks/close-out-pr-2616-current-head-codex-findings-progress.md
+++ b/tasks/close-out-pr-2616-current-head-codex-findings-progress.md
@@ -1,0 +1,13 @@
+# Close out PR #2616 current-head Codex findings
+
+- [x] Load Kanban task and PR context
+- [x] Check out PR branch/head in isolated worktree
+- [x] Inspect current issue-runner restart/diagnostic logic and Codex findings
+- [x] Patch issue-runner restart contract findings
+- [x] Add/update unit tests for the findings
+- [x] Run targeted tests/typecheck
+- [x] Push changes through the approved path or block with exact approval-cop handoff if gated. Pushed `de7234eac13b5ea9d3d992f9699d93cb0d4253c8` to `origin/resolve/issue-1675-late-codex-followup`.
+- [x] Reply/resolve pre-existing Codex threads and trigger fresh current-head @codex review at `2026-07-18T02:11:54Z`.
+- [x] Capture and fix the fresh current-head Codex findings (`3607351492`, `3607351498`) with regression tests.
+- [ ] Push updated fix commit, reply/resolve the fresh Codex threads, and rerun current-head @codex review until clean.
+- [ ] Verify CI, CLEAN mergeability, zero unresolved Codex threads, then merge or block with exact evidence.


### PR DESCRIPTION
## Summary
- fixes late post-merge Codex findings from PR #2560 / issue #1675 without reopening or closing other issues
- lets newer terminal snapshots clear stale dead restart candidates while preserving live terminal stale snapshots as non-siblings
- defers active-owner spawn failures before doctor replacement and treats status-only crash snapshots as retryable dead crashes

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/unit/issues/issue-runner.test.ts (123 passed)
- npm run typecheck --workspace @franken/orchestrator
- npm run build
- npm run lint --workspace @franken/orchestrator (passes with existing warnings)

Follow-up for #1675 and PR #2560.