### PR TITLE
docs(security): document Telegram webhook migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,13 +930,13 @@ Channels route through the orchestrator comms pipeline. See [ADR-016](docs/adr/0
 
 ### Telegram webhook setup and migration
 
-Telegram updates use the fixed `https://<public-host>/webhooks/telegram` route. Configure a dedicated, randomly generated webhook secret through `comms.telegram.webhookSecretTokenRef`, then pass the resolved value as Telegram's `secret_token` when registering the webhook. Telegram sends that value in `X-Telegram-Bot-Api-Secret-Token`; Frankenbeast rejects requests whose header is missing or invalid. Do not append the bot token to the webhook URL.
+Telegram updates use the fixed `https://<public-host>/webhooks/telegram` route. Configure a dedicated, randomly generated webhook secret through `comms.telegram.webhookSecretTokenRef`, then pass the resolved value as Telegram's `secret_token` when registering the webhook. The secret must be 1–256 characters using only A-Z, a-z, 0-9, `_`, and `-`, as required by the Telegram Bot API. Telegram sends that value in `X-Telegram-Bot-Api-Secret-Token`; Frankenbeast rejects requests whose header is missing or invalid. Do not append the bot token to the webhook URL.
 
 To migrate an existing token-bearing webhook URL:
 
-1. Generate and store a new webhook secret that is independent of the Telegram bot token, then update `comms.telegram.webhookSecretTokenRef` through `frankenbeast init --repair` or the configured secret backend.
+1. Generate a new webhook secret that is independent of the Telegram bot token and store it directly in the configured secret backend under the reference named by `comms.telegram.webhookSecretTokenRef`. If the logical reference changes, update `.fbeast/config.json` too. Do not rely on `frankenbeast init --repair` to rotate a complete configuration; it exits without changing secrets when verification already passes.
 2. After storing the secret, re-register the webhook with Telegram using the fixed `/webhooks/telegram` URL and the same new value in the Bot API `secret_token` parameter. Telegram's `setWebhook` call replaces the previous webhook URL.
-3. Send a test update and confirm the fixed route accepts the `X-Telegram-Bot-Api-Secret-Token` header while the old token-bearing path returns `404`.
+3. Send a test update and confirm the fixed route accepts the `X-Telegram-Bot-Api-Secret-Token` header. A legacy token-bearing path returns `404` when sent directly to the chat server. The supported `dashboard-web` reverse proxy instead rewrites legacy token-bearing paths to `/webhooks/telegram` before forwarding, so verify the fixed upstream route and header validation rather than expecting a proxy-level `404`.
 4. If the old URL may have appeared in proxy logs, screenshots, or support tools, rotate the bot token with BotFather and update `comms.telegram.botTokenRef`; then remove or redact retained copies of the old URL.
 
 Never log the resolved bot token or webhook secret. Treat both secret-store references as server-side configuration.

--- a/README.md
+++ b/README.md
@@ -923,10 +923,23 @@ External communications are implemented in `@franken/orchestrator` under `packag
 |---------|-----------|----------|
 | Slack | Events API + Interactivity | HMAC-SHA256 signature verification |
 | Discord | Gateway events | ED25519 signature verification |
-| Telegram | Webhook | Token-based authentication |
+| Telegram | Webhook | Telegram `secret_token` header validation |
 | WhatsApp | Cloud API | SHA256 signature verification |
 
 Channels route through the orchestrator comms pipeline. See [ADR-016](docs/adr/016-external-comms-gateway.md) for the original gateway decision and the orchestrator comms source for current implementation details.
+
+### Telegram webhook setup and migration
+
+Telegram updates use the fixed `https://<public-host>/webhooks/telegram` route. Configure a dedicated, randomly generated webhook secret through `comms.telegram.webhookSecretTokenRef`, then pass the resolved value as Telegram's `secret_token` when registering the webhook. Telegram sends that value in `X-Telegram-Bot-Api-Secret-Token`; Frankenbeast rejects requests whose header is missing or invalid. Do not append the bot token to the webhook URL.
+
+To migrate an existing token-bearing webhook URL:
+
+1. Generate and store a new webhook secret that is independent of the Telegram bot token, then update `comms.telegram.webhookSecretTokenRef` through `frankenbeast init --repair` or the configured secret backend.
+2. After storing the secret, re-register the webhook with Telegram using the fixed `/webhooks/telegram` URL and the same new value in the Bot API `secret_token` parameter. Telegram's `setWebhook` call replaces the previous webhook URL.
+3. Send a test update and confirm the fixed route accepts the `X-Telegram-Bot-Api-Secret-Token` header while the old token-bearing path returns `404`.
+4. If the old URL may have appeared in proxy logs, screenshots, or support tools, rotate the bot token with BotFather and update `comms.telegram.botTokenRef`; then remove or redact retained copies of the old URL.
+
+Never log the resolved bot token or webhook secret. Treat both secret-store references as server-side configuration.
 
 Delivery-channel sensitivity defaults fail-closed: runtime replies marked with `sensitivity: "sensitive"` or metadata `deliverySensitivity: "sensitive"` are withheld from Slack, Discord, Telegram, and WhatsApp unless that channel explicitly sets `allowSensitiveDelivery: true`. Unknown sensitivity labels are treated as sensitive. Withheld messages send a generic operator guidance notice and route metadata only, never the sensitive payload or interactive actions.
 

--- a/tests/docs-issue-3147.test.ts
+++ b/tests/docs-issue-3147.test.ts
@@ -10,6 +10,7 @@ describe('issue #3147 Telegram webhook migration docs', () => {
     expect(README).toContain('/webhooks/telegram');
     expect(README).toContain('X-Telegram-Bot-Api-Secret-Token');
     expect(README).toContain('webhookSecretTokenRef');
+    expect(README).toContain('A-Z, a-z, 0-9, `_`, and `-`');
     expect(README).not.toContain('| Telegram | Webhook | Token-based authentication |');
   });
 
@@ -18,5 +19,8 @@ describe('issue #3147 Telegram webhook migration docs', () => {
     expect(README).toContain('re-register the webhook');
     expect(README).toContain('rotate the bot token with BotFather');
     expect(README).toContain('secret_token');
+    expect(README).toContain('dashboard-web');
+    expect(README).toContain('rewrites legacy token-bearing paths');
+    expect(README).not.toContain('webhookSecretTokenRef` through `frankenbeast init --repair`');
   });
 });

