### PR TITLE
fix(brain): prune persisted memory on reduced entry limits

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1231,6 +1231,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       key: string;
       normalized: unknown;
       serialized: string;
+      persistedSerialized: string;
       size: number;
       updatedAt: string;
       protected: boolean;
@@ -1248,6 +1249,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         key: row.key,
         normalized,
         serialized,
+        persistedSerialized: row.serialized,
         size,
         updatedAt: row.updatedAt,
         protected: MEMORY_RETENTION_POLICIES[classifyMemoryEntry({
@@ -1326,7 +1328,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     }
   }
 
-  private prunePersistedRows(rows: ReadonlyArray<{ key: string; serialized: string; updatedAt: string }>): void {
+  private prunePersistedRows(rows: ReadonlyArray<{ key: string; persistedSerialized: string; updatedAt: string }>): void {
     if (rows.length === 0) return;
     const selectKey = this.db.prepare(`SELECT value, updated_at AS updatedAt FROM working_memory WHERE key = ?`);
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
@@ -1337,7 +1339,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       for (const row of rows) {
         const current = selectKey.get(row.key) as { value: string; updatedAt: string } | undefined;
         const currentSerialized = current ? (this.encryption?.decrypt(current.value) ?? current.value) : undefined;
-        if (currentSerialized !== row.serialized || current?.updatedAt !== row.updatedAt) {
+        if (currentSerialized !== row.persistedSerialized || current?.updatedAt !== row.updatedAt) {
           throw new WorkingMemoryLimitError(
             `Persisted working memory row ${row.key} changed before startup pruning could delete it`,
           );
@@ -1360,6 +1362,9 @@ class SqliteWorkingMemory implements IWorkingMemory {
 
   expirePrunedRuntimeKeys(keys: readonly string[]): void {
     for (const key of keys) {
+      if (this.dirtyKeys.has(key) || this.deletedKeys.has(key)) {
+        continue;
+      }
       if (this.store.has(key)) {
         this.totalBytes -= this.sizes.get(key) ?? 0;
       }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1180,6 +1180,16 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private deletedKeys = new Set<string>();
   private totalBytes = 0;
 
+  private static readonly persistedRowOrder = (
+    left: { key: string; updatedAt: string },
+    right: { key: string; updatedAt: string },
+  ): number => {
+    const updatedAtComparison = left.updatedAt.localeCompare(right.updatedAt);
+    return updatedAtComparison === 0
+      ? left.key.localeCompare(right.key)
+      : updatedAtComparison;
+  };
+
   constructor(
     private db: Database.Database,
     private limits: WorkingMemoryLimits = DEFAULT_WORKING_MEMORY_LIMITS,
@@ -1196,13 +1206,15 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private loadPersistedSerializedFromDb(): Array<{
     key: string;
     value: string;
+    updatedAt: string;
   }> {
     const rows = this.db
-      .prepare(`SELECT key, value FROM working_memory ORDER BY key ASC`)
-      .all() as Array<{ key: string; value: string }>;
+      .prepare(`SELECT key, value, updated_at AS updatedAt FROM working_memory ORDER BY key ASC`)
+      .all() as Array<{ key: string; value: string; updatedAt: string }>;
     const decryptedRows = rows.map((row) => ({
       key: row.key,
       value: this.encryption?.decrypt(row.value) ?? row.value,
+      updatedAt: row.updatedAt,
     }));
     this.persistedSerialized = new Map(
       decryptedRows.map((row) => [row.key, row.value]),
@@ -1214,7 +1226,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private loadFromDb(): void {
     const rows = this.loadPersistedSerializedFromDb();
 
-    const prepared: Array<[string, unknown, string, number]> = [];
+    let prepared: Array<[string, unknown, string, number, string]> = [];
     const expiredRows: Array<{ key: string; serialized: string }> = [];
     let total = 0;
     for (const row of rows) {
@@ -1228,7 +1240,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         parsed,
       );
       total += size;
-      prepared.push([row.key, normalized, serialized, size]);
+      prepared.push([row.key, normalized, serialized, size, row.updatedAt]);
     }
     const preservedRows = this.deleteExpiredPersistedRows(expiredRows);
     const preparedKeys = new Set(prepared.map(([key]) => key));
@@ -1241,13 +1253,22 @@ class SqliteWorkingMemory implements IWorkingMemory {
         parsed,
       );
       total += size;
-      prepared.push([row.key, normalized, serialized, size]);
+      prepared.push([row.key, normalized, serialized, size, row.updatedAt]);
       preparedKeys.add(row.key);
     }
     if (prepared.length > this.limits.maxEntries) {
-      throw new WorkingMemoryLimitError(
-        `Persisted working memory has ${prepared.length} entries after TTL cleanup, exceeding maxEntries (${this.limits.maxEntries})`,
-      );
+      const rowsToDrop = [...prepared]
+        .sort(([leftKey, , , , leftUpdatedAt], [rightKey, , , , rightUpdatedAt]) =>
+          SqliteWorkingMemory.persistedRowOrder(
+            { key: leftKey, updatedAt: leftUpdatedAt },
+            { key: rightKey, updatedAt: rightUpdatedAt },
+          ),
+        )
+        .slice(0, prepared.length - this.limits.maxEntries);
+      this.prunePersistedRows(rowsToDrop.map(([key]) => key));
+      const droppedKeys = new Set(rowsToDrop.map(([key]) => key));
+      prepared = prepared.filter(([key]) => !droppedKeys.has(key));
+      total = prepared.reduce((sum, [, , , size]) => sum + size, 0);
     }
     if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
       throw new WorkingMemoryLimitError(
@@ -1267,6 +1288,26 @@ class SqliteWorkingMemory implements IWorkingMemory {
       this.sizes.set(key, size);
       this.serialized.set(key, serialized);
       this.totalBytes += size;
+    }
+  }
+
+  private prunePersistedRows(keys: readonly string[]): void {
+    if (keys.length === 0) return;
+    const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
+    const deleteProvenance = this.db.prepare(
+      `DELETE FROM memory_review_provenance WHERE target_store = 'working' AND memory_key = ?`,
+    );
+    const tx = this.db.transaction(() => {
+      for (const key of keys) {
+        deleteProvenance.run(key);
+        deleteKey.run(key);
+      }
+    });
+    tx.immediate();
+    for (const key of keys) {
+      this.persistedSerialized.delete(key);
+      this.dirtyKeys.delete(key);
+      this.deletedKeys.delete(key);
     }
   }
 
@@ -1655,13 +1696,13 @@ class SqliteWorkingMemory implements IWorkingMemory {
 
   private deleteExpiredPersistedRows(
     rows: ReadonlyArray<{ key: string; serialized: string | undefined }>,
-  ): Array<{ key: string; serialized: string }> {
-    const preservedRows: Array<{ key: string; serialized: string }> = [];
+  ): Array<{ key: string; serialized: string; updatedAt: string }> {
+    const preservedRows: Array<{ key: string; serialized: string; updatedAt: string }> = [];
     if (rows.length === 0) return preservedRows;
-    const selectValue = this.db.prepare(`SELECT value FROM working_memory WHERE key = ?`);
+    const selectValue = this.db.prepare(`SELECT value, updated_at AS updatedAt FROM working_memory WHERE key = ?`);
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
     for (const { key, serialized } of rows) {
-      const row = selectValue.get(key) as { value: string } | undefined;
+      const row = selectValue.get(key) as { value: string; updatedAt: string } | undefined;
       if (row === undefined) {
         this.persistedSerialized.delete(key);
         this.deletedKeys.delete(key);
@@ -1671,13 +1712,13 @@ class SqliteWorkingMemory implements IWorkingMemory {
       const currentSerialized = this.encryption?.decrypt(row.value) ?? row.value;
       if (serialized !== undefined && currentSerialized !== serialized) {
         this.persistedSerialized.set(key, currentSerialized);
-        preservedRows.push({ key, serialized: currentSerialized });
+        preservedRows.push({ key, serialized: currentSerialized, updatedAt: row.updatedAt });
         continue;
       }
       const parsed = parseStoredWorkingMemoryValue(currentSerialized);
       if (!isExpiredWorkingMemoryValue(parsed)) {
         this.persistedSerialized.set(key, currentSerialized);
-        preservedRows.push({ key, serialized: currentSerialized });
+        preservedRows.push({ key, serialized: currentSerialized, updatedAt: row.updatedAt });
         continue;
       }
       deleteKey.run(key);

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1196,6 +1196,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     hydrateFromDb = true,
     private encryption?: MemoryCipher,
     private audit?: MemoryAccessAuditRecorder,
+    private onPrunedPersistedKeys?: (keys: readonly string[]) => void,
   ) {
     this.loadPersistedSerializedFromDb();
     if (hydrateFromDb) {
@@ -1226,49 +1227,83 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private loadFromDb(): void {
     const rows = this.loadPersistedSerializedFromDb();
 
-    let prepared: Array<[string, unknown, string, number, string]> = [];
+    let prepared: Array<{
+      key: string;
+      normalized: unknown;
+      serialized: string;
+      size: number;
+      updatedAt: string;
+      protected: boolean;
+    }> = [];
     const expiredRows: Array<{ key: string; serialized: string }> = [];
     let total = 0;
+    const prepareRow = (row: { key: string; serialized: string; updatedAt: string }) => {
+      const parsed = parseStoredWorkingMemoryValue(row.serialized);
+      if (isExpiredWorkingMemoryValue(parsed)) return undefined;
+      const { normalized, serialized, size } = this.prepareEntry(
+        row.key,
+        parsed,
+      );
+      return {
+        key: row.key,
+        normalized,
+        serialized,
+        size,
+        updatedAt: row.updatedAt,
+        protected: MEMORY_RETENTION_POLICIES[classifyMemoryEntry({
+          store: 'working',
+          key: row.key,
+          value: normalized,
+        })].protected,
+      };
+    };
     for (const row of rows) {
       const parsed = parseStoredWorkingMemoryValue(row.value);
       if (isExpiredWorkingMemoryValue(parsed)) {
         expiredRows.push({ key: row.key, serialized: row.value });
         continue;
       }
-      const { normalized, serialized, size } = this.prepareEntry(
-        row.key,
-        parsed,
-      );
-      total += size;
-      prepared.push([row.key, normalized, serialized, size, row.updatedAt]);
+      const preparedRow = prepareRow({ key: row.key, serialized: row.value, updatedAt: row.updatedAt });
+      if (!preparedRow) continue;
+      total += preparedRow.size;
+      prepared.push(preparedRow);
     }
     const preservedRows = this.deleteExpiredPersistedRows(expiredRows);
-    const preparedKeys = new Set(prepared.map(([key]) => key));
+    const preparedKeys = new Set(prepared.map(({ key }) => key));
     for (const row of preservedRows) {
       if (preparedKeys.has(row.key)) continue;
-      const parsed = parseStoredWorkingMemoryValue(row.serialized);
-      if (isExpiredWorkingMemoryValue(parsed)) continue;
-      const { normalized, serialized, size } = this.prepareEntry(
-        row.key,
-        parsed,
-      );
-      total += size;
-      prepared.push([row.key, normalized, serialized, size, row.updatedAt]);
+      const preparedRow = prepareRow(row);
+      if (!preparedRow) continue;
+      total += preparedRow.size;
+      prepared.push(preparedRow);
       preparedKeys.add(row.key);
     }
     if (prepared.length > this.limits.maxEntries) {
-      const rowsToDrop = [...prepared]
-        .sort(([leftKey, , , , leftUpdatedAt], [rightKey, , , , rightUpdatedAt]) =>
+      const rowsToDrop = prepared
+        .filter((row) => !row.protected)
+        .sort((left, right) =>
           SqliteWorkingMemory.persistedRowOrder(
-            { key: leftKey, updatedAt: leftUpdatedAt },
-            { key: rightKey, updatedAt: rightUpdatedAt },
+            { key: left.key, updatedAt: left.updatedAt },
+            { key: right.key, updatedAt: right.updatedAt },
           ),
         )
         .slice(0, prepared.length - this.limits.maxEntries);
-      this.prunePersistedRows(rowsToDrop.map(([key]) => key));
-      const droppedKeys = new Set(rowsToDrop.map(([key]) => key));
-      prepared = prepared.filter(([key]) => !droppedKeys.has(key));
-      total = prepared.reduce((sum, [, , , size]) => sum + size, 0);
+      if (prepared.length - rowsToDrop.length > this.limits.maxEntries) {
+        throw new WorkingMemoryLimitError(
+          `Persisted working memory has ${prepared.length} entries but only ${rowsToDrop.length} unprotected entries are eligible for startup pruning, exceeding maxEntries (${this.limits.maxEntries})`,
+        );
+      }
+      const droppedKeys = new Set(rowsToDrop.map(({ key }) => key));
+      const retainedRows = prepared.filter(({ key }) => !droppedKeys.has(key));
+      const retainedTotal = retainedRows.reduce((sum, { size }) => sum + size, 0);
+      if (!Number.isSafeInteger(retainedTotal) || retainedTotal > this.limits.maxTotalBytes) {
+        throw new WorkingMemoryLimitError(
+          `Persisted working memory is ${retainedTotal} bytes after startup pruning, exceeding maxTotalBytes (${this.limits.maxTotalBytes})`,
+        );
+      }
+      this.prunePersistedRows(rowsToDrop);
+      prepared = retainedRows;
+      total = retainedTotal;
     }
     if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
       throw new WorkingMemoryLimitError(
@@ -1283,7 +1318,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     this.deletedKeys.clear();
     this.totalBytes = 0;
 
-    for (const [key, normalized, serialized, size] of prepared) {
+    for (const { key, normalized, serialized, size } of prepared) {
       this.store.set(key, normalized);
       this.sizes.set(key, size);
       this.serialized.set(key, serialized);
@@ -1291,20 +1326,46 @@ class SqliteWorkingMemory implements IWorkingMemory {
     }
   }
 
-  private prunePersistedRows(keys: readonly string[]): void {
-    if (keys.length === 0) return;
+  private prunePersistedRows(rows: ReadonlyArray<{ key: string; serialized: string; updatedAt: string }>): void {
+    if (rows.length === 0) return;
+    const selectKey = this.db.prepare(`SELECT value, updated_at AS updatedAt FROM working_memory WHERE key = ?`);
     const deleteKey = this.db.prepare(`DELETE FROM working_memory WHERE key = ?`);
     const deleteProvenance = this.db.prepare(
       `DELETE FROM memory_review_provenance WHERE target_store = 'working' AND memory_key = ?`,
     );
     const tx = this.db.transaction(() => {
-      for (const key of keys) {
+      for (const row of rows) {
+        const current = selectKey.get(row.key) as { value: string; updatedAt: string } | undefined;
+        const currentSerialized = current ? (this.encryption?.decrypt(current.value) ?? current.value) : undefined;
+        if (currentSerialized !== row.serialized || current?.updatedAt !== row.updatedAt) {
+          throw new WorkingMemoryLimitError(
+            `Persisted working memory row ${row.key} changed before startup pruning could delete it`,
+          );
+        }
+      }
+      for (const { key } of rows) {
         deleteProvenance.run(key);
         deleteKey.run(key);
       }
     });
     tx.immediate();
+    const keys = rows.map(({ key }) => key);
     for (const key of keys) {
+      this.persistedSerialized.delete(key);
+      this.dirtyKeys.delete(key);
+      this.deletedKeys.delete(key);
+    }
+    this.onPrunedPersistedKeys?.(keys);
+  }
+
+  expirePrunedRuntimeKeys(keys: readonly string[]): void {
+    for (const key of keys) {
+      if (this.store.has(key)) {
+        this.totalBytes -= this.sizes.get(key) ?? 0;
+      }
+      this.store.delete(key);
+      this.sizes.delete(key);
+      this.serialized.delete(key);
       this.persistedSerialized.delete(key);
       this.dirtyKeys.delete(key);
       this.deletedKeys.delete(key);
@@ -5202,6 +5263,7 @@ export class SqliteBrain implements IBrain {
       options.hydrateWorkingMemoryFromDb ?? true,
       encryption,
       (event) => this.auditRecorder(event),
+      (keys) => SqliteBrain.expireLivePrunedWorkingKeys(this.dbPath, keys),
     );
     this.episodic = new SqliteEpisodicMemory(
       this.db,
@@ -5336,6 +5398,16 @@ export class SqliteBrain implements IBrain {
     liveBrains.delete(brain);
     if (liveBrains.size === 0) {
       liveSqliteBrainsByPath.delete(dbPath);
+    }
+  }
+
+  private static expireLivePrunedWorkingKeys(dbPath: string, keys: readonly string[]): void {
+    const normalizedDbPath = normalizeSqliteDbPath(dbPath);
+    if (normalizedDbPath === ':memory:' || keys.length === 0) return;
+    const liveBrains = liveSqliteBrainsByPath.get(normalizedDbPath);
+    if (!liveBrains) return;
+    for (const brain of liveBrains) {
+      brain.working.expirePrunedRuntimeKeys(keys);
     }
   }
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1755,6 +1755,85 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('preserves dirty live updates when another startup prunes the persisted row', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-dirty-prune-'));
+      const dbPath = join(dir, 'brain.db');
+      let live: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        live = new SqliteBrain(dbPath, { maxEntries: 3 });
+        live.working.set('oldest', { value: 1 });
+        live.working.set('middle', { value: 2 });
+        live.working.set('newest', { value: 3 });
+        live.flush();
+        live.working.set('oldest', { value: 'dirty' });
+
+        db = new Database(dbPath);
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-01T00:00:00.000Z', 'oldest');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-02T00:00:00.000Z', 'middle');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-03T00:00:00.000Z', 'newest');
+        db.close();
+        db = undefined;
+
+        reopened = new SqliteBrain(dbPath, { maxEntries: 2 });
+        expect(live.working.get('oldest')).toEqual({ value: 'dirty' });
+        live.flush();
+
+        db = new Database(dbPath);
+        expect(
+          db.prepare(`SELECT key FROM working_memory ORDER BY key ASC`).all(),
+        ).toEqual([{ key: 'middle' }, { key: 'newest' }, { key: 'oldest' }]);
+      } finally {
+        db?.close();
+        reopened?.close();
+        live?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('prunes legacy plain-text persisted rows when startup entry limits are reduced', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-legacy-prune-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath, { maxEntries: 3 });
+        seeded.close();
+        seeded = undefined;
+
+        db = new Database(dbPath);
+        db.prepare(`INSERT INTO working_memory (key, value, updated_at) VALUES (?, ?, ?)`).run(
+          'legacy',
+          'plain text value',
+          '2026-07-01T00:00:00.000Z',
+        );
+        db.prepare(`INSERT INTO working_memory (key, value, updated_at) VALUES (?, ?, ?)`).run(
+          'middle',
+          JSON.stringify({ value: 2 }),
+          '2026-07-02T00:00:00.000Z',
+        );
+        db.prepare(`INSERT INTO working_memory (key, value, updated_at) VALUES (?, ?, ?)`).run(
+          'newest',
+          JSON.stringify({ value: 3 }),
+          '2026-07-03T00:00:00.000Z',
+        );
+        db.close();
+        db = undefined;
+
+        reopened = new SqliteBrain(dbPath, { maxEntries: 2 });
+        expect(reopened.working.keys().sort()).toEqual(['middle', 'newest']);
+      } finally {
+        db?.close();
+        reopened?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('tracks usage as entries are added, counting key and value bytes', () => {
       brain.working.set('a', 'hello');
       const usage = brain.working.usage();

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1655,6 +1655,106 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('does not prune protected persisted rows when startup entry limits are reduced', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-protected-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath, { maxEntries: 3 });
+        seeded.working.set('preference', { memoryClass: 'user_preference', value: 'keep' });
+        seeded.working.set('middle', { value: 2 });
+        seeded.working.set('newest', { value: 3 });
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        db = new Database(dbPath);
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-01T00:00:00.000Z', 'preference');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-02T00:00:00.000Z', 'middle');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-03T00:00:00.000Z', 'newest');
+        db.close();
+        db = undefined;
+
+        reopened = new SqliteBrain(dbPath, { maxEntries: 2 });
+        expect(reopened.working.keys().sort()).toEqual(['newest', 'preference']);
+        expect(reopened.working.get('preference')).toEqual({ memoryClass: 'user_preference', value: 'keep' });
+      } finally {
+        db?.close();
+        reopened?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves persisted rows intact when retained startup rows exceed byte limits', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-byte-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath, { maxEntries: 2, maxTotalBytes: 10_000 });
+        seeded.working.set('drop', 'x');
+        seeded.working.set('keep', 'retained value is still too large');
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        expect(() => new SqliteBrain(dbPath, { maxEntries: 1, maxTotalBytes: 10 })).toThrow(
+          WorkingMemoryLimitError,
+        );
+
+        db = new Database(dbPath);
+        expect(
+          db.prepare(`SELECT key FROM working_memory ORDER BY key ASC`).all(),
+        ).toEqual([{ key: 'drop' }, { key: 'keep' }]);
+      } finally {
+        db?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('expires pruned keys from other live brain instances sharing the database', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-live-prune-'));
+      const dbPath = join(dir, 'brain.db');
+      let live: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        live = new SqliteBrain(dbPath, { maxEntries: 3 });
+        live.working.set('oldest', { value: 1 });
+        live.working.set('middle', { value: 2 });
+        live.working.set('newest', { value: 3 });
+        live.flush();
+
+        db = new Database(dbPath);
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-01T00:00:00.000Z', 'oldest');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-02T00:00:00.000Z', 'middle');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-03T00:00:00.000Z', 'newest');
+        db.close();
+        db = undefined;
+
+        reopened = new SqliteBrain(dbPath, { maxEntries: 2 });
+        expect(live.working.get('oldest')).toBeUndefined();
+        live.flush();
+
+        db = new Database(dbPath);
+        expect(
+          db.prepare(`SELECT key FROM working_memory ORDER BY key ASC`).all(),
+        ).toEqual([{ key: 'middle' }, { key: 'newest' }]);
+      } finally {
+        db?.close();
+        reopened?.close();
+        live?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('tracks usage as entries are added, counting key and value bytes', () => {
       brain.working.set('a', 'hello');
       const usage = brain.working.usage();

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1614,6 +1614,47 @@ describe('SqliteBrain', () => {
       bounded.close();
     });
 
+    it('prunes oldest persisted rows on startup when maxEntries is reduced', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-reduced-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath, { maxEntries: 3 });
+        seeded.working.set('oldest', { value: 1 });
+        seeded.working.set('middle', { value: 2 });
+        seeded.working.set('newest', { value: 3 });
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        db = new Database(dbPath);
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-01T00:00:00.000Z', 'oldest');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-02T00:00:00.000Z', 'middle');
+        db.prepare(`UPDATE working_memory SET updated_at = ? WHERE key = ?`).run('2026-07-03T00:00:00.000Z', 'newest');
+        db.close();
+        db = undefined;
+
+        expect(() => {
+          reopened = new SqliteBrain(dbPath, { maxEntries: 2 });
+        }).not.toThrow();
+        expect(reopened?.working.keys().sort()).toEqual(['middle', 'newest']);
+        expect(reopened?.working.get('oldest')).toBeUndefined();
+
+        db = new Database(dbPath);
+        expect(
+          db.prepare(`SELECT key FROM working_memory ORDER BY key ASC`).all(),
+        ).toEqual([{ key: 'middle' }, { key: 'newest' }]);
+      } finally {
+        db?.close();
+        reopened?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('tracks usage as entries are added, counting key and value bytes', () => {
       brain.working.set('a', 'hello');
       const usage = brain.working.usage();
@@ -1760,9 +1801,10 @@ describe('SqliteBrain', () => {
       expect(() => brain.working.set('large-token', largeToken)).toThrow(/cannot be safely evaluated/);
     });
 
-    it('constructor hydration honors stricter custom working memory limits', () => {
+    it('constructor hydration prunes persisted rows to honor stricter custom entry limits', () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-'));
       const dbPath = join(dir, 'brain.db');
+      let reopened: SqliteBrain | undefined;
 
       try {
         const roomy = new SqliteBrain(dbPath, { maxEntries: 3 });
@@ -1771,10 +1813,11 @@ describe('SqliteBrain', () => {
         roomy.flush();
         roomy.close();
 
-        expect(() => new SqliteBrain(dbPath, { maxEntries: 1 })).toThrow(
-          WorkingMemoryLimitError,
-        );
+        reopened = new SqliteBrain(dbPath, { maxEntries: 1 });
+        expect(reopened.working.keys()).toHaveLength(1);
+        expect(reopened.working.usage().limits.maxEntries).toBe(1);
       } finally {
+        reopened?.close();
         rmSync(dir, { recursive: true, force: true });
       }
     });


### PR DESCRIPTION
## Summary
- prune the oldest persisted working-memory rows during SQLite startup when maxEntries is reduced
- keep persisted row ordering deterministic with updated_at plus key tiebreaking
- update startup-limit regression tests to assert pruning instead of constructor failure

## Test Plan
- npm run test --workspace @franken/brain -- --run tests/unit/sqlite-brain.test.ts -t "prunes oldest persisted rows on startup when maxEntries is reduced"
- npm run test --workspace @franken/brain -- --run tests/unit/sqlite-brain.test.ts
- npm run build --workspace @franken/types && npm run typecheck --workspace @franken/brain
- npm run lint --workspace @franken/brain
- npm run build --workspace @franken/brain

Closes #2377