### PR TITLE
docs(data-flow): refresh current-state anchor

### DIFF
--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -4,7 +4,7 @@ This document maps how data moves through Frankenbeast today and how it is inten
 
 Two rules for reading this document:
 
-- **Current** means the code-backed behavior in this repository as of `origin/main` at `b835f52` on 2026-03-13.
+- **Current** means the code-backed behavior in the checked-out branch at the time you read or update this document. Some sections may preserve historical context for older target-state decisions, but live behavior should be verified against the active checkout rather than a fixed point-in-time commit.
 - **Target** means the accepted or proposed end-state described by the ADRs and architecture docs, even where the local CLI path is not fully wired yet.
 
 ## Scope


### PR DESCRIPTION
## Summary
- Replace the stale `docs/DATA_FLOW.md` `Current` anchor that pointed at `b835f52` / 2026-03-13 with a checkout-relative definition.
- Keep the implemented-vs-target architecture distinction intact while avoiding a fixed historical validation point for live behavior.

## Test Plan
- `git diff --check`
- `grep -nE 'b835f52|2026-03-13' docs/DATA_FLOW.md` (expected no matches)
- `npm run check:package-manager`

Closes #2642