--- a/tests/docs-issue-3147.test.ts
+++ b/tests/docs-issue-3147.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const README = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+
+describe('issue #3147 Telegram webhook migration docs', () => {
+  it('documents the token-independent webhook route and secret header', () => {
+    expect(README).toContain('/webhooks/telegram');
+    expect(README).toContain('X-Telegram-Bot-Api-Secret-Token');
+    expect(README).toContain('webhookSecretTokenRef');
+    expect(README).not.toContain('| Telegram | Webhook | Token-based authentication |');
+  });
+
+  it('documents migration from token-bearing webhook URLs', () => {
+    expect(README).toContain('Do not append the bot token to the webhook URL');
+    expect(README).toContain('re-register the webhook');
+    expect(README).toContain('rotate the bot token with BotFather');
+    expect(README).toContain('secret_token');
+  });
+});


### PR DESCRIPTION
## Summary
- document the fixed Telegram webhook endpoint and dedicated secret header
- add migration guidance for legacy token-bearing webhook URLs
- add a README regression test for issue #3147 requirements

## Verification
- `npm run test:root -- tests/docs-issue-3147.test.ts`
- `npm run test --workspace @franken/orchestrator -- tests/unit/comms/telegram-router.test.ts tests/unit/http/comms-routes.test.ts`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm test` (one unrelated timeout in `dep-factory-providers.test.ts`; isolated rerun passed all 48 tests)

Closes #3147