### PR TITLE
docs(web): clarify canonical dashboard SSE endpoint

### DIFF
--- a/docs/adr/030-sse-connection-tickets-auth.md
+++ b/docs/adr/030-sse-connection-tickets-auth.md
@@ -14,12 +14,19 @@ The operator token must be validated before establishing the SSE stream, but it 
 
 Use a **connection ticket** pattern — an industry-standard approach for authenticating SSE and WebSocket connections.
 
+**Canonical endpoints:**
+
+- Ticket issuance: `POST /v1/beasts/events/ticket`
+- Dashboard stream: `GET /v1/beasts/events/stream?ticket=<uuid>`
+
+These paths are shared by the daemon routes in `packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts` and the dashboard client in `packages/franken-web/src/lib/beast-api.ts`. Older per-agent `/api/beasts/:id/events` examples are not the dashboard stream contract.
+
 **Flow:**
 
 1. Dashboard calls `POST /v1/beasts/events/ticket` with `Authorization: Bearer <operator-token>`
 2. Daemon validates the bearer token, generates a single-use UUID ticket, stores it in an in-memory map with a 30-second TTL
 3. Response: `{ ticket: "<uuid>" }`
-4. Dashboard opens `EventSource` to `/v1/beasts/events/stream?ticket=<uuid>`
+4. Dashboard opens `EventSource` to the canonical `/v1/beasts/events/stream?ticket=<uuid>` endpoint
 5. Daemon validates the ticket: must exist, not expired, not already used
 6. Ticket is burned (deleted from map) on first use
 7. SSE stream is established and authenticated for the lifetime of the connection
@@ -32,7 +39,7 @@ Use a **connection ticket** pattern — an industry-standard approach for authen
 
 **Reconnection:**
 
-When `EventSource` auto-reconnects (network interruption), it opens a new HTTP request. The client must obtain a fresh ticket before reconnecting. The `useBeastEventStream` React hook handles this: on connection error, request a new ticket, then reconnect.
+When `EventSource` reconnects after a network interruption, it opens a new HTTP request. The client must obtain a fresh ticket before reconnecting. The dashboard client's `BeastApiClient.subscribeToEvents` method handles this by requesting a new ticket and creating a new `EventSource` for the canonical stream endpoint.
 
 ## Consequences
 

--- a/tests/docs-issue-3226.test.ts
+++ b/tests/docs-issue-3226.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+function requireMatch(source: string, pattern: RegExp, description: string): string {
+  const match = source.match(pattern);
+  expect(match, description).not.toBeNull();
+  return match?.[1] ?? '';
+}
+
+describe('issue #3226 dashboard SSE endpoint contract', () => {
+  it('keeps the dashboard client and daemon route on the same canonical stream path', () => {
+    const daemonRoutes = readRepoFile(
+      'packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts',
+    );
+    const dashboardClient = readRepoFile('packages/franken-web/src/lib/beast-api.ts');
+
+    const daemonPath = requireMatch(
+      daemonRoutes,
+      /app\.get\('([^']*\/events\/stream)'/u,
+      'daemon SSE route should be declared',
+    );
+    const dashboardPath = requireMatch(
+      dashboardClient,
+      /`\$\{this\.baseUrl\}(\/[^?]*\/events\/stream)\?\$\{query\.toString\(\)\}`/u,
+      'dashboard EventSource path should be declared',
+    );
+
+    expect(dashboardPath).toBe(daemonPath);
+    expect(daemonPath).toBe('/v1/beasts/events/stream');
+  });
+
+  it('documents the canonical ticket and stream endpoints in ADR-030', () => {
+    const adr = readRepoFile('docs/adr/030-sse-connection-tickets-auth.md');
+
+    expect(adr).toContain('Ticket issuance: `POST /v1/beasts/events/ticket`');
+    expect(adr).toContain(
+      'Dashboard stream: `GET /v1/beasts/events/stream?ticket=<uuid>`',
+    );
+    expect(adr).not.toContain('`useBeastEventStream`');
+  });
+});


### PR DESCRIPTION
## Summary
- identify the ticket and dashboard SSE routes as the canonical ADR-030 endpoints
- replace the stale reconnect hook reference with the live `BeastApiClient.subscribeToEvents` implementation
- add a regression test that compares the frontend EventSource path with the daemon route

## Test plan
- `npm run test:root -- tests/docs-issue-3226.test.ts`
- `npm run lint`
- `npm run typecheck`

Closes #3226