### PR TITLE
fix(mcp-suite): write profile settings atomically

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -26,6 +26,10 @@ function hooksBackups(dir: string): string[] {
   return readdirSync(dir).filter((name) => name.startsWith('hooks.json.invalid-'));
 }
 
+function mutationBackups(dir: string, fileName: string): string[] {
+  return readdirSync(dir).filter((name) => name.startsWith(`${fileName}.backup-`) && name.endsWith('.bak'));
+}
+
 describe('fbeast init', () => {
   const dirs: string[] = [];
 
@@ -214,6 +218,12 @@ describe('fbeast init', () => {
     const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
     expect(settings.mcpServers['fbeast-memory']).toBeUndefined();
     expect(settings.mcpServers['other-settings-server']).toBeDefined();
+    const mcpBackups = mutationBackups(root, '.mcp.json');
+    expect(mcpBackups).toHaveLength(1);
+    expect(readFileSync(join(root, mcpBackups[0]!), 'utf-8')).toContain('legacy-planner');
+    const settingsBackups = mutationBackups(claudeDir, 'settings.json');
+    expect(settingsBackups).toHaveLength(1);
+    expect(readFileSync(join(claudeDir, settingsBackups[0]!), 'utf-8')).toContain('legacy-memory');
   });
 
   it('respects pick list', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -14,7 +14,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { writeHookScripts } from './hook-scripts.js';
 import { codexServerName, ensureCodexProjectId } from './codex-server-names.js';
-import { readJsonObjectFileOrRecover, writeJsonFileAtomic } from './settings-json.js';
+import { readJsonObjectFileOrRecover, writeJsonFileAtomic, writeTextFileAtomic } from './settings-json.js';
 
 const ALL_SERVERS: FbeastServer[] = [
   'memory', 'planner', 'critique', 'firewall', 'observer', 'governor', 'skills',
@@ -242,7 +242,7 @@ function writeCodexProjectConfig(
     ].join('\n');
   }).join('\n\n');
   const content = [cleaned, fbeastConfig].filter(Boolean).join('\n\n') + '\n';
-  writeFileSync(configPath, content);
+  writeTextFileAtomic(configPath, content);
 }
 
 function removeFbeastMcpServerTables(toml: string): string {
@@ -454,9 +454,9 @@ function writeAgentsMd(root: string): void {
     if (startIdx !== -1 && endIdx !== -1) {
       content = content.slice(0, startIdx).trimEnd() + content.slice(endIdx + AGENTS_MD_END.length);
     }
-    writeFileSync(agentsPath, content.trimEnd() + '\n\n' + section + '\n');
+    writeTextFileAtomic(agentsPath, content.trimEnd() + '\n\n' + section + '\n');
   } else {
-    writeFileSync(agentsPath, section + '\n');
+    writeTextFileAtomic(agentsPath, section + '\n');
   }
 }
 

--- a/packages/franken-mcp-suite/src/cli/settings-json.test.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, existsSync, lstatSync, mkdtempSync, readdirSync, readFileSyn
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { parseJsonObjectWithComments, writeJsonFileAtomic } from './settings-json.js';
+import { parseJsonObjectWithComments, writeJsonFileAtomic, writeTextFileAtomic } from './settings-json.js';
 
 describe('settings.json helpers', () => {
   it('parses comments and trailing commas without treating comment markers inside strings as comments', () => {
@@ -56,6 +56,33 @@ describe('settings.json helpers', () => {
 
     expect(statSync(settingsPath).mode & 0o777).toBe(0o600);
     expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toEqual({ existing: true, updated: true });
+  });
+
+  it('creates a timestamped backup before replacing an existing JSON settings file', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(settingsPath, '{"existing":true}\n', 'utf-8');
+
+    writeJsonFileAtomic(settingsPath, { updated: true });
+
+    const backups = readdirSync(dir).filter((entry) => /^settings\.json\.backup-.*\.bak$/.test(entry));
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(dir, backups[0]!), 'utf-8')).toBe('{"existing":true}\n');
+    expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toEqual({ updated: true });
+  });
+
+  it('creates a timestamped backup before replacing existing text settings files', () => {
+    const dir = mkdtempSync(join(tmpdir(), `fbeast-settings-${randomUUID()}`));
+    const configPath = join(dir, 'config.toml');
+    writeFileSync(configPath, '[mcp_servers.keep]\ncommand = "keep"\n', 'utf-8');
+
+    writeTextFileAtomic(configPath, '[mcp_servers.fbeast-memory]\ncommand = "fbeast-memory"\n');
+
+    const backups = readdirSync(dir).filter((entry) => /^config\.toml\.backup-.*\.bak$/.test(entry));
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(dir, backups[0]!), 'utf-8')).toBe('[mcp_servers.keep]\ncommand = "keep"\n');
+    expect(readFileSync(configPath, 'utf-8')).toBe('[mcp_servers.fbeast-memory]\ncommand = "fbeast-memory"\n');
+    expect(readdirSync(dir).filter((entry) => entry.includes('.tmp-'))).toEqual([]);
   });
 
   it('updates the target of a symlinked settings file without replacing the symlink', () => {

--- a/packages/franken-mcp-suite/src/cli/settings-json.ts
+++ b/packages/franken-mcp-suite/src/cli/settings-json.ts
@@ -1,4 +1,4 @@
-import { chmodSync, closeSync, copyFileSync, fsyncSync, lstatSync, openSync, readlinkSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, closeSync, copyFileSync, fsyncSync, lstatSync, openSync, readFileSync, readlinkSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
@@ -32,18 +32,23 @@ export function readJsonObjectFileOrRecover(path: string, content: string): Reco
 
 export function writeJsonFileAtomic(path: string, value: unknown): void {
   const content = JSON.stringify(value, null, 2) + '\n';
+  writeTextFileAtomic(path, content);
+}
+
+export function writeTextFileAtomic(path: string, content: string): void {
   const targetPath = resolveAtomicWriteTarget(path);
   const existingMode = getExistingFileMode(targetPath);
   const dir = dirname(targetPath);
   let tempPath = join(dir, `.${basename(targetPath)}.tmp-${randomUUID()}`);
 
   try {
+    backupExistingFile(targetPath);
     for (;;) {
       try {
         writeFileSync(tempPath, content, { encoding: 'utf-8', flag: 'wx', mode: existingMode });
         break;
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        if (errorCode(error) !== 'EEXIST') throw error;
         tempPath = join(dir, `.${basename(targetPath)}.tmp-${randomUUID()}`);
       }
     }
@@ -54,6 +59,35 @@ export function writeJsonFileAtomic(path: string, value: unknown): void {
   } catch (error) {
     rmSync(tempPath, { force: true });
     throw error;
+  }
+}
+
+export function backupFileBeforeMutation(path: string): string | undefined {
+  return backupExistingFile(resolveAtomicWriteTarget(path));
+}
+
+function backupExistingFile(targetPath: string): string | undefined {
+  let existingMode: number | undefined;
+  try {
+    existingMode = statSync(targetPath).mode & 0o777;
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    throw error;
+  }
+
+  const dir = dirname(targetPath);
+  let backupPath = join(dir, `${basename(targetPath)}.backup-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomUUID()}.bak`);
+  for (;;) {
+    try {
+      writeFileSync(backupPath, readFileSync(targetPath), { flag: 'wx', mode: existingMode });
+      chmodSync(backupPath, existingMode);
+      fsyncFile(backupPath);
+      fsyncDirectory(dir);
+      return backupPath;
+    } catch (error) {
+      if (errorCode(error) !== 'EEXIST') throw error;
+      backupPath = join(dir, `${basename(targetPath)}.backup-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomUUID()}.bak`);
+    }
   }
 }
 
@@ -86,10 +120,16 @@ function getExistingFileMode(path: string): number | undefined {
 }
 
 function isNotFound(error: unknown): boolean {
+  return errorCode(error) === 'ENOENT';
+}
+
+function errorCode(error: unknown): string | undefined {
   return typeof error === 'object'
     && error !== null
     && 'code' in error
-    && (error as { code?: string }).code === 'ENOENT';
+    && typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : undefined;
 }
 
 function stripJsonCommentsAndTrailingCommas(content: string): string {
@@ -229,9 +269,6 @@ function fsyncDirectory(path: string): void {
 }
 
 function isUnsupportedDirectoryFsync(error: unknown): boolean {
-  return typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && (error as { code?: string }).code !== undefined
-    && ['EINVAL', 'EISDIR', 'EPERM', 'ENOTSUP'].includes((error as { code: string }).code);
+  const code = errorCode(error);
+  return code !== undefined && ['EINVAL', 'EISDIR', 'EPERM', 'ENOTSUP'].includes(code);
 }

--- a/packages/franken-mcp-suite/src/cli/uninstall.ts
+++ b/packages/franken-mcp-suite/src/cli/uninstall.ts
@@ -4,14 +4,14 @@ function printLine(...args: unknown[]): void {
   console.info(...args);
 }
 
-import { existsSync, readFileSync, writeFileSync, rmSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolveClientConfigDir, detectMcpClient, parseMcpClient, type McpClient } from './mcp-client-paths.js';
 import { confirmYesNo } from './prompt.js';
 import { codexProjectIds, codexServerNamesForProjectIds } from './codex-server-names.js';
-import { readJsonObjectFileOrRecover, writeJsonFileAtomic } from './settings-json.js';
+import { readJsonObjectFileOrRecover, writeJsonFileAtomic, writeTextFileAtomic, backupFileBeforeMutation } from './settings-json.js';
 import type { FbeastServer } from '../shared/config.js';
 
 export interface UninstallOptions {
@@ -161,9 +161,10 @@ function uninstallCodex(options: {
       content = content.slice(0, startIdx).trimEnd() + content.slice(endIdx + AGENTS_MD_END.length);
       const trimmed = content.trimEnd();
       if (trimmed.length === 0) {
+        backupFileBeforeMutation(agentsPath);
         unlinkSync(agentsPath);
       } else {
-        writeFileSync(agentsPath, trimmed + '\n');
+        writeTextFileAtomic(agentsPath, trimmed + '\n');
       }
     }
   }
@@ -184,7 +185,7 @@ function uninstallCodex(options: {
         }
         existing['hooks'] = hooks;
       }
-      writeFileSync(hooksPath, JSON.stringify(existing, null, 2) + '\n');
+      writeTextFileAtomic(hooksPath, JSON.stringify(existing, null, 2) + '\n');
     } catch { /* ignore parse errors */ }
   }
 
@@ -230,9 +231,10 @@ function removeCodexProjectConfigEntries(root: string): void {
   const existing = readFileSync(configPath, 'utf-8');
   const cleaned = removeFbeastMcpServerTables(existing).trimEnd();
   if (cleaned.length === 0) {
+    backupFileBeforeMutation(configPath);
     unlinkSync(configPath);
   } else {
-    writeFileSync(configPath, `${cleaned}\n`);
+    writeTextFileAtomic(configPath, `${cleaned}\n`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a shared text/JSON atomic writer that creates timestamped backups before replacing existing MCP profile settings.
- Route Codex config/AGENTS.md init and uninstall mutations through the atomic writer; back up files before delete-only mutations.
- Add behavior-focused coverage for backup creation, temp-file cleanup, and init plumbing.

Closes #2499

## Test Plan
- [x] `npm ci`
- [x] `npm test --workspace @franken/mcp-suite -- --run src/cli/settings-json.test.ts src/cli/init.test.ts src/cli/uninstall.test.ts src/integration/init-uninstall.integration.test.ts`
- [x] `npm test --workspace @franken/mcp-suite` (37 files / 469 tests passed)
- [x] `npm run lint --workspace @franken/mcp-suite` (0 errors; existing warnings remain)
- [ ] `npm run typecheck --workspace @franken/mcp-suite` (blocked by existing unrelated adapter package/type errors)
- [ ] `npm run build --workspace @franken/mcp-suite` (same pre-existing typecheck blockers)
