### PR TITLE
fix(orchestrator): rate-limit tracked-agent lifecycle actions

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -76,7 +76,7 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
       limiter,
       (authHeader, path) => `${authHeader ?? 'anonymous'}:${path}`,
     );
-    app.use('/v1/beasts/agents', rateLimit);
+    app.use('/v1/beasts/agents/*', rateLimit);
   }
 
   app.post('/v1/beasts/agents', async (c) => {

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -1443,6 +1443,55 @@ describe('agent routes integration', () => {
     expect(r3.status).toBe(429);
   });
 
+  it('rate-limits tracked-agent lifecycle action requests', async () => {
+    const { app, operatorToken } = createIntegratedBeastApp({ rateLimitMax: 1 });
+    const headers = {
+      authorization: `Bearer ${operatorToken}`,
+      'content-type': 'application/json',
+    };
+
+    const createResponse = await app.request('/v1/beasts/agents', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        definitionId: 'design-interview',
+        initAction: {
+          kind: 'design-interview',
+          command: '/interview',
+          config: {
+            goal: 'Rate-limit lifecycle action',
+            outputPath: 'docs/design.md',
+          },
+        },
+        initConfig: {
+          goal: 'Rate-limit lifecycle action',
+          outputPath: 'docs/design.md',
+        },
+        autoDispatch: false,
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+    const created = await createResponse.json() as { data: { id: string } };
+
+    const firstStart = await app.request(`/v1/beasts/agents/${created.data.id}/start`, {
+      method: 'POST',
+      headers,
+    });
+    const secondStart = await app.request(`/v1/beasts/agents/${created.data.id}/start`, {
+      method: 'POST',
+      headers,
+    });
+
+    expect(firstStart.status).toBe(200);
+    expect(secondStart.status).toBe(429);
+    expect(await secondStart.json()).toEqual({
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'Rate limit exceeded',
+      },
+    });
+  });
+
   it('returns an explicit error when dispatch throws after creating the tracked agent', async () => {
     const { app, operatorToken } = createIntegratedBeastApp();
     const headers = {


### PR DESCRIPTION
## Summary
- applies Beast agent route rate limiting to tracked-agent lifecycle action paths
- adds an integration regression for repeated `/start` requests returning the existing 429 rate-limit response
- keeps existing agent creation rate-limit behavior covered

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/integration/beasts/agent-routes.test.ts -t "rate-limits tracked-agent lifecycle action requests" (fails before fix: second start returned 409)
- npm run test --workspace @franken/orchestrator -- tests/integration/beasts/agent-routes.test.ts -t "rate-limits tracked-agent lifecycle action requests|rate-limits agent creation requests"
- npm run test --workspace @franken/orchestrator -- tests/integration/beasts/agent-routes.test.ts
- npm run lint --workspace @franken/orchestrator
- npm run build
- npm run typecheck --workspace @franken/orchestrator

Closes #2648
