### PR TITLE
docs(observer): fix SamplingAdapter SQLite example

### DIFF
--- a/packages/franken-observer/src/sampling/TraceSampler.ts
+++ b/packages/franken-observer/src/sampling/TraceSampler.ts
@@ -126,7 +126,7 @@ export interface SamplingAdapterOptions {
  * ```ts
  * const adapter = new SamplingAdapter({
  *   strategy: new ProbabilisticSampler(0.1), // keep 10%
- *   adapter: new SQLiteAdapter({ path: 'traces.db' }),
+ *   adapter: new SQLiteAdapter('traces.db'),
  * })
  * await adapter.flush(trace) // ~90% of calls are silently dropped
  * ```


### PR DESCRIPTION
## Summary
- Fix the SamplingAdapter JSDoc example to construct SQLiteAdapter with the documented string path API
- Keep the example aligned with the adapter guide and SQLiteAdapter tests

## Test Plan
- npm run test --workspace @franken/observer -- src/sampling/TraceSampler.test.ts
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/observer
- npm run build --workspace @franken/observer
- npm run lint --workspace @franken/observer

Closes #2628