### PR TITLE
fix(web): close SSE ticket persistence gaps

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -22,7 +22,7 @@ export interface SseConnectionTicketStoreOptions {
   ttlMs?: number;
   cleanupIntervalMs?: number;
   /** Best-effort observer for periodic cleanup failures. */
-  onCleanupError?: (error: unknown) => void;
+  onCleanupError?: (error: unknown) => void | Promise<void>;
   /** SQLite database shared by daemon processes. Omit only for isolated/test stores. */
   databasePath?: string;
   /**
@@ -113,7 +113,7 @@ export class SseConnectionTicketStore {
         // not escape the timer callback and terminate the daemon; the next
         // interval retries it.
         try {
-          options?.onCleanupError?.(error);
+          void Promise.resolve(options?.onCleanupError?.(error)).catch(() => {});
         } catch {
           // Observability hooks must not turn a recoverable cleanup failure
           // back into an uncaught timer exception.

--- a/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
+++ b/packages/franken-orchestrator/src/beasts/events/sse-connection-ticket.ts
@@ -21,6 +21,8 @@ interface PersistedTicketRow {
 export interface SseConnectionTicketStoreOptions {
   ttlMs?: number;
   cleanupIntervalMs?: number;
+  /** Best-effort observer for periodic cleanup failures. */
+  onCleanupError?: (error: unknown) => void;
   /** SQLite database shared by daemon processes. Omit only for isolated/test stores. */
   databasePath?: string;
   /**
@@ -103,7 +105,21 @@ export class SseConnectionTicketStore {
       `);
     }
 
-    this.cleanupInterval = setInterval(() => this.cleanup(), cleanupMs);
+    this.cleanupInterval = setInterval(() => {
+      try {
+        this.cleanup();
+      } catch (error) {
+        // Cleanup is opportunistic. A transient SQLITE_BUSY/I/O failure must
+        // not escape the timer callback and terminate the daemon; the next
+        // interval retries it.
+        try {
+          options?.onCleanupError?.(error);
+        } catch {
+          // Observability hooks must not turn a recoverable cleanup failure
+          // back into an uncaught timer exception.
+        }
+      }
+    }, cleanupMs);
     this.cleanupInterval.unref?.();
   }
 

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server as HttpServer } from 'node:http';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { Hono } from 'hono';
@@ -308,9 +308,13 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       : undefined);
   const chatStreamTicketStore = effectiveOperatorToken
     ? (() => {
-        mkdirSync(options.sessionStoreDir, { recursive: true });
+        const ticketStoreDir = join(options.sessionStoreDir, 'sse-connection-tickets');
+        mkdirSync(ticketStoreDir, { recursive: true, mode: 0o700 });
+        // The directory protects both the database and SQLite WAL sidecars.
+        // Enforce the mode for pre-existing directories as well as new ones.
+        chmodSync(ticketStoreDir, 0o700);
         return new SseConnectionTicketStore({
-          databasePath: join(options.sessionStoreDir, 'sse-connection-tickets.sqlite'),
+          databasePath: join(ticketStoreDir, 'tickets.sqlite'),
         });
       })()
     : undefined;

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -307,9 +307,12 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName, chatRateLimiter)
       : undefined);
   const chatStreamTicketStore = effectiveOperatorToken
-    ? new SseConnectionTicketStore({
-        databasePath: join(options.sessionStoreDir, 'sse-connection-tickets.sqlite'),
-      })
+    ? (() => {
+        mkdirSync(options.sessionStoreDir, { recursive: true });
+        return new SseConnectionTicketStore({
+          databasePath: join(options.sessionStoreDir, 'sse-connection-tickets.sqlite'),
+        });
+      })()
     : undefined;
   const app = createChatApp({
     sessionStore,

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -306,7 +306,11 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
     ?? (options.commsConfig
       ? createCommsRuntimeAdapter(runtime.runtime, sessionStore, options.sessionStoreDir, options.projectName, chatRateLimiter)
       : undefined);
-  const chatStreamTicketStore = effectiveOperatorToken ? new SseConnectionTicketStore() : undefined;
+  const chatStreamTicketStore = effectiveOperatorToken
+    ? new SseConnectionTicketStore({
+        databasePath: join(options.sessionStoreDir, 'sse-connection-tickets.sqlite'),
+      })
+    : undefined;
   const app = createChatApp({
     sessionStore,
     engine: runtime.engine,

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -145,6 +145,30 @@ describe('SseConnectionTicketStore', () => {
     }
   });
 
+  it('contains periodic cleanup failures and reports them without crashing the daemon', () => {
+    vi.useFakeTimers();
+    const onCleanupError = vi.fn();
+    const cleanupStore = new SseConnectionTicketStore({
+      cleanupIntervalMs: 10,
+      onCleanupError,
+    });
+    const failure = new Error('database is busy');
+    const cleanupSpy = vi
+      .spyOn(cleanupStore as unknown as { cleanup(): void }, 'cleanup')
+      .mockImplementationOnce(() => {
+        throw failure;
+      });
+
+    try {
+      expect(() => vi.advanceTimersByTime(10)).not.toThrow();
+      expect(cleanupSpy).toHaveBeenCalledOnce();
+      expect(onCleanupError).toHaveBeenCalledWith(failure);
+    } finally {
+      cleanupStore.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
     'rejects invalid consumedRetentionMs value %s',
     (consumedRetentionMs) => {

--- a/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/events/sse-connection-ticket.test.ts
@@ -145,9 +145,10 @@ describe('SseConnectionTicketStore', () => {
     }
   });
 
-  it('contains periodic cleanup failures and reports them without crashing the daemon', () => {
+  it('contains periodic cleanup and async observer failures without crashing the daemon', async () => {
     vi.useFakeTimers();
-    const onCleanupError = vi.fn();
+    const observerFailure = new Error('observer unavailable');
+    const onCleanupError = vi.fn().mockRejectedValue(observerFailure);
     const cleanupStore = new SseConnectionTicketStore({
       cleanupIntervalMs: 10,
       onCleanupError,
@@ -161,6 +162,7 @@ describe('SseConnectionTicketStore', () => {
 
     try {
       expect(() => vi.advanceTimersByTime(10)).not.toThrow();
+      await Promise.resolve();
       expect(cleanupSpy).toHaveBeenCalledOnce();
       expect(onCleanupError).toHaveBeenCalledWith(failure);
     } finally {

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -77,8 +77,9 @@ describe('startChatServer comms pass-through', () => {
   });
 
   it('persists chat SSE tickets across chat-server restarts', async () => {
-    const sessionStoreDir = await mkdtemp(join(tmpdir(), 'chat-server-sse-tickets-'));
-    tempDirs.push(sessionStoreDir);
+    const projectDir = await mkdtemp(join(tmpdir(), 'chat-server-sse-tickets-'));
+    tempDirs.push(projectDir);
+    const sessionStoreDir = join(projectDir, 'chat');
     const options = {
       host: '127.0.0.1',
       port: 0,

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -76,6 +76,30 @@ describe('startChatServer comms pass-through', () => {
     expect(opts).toHaveProperty('commsRuntime', commsRuntime);
   });
 
+  it('persists chat SSE tickets across chat-server restarts', async () => {
+    const sessionStoreDir = await mkdtemp(join(tmpdir(), 'chat-server-sse-tickets-'));
+    tempDirs.push(sessionStoreDir);
+    const options = {
+      host: '127.0.0.1',
+      port: 0,
+      sessionStoreDir,
+      llm: { complete: vi.fn().mockResolvedValue('ok') },
+      projectName: 'test',
+      operatorToken: TEST_OPERATOR_TOKEN,
+    } as const;
+
+    handle = await startChatServer(options);
+    const issuingStore = mockedCreateChatApp.mock.calls[0]![0].chatStreamTicketStore;
+    const ticket = issuingStore!.issue(TEST_OPERATOR_TOKEN, 'session-1');
+    await handle.close();
+    handle = undefined;
+
+    mockedCreateChatApp.mockClear();
+    handle = await startChatServer(options);
+    const restartedStore = mockedCreateChatApp.mock.calls[0]![0].chatStreamTicketStore;
+    expect(restartedStore!.consume(ticket, TEST_OPERATOR_TOKEN, 'session-1')).toBe('valid');
+  });
+
   it('closes analytics dependencies when the chat server shuts down', async () => {
     const analyticsClose = vi.fn();
     handle = await startChatServer({

--- a/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-server-comms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import process from 'node:process';
@@ -92,6 +92,10 @@ describe('startChatServer comms pass-through', () => {
     handle = await startChatServer(options);
     const issuingStore = mockedCreateChatApp.mock.calls[0]![0].chatStreamTicketStore;
     const ticket = issuingStore!.issue(TEST_OPERATOR_TOKEN, 'session-1');
+    if (process.platform !== 'win32') {
+      const ticketStoreStat = await stat(join(sessionStoreDir, 'sse-connection-tickets'));
+      expect(ticketStoreStat.mode & 0o777).toBe(0o700);
+    }
     await handle.close();
     handle = undefined;
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -352,3 +352,6 @@
 
 ## 2026-07-17 — Orchestrator chaos-test closeout
 - For orchestrator chaos/stability regressions, keep dropped-provider and thrown-tool cases deterministic: use fake timers around never-settling promises, assert cleanup with zero leaked timers, and build dependent workspaces before package typecheck when source-only workspace packages make bare orchestrator `tsc --noEmit` report missing `@franken/*` declarations.
+
+## 2026-07-18 — Durable SSE ticket wiring
+- A persistent store implementation is not durable unless every daemon construction path supplies a stable database path; add a restart-level wiring test, and contain best-effort timer cleanup failures so transient SQLite errors cannot escape callbacks and terminate the process.


### PR DESCRIPTION
## Summary
- wire the chat server SSE ticket store to a stable SQLite file under the configured session store directory
- preserve issued tickets across chat-server process restarts
- contain and optionally report periodic SQLite cleanup failures instead of letting timer callbacks crash the daemon
- add restart-level and timer-failure regressions

Follow-up to #3241 / #3240.

## Test plan
- `npx vitest run tests/unit/beasts/events/sse-connection-ticket.test.ts tests/unit/http/chat-server-comms.test.ts` (39 passed)
- `npm run build` (10 packages successful)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)