### PR TITLE
fix(security): redact deterministic scan credential tokens

### DIFF
--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -28,7 +28,7 @@ const sensitiveEnvNames = [
 ].map((parts) => parts.join('_'));
 
 const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE_KEY|PASSPHRASE)|[A-Z0-9_]*(?:SECRET_KEY|ACCESS_KEY)|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
-const credentialTokenPattern = /\b(?:github_pat_[a-zA-Z0-9_]{40,}|gh[opusr]_[a-zA-Z0-9_.-]{20,}|sk-ant-[a-zA-Z0-9_-]{40,}|AIza[a-zA-Z0-9_-]{35})\b/g;
+const credentialTokenPattern = /\b(?:github_pat_[a-zA-Z0-9_]{40,}(?![a-zA-Z0-9_])|gh[opusr]_[a-zA-Z0-9_.-]{20,}(?![a-zA-Z0-9_.-])|sk-ant-[a-zA-Z0-9_-]{40,}(?![a-zA-Z0-9_-])|AIza[a-zA-Z0-9_-]{35}(?![a-zA-Z0-9_-]))/g;
 const fallbackOperatorPattern = /(?:=|:|\?\?|\|\|)\s*$/;
 const DEFAULT_MAX_SCANNED_FILE_BYTES = 1_000_000;
 const DEFAULT_MAX_SCANNED_LINE_CHARS = 20_000;
