### PR TITLE
test(sandbox): require valid Dockerfile user directive

### DIFF
--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -120,11 +120,10 @@ describe('sandbox Dockerfile', () => {
   }, 60_000);
 
   it('declares a non-root default container UID', () => {
-    const userLine = dockerfile.split('\n').find((line) => line.startsWith('USER '));
+    const userDirective = dockerfile.match(/^USER\s+([^\s:]+)(?::[^\s]+)?\s*$/mu);
 
-    expect(userLine).toBeDefined();
-    expect(userLine).not.toBe('USER root');
-    expect(userLine).not.toBe('USER 0');
-    expect(userLine?.split(/\s+/)[1]?.split(':')[0]).not.toBe('0');
+    expect(userDirective, 'Dockerfile must declare a valid USER directive').not.toBeNull();
+    expect(userDirective?.[1]).not.toBe('root');
+    expect(userDirective?.[1]).not.toBe('0');
   });
 });


### PR DESCRIPTION
## Summary
- require the sandbox Dockerfile to contain a syntactically valid `USER` directive
- validate the parsed user principal rather than allowing missing or malformed values through optional chaining
- preserve explicit rejection of root by name or UID 0

## Test plan
- `npx vitest run tests/sandbox-dockerfile.test.ts -t "declares a non-root default container UID"`
- mutant checks: removed `USER` and malformed `USER :10001` both fail the targeted assertion
- `npm run test:root` (573 passed, 1 skipped)
- `npm run typecheck`
- `npm run lint` (passes with pre-existing warnings)
- `npm run build`

Closes #3228