### PR TITLE
docs: replace legacy architecture labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting, dependency update ex
 
 Frankenbeast is currently organized as 10 npm workspace packages under `packages/*`. Several originally separate MOD packages have been consolidated into the orchestrator or MCP suite: firewall/security middleware, skills/provider loading, heartbeat/reflection, external comms, and MCP registration are current implementation surfaces inside `@franken/orchestrator` and `@franken/mcp-suite`, not standalone package directories.
 
-The diagrams below describe the Beast-loop model and still use MOD labels as capability names. For the exact current package map, treat the package inventory table as authoritative.
+The diagrams below use current package names or implementation-surface names, and the package inventory table remains the authoritative workspace map.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full interconnection diagram.
 
@@ -72,23 +72,23 @@ flowchart TD
         direction TB
 
         subgraph P1["Phase 1: Ingestion"]
-            FW["MOD-01 Firewall<br/>Injection scan, PII mask"]
-            MEM["MOD-03 Brain<br/>Context hydration"]
+            FW["@franken/orchestrator firewall<br/>Injection scan, PII mask"]
+            MEM["@franken/brain<br/>Context hydration"]
         end
 
         subgraph P2["Phase 2: Planning"]
-            PL["MOD-04 Planner<br/>DAG task graph"]
-            CR["MOD-06 Critique<br/>8 evaluators, loop"]
+            PL["@franken/planner<br/>DAG task graph"]
+            CR["@franken/critique<br/>8 evaluators, loop"]
         end
 
         subgraph P3["Phase 3: Execution"]
-            SK["MOD-02 Skills<br/>Registry + MCP tools"]
-            GOV["MOD-07 Governor<br/>HITL approval gates"]
+            SK["@franken/orchestrator skills<br/>Registry + MCP tools"]
+            GOV["@franken/governor<br/>HITL approval gates"]
         end
 
         subgraph P4["Phase 4: Closure"]
-            OB["MOD-05 Observer<br/>Traces, cost, evals"]
-            HB["MOD-08 Heartbeat<br/>Reflection + briefs"]
+            OB["@franken/observer<br/>Traces, cost, evals"]
+            HB["@franken/orchestrator heartbeat<br/>Reflection + briefs"]
         end
 
         CB["Circuit Breakers<br/>Injection → halt | Budget → HITL | Spiral → escalate"]
