### PR TITLE
fix(web): reset force restart state per tracked agent

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-action-bar.tsx
+++ b/packages/franken-web/src/components/beasts/agent-action-bar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 
 export type AgentLifecycleAction = 'start' | 'stop' | 'restart' | 'resume' | 'delete' | 'kill';
@@ -7,6 +7,7 @@ interface AgentActionBarProps {
   status: string;
   hasLinkedRun: boolean;
   agentLabel?: string;
+  resetKey?: string;
   pendingAction?: AgentLifecycleAction | null;
   onStart: () => void;
   onStop: () => void;
@@ -86,8 +87,12 @@ function actionLabel(action: AgentLifecycleAction, label: string, pendingAction:
   return pendingAction === action ? PENDING_LABELS[action] : label;
 }
 
-export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracked agent', pendingAction = null, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
+export function AgentActionBar({ status, hasLinkedRun, agentLabel = 'this tracked agent', resetKey, pendingAction = null, onStart, onStop, onRestart, onResume, onDelete, onKill }: AgentActionBarProps) {
   const [forceRestart, setForceRestart] = useState(false);
+
+  useEffect(() => {
+    setForceRestart(false);
+  }, [resetKey, status]);
 
   const isInitOrDispatch = status === 'initializing' || status === 'dispatching';
   const isRunning = status === 'running';

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -137,6 +137,7 @@ export function AgentDetailPanel({
           status={agent.status}
           hasLinkedRun={!!agent.dispatchRunId}
           agentLabel={agent.name?.trim() ? agent.name : agent.id}
+          resetKey={`${isOpen ? 'open' : 'closed'}:${agent.id}`}
           pendingAction={pendingAction}
           onStart={onStart}
           onStop={onStop}

--- a/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
@@ -178,6 +178,30 @@ describe('AgentDetailPanel', () => {
     expect(screen.queryByDisplayValue('Unsaved old agent')).toBeNull();
   });
 
+  it('resets Force Restart state when the selected running agent changes', () => {
+    const { rerender } = render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
+
+    const forceCheckbox = screen.getByLabelText('Force') as HTMLInputElement;
+    fireEvent.click(forceCheckbox);
+    expect(forceCheckbox.checked).toBe(true);
+
+    rerender(<AgentDetailPanel
+      isOpen={true}
+      detail={{
+        ...detail,
+        agent: {
+          ...detail.agent,
+          id: 'agent-2',
+          name: 'Second agent',
+        },
+      }}
+      logs={[]}
+      {...handlers}
+    />);
+
+    expect((screen.getByLabelText('Force') as HTMLInputElement).checked).toBe(false);
+  });
+
   it('keeps edit mode open and surfaces save errors', async () => {
     handlers.onSaveConfig.mockRejectedValueOnce(new Error('HTTP 500'));
     render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);


### PR DESCRIPTION
## Summary
- resets the tracked-agent action bar Force Restart state when the selected agent, panel-open reset key, or status changes
- passes the detail panel's selected agent/open state into the action bar reset boundary
- adds a React Testing Library regression for switching from one running agent to another after enabling Force

## Test Plan
- npm test -- tests/components/beasts/agent-detail-panel.test.tsx
- npm test -- tests/components/beasts/agent-action-bar.test.tsx tests/components/beasts/agent-detail-panel.test.tsx
- npm run lint --workspace @franken/web
- npm run build --workspace @franken/types
- npm run typecheck --workspace @franken/web
- npm run build --workspace @franken/web

Closes #2643