### PR TITLE
fix(security): gate cron skip-permissions mode

### DIFF
--- a/docs/cron-script-error-envelopes.md
+++ b/docs/cron-script-error-envelopes.md
@@ -6,7 +6,9 @@ Use `scripts/run-cron-script.mjs` when a scheduled or cron-owned command needs m
 node scripts/run-cron-script.mjs --name nightly-smoke -- npm run test:root -- tests/unit/cron-script-error-envelope.test.ts
 ```
 
-When the wrapped command exits successfully, the wrapper exits `0` and does not add extra output. When the command fails to start, exits non-zero, receives a signal, or the wrapper is invoked incorrectly, it writes one JSON object to stderr:
+When the wrapped command exits successfully, the wrapper exits `0` and does not add extra output. If the command line includes `--dangerously-skip-permissions`, the wrapper refuses to start it unless the cron entry also includes the explicit wrapper opt-in `--allow-dangerous-skip-permissions` before the `--` command separator. That opt-in is the audit-visible record that this scheduled job intentionally runs in dangerous permission-bypass mode; use it only after documenting the job's trust boundary and blast radius.
+
+When the command fails to start, exits non-zero, receives a signal, is blocked by the dangerous-permissions gate, or the wrapper is invoked incorrectly, it writes one JSON object to stderr:
 
 ```json
 {
@@ -18,6 +20,7 @@ When the wrapped command exits successfully, the wrapper exits `0` and does not 
   "failureKind": "exit",
   "exitCode": 1,
   "signal": null,
+  "permissionMode": "least-privilege",
   "durationMs": 1234,
   "recoverable": false,
   "message": "cron script exited with code 1",
@@ -31,6 +34,7 @@ Fields operators should key on:
 - `script`: cron job name supplied by `--name`; keep it stable across schedule changes.
 - `failureKind`: `usage`, `spawn`, `exit`, `signal`, or `internal`.
 - `exitCode` and `signal`: process outcome suitable for alert routing.
+- `permissionMode`: `least-privilege` by default, or `dangerous-skip-permissions` when the cron command intentionally includes `--dangerously-skip-permissions` with the matching wrapper opt-in.
 - `stderrTail`: capped to the last 4096 characters so alerts stay useful without dumping full logs.
 - `recoverable`: opt-in operator hint; pass `--recoverable` for transient jobs where retrying later is expected.
 

--- a/docs/cron-script-error-envelopes.md
+++ b/docs/cron-script-error-envelopes.md
@@ -32,7 +32,7 @@ Fields operators should key on:
 
 - `type`: stable discriminator for log parsers and liveness monitors.
 - `script`: cron job name supplied by `--name`; keep it stable across schedule changes.
-- `failureKind`: `usage`, `spawn`, `exit`, `signal`, or `internal`.
+- `failureKind`: `usage`, `security`, `spawn`, `exit`, `signal`, or `internal`.
 - `exitCode` and `signal`: process outcome suitable for alert routing.
 - `permissionMode`: `least-privilege` by default, or `dangerous-skip-permissions` when the cron command intentionally includes `--dangerously-skip-permissions` with the matching wrapper opt-in.
 - `stderrTail`: capped to the last 4096 characters so alerts stay useful without dumping full logs.

--- a/scripts/run-cron-script.mjs
+++ b/scripts/run-cron-script.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { constants as osConstants } from 'node:os';
 
-const USAGE = 'Usage: node scripts/run-cron-script.mjs --name <job-name> -- <command> [args...]';
+const USAGE = 'Usage: node scripts/run-cron-script.mjs --name <job-name> [--allow-dangerous-skip-permissions] -- <command> [args...]';
 const STDERR_TAIL_LIMIT = 4_096;
 const STDERR_REDACTION_CONTEXT_LIMIT = STDERR_TAIL_LIMIT * 16;
 const KILL_GRACE_MS = Number.parseInt(process.env.CRON_SCRIPT_KILL_GRACE_MS ?? '5000', 10);
@@ -20,6 +20,7 @@ function parseArgs(argv) {
 
   let name;
   let recoverable = false;
+  let allowDangerousSkipPermissions = false;
   for (let index = 0; index < optionArgs.length; index += 1) {
     const arg = optionArgs[index];
     if (arg === '--name') {
@@ -29,6 +30,10 @@ function parseArgs(argv) {
     }
     if (arg === '--recoverable') {
       recoverable = true;
+      continue;
+    }
+    if (arg === '--allow-dangerous-skip-permissions') {
+      allowDangerousSkipPermissions = true;
       continue;
     }
     throw Object.assign(new Error(`${USAGE}; unknown option ${JSON.stringify(arg)}`), {
@@ -42,7 +47,24 @@ function parseArgs(argv) {
     throw Object.assign(new Error(USAGE), { exitCode: 2, failureKind: 'usage', scriptName: name || 'unknown' });
   }
 
-  return { name, recoverable, command };
+  const permissionMode = commandUsesDangerousSkipPermissions(command) ? 'dangerous-skip-permissions' : 'least-privilege';
+  if (permissionMode === 'dangerous-skip-permissions' && !allowDangerousSkipPermissions) {
+    throw Object.assign(new Error(
+      'Refusing to run unattended cron command with --dangerously-skip-permissions; pass --allow-dangerous-skip-permissions only after documenting the trust boundary and blast radius.',
+    ), {
+      exitCode: 64,
+      failureKind: 'security',
+      scriptName: name,
+      command,
+      permissionMode,
+    });
+  }
+
+  return { name, recoverable, command, permissionMode };
+}
+
+function commandUsesDangerousSkipPermissions(command) {
+  return command.some((part) => part === '--dangerously-skip-permissions');
 }
 
 function appendTail(current, chunk, limit = STDERR_TAIL_LIMIT) {
@@ -443,7 +465,7 @@ function spawnFailureExitCode(error) {
   return error?.code === 'EACCES' || error?.code === 'EPERM' ? 126 : 127;
 }
 
-function writeEnvelope({ script, command, exitCode, signal = null, failureKind = 'exit', message, stderrTail = '', durationMs, recoverable = false }) {
+function writeEnvelope({ script, command, exitCode, signal = null, failureKind = 'exit', message, stderrTail = '', durationMs, recoverable = false, permissionMode = 'least-privilege' }) {
   const envelope = {
     schemaVersion: 1,
     type: 'franken.cron.script.error',
@@ -453,6 +475,7 @@ function writeEnvelope({ script, command, exitCode, signal = null, failureKind =
     failureKind,
     exitCode,
     signal,
+    permissionMode,
     durationMs,
     recoverable,
     message: redactMessage(message, command),
@@ -481,7 +504,7 @@ function findJsonStringEnd(text, start, delimiter, initialBackslashes = 0) {
   return -1;
 }
 
-async function runCronScript({ name, recoverable, command }) {
+async function runCronScript({ name, recoverable, command, permissionMode }) {
   const started = Date.now();
   const [bin, ...args] = command;
   let stderrTail = '';
@@ -556,6 +579,7 @@ async function runCronScript({ name, recoverable, command }) {
         stderrTail,
         durationMs,
         recoverable,
+        permissionMode,
       });
     };
 
@@ -631,7 +655,7 @@ async function runCronScript({ name, recoverable, command }) {
 
     child = spawn(bin, args, {
       cwd: process.cwd(),
-      env: process.env,
+      env: { ...process.env, FRANKENBEAST_CRON_PERMISSION_MODE: permissionMode },
       shell: process.platform === 'win32',
       stdio: ['inherit', 'inherit', 'pipe'],
     });
@@ -678,6 +702,7 @@ async function runCronScript({ name, recoverable, command }) {
           stderrTail,
           durationMs,
           recoverable,
+          permissionMode,
         });
       }
       finish(exitCode);
@@ -736,6 +761,7 @@ async function runCronScript({ name, recoverable, command }) {
         stderrTail,
         durationMs,
         recoverable,
+        permissionMode,
       });
       finish(exitCode);
     });
@@ -760,13 +786,16 @@ main().catch((error) => {
   const exitCode = Number.isInteger(error?.exitCode) ? error.exitCode : 1;
   const failureKind = typeof error?.failureKind === 'string' ? error.failureKind : 'internal';
   const script = typeof error?.scriptName === 'string' ? error.scriptName : 'unknown';
+  const command = Array.isArray(error?.command) ? error.command : [];
+  const permissionMode = typeof error?.permissionMode === 'string' ? error.permissionMode : 'least-privilege';
   writeEnvelope({
     script,
-    command: [],
+    command,
     exitCode,
     failureKind,
     message: error instanceof Error ? error.message : String(error),
     durationMs: 0,
+    permissionMode,
   });
   process.exitCode = exitCode;
 });

--- a/scripts/run-cron-script.mjs
+++ b/scripts/run-cron-script.mjs
@@ -64,7 +64,7 @@ function parseArgs(argv) {
 }
 
 function commandUsesDangerousSkipPermissions(command) {
-  return command.some((part) => part === '--dangerously-skip-permissions');
+  return command.some((part) => part.includes('--dangerously-skip-permissions'));
 }
 
 function appendTail(current, chunk, limit = STDERR_TAIL_LIMIT) {

--- a/tests/unit/cron-script-error-envelope.test.ts
+++ b/tests/unit/cron-script-error-envelope.test.ts
@@ -249,6 +249,49 @@ describe('cron script error envelope runner', () => {
     expect(envelope.stderrTail).toContain('TRUNCATED_SECRET=[REDACTED]');
   });
 
+  it('refuses dangerous skip-permissions cron commands without explicit opt-in', () => {
+    const result = runCronScript([
+      '--name',
+      'unsafe-agent-cron',
+      '--',
+      process.execPath,
+      '-e',
+      'process.exit(0)',
+      '--dangerously-skip-permissions',
+    ]);
+
+    expect(result.status).toBe(64);
+    const envelope = parseEnvelope(result.stderr);
+    expect(envelope).toMatchObject({
+      schemaVersion: 1,
+      type: 'franken.cron.script.error',
+      script: 'unsafe-agent-cron',
+      exitCode: 64,
+      signal: null,
+      failureKind: 'security',
+      permissionMode: 'dangerous-skip-permissions',
+    });
+    expect(envelope.command).toContain('--dangerously-skip-permissions');
+    expect(envelope.message).toContain('Refusing to run unattended cron command');
+  });
+
+  it('runs dangerous skip-permissions cron commands only with auditable opt-in', () => {
+    const result = runCronScript([
+      '--name',
+      'acknowledged-agent-cron',
+      '--allow-dangerous-skip-permissions',
+      '--',
+      process.execPath,
+      '-e',
+      "if (process.env.FRANKENBEAST_CRON_PERMISSION_MODE !== 'dangerous-skip-permissions') process.exit(9)",
+      '--',
+      '--dangerously-skip-permissions',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
   it('fails with an explicit envelope when the cron command is missing', () => {
     const result = runCronScript(['--name', 'missing-command']);
 
@@ -261,8 +304,9 @@ describe('cron script error envelope runner', () => {
       exitCode: 2,
       signal: null,
       failureKind: 'usage',
+      permissionMode: 'least-privilege',
     });
-    expect(envelope.message).toContain('Usage: node scripts/run-cron-script.mjs --name <job-name> -- <command> [args...]');
+    expect(envelope.message).toContain('Usage: node scripts/run-cron-script.mjs --name <job-name> [--allow-dangerous-skip-permissions] -- <command> [args...]');
   });
 
   it('keeps the envelope parseable when stderr lacks a trailing newline', () => {

--- a/tests/unit/cron-script-error-envelope.test.ts
+++ b/tests/unit/cron-script-error-envelope.test.ts
@@ -275,6 +275,28 @@ describe('cron script error envelope runner', () => {
     expect(envelope.message).toContain('Refusing to run unattended cron command');
   });
 
+  it('refuses shell-wrapped dangerous skip-permissions cron commands without explicit opt-in', () => {
+    const result = runCronScript([
+      '--name',
+      'unsafe-shell-cron',
+      '--',
+      process.execPath,
+      '-e',
+      "process.exit(process.argv.includes('--dangerously-skip-permissions') ? 0 : 9)",
+      '-- --dangerously-skip-permissions',
+    ]);
+
+    expect(result.status).toBe(64);
+    const envelope = parseEnvelope(result.stderr);
+    expect(envelope).toMatchObject({
+      script: 'unsafe-shell-cron',
+      exitCode: 64,
+      failureKind: 'security',
+      permissionMode: 'dangerous-skip-permissions',
+    });
+    expect(envelope.command).toContain('-- --dangerously-skip-permissions');
+  });
+
   it('runs dangerous skip-permissions cron commands only with auditable opt-in', () => {
     const result = runCronScript([
       '--name',


### PR DESCRIPTION
## Summary
- require an explicit run-cron-script opt-in before unattended commands may use --dangerously-skip-permissions
- record permissionMode in cron error envelopes and propagate FRANKENBEAST_CRON_PERMISSION_MODE to child commands
- document the dangerous-mode audit signal and add coverage for refusal/success paths

## Test Plan
- npm run test:root -- tests/unit/cron-script-error-envelope.test.ts
- npm run typecheck
- npm run lint
- npm run build

Closes #3166