@@ -124,14 +124,14 @@ flowchart TD
 ```mermaid
 sequenceDiagram
     participant U as User
-    participant FW as Firewall (MOD-01)
-    participant MEM as Brain (MOD-03)
-    participant PL as Planner (MOD-04)
-    participant CR as Critique (MOD-06)
-    participant SK as Skills (MOD-02)
-    participant GOV as Governor (MOD-07)
-    participant OB as Observer (MOD-05)
-    participant HB as Heartbeat (MOD-08)
+    participant FW as @franken/orchestrator firewall
+    participant MEM as @franken/brain
+    participant PL as @franken/planner
+    participant CR as @franken/critique
+    participant SK as @franken/orchestrator skills
+    participant GOV as @franken/governor
+    participant OB as @franken/observer
+    participant HB as @franken/orchestrator heartbeat
 
     U->>FW: raw input
 
@@ -188,18 +188,18 @@ sequenceDiagram
 graph TB
     User([User Input])
 
-    subgraph "MOD-01: Firewall"
+    subgraph "@franken/orchestrator firewall"
         FW_IN["Inbound Interceptors<br/>Injection Scanner, PII Masker"]
         FW_ADAPT["Adapter Pipeline<br/>Claude / OpenAI / Ollama"]
         FW_OUT["Outbound Interceptors<br/>Schema Enforcer, Hallucination Scraper"]
         FW_IN --> FW_ADAPT --> FW_OUT
     end
 
-    subgraph "MOD-02: Skills"
+    subgraph "@franken/orchestrator skills"
         SK_REG["Skill Registry<br/>ISkillRegistry"]
     end
 
-    subgraph "MOD-03: Brain"
+    subgraph "@franken/brain"
         MEM_W["Working Memory"]
         MEM_E["Episodic Memory<br/>SQLite"]
         MEM_S["Semantic Memory<br/>ChromaDB"]
@@ -209,12 +209,12 @@ graph TB
         MEM_O --> MEM_S
     end
 
-    subgraph "MOD-04: Planner"
+    subgraph "@franken/planner"
         PL_DAG["DAG Builder<br/>Linear / Parallel / Recursive"]
         PL_COT["CoT Gate<br/>RationaleBlock"]
     end
 
-    subgraph "MOD-05: Observer"
+    subgraph "@franken/observer"
         OB_TRACE["TraceContext + Spans"]
         OB_COST["TokenCounter + CostCalc"]
         OB_CB["Circuit Breaker"]
@@ -223,7 +223,7 @@ graph TB
         OB_COST --> OB_CB
     end
 
-    subgraph "MOD-06: Critique"
+    subgraph "@franken/critique"
         CR_DET["Deterministic Evaluators<br/>Safety, GhostDep, LogicLoop, ADR"]
         CR_HEUR["Heuristic Evaluators<br/>Factuality, Conciseness, Complexity"]
         CR_LOOP["Critique Loop"]
@@ -231,7 +231,7 @@ graph TB
         CR_HEUR --> CR_LOOP
     end
 
-    subgraph "MOD-07: Governor"
+    subgraph "@franken/governor"
         GOV_TRIG["Trigger Evaluators<br/>Budget / Skill / Confidence / Ambiguity"]
         GOV_GW["Approval Gateway<br/>CLI / Slack channels"]
         GOV_SEC["HMAC-SHA256 Signing"]
@@ -239,14 +239,14 @@ graph TB
         GOV_SEC --> GOV_GW
     end
 
-    subgraph "MOD-08: Heartbeat"
+    subgraph "@franken/orchestrator heartbeat"
         HB_DET["Deterministic Check"]
         HB_REFL["Reflection Engine"]
         HB_DISP["Action Dispatcher"]
         HB_DET --> HB_REFL --> HB_DISP
     end
 
-    subgraph "MCP Registry"
+    subgraph "@franken/mcp-suite registry"
         MCP_REG["McpRegistry<br/>Tool routing"]
         MCP_CLI["McpClient<br/>JSON-RPC 2.0"]
         MCP_REG --> MCP_CLI

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,9 +7,9 @@ Frankenbeast is a deterministic guardrails framework for AI agents, organized as
 This document mixes two views:
 
 - **Current implementation**: what is actually wired in `@franken/orchestrator`, `@franken/mcp-suite`, and the current workspaces today
-- **Target / historical architecture**: broader MOD diagrams and pre-consolidation service boundaries that remain useful as design vocabulary, but are not necessarily current package names
+- **Target / historical architecture**: broader conceptual diagrams and pre-consolidation service boundaries that remain useful as design vocabulary, but are not necessarily current package names
 
-Unless a section explicitly says otherwise, diagrams should be read as target architecture and the prose should call out current local limitations where they matter.
+Unless a section explicitly says otherwise, diagrams should use current package or implementation-surface names, and the prose should call out current local limitations where they matter.
 
 | Package | Role |
 |---------|------|
@@ -471,13 +471,13 @@ Canonical type definitions shared across all modules:
 
 ## Module Interconnections
 
-This diagram shows the logical/target module topology. The `pre-consolidation MCP surface` subgraph depicts the pre-consolidation MCP design; the current implementation is `@franken/mcp-suite` (see the [@franken/mcp-suite](#fbeastmcp-suite) section for what does and does not exist today).
+This diagram shows the logical/target module topology using current package or implementation-surface names. The `pre-consolidation MCP surface` subgraph depicts the pre-consolidation MCP design; the current implementation is `@franken/mcp-suite` (see the [@franken/mcp-suite](#fbeastmcp-suite) section for what does and does not exist today).
 
 ```mermaid
     graph TB
         User([User Input])
 
-        subgraph "MOD-01: Frankenfirewall"
+        subgraph "@franken/orchestrator firewall"
             direction TB
             FW_IN["Inbound Interceptors<br/>• Injection Scanner<br/>• PII Masker<br/>• Project Alignment"]
             FW_ADAPT["Adapter Pipeline<br/>• ClaudeAdapter<br/>• OpenAIAdapter<br/>• OllamaAdapter<br/>• (Extensible)"]
@@ -485,7 +485,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             FW_IN --> FW_ADAPT --> FW_OUT
         end
 
-        subgraph "MOD-02: Franken Skills"
+        subgraph "@franken/orchestrator skills"
             direction TB
             SK_REG["Skill Registry<br/>ISkillRegistry"]
             SK_DISC["Discovery Service<br/>Global + Local"]
@@ -494,7 +494,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             SK_VAL --> SK_REG
         end
 
-        subgraph "MOD-03: Franken Brain"
+        subgraph "@franken/brain"
             direction TB
             MEM_ADAPT["Memory adapter ports<br/>Not package exports"]
             MEM_BRAIN["SqliteBrain<br/>Current public API"]
@@ -507,7 +507,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             MEM_BRAIN --> MEM_RECOV
         end
 
