### PR TITLE
fix(security): validate chunk snapshot reasons

### DIFF
--- a/packages/franken-orchestrator/src/session/chunk-session-snapshot-store.ts
+++ b/packages/franken-orchestrator/src/session/chunk-session-snapshot-store.ts
@@ -10,6 +10,10 @@ export class FileChunkSessionSnapshotStore {
   constructor(private readonly rootDir: string) {}
 
   writeSnapshot(session: ChunkSession, reason: string): string {
+    if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/u.test(reason)) {
+      throw new Error('Invalid chunk snapshot reason');
+    }
+
     const dir = this.snapshotDir(session.planName, session.chunkId, session.taskId);
     mkdirSync(dir, { recursive: true });
     const ts = new Date(wallClockNow()).toISOString().replace(/[:.]/g, '-');

--- a/packages/franken-orchestrator/tests/unit/session/chunk-session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/chunk-session-store.test.ts
@@ -84,8 +84,30 @@ describe('FileChunkSessionStore', () => {
 
     const file = snapshots.writeSnapshot(session, 'pre-compaction');
     expect(file).toContain('01_demo');
+    expect(file).toMatch(/-pre-compaction\.json$/u);
     expect(snapshots.list('demo-plan', '01_demo')).toHaveLength(1);
   });
+
+  it.each(['', '../outside', 'shell;touch-pwned', String.raw`path\escape`, 'a'.repeat(65)])(
+    'rejects the unsafe snapshot reason %j before touching the filesystem',
+    (reason) => {
+      const root = mkdtempSync(join(tmpdir(), 'chunk-snapshot-unsafe-reason-'));
+      tmpDirs.push(root);
+      const snapshots = new FileChunkSessionSnapshotStore(root);
+      const session = createChunkSession({
+        planName: 'demo-plan',
+        taskId: 'impl:01_demo',
+        chunkId: '01_demo',
+        promiseTag: 'IMPL_01_demo_DONE',
+        workingDir: root,
+        provider: 'claude',
+        maxTokens: 200000,
+      });
+
+      expect(() => snapshots.writeSnapshot(session, reason)).toThrowError('Invalid chunk snapshot reason');
+      expect(existsSync(join(root, 'demo-plan'))).toBe(false);
+    },
+  );
 
   describe('atomic writes', () => {
     it('leaves no temp files behind after save()', () => {


### PR DESCRIPTION
## Summary
- reject chunk snapshot reasons that are not bounded basename-safe identifiers
- validate reasons before creating snapshot directories or files
- cover normal snapshot filenames plus traversal, shell-sensitive, path-separator, empty, and overlength inputs

## Test plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/session/chunk-session-store.test.ts`
- `npm test --workspace @franken/orchestrator`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #3106
