### PR TITLE
fix(security): redact MCP handler exception details

### DIFF
--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -72,6 +72,25 @@ describe('createMcpServer', () => {
     expect(calls).toEqual([{ msg: 'hi' }]);
   });
 
+  it('returns a stable public error without leaking thrown handler details', async () => {
+    const sensitiveDetail = '/srv/private/config.json?token=' + 'example-secret-value';
+    const tool: ToolDef = {
+      name: 'failing_tool',
+      description: 'fails internally',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async () => { throw new Error(`provider failed while reading ${sensitiveDetail}`); },
+    };
+    const server = createMcpServer('t', '1', [tool]);
+
+    const result = await server.callTool('failing_tool', {});
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: Tool execution failed [MCP_TOOL_HANDLER_ERROR]' }],
+      isError: true,
+    });
+    expect(JSON.stringify(result)).not.toContain(sensitiveDetail);
+  });
+
   it('requires an OWN required property (rejects prototype-chain keys)', async () => {
     const { calls, callTool } = makeServerWithSpy();
     const res = await callTool('echo', Object.create({ msg: 'x' }));

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -808,9 +808,9 @@ async function dispatchTool(
   let result: ToolResult;
   try {
     result = await tool.handler(validated.value);
-  } catch (err) {
+  } catch {
     result = {
-      content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      content: [{ type: 'text' as const, text: 'Error: Tool execution failed [MCP_TOOL_HANDLER_ERROR]' }],
       isError: true,
     };
   }

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -999,6 +999,18 @@ const TOOLS: ToolFull[] = [
       const content = String(args['content']);
       const criteria = splitCsvArg(args['criteria']) ?? ['correctness', 'readability', 'security', 'complexity'];
       const evaluators = splitCsvArg(args['evaluators']);
+      const supportedEvaluators = ['logic-loop', 'complexity', 'conciseness'];
+      const unknownEvaluators = evaluators?.filter((name) => !supportedEvaluators.includes(name)) ?? [];
+      if (unknownEvaluators.length > 0) {
+        const noun = unknownEvaluators.length === 1 ? 'evaluator' : 'evaluators';
+        return {
+          content: [{
+            type: 'text',
+            text: `Error: Unknown critique ${noun}: ${unknownEvaluators.join(', ')}. Expected one of: ${supportedEvaluators.join(', ')}`,
+          }],
+          isError: true,
+        };
+      }
       const result = await critique.evaluate(evaluators ? { content, criteria, evaluators } : { content, criteria });
       const findingsText = result.findings.length > 0 ? result.findings.map((f) => `  [${f.severity}] ${f.message}`).join('\n') : '  None';
       const text = [`## Critique Result`, ``, `**verdict:** ${result.verdict}`, `**score:** ${result.score.toFixed(2)}`, `**findings:**`, findingsText].join('\n');


### PR DESCRIPTION
## Summary
- replace unexpected MCP tool-handler exception details with a stable public error code
- preserve deterministic critique evaluator validation without relying on exception text
- add regression coverage proving thrown sensitive details never reach MCP clients

## Test plan
- `npm test` (packages/franken-mcp-suite): 534 passed
- `npm run typecheck` (packages/franken-mcp-suite)
- `npm run lint` (packages/franken-mcp-suite; 0 errors, 27 pre-existing warnings)
- `npm run build` (repository root): 10/10 tasks successful

Closes #3119