-        subgraph "MOD-04: Franken Planner"
+        subgraph "@franken/planner"
             direction TB
             PL_INTENT["Intent Parser"]
             PL_DAG["DAG Builder<br/>Graph + Cycle Detection"]
@@ -522,7 +522,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             PL_EXEC --> PL_RECOV
         end
 
-        subgraph "MOD-05: Franken Observer"
+        subgraph "@franken/observer"
             direction TB
             OB_TRACE["Trace Context<br/>Spans + Lifecycle"]
             OB_COST["Cost Tracking<br/>TokenCounter + CostCalc"]
@@ -534,7 +534,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             OB_COST --> OB_CB
         end
 
-        subgraph "MOD-06: Franken Critique"
+        subgraph "@franken/critique"
             direction TB
             CR_PIPE["Critique Pipeline"]
             CR_DET["Deterministic Evaluators<br/>• Safety • GhostDep<br/>• LogicLoop • ADR"]
@@ -548,7 +548,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             CR_BREAK --> CR_LOOP
         end
 
-        subgraph "MOD-07: Franken Governor"
+        subgraph "@franken/governor"
             direction TB
             GOV_TRIG["Trigger Evaluators<br/>• Budget • Skill<br/>• Confidence • Ambiguity"]
             GOV_GW["Approval Gateway"]
@@ -560,7 +560,7 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
             GOV_SEC --> GOV_GW
         end
 
-        subgraph "MOD-08: Franken Heartbeat"
+        subgraph "@franken/orchestrator heartbeat"
             direction TB
             HB_DET["Phase 1: Deterministic Check<br/>Watchlist, Git, Tokens"]
             HB_REFL["Phase 2: Reflection Engine<br/>LLM-powered analysis"]
