### PR TITLE
fix(orchestrator): serialize chat session writes

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-rate-limit.ts
+++ b/packages/franken-orchestrator/src/http/chat-rate-limit.ts
@@ -52,11 +52,28 @@ export function chatMutationKey(sessionId: string): string {
 
 export class ChatMutationAdmission {
   private readonly inFlightMutations = new Set<string>();
+  private readonly mutationQueues = new Map<string, Promise<void>>();
 
   constructor(private readonly limiter: InMemoryRateLimiter) {}
 
   takeRateLimit(key: string): boolean {
     return this.limiter.take(key).allowed;
+  }
+
+  async runExclusive<T>(sessionId: string, run: () => Promise<T>): Promise<T> {
+    const mutationKey = chatMutationKey(sessionId);
+    const previous = this.mutationQueues.get(mutationKey) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(run);
+    const currentDone = current.then(() => undefined, () => undefined);
+    this.mutationQueues.set(mutationKey, currentDone);
+
+    try {
+      return await current;
+    } finally {
+      if (this.mutationQueues.get(mutationKey) === currentDone) {
+        this.mutationQueues.delete(mutationKey);
+      }
+    }
   }
 
   begin(sessionId: string): boolean {

--- a/packages/franken-orchestrator/src/http/chat-rate-limit.ts
+++ b/packages/franken-orchestrator/src/http/chat-rate-limit.ts
@@ -51,7 +51,7 @@ export function chatMutationKey(sessionId: string): string {
 }
 
 export class ChatMutationAdmission {
-  private readonly inFlightMutations = new Set<string>();
+  private readonly activeTurns = new Map<string, { done: Promise<void>; release: () => void }>();
   private readonly mutationQueues = new Map<string, Promise<void>>();
 
   constructor(private readonly limiter: InMemoryRateLimiter) {}
@@ -78,14 +78,29 @@ export class ChatMutationAdmission {
 
   begin(sessionId: string): boolean {
     const mutationKey = chatMutationKey(sessionId);
-    if (this.inFlightMutations.has(mutationKey)) {
+    if (this.mutationQueues.has(mutationKey)) {
       return false;
     }
-    this.inFlightMutations.add(mutationKey);
+
+    let release!: () => void;
+    const done = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.activeTurns.set(mutationKey, { done, release });
+    this.mutationQueues.set(mutationKey, done);
     return true;
   }
 
   end(sessionId: string): void {
-    this.inFlightMutations.delete(chatMutationKey(sessionId));
+    const mutationKey = chatMutationKey(sessionId);
+    const activeTurn = this.activeTurns.get(mutationKey);
+    if (!activeTurn) {
+      return;
+    }
+    this.activeTurns.delete(mutationKey);
+    activeTurn.release();
+    if (this.mutationQueues.get(mutationKey) === activeTurn.done) {
+      this.mutationQueues.delete(mutationKey);
+    }
   }
 }

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -160,7 +160,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
   async function withChatMutationAdmission<T>(
     c: Context,
     sessionId: string,
-    run: () => Promise<T>,
+    run: (session: NonNullable<ReturnType<ISessionStore['get']>>) => Promise<T>,
   ): Promise<T> {
     if (!admission.takeRateLimit(chatClientKey({
       action: 'message',
@@ -169,14 +169,8 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     }))) {
       throw new HttpError(429, 'RATE_LIMITED', 'Rate limit exceeded');
     }
-    if (!admission.begin(sessionId)) {
-      throw new HttpError(429, 'RATE_LIMITED', 'Chat mutation already in progress');
-    }
-    try {
-      return await run();
-    } finally {
-      admission.end(sessionId);
-    }
+
+    return admission.runExclusive(sessionId, async () => run(getSessionOrThrow(sessionStore, sessionId)));
   }
 
   function approvalRequester(c: Context): string {
@@ -387,9 +381,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const id = validateChatSessionId(c.req.param('id'));
     const body = await parseJsonBody(c);
     const { content, executionMode } = validateBody(SubmitMessageBody, body);
-    const session = getSessionOrThrow(sessionStore, id);
-
-    return withChatMutationAdmission(c, session.id, async () => {
+    return withChatMutationAdmission(c, id, async (session) => {
       if (session.pendingApproval || session.state === 'pending_approval') {
         return c.json({
           error: {
@@ -466,9 +458,7 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
     const id = validateChatSessionId(c.req.param('id'));
     const body = await parseJsonBody(c);
     const { approved } = validateBody(ApproveBody, body);
-    const session = getSessionOrThrow(sessionStore, id);
-
-    return withChatMutationAdmission(c, session.id, async () => {
+    return withChatMutationAdmission(c, id, async (session) => {
       if (!session.pendingApproval) {
         if (session.state === 'approved' || session.state === 'rejected') {
           return c.json({

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-concurrency.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-concurrency.test.ts
@@ -41,10 +41,29 @@ describe('ChatMutationAdmission concurrency', () => {
 
     await Promise.resolve();
     expect(order).toEqual(['first:start']);
+    expect(admission.begin('session-1')).toBe(false);
 
     releaseFirstRun.resolve();
     await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
     expect(order).toEqual(['first:start', 'first:end', 'second:start', 'second:end']);
+  });
+
+  it('waits for begin/end guarded turns before running queued mutations', async () => {
+    const admission = new ChatMutationAdmission(new InMemoryRateLimiter({ windowMs: 60_000, max: 10 }));
+    const order: string[] = [];
+
+    expect(admission.begin('session-1')).toBe(true);
+    const queued = admission.runExclusive('session-1', async () => {
+      order.push('queued');
+      return 'queued';
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    admission.end('session-1');
+    await expect(queued).resolves.toBe('queued');
+    expect(order).toEqual(['queued']);
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-concurrency.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-concurrency.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createChatApp } from '../../../src/http/chat-app.js';
+import { ChatMutationAdmission } from '../../../src/http/chat-rate-limit.js';
+import { FileSessionStore } from '../../../src/chat/session-store.js';
+import { InMemoryRateLimiter } from '../../../src/beasts/http/beast-rate-limit.js';
+import type { ChatRuntimeState } from '../../../src/chat/runtime.js';
+import type { TranscriptMessage } from '../../../src/chat/types.js';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('ChatMutationAdmission concurrency', () => {
+  it('queues mutations for the same session instead of rejecting overlap', async () => {
+    const admission = new ChatMutationAdmission(new InMemoryRateLimiter({ windowMs: 60_000, max: 10 }));
+    const firstRunStarted = deferred();
+    const releaseFirstRun = deferred();
+    const order: string[] = [];
+
+    const first = admission.runExclusive('session-1', async () => {
+      order.push('first:start');
+      firstRunStarted.resolve();
+      await releaseFirstRun.promise;
+      order.push('first:end');
+      return 'first';
+    });
+    await firstRunStarted.promise;
+
+    const second = admission.runExclusive('session-1', async () => {
+      order.push('second:start');
+      order.push('second:end');
+      return 'second';
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(['first:start']);
+
+    releaseFirstRun.resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
+    expect(order).toEqual(['first:start', 'first:end', 'second:start', 'second:end']);
+  });
+});
+
+describe('chat message route concurrency', () => {
+  let sessionStoreDir: string;
+  let sessionStore: FileSessionStore;
+
+  beforeEach(() => {
+    sessionStoreDir = mkdtempSync(join(tmpdir(), 'franken-chat-message-concurrency-'));
+    sessionStore = new FileSessionStore(sessionStoreDir);
+  });
+
+  afterEach(() => {
+    rmSync(sessionStoreDir, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent submissions for the same session instead of losing a write', async () => {
+    const firstRunStarted = deferred();
+    const releaseFirstRun = deferred();
+    const runtime = {
+      run: vi.fn(async (input: string, state: ChatRuntimeState) => {
+        if (input === 'first') {
+          firstRunStarted.resolve();
+          await releaseFirstRun.promise;
+        }
+
+        const now = new Date().toISOString();
+        const transcript: TranscriptMessage[] = [
+          ...state.transcript,
+          { role: 'user', content: input, timestamp: now },
+          { role: 'assistant', content: `reply to ${input}`, timestamp: now, modelTier: 'cheap' },
+        ];
+
+        return {
+          displayMessages: [{ kind: 'reply' as const, content: `reply to ${input}` }],
+          events: [],
+          pendingApproval: false,
+          state: 'active',
+          tier: 'cheap',
+          transcript,
+          beastContext: null,
+        };
+      }),
+    };
+    const app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+      chatRateLimit: { windowMs: 60_000, max: 10 },
+    });
+    const session = sessionStore.create('project-1');
+
+    const firstResponsePromise = app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'first' }),
+    });
+    await firstRunStarted.promise;
+
+    const secondResponsePromise = app.request(`/v1/chat/sessions/${session.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'second' }),
+    });
+
+    releaseFirstRun.resolve();
+    const [firstResponse, secondResponse] = await Promise.all([firstResponsePromise, secondResponsePromise]);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(runtime.run).toHaveBeenCalledTimes(2);
+    expect(runtime.run.mock.calls[1]?.[1].transcript.map((message: TranscriptMessage) => message.content)).toEqual([
+      'first',
+      'reply to first',
+    ]);
+    expect(sessionStore.get(session.id)?.transcript.map((message) => message.content)).toEqual([
+      'first',
+      'reply to first',
+      'second',
+      'reply to second',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- queue REST chat mutations per session instead of rejecting same-session overlap
- reload the session inside the queued critical section before appending messages or approvals
- add regression coverage for concurrent chat message submissions

## Test Plan
- npm ci
- npm run build --workspace @franken/types
- npm run build --workspace @franken/planner
- npm run build --workspace @franken/brain
- npm run build --workspace @franken/observer
- npm run build --workspace @franken/critique
- npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm test -- --run tests/unit/http/chat-routes-concurrency.test.ts tests/unit/http/chat-routes-approval.test.ts
- npm run test --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (passes with pre-existing warnings)

Closes #2382