### PR TITLE
fix(mcp): enforce per-tool execution deadlines

### DIFF
--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -9,6 +9,7 @@ vi.mock('../shared/tool-registry.js', () => ({
         name: 'test_tool',
         server: 'memory',
         description: 'A test tool',
+        timeoutMs: 10,
         inputSchema: { type: 'object', properties: { key: { type: 'string', description: 'Key' } }, required: ['key'] },
         makeHandler: vi.fn(),
       },
@@ -171,7 +172,33 @@ describe('proxy server', () => {
 
       const toolArgs = { key: 'bar' };
       await executeToolDef.handler({ tool: 'test_tool', args: toolArgs });
-      expect(fakeHandler).toHaveBeenCalledWith(toolArgs);
+      expect(fakeHandler).toHaveBeenCalledWith(toolArgs, expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        timeoutMs: 10,
+      }));
+    });
+
+    it('times out proxied registry handlers and audits the timeout', async () => {
+      const entry = mockRegistry.get('test_tool')!;
+      vi.mocked(entry.makeHandler).mockReturnValue(vi.fn(async () => {
+        await new Promise<void>(() => undefined);
+        return { content: [{ type: 'text', text: 'unreachable' }] };
+      }));
+
+      const result = await executeToolDef.handler({ tool: 'test_tool', args: { key: 'value' } }) as {
+        content: Array<{ type: string; text: string }>;
+        isError: boolean;
+      };
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Error: Tool execution timed out after 10ms [MCP_TOOL_TIMEOUT]' }],
+        isError: true,
+      });
+      expect(auditRecord).toHaveBeenCalledWith(expect.objectContaining({
+        tool: 'test_tool',
+        ok: false,
+        decision: 'timeout',
+      }));
     });
 
     it('validates proxied target tool args before calling the target handler', async () => {

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -97,6 +97,10 @@ describe('proxy server', () => {
   });
 
   describe('execute_tool', () => {
+    it('keeps the proxy wrapper deadline longer than every target deadline', () => {
+      expect(executeToolDef.timeoutMs).toBe(31_000);
+    });
+
     it('calls through to handler and returns its result', async () => {
       const fakeResult = { content: [{ type: 'text', text: 'tool executed' }] };
       const fakeHandler = vi.fn().mockResolvedValue(fakeResult);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -320,6 +320,22 @@ describe('proxy server', () => {
       });
     });
 
+    it('audits an execute_tool wrapper timeout with its sanitized target envelope', async () => {
+      executeToolDef.timeoutMs = 10;
+      gateCheck.mockImplementationOnce(() => new Promise(() => {}));
+      const envelope = { tool: 'test_tool', args: { key: 'v' } };
+
+      const res = await server.callTool('execute_tool', envelope) as { isError?: boolean };
+
+      expect(res.isError).toBe(true);
+      expect(auditRecord).toHaveBeenCalledWith({
+        tool: 'execute_tool',
+        ok: false,
+        decision: 'timeout',
+        args: envelope,
+      });
+    });
+
     it('does NOT double-audit a successful execute_tool call at the wrapper level', async () => {
       const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -44,7 +44,7 @@ const FAKE_STUBS = [
 describe('proxy server', () => {
   let server: ReturnType<typeof createProxyServer>;
   let searchToolsDef: { handler: (args: Record<string, unknown>) => Promise<unknown> };
-  let executeToolDef: { handler: (args: Record<string, unknown>) => Promise<unknown> };
+  let executeToolDef: { timeoutMs?: number; handler: (args: Record<string, unknown>) => Promise<unknown> };
   let gateCheck: ReturnType<typeof vi.fn>;
   let auditRecord: ReturnType<typeof vi.fn>;
 
@@ -98,7 +98,7 @@ describe('proxy server', () => {
 
   describe('execute_tool', () => {
     it('keeps the proxy wrapper deadline longer than every target deadline', () => {
-      expect(executeToolDef.timeoutMs).toBe(31_000);
+      expect(executeToolDef.timeoutMs).toBe(60_000);
     });
 
     it('calls through to handler and returns its result', async () => {

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -51,7 +51,10 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
     (longest, tool) => Math.max(longest, tool.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS),
     DEFAULT_TOOL_TIMEOUT_MS,
   );
-  const proxyExecutionTimeoutMs = longestTargetTimeoutMs + 1_000;
+  // Reserve a bounded 30-second budget for target validation, governance,
+  // adapter setup, and audit so those proxy phases cannot consume a target's
+  // own advertised execution deadline.
+  const proxyExecutionTimeoutMs = longestTargetTimeoutMs + DEFAULT_TOOL_TIMEOUT_MS;
 
   function getAdapters(): AdapterSet {
     if (!cachedAdapters) {

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -172,13 +172,13 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
   // factory rejects malformed `execute_tool`/`search_tools` calls (missing or
   // non-object `args`, non-string `tool`, unknown tool) *before* the handler
   // runs, so those probes never reach the target-level audit. Wire a wrapper
-  // audit that forwards ONLY those pre-handler rejections — keyed by their
-  // `decision` (`validation_error`/`unknown_tool`) — so malformed proxy probes
-  // are recorded without double-auditing successful calls (the handler already
-  // audits the resolved target) or auditing read-only `search_tools` listings.
+  // audit that forwards pre-handler rejections and wrapper timeouts — keyed by
+  // their `decision` — so malformed or stalled proxy attempts are recorded
+  // without double-auditing successful calls (the handler already audits the
+  // resolved target) or auditing read-only `search_tools` listings.
   const wrapperAudit: AuditSink = {
     record(event) {
-      if (event.decision === 'validation_error' || event.decision === 'unknown_tool') {
+      if (event.decision === 'validation_error' || event.decision === 'unknown_tool' || event.decision === 'timeout') {
         return audit.record(event);
       }
     },

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createMcpServer, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef, type ToolResult } from '../shared/server-factory.js';
+import { createMcpServer, DEFAULT_TOOL_TIMEOUT_MS, executeToolWithDeadline, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
 import { handleStartupFailure } from '../shared/shutdown.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
@@ -45,6 +45,12 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
   // lazily, preserving lazy-DB behavior.
   const governance = deps.governance ?? createGovernanceGate(dbPath);
   const audit = deps.audit ?? createAuditSink(dbPath);
+  // The proxy wrapper must outlive the longest registered target deadline; the
+  // resolved target is independently bounded below by executeToolWithDeadline.
+  const proxyExecutionTimeoutMs = [...TOOL_REGISTRY.values()].reduce(
+    (longest, tool) => Math.max(longest, tool.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS),
+    DEFAULT_TOOL_TIMEOUT_MS,
+  );
 
   function getAdapters(): AdapterSet {
     if (!cachedAdapters) {
@@ -76,6 +82,7 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
     {
       name: 'execute_tool',
       description: 'Execute any fbeast tool by name with args object.',
+      timeoutMs: proxyExecutionTimeoutMs,
       inputSchema: {
         type: 'object',
         properties: {
@@ -138,17 +145,19 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
           };
         }
         const adapters = getAdapters();
-        const handler = entry.makeHandler(adapters);
-        let result: ToolResult;
-        try {
-          result = (await handler(validated.value)) as ToolResult;
-        } catch (err) {
-          result = {
-            content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-            isError: true,
-          };
-        }
-        await recordAudit({ ok: !result.isError });
+        const targetTool: ToolDef = {
+          name: entry.name,
+          description: entry.description,
+          inputSchema: entry.inputSchema,
+          ...(entry.timeoutMs !== undefined ? { timeoutMs: entry.timeoutMs } : {}),
+          handler: entry.makeHandler(adapters),
+        };
+        const execution = await executeToolWithDeadline(targetTool, validated.value);
+        const result = execution.result;
+        await recordAudit({
+          ok: !result.isError,
+          ...(execution.timedOut ? { decision: 'timeout' } : {}),
+        });
         return result;
       },
     },

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -47,10 +47,11 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
   const audit = deps.audit ?? createAuditSink(dbPath);
   // The proxy wrapper must outlive the longest registered target deadline; the
   // resolved target is independently bounded below by executeToolWithDeadline.
-  const proxyExecutionTimeoutMs = [...TOOL_REGISTRY.values()].reduce(
+  const longestTargetTimeoutMs = [...TOOL_REGISTRY.values()].reduce(
     (longest, tool) => Math.max(longest, tool.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS),
     DEFAULT_TOOL_TIMEOUT_MS,
   );
+  const proxyExecutionTimeoutMs = longestTargetTimeoutMs + 1_000;
 
   function getAdapters(): AdapterSet {
     if (!cachedAdapters) {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -121,6 +121,34 @@ describe('createMcpServer', () => {
     ]);
   });
 
+  it('reports synchronous work that finishes after its deadline as timed out', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const server = createMcpServer('test', '1.0.0', [
+      {
+        name: 'blocking',
+        description: 'Blocks before resolving',
+        timeoutMs: 5,
+        inputSchema: { type: 'object', properties: {} },
+        async handler(_args, context) {
+          receivedSignal = context!.signal;
+          const stopAt = Date.now() + 15;
+          while (Date.now() < stopAt) {
+            // Model an existing synchronous filesystem/CPU handler.
+          }
+          return { content: [{ type: 'text', text: 'late success' }] };
+        },
+      },
+    ]);
+
+    const result = await server.callTool('blocking', {});
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: Tool execution timed out after 5ms [MCP_TOOL_TIMEOUT]' }],
+      isError: true,
+    });
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
   it('honors a per-tool timeout override while preserving nominal results', async () => {
     const tool: ToolDef = {
       name: 'slow_tool',

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -91,6 +91,65 @@ describe('createMcpServer', () => {
     expect(JSON.stringify(result)).not.toContain(sensitiveDetail);
   });
 
+  it('bounds hanging handlers with a structured timeout and abort signal', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const auditEvents: Parameters<AuditSink['record']>[0][] = [];
+    const tool: ToolDef = {
+      name: 'hanging_tool',
+      description: 'hangs until cancelled',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_args, context) => {
+        receivedSignal = context!.signal;
+        await new Promise<void>(() => undefined);
+        return { content: [{ type: 'text' as const, text: 'unreachable' }] };
+      },
+    };
+    const server = createMcpServer('t', '1', [tool], {
+      defaultToolTimeoutMs: 10,
+      audit: { record: async (event) => { auditEvents.push(event); } },
+    });
+
+    const result = await server.callTool('hanging_tool', {});
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: Tool execution timed out after 10ms [MCP_TOOL_TIMEOUT]' }],
+      isError: true,
+    });
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(auditEvents).toEqual([
+      expect.objectContaining({ tool: 'hanging_tool', ok: false, decision: 'timeout' }),
+    ]);
+  });
+
+  it('honors a per-tool timeout override while preserving nominal results', async () => {
+    const tool: ToolDef = {
+      name: 'slow_tool',
+      description: 'finishes within its override',
+      inputSchema: { type: 'object', properties: {} },
+      timeoutMs: 100,
+      handler: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { content: [{ type: 'text' as const, text: 'ok' }] };
+      },
+    };
+    const server = createMcpServer('t', '1', [tool], { defaultToolTimeoutMs: 5 });
+
+    await expect(server.callTool('slow_tool', {})).resolves.toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+  });
+
+  it('rejects invalid timeout configuration before serving requests', () => {
+    expect(() => createMcpServer('t', '1', [], { defaultToolTimeoutMs: 0 })).toThrow(/defaultToolTimeoutMs/);
+    expect(() => createMcpServer('t', '1', [{
+      name: 'bad_timeout',
+      description: 'invalid timeout',
+      inputSchema: { type: 'object', properties: {} },
+      timeoutMs: Number.POSITIVE_INFINITY,
+      handler: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    }])).toThrow(/timeoutMs/);
+  });
+
   it('requires an OWN required property (rejects prototype-chain keys)', async () => {
     const { calls, callTool } = makeServerWithSpy();
     const res = await callTool('echo', Object.create({ msg: 'x' }));

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -160,7 +160,6 @@ export async function executeToolWithDeadline(
       abortForTimeout();
       reject(timeoutError);
     }, timeoutMs);
-    timer.unref?.();
   });
 
   try {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -143,27 +143,40 @@ export async function executeToolWithDeadline(
     timeoutMs,
   };
   const timeoutError = Symbol('tool-timeout');
+  const timeoutReason = () => new Error(`Tool execution timed out after ${timeoutMs}ms`);
+  const timeoutResult = (): ToolExecutionResult => ({
+    result: {
+      content: [{ type: 'text', text: `Error: Tool execution timed out after ${timeoutMs}ms [MCP_TOOL_TIMEOUT]` }],
+      isError: true,
+    },
+    timedOut: true,
+  });
+  const abortForTimeout = (): void => {
+    if (!controller.signal.aborted) controller.abort(timeoutReason());
+  };
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(() => {
+      abortForTimeout();
       reject(timeoutError);
-      controller.abort(new Error(`Tool execution timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     timer.unref?.();
   });
 
   try {
     const result = await Promise.race([tool.handler(args, context), timeout]);
+    // Timers cannot preempt synchronous/blocking handler work. Re-check the
+    // wall clock so a handler that returns after its deadline cannot win the
+    // Promise.race merely because the event loop was blocked.
+    if (Date.now() >= context.deadlineAt) {
+      abortForTimeout();
+      return timeoutResult();
+    }
     return { result, timedOut: false };
   } catch (error) {
-    if (error === timeoutError) {
-      return {
-        result: {
-          content: [{ type: 'text', text: `Error: Tool execution timed out after ${timeoutMs}ms [MCP_TOOL_TIMEOUT]` }],
-          isError: true,
-        },
-        timedOut: true,
-      };
+    if (error === timeoutError || Date.now() >= context.deadlineAt) {
+      abortForTimeout();
+      return timeoutResult();
     }
     return {
       result: {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -26,9 +26,20 @@ export interface ToolSchemaDef {
   inputSchema: ToolInputSchema;
 }
 
+export interface ToolExecutionContext {
+  /** Aborted when the tool reaches its execution deadline. */
+  signal: AbortSignal;
+  /** Absolute Unix timestamp, in milliseconds, when execution expires. */
+  deadlineAt: number;
+  /** Effective deadline duration after applying any per-tool override. */
+  timeoutMs: number;
+}
+
 export interface ToolDef extends ToolSchemaDef {
   description: string;
-  handler: (args: Record<string, unknown>) => Promise<ToolResult>;
+  /** Optional per-tool override for the server's default execution deadline. */
+  timeoutMs?: number;
+  handler: (args: Record<string, unknown>, context?: ToolExecutionContext) => Promise<ToolResult>;
 }
 
 export interface FbeastMcpServer {
@@ -90,6 +101,80 @@ export interface CreateMcpServerOptions {
    * giving the central path a server-side audit trail independent of hooks.
    */
   audit?: AuditSink;
+  /** Default execution deadline for each tool call. Defaults to 30 seconds. */
+  defaultToolTimeoutMs?: number;
+}
+
+export const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
+const MAX_TOOL_TIMEOUT_MS = 2_147_483_647;
+
+function validateToolTimeoutMs(name: string, value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_TOOL_TIMEOUT_MS) {
+    throw new RangeError(`${name} must be an integer between 1 and ${MAX_TOOL_TIMEOUT_MS} milliseconds`);
+  }
+  return value;
+}
+
+function validateToolDeadlineConfiguration(tools: ToolDef[], options: CreateMcpServerOptions): void {
+  validateToolTimeoutMs('defaultToolTimeoutMs', options.defaultToolTimeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS);
+  for (const tool of tools) {
+    if (tool.timeoutMs !== undefined) validateToolTimeoutMs(`${tool.name}.timeoutMs`, tool.timeoutMs);
+  }
+}
+
+export interface ToolExecutionResult {
+  result: ToolResult;
+  timedOut: boolean;
+}
+
+export async function executeToolWithDeadline(
+  tool: ToolDef,
+  args: Record<string, unknown>,
+  defaultToolTimeoutMs = DEFAULT_TOOL_TIMEOUT_MS,
+): Promise<ToolExecutionResult> {
+  validateToolTimeoutMs('defaultToolTimeoutMs', defaultToolTimeoutMs);
+  const timeoutMs = tool.timeoutMs === undefined
+    ? defaultToolTimeoutMs
+    : validateToolTimeoutMs(`${tool.name}.timeoutMs`, tool.timeoutMs);
+  const controller = new AbortController();
+  const context: ToolExecutionContext = {
+    signal: controller.signal,
+    deadlineAt: Date.now() + timeoutMs,
+    timeoutMs,
+  };
+  const timeoutError = Symbol('tool-timeout');
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(timeoutError);
+      controller.abort(new Error(`Tool execution timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    const result = await Promise.race([tool.handler(args, context), timeout]);
+    return { result, timedOut: false };
+  } catch (error) {
+    if (error === timeoutError) {
+      return {
+        result: {
+          content: [{ type: 'text', text: `Error: Tool execution timed out after ${timeoutMs}ms [MCP_TOOL_TIMEOUT]` }],
+          isError: true,
+        },
+        timedOut: true,
+      };
+    }
+    return {
+      result: {
+        content: [{ type: 'text', text: 'Error: Tool execution failed [MCP_TOOL_HANDLER_ERROR]' }],
+        isError: true,
+      },
+      timedOut: false,
+    };
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 const DENIED_ARGUMENT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
@@ -805,16 +890,17 @@ async function dispatchTool(
       };
     }
   }
-  let result: ToolResult;
-  try {
-    result = await tool.handler(validated.value);
-  } catch {
-    result = {
-      content: [{ type: 'text' as const, text: 'Error: Tool execution failed [MCP_TOOL_HANDLER_ERROR]' }],
-      isError: true,
-    };
-  }
-  await recordAudit({ ok: !result.isError, args: validated.value });
+  const execution = await executeToolWithDeadline(
+    tool,
+    validated.value,
+    options.defaultToolTimeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS,
+  );
+  const result = execution.result;
+  await recordAudit({
+    ok: !result.isError,
+    ...(execution.timedOut ? { decision: 'timeout' } : {}),
+    args: validated.value,
+  });
   return result;
 }
 
@@ -824,6 +910,7 @@ export function createMcpServer(
   tools: ToolDef[],
   options: CreateMcpServerOptions = {},
 ): FbeastMcpServer {
+  validateToolDeadlineConfiguration(tools, options);
   const server = new Server({ name, version }, { capabilities: { tools: {} } });
   const toolMap = new Map(tools.map((t) => [t.name, t]));
 

--- a/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createAdapterSet, TOOL_STUBS, TOOL_REGISTRY, searchTools, type AdapterSet } from './tool-registry.js';
+import { createAdapterSet, createToolDefsForServer, TOOL_STUBS, TOOL_REGISTRY, searchTools, type AdapterSet } from './tool-registry.js';
 
 const EXPECTED_COUNT = 30;
 
@@ -37,6 +37,13 @@ describe('TOOL_REGISTRY', () => {
     for (const [name, tool] of TOOL_REGISTRY) {
       expect(typeof tool.makeHandler, `${name} makeHandler is not a function`).toBe('function');
     }
+  });
+
+  it('propagates registry deadline overrides to standalone tool definitions', () => {
+    const tool = createToolDefsForServer('firewall', {} as AdapterSet)
+      .find(({ name }) => name === 'fbeast_firewall_scan_file');
+
+    expect(tool?.timeoutMs).toBe(60_000);
   });
 
   it('TOOL_STUBS and TOOL_REGISTRY contain the same 30 tool names', () => {

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -6,7 +6,7 @@ import { createObserverAdapter, type ObserverAdapter } from '../adapters/observe
 import { createPlannerAdapter, type PlannerAdapter } from '../adapters/planner-adapter.js';
 import { createSkillsAdapter, type SkillsAdapter } from '../adapters/skills-adapter.js';
 import { parseObserverCostArgs } from './observer-cost-validation.js';
-import type { ToolDef, ToolInputSchema, ToolResult } from './server-factory.js';
+import type { ToolDef, ToolExecutionContext, ToolInputSchema, ToolResult } from './server-factory.js';
 
 export interface AdapterSet {
   brain: BrainAdapter;
@@ -28,7 +28,12 @@ interface ToolStub {
 
 interface ToolFull extends ToolStub {
   inputSchema: ToolInputSchema;
-  makeHandler: (adapters: AdapterSet) => (args: Record<string, unknown>) => Promise<ToolResult>;
+  /** Optional execution deadline override for this registry entry. */
+  timeoutMs?: number;
+  makeHandler: (adapters: AdapterSet) => (
+    args: Record<string, unknown>,
+    context?: ToolExecutionContext,
+  ) => Promise<ToolResult>;
 }
 
 export type ServerAdapterDeps = Partial<AdapterSet>;
@@ -1063,6 +1068,7 @@ const TOOLS: ToolFull[] = [
     name: 'fbeast_firewall_scan_file',
     server: 'firewall',
     description: 'Detect prompt injection in file contents',
+    timeoutMs: 60_000,
     inputSchema: {
       type: 'object',
       properties: {
@@ -1323,10 +1329,11 @@ export const TOOL_REGISTRY: Map<string, ToolFull> = new Map(TOOLS.map((t) => [t.
 export function createToolDefsForServer(server: ToolServer, adapters: ServerAdapterDeps): ToolDef[] {
   return TOOLS
     .filter((tool) => tool.server === server)
-    .map(({ name, description, inputSchema, makeHandler }) => ({
+    .map(({ name, description, inputSchema, timeoutMs, makeHandler }) => ({
       name,
       description,
       inputSchema,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       handler: makeHandler(adapters as AdapterSet),
     }));
 }

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-18 — MCP execution deadline review fixes
-- A `Promise.race` timer cannot preempt synchronous handler work because the event loop is blocked; deadline wrappers must re-check wall-clock time after handler resolution/rejection and convert late completion into the same structured timeout while aborting the supplied signal.
+- A `Promise.race` timer cannot preempt synchronous handler work because the event loop is blocked; deadline wrappers must re-check wall-clock time after handler resolution/rejection and convert late completion into the same structured timeout while aborting the supplied signal. Keep that timer ref'ed so in-process callers with no other active handles still receive the timeout result.
 - Nested dispatch wrappers must have a deadline strictly longer than the longest inner target deadline, including validation/governance/audit slack, or the wrapper can win the timeout race and lose resolved-target timeout auditing.
 
 ## 2026-07-17 — PR #2358 stalled closeout and Codex gate handling

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-18 — MCP execution deadline review fixes
+- A `Promise.race` timer cannot preempt synchronous handler work because the event loop is blocked; deadline wrappers must re-check wall-clock time after handler resolution/rejection and convert late completion into the same structured timeout while aborting the supplied signal.
+- Nested dispatch wrappers must have a deadline strictly longer than the longest inner target deadline, including validation/governance/audit slack, or the wrapper can win the timeout race and lose resolved-target timeout auditing.
+
 ## 2026-07-17 — PR #2358 stalled closeout and Codex gate handling
 - For stalled PR closeout, re-verify live PR head, mergeability, CI rollup, unresolved Codex threads, and the latest top-level Codex response before acting; a stale green/clean state can become `mergeable=CONFLICTING`/`mergeStateStatus=DIRTY` after main advances even when required CI is still green.
 - Treat Codex usage-limit responses as a hard review-gate blocker for the current round: do not repeatedly retrigger `@codex review`, do not treat historical inline finding lists as active blockers when GraphQL review threads are resolved, and wait for restored usage/approved over-cap review before merging.


### PR DESCRIPTION
## Summary
- bound shared MCP handler execution with a configurable default deadline and per-tool overrides
- propagate AbortSignal/deadline context to handlers and return stable `MCP_TOOL_TIMEOUT` errors
- enforce registry deadlines through proxy dispatch and audit timeout decisions
- add regression coverage for direct, registry, and proxy invocation paths

## Verification
- `npm test --workspace=@franken/mcp-suite` (539 passed)
- `npm run typecheck --workspace=@franken/mcp-suite`
- `npm run lint --workspace=@franken/mcp-suite`
- `npm run build`

Closes #3118