### PR TITLE
fix(security): keep secret store writes off argv

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -739,6 +739,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     if (!validBackends.has(initBackend)) {
       throw new TypeError(`Invalid init backend '${values.backend}'. Valid: local-encrypted, os-keychain, 1password, bitwarden`);
     }
+    if (initBackend === 'os-keychain' && process.platform !== 'linux') {
+      throw new TypeError('Invalid init backend os-keychain on this platform. os-keychain is write-capable only on Linux Secret Service; use local-encrypted, 1password, or bitwarden.');
+    }
   }
 
   const providersRaw = values.providers;

--- a/packages/franken-orchestrator/src/cli/init-command.ts
+++ b/packages/franken-orchestrator/src/cli/init-command.ts
@@ -57,7 +57,8 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
   }
 
   // Interactive and repair paths need the secret store
-  const secureBackend = options.config.network.secureBackend ?? 'local-encrypted';
+  const initBackend = options.args.initBackend as SecureBackend | undefined;
+  const secureBackend = initBackend ?? options.config.network.secureBackend ?? 'local-encrypted';
   let passphrase: string | undefined = process.env.FRANKENBEAST_PASSPHRASE;
   if (secureBackend === 'local-encrypted' && !passphrase) {
     passphrase = (await options.io.ask('Enter passphrase for local encrypted store:')).trim() || undefined;
@@ -67,7 +68,6 @@ export async function handleInitCommand(options: InitCommandOptions): Promise<vo
     io: options.io,
     passphrase,
   });
-  const initBackend = options.args.initBackend as SecureBackend | undefined;
 
   if (options.args.initRepair) {
     const result = await runRepairInit({

--- a/packages/franken-orchestrator/src/init/init-wizard.ts
+++ b/packages/franken-orchestrator/src/init/init-wizard.ts
@@ -229,6 +229,10 @@ export async function runInitWizard(options: RunInitWizardOptions): Promise<Init
       if (detection.setupInstructions) {
         options.io.display(detection.setupInstructions);
       }
+      completedSteps.add('secret-backend-selection');
+      if (!secretBackendOnly) {
+        throw new Error(`Secret backend '${options.secretStore.id}' is not available: ${detection.reason ?? 'unknown reason'}`);
+      }
     }
     completedSteps.add('secret-backend-selection');
   }

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { z } from 'zod';
 
 const HostSchema = z.string().min(1).default('127.0.0.1');
@@ -77,7 +78,14 @@ const LEGACY_BACKEND_MAP: Record<string, string> = {
 
 export const SecureBackendSchema = z.preprocess(
   (val) => (typeof val === 'string' ? (LEGACY_BACKEND_MAP[val] ?? val) : val),
-  z.enum(['1password', 'bitwarden', 'os-keychain', 'local-encrypted']),
+  z.enum(['1password', 'bitwarden', 'os-keychain', 'local-encrypted']).superRefine((value, ctx) => {
+    if (value === 'os-keychain' && process.platform !== 'linux') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'os-keychain is only supported as a write-capable backend on Linux Secret Service; use local-encrypted, 1password, or bitwarden on macOS/Windows.',
+      });
+    }
+  }),
 );
 
 export const NetworkOperatorConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import { z } from 'zod';
 
 const HostSchema = z.string().min(1).default('127.0.0.1');