@@ -614,60 +614,60 @@ This diagram shows the logical/target module topology. The `pre-consolidation MC
         FW_ADAPT --> LLM
         LLM --> FW_ADAPT
 
-        %% === MOD-01 → MOD-04: Sanitized Intent ===
+        %% === Orchestrator firewall → planner: Sanitized Intent ===
         FW_OUT -- "getSanitizedIntent()<br/>→ Intent" --> PL_INTENT
 
-        %% === MOD-01 ↔ MOD-02: Tool call grounding ===
+        %% === Orchestrator firewall ↔ orchestrator skills: Tool call grounding ===
         FW_OUT -- "validateToolCalls()<br/>against registry" --> SK_REG
 
-        %% === MOD-04 → MOD-02: Skill discovery ===
+        %% === Planner → orchestrator skills: Skill discovery ===
         PL_DAG -- "getAvailableSkills()<br/>hasSkill()" --> SK_REG
 
-        %% === MOD-04 → MOD-03: Context loading ===
+        %% === Planner → brain: Context loading ===
         PL_DAG -- "IMemoryModule.getContext()" --> MEM_ADAPT
         PL_EXEC -- "IMemoryModule.recordTrace()" --> MEM_ADAPT
 
-        %% === MOD-04 → MOD-07: CoT verification ===
+        %% === Planner → governor: CoT verification ===
         PL_COT -- "verifyRationale()<br/>RationaleBlock" --> GOV_TRIG
 
-        %% === MOD-06 → MOD-01: Safety rules ===
+        %% === Critique → orchestrator firewall: Safety rules ===
         CR_DET -- "getSafetyRules()<br/>executeSandbox()" --> FW_IN
 
-        %% === MOD-06 → MOD-03: ADRs + lessons ===
+        %% === Critique → brain: ADRs + lessons ===
         CR_DET -- "MemoryPort.searchADRs()" --> MEM_ADAPT
         CR_LESSON -- "MemoryPort.recordLesson()" --> MEM_ADAPT
 
-        %% === MOD-06 → MOD-05: Token spend ===
+        %% === Critique → observer: Token spend ===
         CR_BREAK -- "getTokenSpend()" --> OB_COST
 
-        %% === MOD-06 → MOD-07: Escalation ===
+        %% === Critique → governor: Escalation ===
         CR_LOOP -- "requestHumanReview()<br/>on escalation" --> GOV_GW
 
-        %% === MOD-07 → MOD-03: Audit trail ===
+        %% === Governor → brain: Audit trail ===
         GOV_AUDIT -- "record audit<br/>EpisodicTrace" --> MEM_EPIS
 
-        %% === MOD-07 → MOD-02: HITL skill check ===
+        %% === Governor → orchestrator skills: HITL skill check ===
         GOV_TRIG -- "requires_hitl?" --> SK_REG
 
-        %% === MOD-07 → MOD-05: Budget trigger ===
+        %% === Governor → observer: Budget trigger ===
         GOV_TRIG -- "budget check" --> OB_CB
 
-        %% === MOD-08: Reflection pulse ===
+        %% === Orchestrator heartbeat: Reflection pulse ===
         BL_CLOSE -- "optional pulse()" --> HB_REFL
 
-        %% === MOD-08 → MOD-05: Observability ===
+        %% === Orchestrator heartbeat → observer: Observability ===
         HB_DET -- "getTraces()<br/>getTokenSpend()" --> OB_TRACE
 
-        %% === MOD-08 → MOD-04: Task injection ===
+        %% === Orchestrator heartbeat → planner: Task injection ===
         HB_DISP -- "injectTask()<br/>self-improvement" --> PL_EXEC
 
-        %% === MOD-08 → MOD-06: Audit conclusions ===
+        %% === Orchestrator heartbeat → critique: Audit conclusions ===
         HB_REFL -- "auditConclusions()" --> CR_LOOP
 
-        %% === MOD-08 → MOD-07: Alerts + brief ===
+        %% === Orchestrator heartbeat → governor: Alerts + brief ===
         HB_BRIEF -- "sendMorningBrief()<br/>notifyAlert()" --> GOV_GW
 
-        %% === MOD-05 ← All: Span emission ===
+        %% === Observer ← All: Span emission ===
         PL_EXEC -. "emit spans" .-> OB_TRACE
         FW_ADAPT -. "emit spans" .-> OB_TRACE
         CR_LOOP -. "emit spans" .-> OB_TRACE

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-17 — Architecture docs package-name consistency
+- For docs-only architecture fixes, add narrow regression tests that slice the relevant README/docs sections and assert legacy labels are absent there, rather than banning every historical MOD reference across the repository; configuration/env docs may still need legacy toggles for compatibility.
+
 ## 2026-07-17 — Setup healthcheck Codex closeout
 - For onboarding setup healthchecks, distinguish pre-service bootstrap from strict local service verification: occupied optional ports should warn with conflict guidance before Docker starts, while `--require-services` can treat expected open ports as healthy. Keep JSON check schemas stable by serializing nullable fields like `action`, and let tests override service URLs so host-running Grafana/Tempo cannot flip optional-service assertions.
 

--- a/tests/docs-issue-2652.test.ts
+++ b/tests/docs-issue-2652.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readDoc(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+function sectionBetween(doc: string, start: string, end: string): string {
+  const startIndex = doc.indexOf(start);
+  const endIndex = doc.indexOf(end, startIndex + start.length);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return doc.slice(startIndex, endIndex);
+}
+
+describe('issue #2652 architecture labels', () => {
+  it('keeps README architecture diagrams on current package and implementation-surface names', () => {
+    const readmeArchitecture = sectionBetween(
+      readDoc('README.md'),
+      '## Architecture',
+      '## Current workspace packages',
+    );
+
+    expect(readmeArchitecture).not.toMatch(/MOD-\d{2}/);
+    expect(readmeArchitecture).not.toContain('still use MOD labels');
+    expect(readmeArchitecture).toContain('@franken/orchestrator');
+    expect(readmeArchitecture).toContain('@franken/mcp-suite');
+    expect(readmeArchitecture).toContain('@franken/brain');
+    expect(readmeArchitecture).toContain('@franken/planner');
+    expect(readmeArchitecture).toContain('@franken/observer');
+    expect(readmeArchitecture).toContain('@franken/critique');
+    expect(readmeArchitecture).toContain('@franken/governor');
+  });
+
+  it('keeps the detailed architecture interconnection diagram off legacy MOD labels', () => {
+    const moduleInterconnections = sectionBetween(
+      readDoc('docs/ARCHITECTURE.md'),
+      '## Module Interconnections',
+      '## Port Interfaces',
+    );
+
+    expect(moduleInterconnections).not.toMatch(/MOD-\d{2}/);
+    expect(moduleInterconnections).toContain('@franken/orchestrator');
+    expect(moduleInterconnections).toContain('@franken/mcp-suite');
+    expect(moduleInterconnections).toContain('@franken/brain');
+    expect(moduleInterconnections).toContain('@franken/planner');
+    expect(moduleInterconnections).toContain('@franken/observer');
+    expect(moduleInterconnections).toContain('@franken/critique');
+    expect(moduleInterconnections).toContain('@franken/governor');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces legacy MOD labels in README architecture diagrams with current package and implementation-surface names.
- Updates detailed architecture interconnection diagram text/comments to use canonical package surfaces.
- Adds a focused regression test for issue #2652 and records a reusable docs-testing lesson.

## Test Plan
- npm run test:root -- tests/docs-issue-2652.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #2652