@@ -216,8 +216,11 @@ function redactSourceLine(line) {
 
 function hardcodedSensitiveEnvFinding(line) {
   const trimmed = line.trimStart();
-  if (!trimmed || trimmed.startsWith('#')) {
+  if (!trimmed) {
     return null;
+  }
+  if (trimmed.startsWith('#')) {
+    return hasCredentialToken(trimmed) ? '<redacted>' : null;
   }
   const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
   if (!match) {
@@ -395,7 +398,7 @@ async function scanSourceFile(file, findings) {
     const code = stripComments(line, commentState).trim();
 
     if (hasCredentialToken(line)) {
-      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(line.trim())}`);
+      findings.push(`${toRepoPath(file)}:${index + 1}: <redacted>`);
       pendingSensitiveFallbackLine = null;
       continue;
     }

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -219,7 +219,7 @@ function hardcodedSensitiveEnvFinding(line) {
   if (!trimmed || trimmed.startsWith('#')) {
     return null;
   }
-  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]+)\s*=\s*(.*)$/);
+  const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
   if (!match) {
     return null;
   }
@@ -393,13 +393,14 @@ async function scanSourceFile(file, findings) {
 
   for (const [index, line] of lines.entries()) {
     const code = stripComments(line, commentState).trim();
-    if (!code) {
+
+    if (hasCredentialToken(line)) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(line.trim())}`);
+      pendingSensitiveFallbackLine = null;
       continue;
     }
 
-    if (hasCredentialToken(code)) {
-      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(code)}`);
-      pendingSensitiveFallbackLine = null;
+    if (!code) {
       continue;
     }
 

--- a/scripts/check-hardcoded-secrets.mjs
+++ b/scripts/check-hardcoded-secrets.mjs
@@ -28,6 +28,7 @@ const sensitiveEnvNames = [
 ].map((parts) => parts.join('_'));
 
 const sensitiveIdentifierPattern = /\b(?:[A-Z0-9_]*(?:API_KEY|SECRET|PASSWORD|TOKEN|PRIVATE_KEY|PASSPHRASE)|[A-Z0-9_]*(?:SECRET_KEY|ACCESS_KEY)|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY)\b/i;
+const credentialTokenPattern = /\b(?:github_pat_[a-zA-Z0-9_]{40,}|gh[opusr]_[a-zA-Z0-9_.-]{20,}|sk-ant-[a-zA-Z0-9_-]{40,}|AIza[a-zA-Z0-9_-]{35})\b/g;
 const fallbackOperatorPattern = /(?:=|:|\?\?|\|\|)\s*$/;
 const DEFAULT_MAX_SCANNED_FILE_BYTES = 1_000_000;
 const DEFAULT_MAX_SCANNED_LINE_CHARS = 20_000;
@@ -188,19 +189,28 @@ function redactEnvAssignment(name) {
   return `${name}=<redacted>`;
 }
 
+function redactCredentialTokens(text) {
+  return text.replace(credentialTokenPattern, '[REDACTED]');
+}
+
+function hasCredentialToken(text) {
+  credentialTokenPattern.lastIndex = 0;
+  return credentialTokenPattern.test(text);
+}
+
 function redactSourceLine(line) {
   const literals = stringLiterals(line);
   if (literals.length === 0) {
-    return line;
+    return redactCredentialTokens(line);
   }
   let redacted = '';
   let cursor = 0;
   for (const literal of literals) {
-    redacted += line.slice(cursor, literal.start);
+    redacted += redactCredentialTokens(line.slice(cursor, literal.start));
     redacted += literal.closed ? `${literal.quote}<redacted>${literal.quote}` : `${literal.quote}<redacted>`;
     cursor = literal.end;
   }
-  redacted += line.slice(cursor);
+  redacted += redactCredentialTokens(line.slice(cursor));
   return redacted;
 }
 
@@ -209,12 +219,19 @@ function hardcodedSensitiveEnvFinding(line) {
   if (!trimmed || trimmed.startsWith('#')) {
     return null;
   }
-  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]*(?:KEY|SECRET|TOKEN|PASSWORD|ACCESS|PASSPHRASE)[A-Z0-9_]*)\s*=\s*(.*)$/);
+  const match = trimmed.match(/^(?:export\s+)?([A-Z0-9_]+)\s*=\s*(.*)$/);
   if (!match) {
     return null;
   }
   const [, name, value] = match;
-  if (!sensitiveIdentifierPattern.test(name) || value.trim().length === 0) {
+  const hasValue = value.trim().length > 0;
+  if (!hasValue) {
+    return null;
+  }
+  if (hasCredentialToken(value)) {
+    return redactEnvAssignment(name);
+  }
+  if (!sensitiveIdentifierPattern.test(name)) {
     return null;
   }
   return redactEnvAssignment(name);
@@ -377,6 +394,12 @@ async function scanSourceFile(file, findings) {
   for (const [index, line] of lines.entries()) {
     const code = stripComments(line, commentState).trim();
     if (!code) {
+      continue;
+    }
+
+    if (hasCredentialToken(code)) {
+      findings.push(`${toRepoPath(file)}:${index + 1}: ${redactSourceLine(code)}`);
+      pendingSensitiveFallbackLine = null;
       continue;
     }
 

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -389,6 +389,8 @@ describe('hard-coded example secret scanner', () => {
         `export const google = '${googleToken}';`,
         `export const classicGitHub = '${classicGithubToken}';`,
         `const jwtSecret = '${adjacentSecret}'; const gh = '${githubToken}';`,
+        `// leaked token: ${githubToken}`,
+        `/* leaked token: ${anthropicToken} */`,
       ].join('\n'),
       'utf8',
     );
@@ -396,6 +398,7 @@ describe('hard-coded example secret scanner', () => {
       join(root, '.env.example'),
       [
         `SERVICE_URL=https://user:dbpass@example.test?token=${githubToken}`,
+        `service_url=https://example.test/?token=${googleToken}`,
         `JWT_SECRET=prefix-${classicGithubToken}-local-secret`,
       ].join('\n'),
       'utf8',
@@ -409,7 +412,10 @@ describe('hard-coded example secret scanner', () => {
     expect(result.stderr).toContain('packages/example/src/config.ts:3');
     expect(result.stderr).toContain('packages/example/src/config.ts:4');
     expect(result.stderr).toContain('packages/example/src/config.ts:5');
+    expect(result.stderr).toContain('packages/example/src/config.ts:6');
+    expect(result.stderr).toContain('packages/example/src/config.ts:7');
     expect(result.stderr).toContain('SERVICE_URL=<redacted>');
+    expect(result.stderr).toContain('service_url=<redacted>');
     expect(result.stderr).toContain('JWT_SECRET=<redacted>');
     expect(result.stderr).not.toContain(githubToken);
     expect(result.stderr).not.toContain(classicGithubToken);

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -380,6 +380,7 @@ describe('hard-coded example secret scanner', () => {
     const classicGithubToken = `ghp_${'D'.repeat(40)}`;
     const anthropicToken = `sk-ant-${'B'.repeat(40)}`;
     const googleToken = `AIza${'C'.repeat(35)}`;
+    const googleTokenEndingInDash = `AIza${'E'.repeat(34)}-`;
     const adjacentSecret = 'super-secret';
     writeFileSync(
       join(sourceDir, 'config.ts'),
@@ -389,8 +390,9 @@ describe('hard-coded example secret scanner', () => {
         `export const google = '${googleToken}';`,
         `export const classicGitHub = '${classicGithubToken}';`,
         `const jwtSecret = '${adjacentSecret}'; const gh = '${githubToken}';`,
-        `// leaked token: ${githubToken}`,
+        `// db password=${adjacentSecret} leaked token: ${githubToken}`,
         `/* leaked token: ${anthropicToken} */`,
+        `export const suffixed = '${googleTokenEndingInDash}';`,
       ].join('\n'),
       'utf8',
     );
@@ -400,6 +402,7 @@ describe('hard-coded example secret scanner', () => {
         `SERVICE_URL=https://user:dbpass@example.test?token=${githubToken}`,
         `service_url=https://example.test/?token=${googleToken}`,
         `JWT_SECRET=prefix-${classicGithubToken}-local-secret`,
+        `# leaked token: ${githubToken}`,
       ].join('\n'),
       'utf8',
     );
@@ -414,13 +417,16 @@ describe('hard-coded example secret scanner', () => {
     expect(result.stderr).toContain('packages/example/src/config.ts:5');
     expect(result.stderr).toContain('packages/example/src/config.ts:6');
     expect(result.stderr).toContain('packages/example/src/config.ts:7');
+    expect(result.stderr).toContain('packages/example/src/config.ts:8');
     expect(result.stderr).toContain('SERVICE_URL=<redacted>');
     expect(result.stderr).toContain('service_url=<redacted>');
     expect(result.stderr).toContain('JWT_SECRET=<redacted>');
+    expect(result.stderr).toContain('.env.example:4: <redacted>');
     expect(result.stderr).not.toContain(githubToken);
     expect(result.stderr).not.toContain(classicGithubToken);
     expect(result.stderr).not.toContain(anthropicToken);
     expect(result.stderr).not.toContain(googleToken);
+    expect(result.stderr).not.toContain(googleTokenEndingInDash);
     expect(result.stderr).not.toContain(adjacentSecret);
     expect(result.stderr).not.toContain('dbpass');
     expect(result.stderr).not.toContain('local-secret');

--- a/tests/unit/hardcoded-secrets.test.ts
+++ b/tests/unit/hardcoded-secrets.test.ts
@@ -371,4 +371,52 @@ describe('hard-coded example secret scanner', () => {
     expect(result.stderr).toContain('parser=secret-env-scanner input=file-too-large');
     expect(result.stderr).not.toContain(oversizedPayload);
   });
+
+  it('redacts raw credential-shaped token matches from deterministic scan findings', () => {
+    const root = makeFixtureRoot();
+    const sourceDir = join(root, 'packages', 'example', 'src');
+    mkdirSync(sourceDir, { recursive: true });
+    const githubToken = `github_pat_${'A'.repeat(40)}`;
+    const classicGithubToken = `ghp_${'D'.repeat(40)}`;
+    const anthropicToken = `sk-ant-${'B'.repeat(40)}`;
+    const googleToken = `AIza${'C'.repeat(35)}`;
+    const adjacentSecret = 'super-secret';
+    writeFileSync(
+      join(sourceDir, 'config.ts'),
+      [
+        `export const github = '${githubToken}';`,
+        `export const anthropic = '${anthropicToken}';`,
+        `export const google = '${googleToken}';`,
+        `export const classicGitHub = '${classicGithubToken}';`,
+        `const jwtSecret = '${adjacentSecret}'; const gh = '${githubToken}';`,
+      ].join('\n'),
+      'utf8',
+    );
+    writeFileSync(
+      join(root, '.env.example'),
+      [
+        `SERVICE_URL=https://user:dbpass@example.test?token=${githubToken}`,
+        `JWT_SECRET=prefix-${classicGithubToken}-local-secret`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('packages/example/src/config.ts:1');
+    expect(result.stderr).toContain('packages/example/src/config.ts:2');
+    expect(result.stderr).toContain('packages/example/src/config.ts:3');
+    expect(result.stderr).toContain('packages/example/src/config.ts:4');
+    expect(result.stderr).toContain('packages/example/src/config.ts:5');
+    expect(result.stderr).toContain('SERVICE_URL=<redacted>');
+    expect(result.stderr).toContain('JWT_SECRET=<redacted>');
+    expect(result.stderr).not.toContain(githubToken);
+    expect(result.stderr).not.toContain(classicGithubToken);
+    expect(result.stderr).not.toContain(anthropicToken);
+    expect(result.stderr).not.toContain(googleToken);
+    expect(result.stderr).not.toContain(adjacentSecret);
+    expect(result.stderr).not.toContain('dbpass');
+    expect(result.stderr).not.toContain('local-secret');
+  });
 });


### PR DESCRIPTION
## Summary
- detect credential-shaped GitHub, Anthropic, and Google API tokens in deterministic secret scan findings
- redact matched token substrings with `[REDACTED]` while preserving file/line evidence
- add regression coverage proving raw token-like values are absent from scanner output

## Test Plan
- `npm run test:root -- --run tests/unit/hardcoded-secrets.test.ts`
- `npm run lint:security`
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run test:root`

Closes #3170