@@ -78,14 +77,7 @@ const LEGACY_BACKEND_MAP: Record<string, string> = {
 
 export const SecureBackendSchema = z.preprocess(
   (val) => (typeof val === 'string' ? (LEGACY_BACKEND_MAP[val] ?? val) : val),
-  z.enum(['1password', 'bitwarden', 'os-keychain', 'local-encrypted']).superRefine((value, ctx) => {
-    if (value === 'os-keychain' && process.platform !== 'linux') {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'os-keychain is only supported as a write-capable backend on Linux Secret Service; use local-encrypted, 1password, or bitwarden on macOS/Windows.',
-      });
-    }
-  }),
+  z.enum(['1password', 'bitwarden', 'os-keychain', 'local-encrypted']),
 );
 
 export const NetworkOperatorConfigSchema = z.object({

--- a/packages/franken-orchestrator/src/network/secret-backends/bitwarden-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/bitwarden-store.ts
@@ -1,7 +1,9 @@
+import { Buffer } from 'node:buffer';
 import type { CliResult } from './cli-runner.js';
 import type { ISecretStore, SecretStoreDetection } from '../secret-store.js';
 
 type CliRunner = (command: string, args: string[]) => Promise<CliResult>;
+type StdinRunner = (command: string, args: string[], stdin: string) => Promise<CliResult>;
 
 const TITLE_PREFIX = 'frankenbeast/';
 
@@ -14,7 +16,10 @@ interface BwItem {
 export class BitwardenStore implements ISecretStore {
   readonly id = 'bitwarden';
 
-  constructor(private readonly runner: CliRunner) {}
+  constructor(
+    private readonly runner: CliRunner,
+    private readonly stdinRunner?: StdinRunner | undefined,
+  ) {}
 
   async detect(): Promise<SecretStoreDetection> {
     const result = await this.runner('bw', ['--version']);
@@ -30,17 +35,22 @@ export class BitwardenStore implements ISecretStore {
   }
 
   async store(key: string, value: string): Promise<void> {
+    if (!this.stdinRunner) {
+      throw new Error('Bitwarden store writes require a stdin-capable runner to avoid exposing secret values in process arguments.');
+    }
+
     const name = `${TITLE_PREFIX}${key}`;
     const getResult = await this.runner('bw', ['get', 'item', name]);
 
     if (getResult.exitCode === 0) {
-      // Item exists — edit it
+      // Item exists — edit it. Send the encoded payload through stdin so neither the
+      // plaintext note nor its reversible base64 form appears in process arguments.
       const existing = JSON.parse(getResult.stdout) as BwItem;
       const payload = { ...existing, notes: value };
       const encoded = Buffer.from(JSON.stringify(payload)).toString('base64');
-      await this.runner('bw', ['edit', 'item', existing.id, encoded]);
+      await this.stdinRunner('bw', ['edit', 'item', existing.id], encoded);
     } else {
-      // Item does not exist — create it
+      // Item does not exist — create it. Keep the encoded payload off argv.
       const payload = {
         type: 2,
         name,
@@ -48,7 +58,7 @@ export class BitwardenStore implements ISecretStore {
         secureNote: { type: 0 },
       };
       const encoded = Buffer.from(JSON.stringify(payload)).toString('base64');
-      await this.runner('bw', ['create', 'item', encoded]);
+      await this.stdinRunner('bw', ['create', 'item'], encoded);
     }
   }
 

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -9,7 +9,7 @@ const TITLE_PREFIX = 'frankenbeast/';
 
 const REQUIRED_OP_EDIT_STDIN_VERSION = [2, 23, 0] as const;
 
-interface OnePasswordItemTemplate {
+interface OnePasswordItemTemplate extends Record<string, unknown> {
   id?: string;
   title?: string;
   category?: string;
@@ -48,6 +48,43 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
         value,
       },
     ],
+  };
+}
+
+function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, value: string): OnePasswordItemTemplate {
+  let item: OnePasswordItemTemplate;
+  try {
+    item = JSON.parse(stdout) as OnePasswordItemTemplate;
+  } catch {
+    throw new Error('1Password item already exists but its JSON could not be parsed; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  const passkeys = item.passkeys;
+  if (Array.isArray(passkeys) && passkeys.length > 0) {
+    throw new Error('1Password item already exists with passkeys; refusing to edit because unsupported item data cannot be safely preserved. Delete and recreate the item to rotate this secret.');
+  }
+
+  if (!Array.isArray(item.fields)) {
+    throw new Error('1Password item already exists without editable fields; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  const passwordFieldIndex = item.fields.findIndex((field) =>
+    field.id === 'password'
+    || field.purpose === 'PASSWORD'
+    || field.label === 'password');
+  if (passwordFieldIndex < 0) {
+    throw new Error('1Password item already exists without a password field; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  return {
+    ...item,
+    title: item.title ?? fallbackTitle,
+    category: item.category ?? 'LOGIN',
+    fields: item.fields.map((field, index) => (
+      index === passwordFieldIndex
+        ? { ...field, value }
+        : field
+    )),
   };
 }
 
@@ -109,10 +146,16 @@ export class OnePasswordStore implements ISecretStore {
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      // 1Password JSON-template edits can drop unsupported item data such as passkeys,
-      // and field assignment edits would put secret values in argv. Fail closed for
-      // existing items until the CLI exposes a reliable stdin update primitive.
-      throw new Error('1Password item already exists; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
+      const itemId = itemIdFromJson(getResult.stdout) ?? title;
+      const template = itemTemplateForExistingSecret(getResult.stdout, title, value);
+      const result = await this.stdinRunner('op', [
+        'item',
+        'edit',
+        itemId,
+        `--vault=${VAULT}`,
+      ], JSON.stringify(template));
+      assertSuccess(result, '1Password item edit');
+      return;
     }
 
     // Item does not exist — create it from a piped JSON template instead of argv assignments.

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -22,7 +22,6 @@ interface OnePasswordItemTemplate {
     label?: string;
     value?: string;
   }>;
-  passkeys?: unknown;
 }
 
 function titleForKey(key: string): string {
@@ -42,7 +41,6 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   return {
     title,
     category: 'LOGIN',
-    passkeys: [],
     fields: [
       {
         id: 'password',
@@ -61,52 +59,12 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   };
 }
 
-function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, value: string): OnePasswordItemTemplate {
-  let item: OnePasswordItemTemplate;
-  try {
-    item = JSON.parse(stdout) as OnePasswordItemTemplate;
-  } catch {
-    throw new Error('1Password item already exists but its JSON could not be parsed; refusing to edit because the existing item cannot be safely preserved.');
-  }
-
-  const passkeys = item.passkeys;
-  if (!Object.prototype.hasOwnProperty.call(item, 'passkeys') || !Array.isArray(passkeys)) {
-    throw new Error('1Password item already exists without explicit passkey metadata; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
-  }
-  if (passkeys.length > 0) {
-    throw new Error('1Password item already exists with passkeys; refusing to edit because unsupported item data cannot be safely preserved. Delete and recreate the item to rotate this secret.');
-  }
-
-  if (!Array.isArray(item.fields)) {
-    throw new Error('1Password item already exists without editable fields; refusing to edit because the existing item cannot be safely preserved.');
-  }
-
-  const hasBackendMarker = item.fields.some(field =>
-    field.id === BACKEND_MARKER_ID
-    && field.label === BACKEND_MARKER_ID
-    && field.value === BACKEND_MARKER_VALUE);
-  if (!hasBackendMarker) {
-    throw new Error('1Password item already exists but is not marked as frankenbeast-managed; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
-  }
-
-  const passwordFieldIndex = item.fields.findIndex((field) =>
-    field.id === 'password'
-    || field.purpose === 'PASSWORD'
-    || field.label === 'password');
-  if (passwordFieldIndex < 0) {
-    throw new Error('1Password item already exists without a password field; refusing to edit because the existing item cannot be safely preserved.');
-  }
-
-  return {
-    ...item,
-    title: item.title ?? fallbackTitle,
-    category: item.category ?? 'LOGIN',
-    fields: item.fields.map((field, index) => (
-      index === passwordFieldIndex
-        ? { ...field, value }
-        : field
-    )),
-  };
+function itemTemplateForExistingSecret(_stdout: string, _fallbackTitle: string, _value: string): OnePasswordItemTemplate {
+  // 1Password JSON-template edits overwrite unsupported data such as passkeys,
+  // and field assignment edits would put secret values in argv. Fail closed for
+  // existing items until the CLI exposes a reliable stdin update primitive that
+  // can prove unsupported item data will be preserved.
+  throw new Error('1Password item already exists; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
 }
 
 function parseVersion(stdout: string): [number, number, number] | undefined {
@@ -167,15 +125,7 @@ export class OnePasswordStore implements ISecretStore {
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      const itemId = itemIdFromJson(getResult.stdout) ?? title;
-      const template = itemTemplateForExistingSecret(getResult.stdout, title, value);
-      const result = await this.stdinRunner('op', [
-        'item',
-        'edit',
-        itemId,
-        `--vault=${VAULT}`,
-      ], JSON.stringify(template));
-      assertSuccess(result, '1Password item edit');
+      itemTemplateForExistingSecret(getResult.stdout, title, value);
       return;
     }
 

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -20,7 +20,6 @@ interface OnePasswordItemTemplate {
     label?: string;
     value?: string;
   }>;
-  passkeys?: unknown;
 }
 
 function titleForKey(key: string): string {
@@ -36,41 +35,20 @@ function itemIdFromJson(stdout: string): string | undefined {
   }
 }
 
-function itemTemplateForSecret(title: string, value: string, existing?: OnePasswordItemTemplate): OnePasswordItemTemplate {
-  const fields = [...(existing?.fields ?? [])];
-  const passwordField = fields.find(
-    field => field.id === 'password' || field.purpose === 'PASSWORD' || field.label === 'password',
-  );
-
-  if (passwordField) {
-    passwordField.value = value;
-    passwordField.type = passwordField.type ?? 'CONCEALED';
-    passwordField.purpose = passwordField.purpose ?? 'PASSWORD';
-  } else {
-    fields.push({
-      id: 'password',
-      type: 'CONCEALED',
-      purpose: 'PASSWORD',
-      label: 'password',
-      value,
-    });
-  }
-
+function itemTemplateForSecret(title: string, value: string): OnePasswordItemTemplate {
   return {
-    ...existing,
-    title: existing?.title ?? title,
-    category: existing?.category ?? 'LOGIN',
-    fields,
+    title,
+    category: 'LOGIN',
+    fields: [
+      {
+        id: 'password',
+        type: 'CONCEALED',
+        purpose: 'PASSWORD',
+        label: 'password',
+        value,
+      },
+    ],
   };
-}
-
-function parseItemTemplate(stdout: string): OnePasswordItemTemplate | undefined {
-  try {
-    const parsed = JSON.parse(stdout) as OnePasswordItemTemplate;
-    return parsed && typeof parsed === 'object' ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function parseVersion(stdout: string): [number, number, number] | undefined {
@@ -88,8 +66,10 @@ function versionAtLeast(actual: [number, number, number] | undefined, required: 
   return true;
 }
 
-function hasPasskeys(item: OnePasswordItemTemplate | undefined): boolean {
-  return Array.isArray(item?.passkeys) && item.passkeys.length > 0;
+function assertSuccess(result: CliResult, operation: string): void {
+  if (result.exitCode !== 0) {
+    throw new Error(`${operation} failed: ${result.stderr || result.stdout}`);
+  }
 }
 
 export class OnePasswordStore implements ISecretStore {
@@ -106,8 +86,8 @@ export class OnePasswordStore implements ISecretStore {
       if (!versionAtLeast(parseVersion(result.stdout), REQUIRED_OP_EDIT_STDIN_VERSION)) {
         return {
           available: false,
-          reason: `1Password CLI ${result.stdout.trim() || 'version unknown'} does not support JSON-template edits from stdin`,
-          setupInstructions: 'Install 1Password CLI 2.23.0 or newer so secret updates can use stdin without exposing values in process arguments.',
+          reason: `1Password CLI ${result.stdout.trim() || 'version unknown'} does not support JSON-template creates from stdin`,
+          setupInstructions: 'Install 1Password CLI 2.23.0 or newer so secret creates can use stdin without exposing values in process arguments.',
         };
       }
       return { available: true };
@@ -129,28 +109,21 @@ export class OnePasswordStore implements ISecretStore {
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      // Item exists — edit it by piping a JSON template so sensitive fields never appear in argv.
-      const existing = parseItemTemplate(getResult.stdout);
-      if (hasPasskeys(existing)) {
-        throw new Error('1Password item contains passkeys; refusing whole-template edit because the 1Password CLI does not preserve passkeys in JSON templates.');
-      }
-      const template = itemTemplateForSecret(title, value, existing);
-      await this.stdinRunner('op', [
-        'item',
-        'edit',
-        title,
-        `--vault=${VAULT}`,
-      ], JSON.stringify(template));
-    } else {
-      // Item does not exist — create it from a piped JSON template instead of argv assignments.
-      const template = itemTemplateForSecret(title, value);
-      await this.stdinRunner('op', [
-        'item',
-        'create',
-        `--vault=${VAULT}`,
-        '-',
-      ], JSON.stringify(template));
+      // 1Password JSON-template edits can drop unsupported item data such as passkeys,
+      // and field assignment edits would put secret values in argv. Fail closed for
+      // existing items until the CLI exposes a reliable stdin update primitive.
+      throw new Error('1Password item already exists; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
     }
+
+    // Item does not exist — create it from a piped JSON template instead of argv assignments.
+    const template = itemTemplateForSecret(title, value);
+    const result = await this.stdinRunner('op', [
+      'item',
+      'create',
+      `--vault=${VAULT}`,
+      '-',
+    ], JSON.stringify(template));
+    assertSuccess(result, '1Password item create');
   }
 
   async resolve(key: string): Promise<string | undefined> {

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -8,8 +8,10 @@ const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
 const REQUIRED_OP_EDIT_STDIN_VERSION = [2, 23, 0] as const;
+const BACKEND_MARKER_ID = 'frankenbeast-managed';
+const BACKEND_MARKER_VALUE = 'secret-store-v1';
 
-interface OnePasswordItemTemplate extends Record<string, unknown> {
+interface OnePasswordItemTemplate {
   id?: string;
   title?: string;
   category?: string;
@@ -20,6 +22,7 @@ interface OnePasswordItemTemplate extends Record<string, unknown> {
     label?: string;
     value?: string;
   }>;
+  passkeys?: unknown;
 }
 
 function titleForKey(key: string): string {
@@ -39,6 +42,7 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   return {
     title,
     category: 'LOGIN',
+    passkeys: [],
     fields: [
       {
         id: 'password',
@@ -46,6 +50,12 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
         purpose: 'PASSWORD',
         label: 'password',
         value,
+      },
+      {
+        id: BACKEND_MARKER_ID,
+        type: 'STRING',
+        label: BACKEND_MARKER_ID,
+        value: BACKEND_MARKER_VALUE,
       },
     ],
   };
@@ -60,12 +70,23 @@ function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, va
   }
 
   const passkeys = item.passkeys;
-  if (Array.isArray(passkeys) && passkeys.length > 0) {
+  if (!Object.prototype.hasOwnProperty.call(item, 'passkeys') || !Array.isArray(passkeys)) {
+    throw new Error('1Password item already exists without explicit passkey metadata; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
+  }
+  if (passkeys.length > 0) {
     throw new Error('1Password item already exists with passkeys; refusing to edit because unsupported item data cannot be safely preserved. Delete and recreate the item to rotate this secret.');
   }
 
   if (!Array.isArray(item.fields)) {
     throw new Error('1Password item already exists without editable fields; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  const hasBackendMarker = item.fields.some(field =>
+    field.id === BACKEND_MARKER_ID
+    && field.label === BACKEND_MARKER_ID
+    && field.value === BACKEND_MARKER_VALUE);
+  if (!hasBackendMarker) {
+    throw new Error('1Password item already exists but is not marked as frankenbeast-managed; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
   }
 
   const passwordFieldIndex = item.fields.findIndex((field) =>

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -84,11 +84,30 @@ function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, va
     field.id === BACKEND_MARKER_ID
     && field.label === BACKEND_MARKER_ID
     && field.value === BACKEND_MARKER_VALUE);
-  if (!hasBackendMarker) {
-    throw new Error('1Password item already exists but is not marked as frankenbeast-managed; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
+  const passwordFields = item.fields.filter((field) =>
+    field.id === 'password'
+    || field.purpose === 'PASSWORD'
+    || field.label === 'password');
+  const legacyBackendOwnedItem = !hasBackendMarker
+    && item.title === fallbackTitle
+    && item.category === 'LOGIN'
+    && passwordFields.length === 1;
+  if (!hasBackendMarker && !legacyBackendOwnedItem) {
+    throw new Error('1Password item already exists but is not marked as frankenbeast-managed; refusing to template-edit because unsupported item data cannot be reliably attributed to this backend. Delete and recreate the item to rotate this secret.');
   }
+  const migratedFields = hasBackendMarker
+    ? item.fields
+    : [
+        ...item.fields,
+        {
+          id: BACKEND_MARKER_ID,
+          type: 'STRING',
+          label: BACKEND_MARKER_ID,
+          value: BACKEND_MARKER_VALUE,
+        },
+      ];
 
-  const passwordFieldIndex = item.fields.findIndex((field) =>
+  const passwordFieldIndex = migratedFields.findIndex((field) =>
     field.id === 'password'
     || field.purpose === 'PASSWORD'
     || field.label === 'password');
@@ -100,7 +119,7 @@ function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, va
     ...item,
     title: item.title ?? fallbackTitle,
     category: item.category ?? 'LOGIN',
-    fields: item.fields.map((field, index) => (
+    fields: migratedFields.map((field, index) => (
       index === passwordFieldIndex
         ? { ...field, value }
         : field

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -7,6 +7,19 @@ type StdinRunner = (command: string, args: string[], stdin: string) => Promise<C
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
+interface OnePasswordItemTemplate {
+  id?: string;
+  title?: string;
+  category?: string;
+  fields?: Array<{
+    id?: string;
+    type?: string;
+    purpose?: string;
+    label?: string;
+    value?: string;
+  }>;
+}
+
 function titleForKey(key: string): string {
   return `${TITLE_PREFIX}${key}`;
 }
@@ -15,6 +28,43 @@ function itemIdFromJson(stdout: string): string | undefined {
   try {
     const item = JSON.parse(stdout) as { id?: unknown };
     return typeof item.id === 'string' && item.id.length > 0 ? item.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function itemTemplateForSecret(title: string, value: string, existing?: OnePasswordItemTemplate): OnePasswordItemTemplate {
+  const fields = [...(existing?.fields ?? [])];
+  const passwordField = fields.find(
+    field => field.id === 'password' || field.purpose === 'PASSWORD' || field.label === 'password',
+  );
+
+  if (passwordField) {
+    passwordField.value = value;
+    passwordField.type = passwordField.type ?? 'CONCEALED';
+    passwordField.purpose = passwordField.purpose ?? 'PASSWORD';
+  } else {
+    fields.push({
+      id: 'password',
+      type: 'CONCEALED',
+      purpose: 'PASSWORD',
+      label: 'password',
+      value,
+    });
+  }
+
+  return {
+    ...existing,
+    title: existing?.title ?? title,
+    category: existing?.category ?? 'LOGIN',
+    fields,
+  };
+}
+
+function parseItemTemplate(stdout: string): OnePasswordItemTemplate | undefined {
+  try {
+    const parsed = JSON.parse(stdout) as OnePasswordItemTemplate;
+    return parsed && typeof parsed === 'object' ? parsed : undefined;
   } catch {
     return undefined;
   }
@@ -47,27 +97,28 @@ export class OnePasswordStore implements ISecretStore {
     }
 
     const title = titleForKey(key);
-    const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`]);
+    const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      // Item exists — edit it. `password=-` makes op read the concealed field from stdin.
+      // Item exists — edit it by piping a JSON template so sensitive fields never appear in argv.
+      const existing = parseItemTemplate(getResult.stdout);
+      const template = itemTemplateForSecret(title, value, existing);
       await this.stdinRunner('op', [
         'item',
         'edit',
         title,
         `--vault=${VAULT}`,
-        'password=-',
-      ], value);
+        '-',
+      ], JSON.stringify(template));
     } else {
-      // Item does not exist — create it. `password=-` makes op read the concealed field from stdin.
+      // Item does not exist — create it from a piped JSON template instead of argv assignments.
+      const template = itemTemplateForSecret(title, value);
       await this.stdinRunner('op', [
         'item',
         'create',
-        '--category=Login',
-        `--title=${title}`,
         `--vault=${VAULT}`,
-        'password=-',
-      ], value);
+        '-',
+      ], JSON.stringify(template));
     }
   }
 
@@ -84,12 +135,10 @@ export class OnePasswordStore implements ISecretStore {
     if (itemResult.exitCode !== 0) {
       return undefined;
     }
-
     const itemId = itemIdFromJson(itemResult.stdout);
     if (!itemId) {
       return undefined;
     }
-
     const result = await this.runner('op', ['read', `op://${VAULT}/${itemId}/password`]);
     if (result.exitCode !== 0) {
       return undefined;

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -6,7 +6,7 @@ type StdinRunner = (command: string, args: string[], stdin: string) => Promise<C
 
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
-
+const REQUIRED_OP_EDIT_STDIN_VERSION = [2, 23, 0] as const;
 const BACKEND_MARKER_ID = 'frankenbeast-managed';
 const BACKEND_MARKER_VALUE = 'secret-store-v1';
 
@@ -14,6 +14,7 @@ interface OnePasswordItemTemplate {
   id?: string;
   title?: string;
   category?: string;
+  passkeys?: unknown;
   fields?: Array<{
     id?: string;
     type?: string;
@@ -40,6 +41,7 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   return {
     title,
     category: 'LOGIN',
+    passkeys: [],
     fields: [
       {
         id: 'password',
@@ -58,8 +60,67 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   };
 }
 
-function existingItemEditError(): Error {
-  return new Error('1Password item already exists with a different value; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
+function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, value: string): OnePasswordItemTemplate {
+  let item: OnePasswordItemTemplate;
+  try {
+    item = JSON.parse(stdout) as OnePasswordItemTemplate;
+  } catch {
+    throw new Error('1Password item already exists but its JSON could not be parsed; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  const passkeys = item.passkeys;
+  if (!Object.prototype.hasOwnProperty.call(item, 'passkeys') || !Array.isArray(passkeys)) {
+    throw new Error('1Password item already exists without explicit passkey metadata; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
+  }
+  if (passkeys.length > 0) {
+    throw new Error('1Password item already exists with passkeys; refusing to edit because unsupported item data cannot be safely preserved. Delete and recreate the item to rotate this secret.');
+  }
+
+  if (!Array.isArray(item.fields)) {
+    throw new Error('1Password item already exists without editable fields; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  const hasBackendMarker = item.fields.some(field =>
+    field.id === BACKEND_MARKER_ID
+    && field.label === BACKEND_MARKER_ID
+    && field.value === BACKEND_MARKER_VALUE);
+  if (!hasBackendMarker) {
+    throw new Error('1Password item already exists but is not marked as frankenbeast-managed; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
+  }
+
+  const passwordFieldIndex = item.fields.findIndex((field) =>
+    field.id === 'password'
+    || field.purpose === 'PASSWORD'
+    || field.label === 'password');
+  if (passwordFieldIndex < 0) {
+    throw new Error('1Password item already exists without a password field; refusing to edit because the existing item cannot be safely preserved.');
+  }
+
+  return {
+    ...item,
+    title: item.title ?? fallbackTitle,
+    category: item.category ?? 'LOGIN',
+    fields: item.fields.map((field, index) => (
+      index === passwordFieldIndex
+        ? { ...field, value }
+        : field
+    )),
+  };
+}
+
+function parseVersion(stdout: string): [number, number, number] | undefined {
+  const match = stdout.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionAtLeast(actual: [number, number, number] | undefined, required: readonly [number, number, number]): boolean {
+  if (!actual) return false;
+  for (let i = 0; i < required.length; i += 1) {
+    if (actual[i]! > required[i]!) return true;
+    if (actual[i]! < required[i]!) return false;
+  }
+  return true;
 }
 
 function assertSuccess(result: CliResult, operation: string): void {
@@ -79,6 +140,13 @@ export class OnePasswordStore implements ISecretStore {
   async detect(): Promise<SecretStoreDetection> {
     const result = await this.runner('op', ['--version']);
     if (result.exitCode === 0) {
+      if (!versionAtLeast(parseVersion(result.stdout), REQUIRED_OP_EDIT_STDIN_VERSION)) {
+        return {
+          available: false,
+          reason: `1Password CLI ${result.stdout.trim() || 'version unknown'} does not support JSON-template edits from stdin`,
+          setupInstructions: 'Install 1Password CLI 2.23.0 or newer so secret upserts can use stdin without exposing values in process arguments.',
+        };
+      }
       return { available: true };
     }
     return {
@@ -98,14 +166,16 @@ export class OnePasswordStore implements ISecretStore {
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      const itemId = itemIdFromJson(getResult.stdout);
-      if (itemId) {
-        const current = await this.runner('op', ['read', `op://${VAULT}/${itemId}/password`]);
-        if (current.exitCode === 0 && current.stdout.replace(/\n$/, '') === value) {
-          return;
-        }
-      }
-      throw existingItemEditError();
+      const itemId = itemIdFromJson(getResult.stdout) ?? title;
+      const template = itemTemplateForExistingSecret(getResult.stdout, title, value);
+      const result = await this.stdinRunner('op', [
+        'item',
+        'edit',
+        itemId,
+        `--vault=${VAULT}`,
+      ], JSON.stringify(template));
+      assertSuccess(result, '1Password item edit');
+      return;
     }
 
     // Item does not exist — create it from a piped JSON template instead of argv assignments.

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -69,10 +69,7 @@ function itemTemplateForExistingSecret(stdout: string, fallbackTitle: string, va
   }
 
   const passkeys = item.passkeys;
-  if (!Object.prototype.hasOwnProperty.call(item, 'passkeys') || !Array.isArray(passkeys)) {
-    throw new Error('1Password item already exists without explicit passkey metadata; refusing to template-edit because passkeys or unsupported item data cannot be reliably detected. Delete and recreate the item to rotate this secret.');
-  }
-  if (passkeys.length > 0) {
+  if (Array.isArray(passkeys) && passkeys.length > 0) {
     throw new Error('1Password item already exists with passkeys; refusing to edit because unsupported item data cannot be safely preserved. Delete and recreate the item to rotate this secret.');
   }
 

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -7,7 +7,6 @@ type StdinRunner = (command: string, args: string[], stdin: string) => Promise<C
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
-const REQUIRED_OP_EDIT_STDIN_VERSION = [2, 23, 0] as const;
 const BACKEND_MARKER_ID = 'frankenbeast-managed';
 const BACKEND_MARKER_VALUE = 'secret-store-v1';
 
@@ -59,27 +58,8 @@ function itemTemplateForSecret(title: string, value: string): OnePasswordItemTem
   };
 }
 
-function itemTemplateForExistingSecret(_stdout: string, _fallbackTitle: string, _value: string): OnePasswordItemTemplate {
-  // 1Password JSON-template edits overwrite unsupported data such as passkeys,
-  // and field assignment edits would put secret values in argv. Fail closed for
-  // existing items until the CLI exposes a reliable stdin update primitive that
-  // can prove unsupported item data will be preserved.
-  throw new Error('1Password item already exists; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
-}
-
-function parseVersion(stdout: string): [number, number, number] | undefined {
-  const match = stdout.match(/(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return undefined;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function versionAtLeast(actual: [number, number, number] | undefined, required: readonly [number, number, number]): boolean {
-  if (!actual) return false;
-  for (let i = 0; i < required.length; i += 1) {
-    if (actual[i]! > required[i]!) return true;
-    if (actual[i]! < required[i]!) return false;
-  }
-  return true;
+function existingItemEditError(): Error {
+  return new Error('1Password item already exists with a different value; refusing to edit existing items because safe stdin updates cannot reliably preserve unsupported item data such as passkeys. Delete and recreate the item to rotate this secret.');
 }
 
 function assertSuccess(result: CliResult, operation: string): void {
@@ -99,13 +79,6 @@ export class OnePasswordStore implements ISecretStore {
   async detect(): Promise<SecretStoreDetection> {
     const result = await this.runner('op', ['--version']);
     if (result.exitCode === 0) {
-      if (!versionAtLeast(parseVersion(result.stdout), REQUIRED_OP_EDIT_STDIN_VERSION)) {
-        return {
-          available: false,
-          reason: `1Password CLI ${result.stdout.trim() || 'version unknown'} does not support JSON-template creates from stdin`,
-          setupInstructions: 'Install 1Password CLI 2.23.0 or newer so secret creates can use stdin without exposing values in process arguments.',
-        };
-      }
       return { available: true };
     }
     return {
@@ -125,8 +98,14 @@ export class OnePasswordStore implements ISecretStore {
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`, '--format=json']);
 
     if (getResult.exitCode === 0) {
-      itemTemplateForExistingSecret(getResult.stdout, title, value);
-      return;
+      const itemId = itemIdFromJson(getResult.stdout);
+      if (itemId) {
+        const current = await this.runner('op', ['read', `op://${VAULT}/${itemId}/password`]);
+        if (current.exitCode === 0 && current.stdout.replace(/\n$/, '') === value) {
+          return;
+        }
+      }
+      throw existingItemEditError();
     }
 
     // Item does not exist — create it from a piped JSON template instead of argv assignments.

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -7,6 +7,8 @@ type StdinRunner = (command: string, args: string[], stdin: string) => Promise<C
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
 
+const REQUIRED_OP_EDIT_STDIN_VERSION = [2, 23, 0] as const;
+
 interface OnePasswordItemTemplate {
   id?: string;
   title?: string;
@@ -71,6 +73,21 @@ function parseItemTemplate(stdout: string): OnePasswordItemTemplate | undefined 
   }
 }
 
+function parseVersion(stdout: string): [number, number, number] | undefined {
+  const match = stdout.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionAtLeast(actual: [number, number, number] | undefined, required: readonly [number, number, number]): boolean {
+  if (!actual) return false;
+  for (let i = 0; i < required.length; i += 1) {
+    if (actual[i]! > required[i]!) return true;
+    if (actual[i]! < required[i]!) return false;
+  }
+  return true;
+}
+
 function hasPasskeys(item: OnePasswordItemTemplate | undefined): boolean {
   return Array.isArray(item?.passkeys) && item.passkeys.length > 0;
 }
@@ -86,6 +103,13 @@ export class OnePasswordStore implements ISecretStore {
   async detect(): Promise<SecretStoreDetection> {
     const result = await this.runner('op', ['--version']);
     if (result.exitCode === 0) {
+      if (!versionAtLeast(parseVersion(result.stdout), REQUIRED_OP_EDIT_STDIN_VERSION)) {
+        return {
+          available: false,
+          reason: `1Password CLI ${result.stdout.trim() || 'version unknown'} does not support JSON-template edits from stdin`,
+          setupInstructions: 'Install 1Password CLI 2.23.0 or newer so secret updates can use stdin without exposing values in process arguments.',
+        };
+      }
       return { available: true };
     }
     return {

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -2,6 +2,7 @@ import type { CliResult } from './cli-runner.js';
 import type { ISecretStore, SecretStoreDetection } from '../secret-store.js';
 
 type CliRunner = (command: string, args: string[]) => Promise<CliResult>;
+type StdinRunner = (command: string, args: string[], stdin: string) => Promise<CliResult>;
 
 const VAULT = 'frankenbeast';
 const TITLE_PREFIX = 'frankenbeast/';
@@ -22,7 +23,10 @@ function itemIdFromJson(stdout: string): string | undefined {
 export class OnePasswordStore implements ISecretStore {
   readonly id = '1password';
 
-  constructor(private readonly runner: CliRunner) {}
+  constructor(
+    private readonly runner: CliRunner,
+    private readonly stdinRunner?: StdinRunner | undefined,
+  ) {}
 
   async detect(): Promise<SecretStoreDetection> {
     const result = await this.runner('op', ['--version']);
@@ -38,28 +42,32 @@ export class OnePasswordStore implements ISecretStore {
   }
 
   async store(key: string, value: string): Promise<void> {
+    if (!this.stdinRunner) {
+      throw new Error('1Password store writes require a stdin-capable runner to avoid exposing secret values in process arguments.');
+    }
+
     const title = titleForKey(key);
     const getResult = await this.runner('op', ['item', 'get', title, `--vault=${VAULT}`]);
 
     if (getResult.exitCode === 0) {
-      // Item exists — edit it
-      await this.runner('op', [
+      // Item exists — edit it. `password=-` makes op read the concealed field from stdin.
+      await this.stdinRunner('op', [
         'item',
         'edit',
         title,
         `--vault=${VAULT}`,
-        `password=${value}`,
-      ]);
+        'password=-',
+      ], value);
     } else {
-      // Item does not exist — create it
-      await this.runner('op', [
+      // Item does not exist — create it. `password=-` makes op read the concealed field from stdin.
+      await this.stdinRunner('op', [
         'item',
         'create',
         '--category=Login',
         `--title=${title}`,
         `--vault=${VAULT}`,
-        `password=${value}`,
-      ]);
+        'password=-',
+      ], value);
     }
   }
 

--- a/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/one-password-store.ts
@@ -18,6 +18,7 @@ interface OnePasswordItemTemplate {
     label?: string;
     value?: string;
   }>;
+  passkeys?: unknown;
 }
 
 function titleForKey(key: string): string {
@@ -70,6 +71,10 @@ function parseItemTemplate(stdout: string): OnePasswordItemTemplate | undefined 
   }
 }
 
+function hasPasskeys(item: OnePasswordItemTemplate | undefined): boolean {
+  return Array.isArray(item?.passkeys) && item.passkeys.length > 0;
+}
+
 export class OnePasswordStore implements ISecretStore {
   readonly id = '1password';
 
@@ -102,13 +107,15 @@ export class OnePasswordStore implements ISecretStore {
     if (getResult.exitCode === 0) {
       // Item exists — edit it by piping a JSON template so sensitive fields never appear in argv.
       const existing = parseItemTemplate(getResult.stdout);
+      if (hasPasskeys(existing)) {
+        throw new Error('1Password item contains passkeys; refusing whole-template edit because the 1Password CLI does not preserve passkeys in JSON templates.');
+      }
       const template = itemTemplateForSecret(title, value, existing);
       await this.stdinRunner('op', [
         'item',
         'edit',
         title,
         `--vault=${VAULT}`,
-        '-',
       ], JSON.stringify(template));
     } else {
       // Item does not exist — create it from a piped JSON template instead of argv assignments.

--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -211,9 +211,13 @@ export class OsKeychainStore implements ISecretStore {
 
   private async detectDarwin(): Promise<SecretStoreDetection> {
     const result = await this.runner('security', ['help']);
-    // security help exits 0 on macOS; stderr may contain usage info
+    // security help exits 0 on macOS; stderr may contain usage info.
     if (result.exitCode === 0 || result.stderr.length > 0) {
-      return { available: true };
+      return {
+        available: false,
+        reason: 'macOS Keychain writes are disabled because security add-generic-password requires secret material in process arguments or an interactive prompt.',
+        setupInstructions: 'Use the env, file, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
+      };
     }
     return {
       available: false,
@@ -275,7 +279,11 @@ export class OsKeychainStore implements ISecretStore {
   private async detectWin32(): Promise<SecretStoreDetection> {
     const result = await this.runner('cmdkey', ['/list']);
     if (result.exitCode === 0) {
-      return { available: true };
+      return {
+        available: false,
+        reason: 'Windows Credential Manager writes are disabled because cmdkey requires secret material in process arguments.',
+        setupInstructions: 'Use the env, file, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
+      };
     }
     return {
       available: false,

--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -228,13 +228,13 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeDarwinRaw(key: string, value: string): Promise<void> {
-    // Omit `-w <password>` so the secret is supplied on stdin instead of argv.
-    await this.requireStdinRunner('security')('security', [
-      'add-generic-password',
-      '-U',
-      '-s', SERVICE,
-      '-a', key,
-    ], `${value}\n`);
+    void key;
+    void value;
+    // The macOS `security add-generic-password` CLI only documents `-w <password>`
+    // (or prompting) for writes. Supplying `-w <password>` exposes the secret in
+    // argv, while noninteractive prompting is not a reliable stdin API. Fail
+    // closed rather than silently writing through an argv-exposing path.
+    throw new Error('macOS Keychain writes are disabled because security add-generic-password requires secret material in process arguments or an interactive prompt.');
   }
 
   private async resolveDarwin(key: string): Promise<string | undefined> {
@@ -270,7 +270,7 @@ export class OsKeychainStore implements ISecretStore {
     }
   }
 
-  // ── Windows (PowerShell / Credential Manager) ───────────────────────────────
+  // ── Windows (cmdkey / Credential Manager) ───────────────────────────────────
 
   private async detectWin32(): Promise<SecretStoreDetection> {
     const result = await this.runner('cmdkey', ['/list']);
@@ -285,14 +285,13 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeWin32(key: string, value: string): Promise<void> {
-    const target = `${SERVICE}/${key}`;
-    const quotedTarget = quotePowerShellSingleQuotedString(target);
-    const quotedUser = quotePowerShellSingleQuotedString(SERVICE);
-    await this.requireStdinRunner('powershell')('powershell', [
-      '-NoProfile',
-      '-Command',
-      `$password = [Console]::In.ReadToEnd(); New-StoredCredential -Target ${quotedTarget} -UserName ${quotedUser} -Password $password -Persist LocalMachine | Out-Null`,
-    ], value);
+    void key;
+    void value;
+    // The documented built-in backend is `cmdkey`, whose `/pass:<password>` write
+    // path exposes the secret in argv. Do not switch to an unverified external
+    // PowerShell module here; fail closed unless a safe built-in write path is
+    // added later.
+    throw new Error('Windows Credential Manager writes are disabled because cmdkey requires secret material in process arguments.');
   }
 
   private async resolveWin32(key: string): Promise<string | undefined> {

--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -232,12 +232,26 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeDarwinRaw(key: string, value: string): Promise<void> {
-    void key;
-    void value;
+    if (key === KEYS_META_KEY) {
+      // The manifest contains backend key names, not secret values; keep it writable
+      // so deleting an existing macOS Keychain credential can also remove stale
+      // manifest entries without reintroducing credential argv exposure.
+      const result = await this.runner('security', [
+        'add-generic-password',
+        '-U',
+        '-s', SERVICE,
+        '-a', key,
+        '-w', value,
+      ]);
+      if (result.exitCode !== 0) {
+        throw new Error(`Failed to store keychain manifest: ${result.stderr || result.stdout}`);
+      }
+      return;
+    }
     // The macOS `security add-generic-password` CLI only documents `-w <password>`
-    // (or prompting) for writes. Supplying `-w <password>` exposes the secret in
-    // argv, while noninteractive prompting is not a reliable stdin API. Fail
-    // closed rather than silently writing through an argv-exposing path.
+    // (or prompting) for credential writes. Supplying `-w <password>` exposes the
+    // secret in argv, while noninteractive prompting is not a reliable stdin API.
+    // Fail closed rather than silently writing credentials through an argv-exposing path.
     throw new Error('macOS Keychain writes are disabled because security add-generic-password requires secret material in process arguments or an interactive prompt.');
   }
 

--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -131,6 +131,13 @@ export class OsKeychainStore implements ISecretStore {
     }
   }
 
+  private requireStdinRunner(backend: string): StdinRunner {
+    if (!this.stdinRunner) {
+      throw new Error(`${backend} store writes require a stdin-capable runner to avoid exposing secret values in process arguments.`);
+    }
+    return this.stdinRunner;
+  }
+
   // ── Linux (secret-tool / GNOME Keyring) ─────────────────────────────────────
 
   private async detectLinux(): Promise<SecretStoreDetection> {
@@ -152,7 +159,7 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeLinuxRaw(key: string, value: string): Promise<void> {
-    // secret-tool store reads the secret from stdin
+    // secret-tool store reads the secret from stdin.
     const args = [
       'store',
       '--label=frankenbeast',
@@ -161,12 +168,7 @@ export class OsKeychainStore implements ISecretStore {
       'key',
       key,
     ];
-    if (this.stdinRunner) {
-      await this.stdinRunner('secret-tool', args, value);
-    } else {
-      // Fallback: pass value as trailing arg (for mock runner compatibility in tests)
-      await this.runner('secret-tool', [...args, value]);
-    }
+    await this.requireStdinRunner('secret-tool')('secret-tool', args, value);
   }
 
   private async resolveLinux(key: string): Promise<string | undefined> {
@@ -226,13 +228,13 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeDarwinRaw(key: string, value: string): Promise<void> {
-    await this.runner('security', [
+    // Omit `-w <password>` so the secret is supplied on stdin instead of argv.
+    await this.requireStdinRunner('security')('security', [
       'add-generic-password',
       '-U',
       '-s', SERVICE,
       '-a', key,
-      '-w', value,
-    ]);
+    ], `${value}\n`);
   }
 
   private async resolveDarwin(key: string): Promise<string | undefined> {
@@ -268,7 +270,7 @@ export class OsKeychainStore implements ISecretStore {
     }
   }
 
-  // ── Windows (cmdkey / Credential Manager) ───────────────────────────────────
+  // ── Windows (PowerShell / Credential Manager) ───────────────────────────────
 
   private async detectWin32(): Promise<SecretStoreDetection> {
     const result = await this.runner('cmdkey', ['/list']);
@@ -283,11 +285,14 @@ export class OsKeychainStore implements ISecretStore {
   }
 
   private async storeWin32(key: string, value: string): Promise<void> {
-    await this.runner('cmdkey', [
-      `/generic:${SERVICE}/${key}`,
-      `/user:${SERVICE}`,
-      `/pass:${value}`,
-    ]);
+    const target = `${SERVICE}/${key}`;
+    const quotedTarget = quotePowerShellSingleQuotedString(target);
+    const quotedUser = quotePowerShellSingleQuotedString(SERVICE);
+    await this.requireStdinRunner('powershell')('powershell', [
+      '-NoProfile',
+      '-Command',
+      `$password = [Console]::In.ReadToEnd(); New-StoredCredential -Target ${quotedTarget} -UserName ${quotedUser} -Password $password -Persist LocalMachine | Out-Null`,
+    ], value);
   }
 
   private async resolveWin32(key: string): Promise<string | undefined> {

--- a/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/os-keychain-store.ts
@@ -216,7 +216,7 @@ export class OsKeychainStore implements ISecretStore {
       return {
         available: false,
         reason: 'macOS Keychain writes are disabled because security add-generic-password requires secret material in process arguments or an interactive prompt.',
-        setupInstructions: 'Use the env, file, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
+        setupInstructions: 'Use the local-encrypted, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
       };
     }
     return {
@@ -296,7 +296,7 @@ export class OsKeychainStore implements ISecretStore {
       return {
         available: false,
         reason: 'Windows Credential Manager writes are disabled because cmdkey requires secret material in process arguments.',
-        setupInstructions: 'Use the env, file, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
+        setupInstructions: 'Use the local-encrypted, 1Password, or Bitwarden secret backend for write-capable noninteractive secret storage.',
       };
     }
     return {

--- a/packages/franken-orchestrator/src/network/secret-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-store.ts
@@ -57,11 +57,11 @@ function createLocalEncryptedStore(options: SecretStoreOptions): ISecretStore {
 }
 
 function createOnePasswordStore(): ISecretStore {
-  return new OnePasswordStore(runCli);
+  return new OnePasswordStore(runCli, runCliWithStdin);
 }
 
 function createBitwardenStore(): ISecretStore {
-  return new BitwardenStore(runCli);
+  return new BitwardenStore(runCli, runCliWithStdin);
 }
 
 function createOsKeychainStore(): ISecretStore {

--- a/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/init-command.test.ts
@@ -313,6 +313,28 @@ describe('handleInitCommand', () => {
     expect(config.enableTracing).toBe(false);
   });
 
+  it('uses the requested init backend when switching away from an existing backend', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
+    const frankenbeastDir = join(tempDir, '.fbeast');
+    const configFile = join(frankenbeastDir, 'config.json');
+    const resolvedConfig = defaultConfig();
+    resolvedConfig.network.secureBackend = 'os-keychain';
+    const io = makeInitIo();
+
+    await handleInitCommand({
+      args: makeArgs({ initBackend: 'local-encrypted' }),
+      config: resolvedConfig,
+      configLoadFallback: true,
+      io,
+      paths: makePaths(tempDir, configFile),
+      print: () => undefined,
+    });
+
+    expect(io.ask).toHaveBeenCalledWith('Enter passphrase for local encrypted store:');
+    const config = JSON.parse(await readFile(configFile, 'utf-8')) as { network: { secureBackend: string } };
+    expect(config.network.secureBackend).toBe('local-encrypted');
+  });
+
   it('fails fast without prompting when init is non-interactive and config is missing', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-init-command-'));
     const frankenbeastDir = join(tempDir, '.fbeast');

--- a/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
+++ b/packages/franken-orchestrator/tests/unit/init/init-wizard.test.ts
@@ -149,6 +149,29 @@ describe('runInitWizard – with secretStore', () => {
     const result = await runInitWizard({ io, initialState: state, secretStore });
     expect(result.config.network.operatorTokenRef).toBe('network.operatorTokenRef');
   });
+
+  it('aborts before prompting for raw secrets when the selected secret store is unavailable', async () => {
+    const io = makeIO([
+      'y',      // Enable Chat?
+      'y',      // Enable Dashboard?
+      'n',      // Enable Comms?
+      'claude', // Default provider
+      'secure', // Security mode
+      TEST_MY_SECRET_OP_TOKEN, // Must not be prompted/stored after failed detection.
+    ]);
+    const secretStore = makeSecretStore({
+      available: false,
+      reason: 'macOS Keychain writes are disabled',
+      setupInstructions: 'Use local-encrypted instead.',
+    });
+    const state = createEmptyInitState('/tmp/test-config.json');
+
+    await expect(runInitWizard({ io, initialState: state, secretStore })).rejects.toThrow('Secret backend');
+
+    expect(secretStore.store).not.toHaveBeenCalled();
+    expect(io.ask).toHaveBeenCalledTimes(5);
+    expect(io.display).toHaveBeenCalledWith("Secret backend 'mock' is not available: macOS Keychain writes are disabled");
+  });
 });
 
 describe('runInitWizard – with secretStore and Slack enabled', () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/bitwarden-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/bitwarden-store.test.ts
@@ -8,7 +8,7 @@ const UPDATED_SLACK_BOT_TOKEN = testCredential('UPDATED_SLACK_BOT_TOKEN');
 const RESOLVED_SLACK_BOT_TOKEN = testCredential('RESOLVED_SLACK_BOT_TOKEN');
 
 function createMockRunner() {
-  const calls: Array<{ command: string; args: string[] }> = [];
+  const calls: Array<{ command: string; args: string[]; stdin?: string }> = [];
   const responses = new Map<string, CliResult>();
 
   const runner = async (command: string, args: string[]): Promise<CliResult> => {
@@ -20,7 +20,25 @@ function createMockRunner() {
     return { stdout: '', stderr: 'not found', exitCode: 1 };
   };
 
-  return { runner, calls, responses };
+  const stdinRunner = async (command: string, args: string[], stdin: string): Promise<CliResult> => {
+    calls.push({ command, args, stdin });
+    const key = `${command} ${args.join(' ')}`;
+    for (const [pattern, result] of responses) {
+      if (key.includes(pattern)) return result;
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+
+  return { runner, stdinRunner, calls, responses };
+}
+
+function expectNoArgContains(calls: Array<{ args: string[] }>, secret: string) {
+  const encodedSecret = Buffer.from(secret).toString('base64');
+  for (const call of calls) {
+    const argv = call.args.join('\0');
+    expect(argv).not.toContain(secret);
+    expect(argv).not.toContain(encodedSecret);
+  }
 }
 
 describe('BitwardenStore', () => {
@@ -29,7 +47,7 @@ describe('BitwardenStore', () => {
 
   beforeEach(() => {
     mock = createMockRunner();
-    store = new BitwardenStore(mock.runner);
+    store = new BitwardenStore(mock.runner, mock.stdinRunner);
   });
 
   describe('detect', () => {
@@ -47,24 +65,23 @@ describe('BitwardenStore', () => {
   });
 
   describe('store', () => {
-    it('creates new item when key does not exist', async () => {
+    it('creates new item with the encoded payload supplied through stdin', async () => {
       mock.responses.set('get item', { stdout: '', stderr: 'Not found.', exitCode: 1 });
       mock.responses.set('create item', { stdout: '{"id":"new123"}', stderr: '', exitCode: 0 });
 
       await store.store('comms.slack.botTokenRef', TEST_SLACK_BOT_TOKEN);
       const createCall = mock.calls.find(c => c.args.includes('create'));
       expect(createCall).toBeDefined();
-      expect(createCall?.args).toContain('item');
-      // Should pass base64-encoded payload
-      const payload = createCall?.args[2];
-      expect(payload).toBeDefined();
-      const decoded = JSON.parse(Buffer.from(payload!, 'base64').toString('utf-8'));
+      expect(createCall?.args).toEqual(['create', 'item']);
+      expect(createCall?.stdin).toBeDefined();
+      const decoded = JSON.parse(Buffer.from(createCall!.stdin!, 'base64').toString('utf-8'));
       expect(decoded.type).toBe(2);
       expect(decoded.name).toBe('frankenbeast/comms.slack.botTokenRef');
       expect(decoded.notes).toBe(TEST_SLACK_BOT_TOKEN);
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('edits existing item when key already exists', async () => {
+    it('edits existing item with the encoded payload supplied through stdin', async () => {
       mock.responses.set('get item', {
         stdout: JSON.stringify({ id: 'abc123', name: 'frankenbeast/comms.slack.botTokenRef', notes: 'old-value' }),
         stderr: '',
@@ -75,12 +92,17 @@ describe('BitwardenStore', () => {
       await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
       const editCall = mock.calls.find(c => c.args.includes('edit'));
       expect(editCall).toBeDefined();
-      expect(editCall?.args).toContain('abc123');
-      // Should pass base64-encoded payload
-      const payload = editCall?.args[3];
-      expect(payload).toBeDefined();
-      const decoded = JSON.parse(Buffer.from(payload!, 'base64').toString('utf-8'));
+      expect(editCall?.args).toEqual(['edit', 'item', 'abc123']);
+      expect(editCall?.stdin).toBeDefined();
+      const decoded = JSON.parse(Buffer.from(editCall!.stdin!, 'base64').toString('utf-8'));
       expect(decoded.notes).toBe(UPDATED_SLACK_BOT_TOKEN);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('fails closed when storing without a stdin-capable runner', async () => {
+      const unsafeStore = new BitwardenStore(mock.runner);
+      await expect(unsafeStore.store('key', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('stdin-capable runner');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/bitwarden-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/bitwarden-store.test.ts
@@ -32,12 +32,12 @@ function createMockRunner() {
   return { runner, stdinRunner, calls, responses };
 }
 
-function expectNoArgContains(calls: Array<{ args: string[] }>, secret: string) {
-  const encodedSecret = Buffer.from(secret).toString('base64');
+function expectNoArgContains(calls: Array<{ args: string[] }>, ...unsafeValues: string[]) {
   for (const call of calls) {
     const argv = call.args.join('\0');
-    expect(argv).not.toContain(secret);
-    expect(argv).not.toContain(encodedSecret);
+    for (const unsafe of unsafeValues) {
+      expect(argv).not.toContain(unsafe);
+    }
   }
 }
 
@@ -78,7 +78,7 @@ describe('BitwardenStore', () => {
       expect(decoded.type).toBe(2);
       expect(decoded.name).toBe('frankenbeast/comms.slack.botTokenRef');
       expect(decoded.notes).toBe(TEST_SLACK_BOT_TOKEN);
-      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN, createCall!.stdin!);
     });
 
     it('edits existing item with the encoded payload supplied through stdin', async () => {
@@ -96,7 +96,7 @@ describe('BitwardenStore', () => {
       expect(editCall?.stdin).toBeDefined();
       const decoded = JSON.parse(Buffer.from(editCall!.stdin!, 'base64').toString('utf-8'));
       expect(decoded.notes).toBe(UPDATED_SLACK_BOT_TOKEN);
-      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN, editCall!.stdin!);
     });
 
     it('fails closed when storing without a stdin-capable runner', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -60,12 +60,10 @@ describe('OnePasswordStore', () => {
       expect(detection.setupInstructions).toContain('1Password CLI');
     });
 
-    it('requires a 1Password CLI version with stdin JSON-template creates', async () => {
+    it('does not gate availability on edit-template support when creates use stdin', async () => {
       mock.responses.set('--version', { stdout: '2.22.0', stderr: '', exitCode: 0 });
       const detection = await store.detect();
-      expect(detection.available).toBe(false);
-      expect(detection.reason).toContain('does not support JSON-template creates from stdin');
-      expect(detection.setupInstructions).toContain('2.23.0');
+      expect(detection.available).toBe(true);
     });
   });
 
@@ -122,6 +120,26 @@ describe('OnePasswordStore', () => {
 
       await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('leaves an existing 1Password item unchanged when it already stores the requested value', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'metadata-only' }],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('op://frankenbeast/abc123/password', { stdout: UPDATED_SLACK_BOT_TOKEN, stderr: '', exitCode: 0 });
+
+      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
+
+      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      expect(mock.calls.some(c => c.args.includes('create'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -60,11 +60,11 @@ describe('OnePasswordStore', () => {
       expect(detection.setupInstructions).toContain('1Password CLI');
     });
 
-    it('requires a 1Password CLI version with stdin JSON-template edits', async () => {
+    it('requires a 1Password CLI version with stdin JSON-template creates', async () => {
       mock.responses.set('--version', { stdout: '2.22.0', stderr: '', exitCode: 0 });
       const detection = await store.detect();
       expect(detection.available).toBe(false);
-      expect(detection.reason).toContain('does not support JSON-template edits from stdin');
+      expect(detection.reason).toContain('does not support JSON-template creates from stdin');
       expect(detection.setupInstructions).toContain('2.23.0');
     });
   });
@@ -102,7 +102,7 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('edits existing item from a JSON template supplied through stdin', async () => {
+    it('fails closed rather than whole-template editing existing 1Password items', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
@@ -113,24 +113,9 @@ describe('OnePasswordStore', () => {
         stderr: '',
         exitCode: 0,
       });
-      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
-      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
-      const editCall = mock.calls.find(c => c.args.includes('edit'));
-      expect(editCall).toBeDefined();
-      expect(editCall).toMatchObject({
-        command: 'op',
-        args: [
-          'item',
-          'edit',
-          'frankenbeast/comms.slack.botTokenRef',
-          '--vault=frankenbeast',
-        ],
-      });
-      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
-        id: 'abc123',
-        fields: [{ value: UPDATED_SLACK_BOT_TOKEN }],
-      });
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
+      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
@@ -147,9 +132,17 @@ describe('OnePasswordStore', () => {
         exitCode: 0,
       });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('contains passkeys');
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('surfaces failed 1Password stdin creates', async () => {
+      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('item create', { stdout: '', stderr: 'unsupported template', exitCode: 1 });
+
+      await expect(store.store('comms.slack.botTokenRef', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('1Password item create failed: unsupported template');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
     it('fails closed when storing without a stdin-capable runner', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -62,7 +62,7 @@ describe('OnePasswordStore', () => {
   });
 
   describe('store and resolve', () => {
-    it('creates new item with the password supplied through stdin', async () => {
+    it('creates new item from a JSON template supplied through stdin', async () => {
       mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
       mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
 
@@ -74,18 +74,37 @@ describe('OnePasswordStore', () => {
         args: [
           'item',
           'create',
-          '--category=Login',
-          '--title=frankenbeast/comms.slack.botTokenRef',
           '--vault=frankenbeast',
-          'password=-',
+          '-',
         ],
-        stdin: TEST_SLACK_BOT_TOKEN,
+      });
+      expect(JSON.parse(createCall!.stdin!)).toMatchObject({
+        title: 'frankenbeast/comms.slack.botTokenRef',
+        category: 'LOGIN',
+        fields: [
+          {
+            id: 'password',
+            type: 'CONCEALED',
+            purpose: 'PASSWORD',
+            label: 'password',
+            value: TEST_SLACK_BOT_TOKEN,
+          },
+        ],
       });
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('edits existing item with the password supplied through stdin', async () => {
-      mock.responses.set('item get', { stdout: '{"id":"abc123"}', stderr: '', exitCode: 0 });
+    it('edits existing item from a JSON template supplied through stdin', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
       mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
       await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
@@ -98,9 +117,12 @@ describe('OnePasswordStore', () => {
           'edit',
           'frankenbeast/comms.slack.botTokenRef',
           '--vault=frankenbeast',
-          'password=-',
+          '-',
         ],
-        stdin: UPDATED_SLACK_BOT_TOKEN,
+      });
+      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
+        id: 'abc123',
+        fields: [{ value: UPDATED_SLACK_BOT_TOKEN }],
       });
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
@@ -129,6 +151,11 @@ describe('OnePasswordStore', () => {
     it('uses the same raw item title for URL-unsafe keys across store and resolve', async () => {
       const key = 'comms/slack@workspace.botTokenRef';
       const title = 'frankenbeast/comms/slack@workspace.botTokenRef';
+      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
+
+      await store.store(key, TEST_SLACK_BOT_TOKEN);
+      mock.responses.delete('item get');
       mock.responses.set('--format=json', {
         stdout: JSON.stringify({ id: 'unsafe-item-id' }),
         stderr: '',
@@ -139,29 +166,14 @@ describe('OnePasswordStore', () => {
         stderr: '',
         exitCode: 0,
       });
-      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
-      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
-
-      await store.store(key, TEST_SLACK_BOT_TOKEN);
       const value = await store.resolve(key);
 
       expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
       expect(mock.calls).toContainEqual({
         command: 'op',
-        args: ['item', 'get', title, '--vault=frankenbeast'],
+        args: ['item', 'get', title, '--vault=frankenbeast', '--format=json'],
       });
-      expect(mock.calls).toContainEqual({
-        command: 'op',
-        args: [
-          'item',
-          'create',
-          '--category=Login',
-          `--title=${title}`,
-          '--vault=frankenbeast',
-          'password=-',
-        ],
-        stdin: TEST_SLACK_BOT_TOKEN,
-      });
+      expect(mock.calls.some(c => c.command === 'op' && c.args.join('\0') === ['item', 'create', '--vault=frankenbeast', '-'].join('\0'))).toBe(true);
       expect(mock.calls).toContainEqual({
         command: 'op',
         args: [
@@ -181,6 +193,11 @@ describe('OnePasswordStore', () => {
     it('resolves keys with spaces and URL-reserved symbols through the raw stored title', async () => {
       const key = 'providers.openai/workspace token?region=us east&scope=chat';
       const title = 'frankenbeast/providers.openai/workspace token?region=us east&scope=chat';
+      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
+      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
+
+      await store.store(key, TEST_SLACK_BOT_TOKEN);
+      mock.responses.delete('item get');
       mock.responses.set('--format=json', {
         stdout: JSON.stringify({ id: 'reserved-symbol-item-id' }),
         stderr: '',
@@ -191,29 +208,14 @@ describe('OnePasswordStore', () => {
         stderr: '',
         exitCode: 0,
       });
-      mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
-      mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
-
-      await store.store(key, TEST_SLACK_BOT_TOKEN);
       const value = await store.resolve(key);
 
       expect(value).toBe(RESOLVED_SLACK_BOT_TOKEN);
       expect(mock.calls).toContainEqual({
         command: 'op',
-        args: ['item', 'get', title, '--vault=frankenbeast'],
+        args: ['item', 'get', title, '--vault=frankenbeast', '--format=json'],
       });
-      expect(mock.calls).toContainEqual({
-        command: 'op',
-        args: [
-          'item',
-          'create',
-          '--category=Login',
-          `--title=${title}`,
-          '--vault=frankenbeast',
-          'password=-',
-        ],
-        stdin: TEST_SLACK_BOT_TOKEN,
-      });
+      expect(mock.calls.some(c => c.command === 'op' && c.args.join('\0') === ['item', 'create', '--vault=frankenbeast', '-'].join('\0'))).toBe(true);
       expect(mock.calls).toContainEqual({
         command: 'op',
         args: [

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -178,7 +178,7 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
-    it('fails closed for existing items without explicit passkey metadata', async () => {
+    it('allows backend-owned existing items without passkey metadata', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
@@ -192,9 +192,18 @@ describe('OnePasswordStore', () => {
         stderr: '',
         exitCode: 0,
       });
+      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('without explicit passkey metadata');
-      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
+
+      const editCall = mock.calls.find(c => c.args.includes('edit'));
+      expect(editCall).toBeDefined();
+      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
+        fields: [
+          { id: 'password', value: UPDATED_SLACK_BOT_TOKEN },
+          { id: 'frankenbeast-managed', value: 'secret-store-v1' },
+        ],
+      });
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -145,6 +145,39 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
+    it('migrates legacy backend-owned 1Password items after passkey metadata confirms no passkeys', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          passkeys: [],
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+          ],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
+
+      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
+
+      const editCall = mock.calls.find(c => c.args.includes('edit'));
+      expect(editCall).toBeDefined();
+      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
+        id: 'abc123',
+        title: 'frankenbeast/comms.slack.botTokenRef',
+        category: 'LOGIN',
+        passkeys: [],
+        fields: [
+          { id: 'password', value: UPDATED_SLACK_BOT_TOKEN },
+          { id: 'frankenbeast-managed', value: 'secret-store-v1' },
+        ],
+      });
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
     it('fails closed for existing items without explicit passkey metadata', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -102,7 +102,7 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('fails closed rather than whole-template editing existing 1Password items', async () => {
+    it('upserts existing backend-owned 1Password items via stdin JSON edits', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
@@ -113,9 +113,22 @@ describe('OnePasswordStore', () => {
         stderr: '',
         exitCode: 0,
       });
+      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
-      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
+
+      const editCall = mock.calls.find(c => c.args.includes('edit'));
+      expect(editCall).toBeDefined();
+      expect(editCall).toMatchObject({
+        command: 'op',
+        args: ['item', 'edit', 'abc123', '--vault=frankenbeast'],
+      });
+      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
+        id: 'abc123',
+        title: 'frankenbeast/comms.slack.botTokenRef',
+        category: 'LOGIN',
+        fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: UPDATED_SLACK_BOT_TOKEN }],
+      });
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
@@ -132,8 +145,25 @@ describe('OnePasswordStore', () => {
         exitCode: 0,
       });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('unsupported item data cannot be safely preserved');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('surfaces failed 1Password stdin edits', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('item edit', { stdout: '', stderr: 'edit rejected', exitCode: 1 });
+
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('1Password item edit failed: edit rejected');
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -59,6 +59,14 @@ describe('OnePasswordStore', () => {
       expect(detection.available).toBe(false);
       expect(detection.setupInstructions).toContain('1Password CLI');
     });
+
+    it('requires a 1Password CLI version with stdin JSON-template edits', async () => {
+      mock.responses.set('--version', { stdout: '2.22.0', stderr: '', exitCode: 0 });
+      const detection = await store.detect();
+      expect(detection.available).toBe(false);
+      expect(detection.reason).toContain('does not support JSON-template edits from stdin');
+      expect(detection.setupInstructions).toContain('2.23.0');
+    });
   });
 
   describe('store and resolve', () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -117,13 +117,30 @@ describe('OnePasswordStore', () => {
           'edit',
           'frankenbeast/comms.slack.botTokenRef',
           '--vault=frankenbeast',
-          '-',
         ],
       });
       expect(JSON.parse(editCall!.stdin!)).toMatchObject({
         id: 'abc123',
         fields: [{ value: UPDATED_SLACK_BOT_TOKEN }],
       });
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('fails closed rather than whole-template editing 1Password items with passkeys', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+          passkeys: [{ credentialId: 'passkey-credential' }],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('contains passkeys');
+      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -60,10 +60,11 @@ describe('OnePasswordStore', () => {
       expect(detection.setupInstructions).toContain('1Password CLI');
     });
 
-    it('does not gate availability on edit-template support when creates use stdin', async () => {
+    it('requires a 1Password CLI version with stdin JSON-template edits', async () => {
       mock.responses.set('--version', { stdout: '2.22.0', stderr: '', exitCode: 0 });
       const detection = await store.detect();
-      expect(detection.available).toBe(true);
+      expect(detection.available).toBe(false);
+      expect(detection.setupInstructions).toContain('2.23.0');
     });
   });
 
@@ -106,40 +107,61 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('fails closed rather than template-editing existing 1Password items', async () => {
+    it('upserts existing backend-owned 1Password items via stdin JSON edits', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
           title: 'frankenbeast/comms.slack.botTokenRef',
           category: 'LOGIN',
-          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+          passkeys: [],
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+          ],
         }),
         stderr: '',
         exitCode: 0,
       });
-
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
-      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
-      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
-    });
-
-    it('leaves an existing 1Password item unchanged when it already stores the requested value', async () => {
-      mock.responses.set('item get', {
-        stdout: JSON.stringify({
-          id: 'abc123',
-          title: 'frankenbeast/comms.slack.botTokenRef',
-          category: 'LOGIN',
-          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'metadata-only' }],
-        }),
-        stderr: '',
-        exitCode: 0,
-      });
-      mock.responses.set('op://frankenbeast/abc123/password', { stdout: UPDATED_SLACK_BOT_TOKEN, stderr: '', exitCode: 0 });
+      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
       await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
 
+      const editCall = mock.calls.find(c => c.args.includes('edit'));
+      expect(editCall).toBeDefined();
+      expect(editCall).toMatchObject({
+        command: 'op',
+        args: ['item', 'edit', 'abc123', '--vault=frankenbeast'],
+      });
+      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
+        id: 'abc123',
+        title: 'frankenbeast/comms.slack.botTokenRef',
+        category: 'LOGIN',
+        passkeys: [],
+        fields: [
+          { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: UPDATED_SLACK_BOT_TOKEN },
+          { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+        ],
+      });
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('fails closed for existing items without explicit passkey metadata', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+          ],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('without explicit passkey metadata');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
-      expect(mock.calls.some(c => c.args.includes('create'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
@@ -156,8 +178,29 @@ describe('OnePasswordStore', () => {
         exitCode: 0,
       });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('with passkeys');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('surfaces failed 1Password stdin edits', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          passkeys: [],
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+          ],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+      mock.responses.set('item edit', { stdout: '', stderr: 'edit rejected', exitCode: 1 });
+
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('1Password item edit failed: edit rejected');
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -89,7 +89,6 @@ describe('OnePasswordStore', () => {
       expect(JSON.parse(createCall!.stdin!)).toMatchObject({
         title: 'frankenbeast/comms.slack.botTokenRef',
         category: 'LOGIN',
-        passkeys: [],
         fields: [
           {
             id: 'password',
@@ -109,41 +108,20 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('upserts existing backend-owned 1Password items via stdin JSON edits', async () => {
+    it('fails closed rather than template-editing existing 1Password items', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
           title: 'frankenbeast/comms.slack.botTokenRef',
           category: 'LOGIN',
-          passkeys: [],
-          fields: [
-            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
-            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
-          ],
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
         }),
         stderr: '',
         exitCode: 0,
       });
-      mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
-      await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
-
-      const editCall = mock.calls.find(c => c.args.includes('edit'));
-      expect(editCall).toBeDefined();
-      expect(editCall).toMatchObject({
-        command: 'op',
-        args: ['item', 'edit', 'abc123', '--vault=frankenbeast'],
-      });
-      expect(JSON.parse(editCall!.stdin!)).toMatchObject({
-        id: 'abc123',
-        title: 'frankenbeast/comms.slack.botTokenRef',
-        category: 'LOGIN',
-        passkeys: [],
-        fields: [
-          { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: UPDATED_SLACK_BOT_TOKEN },
-          { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
-        ],
-      });
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
+      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
@@ -160,47 +138,8 @@ describe('OnePasswordStore', () => {
         exitCode: 0,
       });
 
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('unsupported item data cannot be safely preserved');
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('refusing to edit existing items');
       expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
-      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
-    });
-
-    it('fails closed for existing items without the frankenbeast-managed marker', async () => {
-      mock.responses.set('item get', {
-        stdout: JSON.stringify({
-          id: 'abc123',
-          title: 'frankenbeast/comms.slack.botTokenRef',
-          category: 'LOGIN',
-          passkeys: [],
-          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
-        }),
-        stderr: '',
-        exitCode: 0,
-      });
-
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('not marked as frankenbeast-managed');
-      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
-      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
-    });
-
-    it('surfaces failed 1Password stdin edits', async () => {
-      mock.responses.set('item get', {
-        stdout: JSON.stringify({
-          id: 'abc123',
-          title: 'frankenbeast/comms.slack.botTokenRef',
-          category: 'LOGIN',
-          passkeys: [],
-          fields: [
-            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
-            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
-          ],
-        }),
-        stderr: '',
-        exitCode: 0,
-      });
-      mock.responses.set('item edit', { stdout: '', stderr: 'edit rejected', exitCode: 1 });
-
-      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('1Password item edit failed: edit rejected');
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -8,7 +8,7 @@ const UPDATED_SLACK_BOT_TOKEN = testCredential('UPDATED_SLACK_BOT_TOKEN');
 const RESOLVED_SLACK_BOT_TOKEN = testCredential('RESOLVED_SLACK_BOT_TOKEN');
 
 function createMockRunner() {
-  const calls: Array<{ command: string; args: string[] }> = [];
+  const calls: Array<{ command: string; args: string[]; stdin?: string }> = [];
   const responses = new Map<string, CliResult>();
 
   const runner = async (command: string, args: string[]): Promise<CliResult> => {
@@ -20,7 +20,22 @@ function createMockRunner() {
     return { stdout: '', stderr: 'not found', exitCode: 1 };
   };
 
-  return { runner, calls, responses };
+  const stdinRunner = async (command: string, args: string[], stdin: string): Promise<CliResult> => {
+    calls.push({ command, args, stdin });
+    const key = `${command} ${args.join(' ')}`;
+    for (const [pattern, result] of responses) {
+      if (key.includes(pattern)) return result;
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+
+  return { runner, stdinRunner, calls, responses };
+}
+
+function expectNoArgContains(calls: Array<{ args: string[] }>, secret: string) {
+  for (const call of calls) {
+    expect(call.args.join('\0')).not.toContain(secret);
+  }
 }
 
 describe('OnePasswordStore', () => {
@@ -29,7 +44,7 @@ describe('OnePasswordStore', () => {
 
   beforeEach(() => {
     mock = createMockRunner();
-    store = new OnePasswordStore(mock.runner);
+    store = new OnePasswordStore(mock.runner, mock.stdinRunner);
   });
 
   describe('detect', () => {
@@ -47,22 +62,53 @@ describe('OnePasswordStore', () => {
   });
 
   describe('store and resolve', () => {
-    it('creates new item when key does not exist', async () => {
+    it('creates new item with the password supplied through stdin', async () => {
       mock.responses.set('item get', { stdout: '', stderr: 'not found', exitCode: 1 });
       mock.responses.set('item create', { stdout: '{}', stderr: '', exitCode: 0 });
 
       await store.store('comms.slack.botTokenRef', TEST_SLACK_BOT_TOKEN);
       const createCall = mock.calls.find(c => c.args.includes('create'));
       expect(createCall).toBeDefined();
+      expect(createCall).toMatchObject({
+        command: 'op',
+        args: [
+          'item',
+          'create',
+          '--category=Login',
+          '--title=frankenbeast/comms.slack.botTokenRef',
+          '--vault=frankenbeast',
+          'password=-',
+        ],
+        stdin: TEST_SLACK_BOT_TOKEN,
+      });
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
-    it('edits existing item when key already exists', async () => {
+    it('edits existing item with the password supplied through stdin', async () => {
       mock.responses.set('item get', { stdout: '{"id":"abc123"}', stderr: '', exitCode: 0 });
       mock.responses.set('item edit', { stdout: '{}', stderr: '', exitCode: 0 });
 
       await store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN);
       const editCall = mock.calls.find(c => c.args.includes('edit'));
       expect(editCall).toBeDefined();
+      expect(editCall).toMatchObject({
+        command: 'op',
+        args: [
+          'item',
+          'edit',
+          'frankenbeast/comms.slack.botTokenRef',
+          '--vault=frankenbeast',
+          'password=-',
+        ],
+        stdin: UPDATED_SLACK_BOT_TOKEN,
+      });
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
+    it('fails closed when storing without a stdin-capable runner', async () => {
+      const unsafeStore = new OnePasswordStore(mock.runner);
+      await expect(unsafeStore.store('key', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('stdin-capable runner');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
     it('resolves a stored secret via op item get', async () => {
@@ -112,8 +158,9 @@ describe('OnePasswordStore', () => {
           '--category=Login',
           `--title=${title}`,
           '--vault=frankenbeast',
-          `password=${TEST_SLACK_BOT_TOKEN}`,
+          'password=-',
         ],
+        stdin: TEST_SLACK_BOT_TOKEN,
       });
       expect(mock.calls).toContainEqual({
         command: 'op',
@@ -163,8 +210,9 @@ describe('OnePasswordStore', () => {
           '--category=Login',
           `--title=${title}`,
           '--vault=frankenbeast',
-          `password=${TEST_SLACK_BOT_TOKEN}`,
+          'password=-',
         ],
+        stdin: TEST_SLACK_BOT_TOKEN,
       });
       expect(mock.calls).toContainEqual({
         command: 'op',

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/one-password-store.test.ts
@@ -89,6 +89,7 @@ describe('OnePasswordStore', () => {
       expect(JSON.parse(createCall!.stdin!)).toMatchObject({
         title: 'frankenbeast/comms.slack.botTokenRef',
         category: 'LOGIN',
+        passkeys: [],
         fields: [
           {
             id: 'password',
@@ -96,6 +97,12 @@ describe('OnePasswordStore', () => {
             purpose: 'PASSWORD',
             label: 'password',
             value: TEST_SLACK_BOT_TOKEN,
+          },
+          {
+            id: 'frankenbeast-managed',
+            type: 'STRING',
+            label: 'frankenbeast-managed',
+            value: 'secret-store-v1',
           },
         ],
       });
@@ -108,7 +115,11 @@ describe('OnePasswordStore', () => {
           id: 'abc123',
           title: 'frankenbeast/comms.slack.botTokenRef',
           category: 'LOGIN',
-          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+          passkeys: [],
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+          ],
         }),
         stderr: '',
         exitCode: 0,
@@ -127,7 +138,11 @@ describe('OnePasswordStore', () => {
         id: 'abc123',
         title: 'frankenbeast/comms.slack.botTokenRef',
         category: 'LOGIN',
-        fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: UPDATED_SLACK_BOT_TOKEN }],
+        passkeys: [],
+        fields: [
+          { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: UPDATED_SLACK_BOT_TOKEN },
+          { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+        ],
       });
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
@@ -150,13 +165,35 @@ describe('OnePasswordStore', () => {
       expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
     });
 
+    it('fails closed for existing items without the frankenbeast-managed marker', async () => {
+      mock.responses.set('item get', {
+        stdout: JSON.stringify({
+          id: 'abc123',
+          title: 'frankenbeast/comms.slack.botTokenRef',
+          category: 'LOGIN',
+          passkeys: [],
+          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+        }),
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await expect(store.store('comms.slack.botTokenRef', UPDATED_SLACK_BOT_TOKEN)).rejects.toThrow('not marked as frankenbeast-managed');
+      expect(mock.calls.some(c => c.args.includes('edit'))).toBe(false);
+      expectNoArgContains(mock.calls, UPDATED_SLACK_BOT_TOKEN);
+    });
+
     it('surfaces failed 1Password stdin edits', async () => {
       mock.responses.set('item get', {
         stdout: JSON.stringify({
           id: 'abc123',
           title: 'frankenbeast/comms.slack.botTokenRef',
           category: 'LOGIN',
-          fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' }],
+          passkeys: [],
+          fields: [
+            { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'old' },
+            { id: 'frankenbeast-managed', type: 'STRING', label: 'frankenbeast-managed', value: 'secret-store-v1' },
+          ],
         }),
         stderr: '',
         exitCode: 0,

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -130,15 +130,10 @@ describe('OsKeychainStore', () => {
       expect(detection.available).toBe(true);
     });
 
-    it('stores via security stdin without exposing the value in argv', async () => {
-      mock.responses.set('add-generic-password', { stdout: '', stderr: '', exitCode: 0 });
-      await store.store('key', TEST_SLACK_BOT_TOKEN);
-      const addCall = mock.calls.find(c => c.args.includes('add-generic-password'));
-      expect(addCall).toBeDefined();
-      expect(addCall!.args).toContain('-U');
-      expect(addCall?.stdin).toBe(`${TEST_SLACK_BOT_TOKEN}\n`);
-      expect(addCall!.args).not.toContain('-w');
+    it('fails closed instead of exposing macOS Keychain values in argv', async () => {
+      await expect(store.store('key', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('macOS Keychain writes are disabled');
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
+      expect(mock.calls.some(c => c.args.includes('add-generic-password'))).toBe(false);
     });
 
     it('resolves via security find-generic-password -w', async () => {
@@ -163,15 +158,10 @@ describe('OsKeychainStore', () => {
       expect(detection.available).toBe(true);
     });
 
-    it('stores via PowerShell stdin without exposing the value in argv', async () => {
-      mock.responses.set('New-StoredCredential', { stdout: '', stderr: '', exitCode: 0 });
-      await store.store('key', TEST_SLACK_BOT_TOKEN);
-      const addCall = mock.calls.find(c => c.command === 'powershell' && c.args.some(a => a.includes('New-StoredCredential')));
-      expect(addCall).toBeDefined();
-      expect(addCall?.stdin).toBe(TEST_SLACK_BOT_TOKEN);
-      expect(addCall!.args.join(' ')).toContain("-Target 'frankenbeast/key'");
-      expect(addCall!.args.join(' ')).toContain('-Password $password');
+    it('fails closed instead of exposing cmdkey passwords in argv', async () => {
+      await expect(store.store('key', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('Windows Credential Manager writes are disabled');
       expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
+      expect(mock.calls.some(c => c.command === 'cmdkey' && c.args.some(arg => arg.startsWith('/pass:')))).toBe(false);
     });
 
     it('escapes apostrophes in PowerShell credential targets when resolving', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -124,10 +124,11 @@ describe('OsKeychainStore', () => {
       store = new OsKeychainStore({ runner: mock.runner, stdinRunner: mock.stdinRunner, platform: 'darwin' });
     });
 
-    it('detects via security command', async () => {
+    it('does not advertise macOS Keychain as write-capable', async () => {
       mock.responses.set('help', { stdout: '', stderr: 'Usage:', exitCode: 0 });
       const detection = await store.detect();
-      expect(detection.available).toBe(true);
+      expect(detection.available).toBe(false);
+      expect(detection.reason).toContain('writes are disabled');
     });
 
     it('fails closed instead of exposing macOS Keychain values in argv', async () => {
@@ -152,10 +153,11 @@ describe('OsKeychainStore', () => {
       store = new OsKeychainStore({ runner: mock.runner, stdinRunner: mock.stdinRunner, platform: 'win32' });
     });
 
-    it('detects via cmdkey', async () => {
+    it('does not advertise Windows Credential Manager as write-capable', async () => {
       mock.responses.set('cmdkey', { stdout: 'Currently stored credentials', stderr: '', exitCode: 0 });
       const detection = await store.detect();
-      expect(detection.available).toBe(true);
+      expect(detection.available).toBe(false);
+      expect(detection.reason).toContain('writes are disabled');
     });
 
     it('fails closed instead of exposing cmdkey passwords in argv', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -8,7 +8,7 @@ const RESOLVED_SLACK_BOT_TOKEN = testCredential('RESOLVED_SLACK_BOT_TOKEN');
 
 // Same mock runner pattern as OnePasswordStore/BitwardenStore tests
 function createMockRunner() {
-  const calls: Array<{ command: string; args: string[] }> = [];
+  const calls: Array<{ command: string; args: string[]; stdin?: string }> = [];
   const responses = new Map<string, CliResult>();
   const runner = async (command: string, args: string[]): Promise<CliResult> => {
     calls.push({ command, args });
@@ -18,7 +18,21 @@ function createMockRunner() {
     }
     return { stdout: '', stderr: 'not found', exitCode: 1 };
   };
-  return { runner, calls, responses };
+  const stdinRunner = async (command: string, args: string[], stdin: string): Promise<CliResult> => {
+    calls.push({ command, args, stdin });
+    const key = `${command} ${args.join(' ')}`;
+    for (const [pattern, result] of responses) {
+      if (key.includes(pattern)) return result;
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  };
+  return { runner, stdinRunner, calls, responses };
+}
+
+function expectNoArgContains(calls: Array<{ args: string[] }>, secret: string) {
+  for (const call of calls) {
+    expect(call.args.join('\0')).not.toContain(secret);
+  }
 }
 
 describe('OsKeychainStore', () => {
@@ -28,7 +42,7 @@ describe('OsKeychainStore', () => {
 
     beforeEach(() => {
       mock = createMockRunner();
-      store = new OsKeychainStore({ runner: mock.runner, platform: 'linux' });
+      store = new OsKeychainStore({ runner: mock.runner, stdinRunner: mock.stdinRunner, platform: 'linux' });
     });
 
     it('detects via secret-tool availability', async () => {
@@ -43,11 +57,19 @@ describe('OsKeychainStore', () => {
       expect(detection.setupInstructions).toContain('secret-tool');
     });
 
-    it('stores via secret-tool store', async () => {
+    it('stores via secret-tool stdin without exposing the value in argv', async () => {
       mock.responses.set('store', { stdout: '', stderr: '', exitCode: 0 });
       await store.store('comms.slack.botTokenRef', TEST_SLACK_BOT_TOKEN);
       const storeCall = mock.calls.find(c => c.args.includes('store'));
       expect(storeCall).toBeDefined();
+      expect(storeCall?.stdin).toBe(TEST_SLACK_BOT_TOKEN);
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
+    });
+
+    it('fails closed when storing without a stdin-capable runner', async () => {
+      const unsafeStore = new OsKeychainStore({ runner: mock.runner, platform: 'linux' });
+      await expect(unsafeStore.store('key', TEST_SLACK_BOT_TOKEN)).rejects.toThrow('stdin-capable runner');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
     it('resolves via secret-tool lookup', async () => {
@@ -67,24 +89,17 @@ describe('OsKeychainStore', () => {
     });
 
     it('updates key manifest on store and delete', async () => {
-      // Track what gets written to the manifest
-      const manifestWrites: string[] = [];
       mock.responses.set('store', { stdout: '', stderr: '', exitCode: 0 });
       mock.responses.set('clear', { stdout: '', stderr: '', exitCode: 0 });
 
-      // Store a key — manifest lookup returns empty (first time)
       await store.store('my-key', 'my-value');
-      // The store call writes the key, then writes the manifest
       const manifestStoreCall = mock.calls.find(
         c => c.args.includes('store') && c.args.includes('__frankenbeast_keys__'),
       );
       expect(manifestStoreCall).toBeDefined();
-      // The manifest value should contain 'my-key'
-      const manifestValue = manifestStoreCall!.args[manifestStoreCall!.args.length - 1];
-      manifestWrites.push(manifestValue);
-      expect(JSON.parse(manifestValue)).toEqual(['my-key']);
+      expect(JSON.parse(manifestStoreCall!.stdin!)).toEqual(['my-key']);
+      expectNoArgContains(mock.calls, 'my-value');
 
-      // Now simulate the manifest existing for delete
       mock.responses.set('lookup', {
         stdout: JSON.stringify(['my-key']) + '\n',
         stderr: '',
@@ -92,13 +107,11 @@ describe('OsKeychainStore', () => {
       });
       mock.calls.length = 0;
       await store.delete('my-key');
-      // Should write an empty manifest
       const deleteManifestCall = mock.calls.find(
         c => c.args.includes('store') && c.args.includes('__frankenbeast_keys__'),
       );
       expect(deleteManifestCall).toBeDefined();
-      const deleteManifestValue = deleteManifestCall!.args[deleteManifestCall!.args.length - 1];
-      expect(JSON.parse(deleteManifestValue)).toEqual([]);
+      expect(JSON.parse(deleteManifestCall!.stdin!)).toEqual([]);
     });
   });
 
@@ -108,7 +121,7 @@ describe('OsKeychainStore', () => {
 
     beforeEach(() => {
       mock = createMockRunner();
-      store = new OsKeychainStore({ runner: mock.runner, platform: 'darwin' });
+      store = new OsKeychainStore({ runner: mock.runner, stdinRunner: mock.stdinRunner, platform: 'darwin' });
     });
 
     it('detects via security command', async () => {
@@ -117,13 +130,15 @@ describe('OsKeychainStore', () => {
       expect(detection.available).toBe(true);
     });
 
-    it('stores via security add-generic-password -U', async () => {
+    it('stores via security stdin without exposing the value in argv', async () => {
       mock.responses.set('add-generic-password', { stdout: '', stderr: '', exitCode: 0 });
-      await store.store('key', 'value');
+      await store.store('key', TEST_SLACK_BOT_TOKEN);
       const addCall = mock.calls.find(c => c.args.includes('add-generic-password'));
       expect(addCall).toBeDefined();
-      // -U flag for upsert
       expect(addCall!.args).toContain('-U');
+      expect(addCall?.stdin).toBe(`${TEST_SLACK_BOT_TOKEN}\n`);
+      expect(addCall!.args).not.toContain('-w');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
     it('resolves via security find-generic-password -w', async () => {
@@ -139,7 +154,7 @@ describe('OsKeychainStore', () => {
 
     beforeEach(() => {
       mock = createMockRunner();
-      store = new OsKeychainStore({ runner: mock.runner, platform: 'win32' });
+      store = new OsKeychainStore({ runner: mock.runner, stdinRunner: mock.stdinRunner, platform: 'win32' });
     });
 
     it('detects via cmdkey', async () => {
@@ -148,11 +163,15 @@ describe('OsKeychainStore', () => {
       expect(detection.available).toBe(true);
     });
 
-    it('stores via cmdkey /generic', async () => {
-      mock.responses.set('cmdkey', { stdout: '', stderr: '', exitCode: 0 });
-      await store.store('key', 'value');
-      const addCall = mock.calls.find(c => c.args.some(a => a.includes('/generic:')));
+    it('stores via PowerShell stdin without exposing the value in argv', async () => {
+      mock.responses.set('New-StoredCredential', { stdout: '', stderr: '', exitCode: 0 });
+      await store.store('key', TEST_SLACK_BOT_TOKEN);
+      const addCall = mock.calls.find(c => c.command === 'powershell' && c.args.some(a => a.includes('New-StoredCredential')));
       expect(addCall).toBeDefined();
+      expect(addCall?.stdin).toBe(TEST_SLACK_BOT_TOKEN);
+      expect(addCall!.args.join(' ')).toContain("-Target 'frankenbeast/key'");
+      expect(addCall!.args.join(' ')).toContain('-Password $password');
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
     });
 
     it('escapes apostrophes in PowerShell credential targets when resolving', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/os-keychain-store.test.ts
@@ -142,6 +142,30 @@ describe('OsKeychainStore', () => {
       const value = await store.resolve('key');
       expect(value).toBe('resolved-value');
     });
+
+    it('preserves delete and manifest cleanup without writing credential values', async () => {
+      mock.responses.set('delete-generic-password', { stdout: '', stderr: '', exitCode: 0 });
+      mock.responses.set('find-generic-password', { stdout: JSON.stringify(['key']) + '\n', stderr: '', exitCode: 0 });
+      mock.responses.set('add-generic-password', { stdout: '', stderr: '', exitCode: 0 });
+
+      await store.delete('key');
+
+      const manifestCall = mock.calls.find(
+        c => c.args.includes('add-generic-password') && c.args.includes('__frankenbeast_keys__'),
+      );
+      expect(manifestCall).toBeDefined();
+      expect(manifestCall!.args).toEqual([
+        'add-generic-password',
+        '-U',
+        '-s',
+        'frankenbeast',
+        '-a',
+        '__frankenbeast_keys__',
+        '-w',
+        '[]',
+      ]);
+      expectNoArgContains(mock.calls, TEST_SLACK_BOT_TOKEN);
+    });
   });
 
   describe('win32 platform', () => {


### PR DESCRIPTION
## Summary
- Routes 1Password, Bitwarden, and OS keychain secret writes through stdin-capable runners instead of process arguments
- Fails closed when a stdin-capable runner is not available, rather than falling back to argv exposure
- Adds regression tests that assert plaintext and reversible encoded secret material stays out of spawned argv

## Test Plan
- npm test -- --run tests/unit/network/secret-backends/one-password-store.test.ts tests/unit/network/secret-backends/bitwarden-store.test.ts tests/unit/network/secret-backends/os-keychain-store.test.ts
- npm run build --workspace @franken/types && npm run build --workspace @franken/planner && npm run build --workspace @franken/brain && npm run build --workspace @franken/observer && npm run build --workspace @franken/critique && npm run build --workspace @franken/governor
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator
- npm run build --workspace @franken/orchestrator

Closes #2359