### PR TITLE
perf(mcp): validate only audit trail tail on append

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -98,6 +98,54 @@ describe('ObserverAdapter', () => {
     expect(verification).toEqual({ ok: true, checked: 2 });
   });
 
+  it('does not scan the full audit history before appending to a long trail', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+    const sessionId = randomUUID();
+
+    for (let index = 0; index < 200; index += 1) {
+      await observer.log({
+        event: 'tool_call',
+        metadata: JSON.stringify({ tool: 'memory', index }),
+        sessionId,
+      });
+    }
+
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ? AND id = (SELECT MIN(id) FROM audit_trail WHERE session_id = ?)')
+        .run(JSON.stringify({ tool: 'memory', tampered: true }), sessionId, sessionId);
+    });
+
+    await expect(observer.log({
+      event: 'tool_result',
+      metadata: JSON.stringify({ tool: 'memory', ok: true }),
+      sessionId,
+    })).resolves.toEqual(expect.objectContaining({ hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/) }));
+
+    const verification = await observer.verify(sessionId);
+    expect(verification.ok).toBe(false);
+    expect(verification.firstInvalid?.index).toBe(0);
+  });
+
+  it('rejects an append when the audit tail itself is invalid', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+    const sessionId = randomUUID();
+
+    await observer.log({ event: 'tool_call', metadata: JSON.stringify({ tool: 'memory' }), sessionId });
+    await observer.log({ event: 'tool_result', metadata: JSON.stringify({ tool: 'memory', ok: true }), sessionId });
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare('UPDATE audit_trail SET payload = ? WHERE session_id = ? AND id = (SELECT MAX(id) FROM audit_trail WHERE session_id = ?)')
+        .run(JSON.stringify({ tool: 'memory', tampered: true }), sessionId, sessionId);
+    });
+
+    await expect(observer.log({
+      event: 'tool_call',
+      metadata: JSON.stringify({ tool: 'memory', retry: true }),
+      sessionId,
+    })).rejects.toThrow('Cannot append audit row to invalid trail tail');
+  });
+
   it('binds the event type into the first audit hash', async () => {
     const firstHashFrom = async (event: string): Promise<string> => {
       const observer = createObserverAdapter(tracked(tmpDbPath()));
@@ -277,7 +325,7 @@ describe('ObserverAdapter', () => {
     expect(trail[1]!.parentHash).toBe(trail[0]!.hash);
   });
 
-  it('migrates an intact legacy tail before appending a new audit row', async () => {
+  it('leaves a legacy tail untouched on append and migrates it during explicit verification', async () => {
     const dbPath = tracked(tmpDbPath());
     const observer = createObserverAdapter(dbPath);
     const sessionId = randomUUID();
@@ -291,11 +339,15 @@ describe('ObserverAdapter', () => {
     db.close();
 
     await observer.log({ event: 'tool_result', metadata: JSON.stringify({ tool: 'memory', ok: true }), sessionId });
-    const trail = await observer.trail(sessionId);
+    const appendedTrail = await observer.trail(sessionId);
 
-    expect(trail[0]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
-    expect(trail[0]!.hash).not.toBe(firstLegacyHash);
-    expect(trail[1]!.parentHash).toBe(trail[0]!.hash);
+    expect(appendedTrail[0]!.hash).toBe(firstLegacyHash);
+    expect(appendedTrail[1]!.parentHash).toBe(firstLegacyHash);
+
+    expect(await observer.verify(sessionId)).toEqual({ ok: true, checked: 2 });
+    const migratedTrail = await observer.trail(sessionId);
+    expect(migratedTrail[0]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(migratedTrail[1]!.parentHash).toBe(migratedTrail[0]!.hash);
   });
 
   it('does not rewrite a valid legacy prefix when a later row is invalid', async () => {

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -98,37 +98,29 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
     async log(input) {
       const payload = parseMetadata(input.metadata);
       const metadata = canonicalMetadata(input.metadata);
-      const preflight = verifyAuditTrail(store, input.sessionId, {
-        migrate: true,
-        allowUnboundLegacy16Rows: true,
-      });
-      if (!preflight.ok) {
-        throw new Error(`Cannot append audit row to invalid trail at index ${preflight.firstInvalid?.index ?? 'unknown'}`);
-      }
-      const lastRow = store.db.prepare(
-        'SELECT hash FROM audit_trail WHERE session_id = ? ORDER BY id DESC LIMIT 1',
-      ).get(input.sessionId) as { hash: string } | undefined;
-
       const auditEvent = createAuditEvent(input.event, payload, {
         phase: 'mcp',
         provider: 'fbeast-mcp',
         input: metadata,
       });
-
       const baseHash = buildEventBaseHash(input.sessionId, input.event, metadata, auditEvent.inputHash);
-      const hash = buildAuditHash(baseHash, lastRow?.hash);
-      const result = store.db.prepare(`
-        INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash)
-        VALUES (?, ?, ?, ?, ?)
-      `).run(
-        input.sessionId,
-        input.event,
-        metadata,
-        hash,
-        lastRow?.hash ?? null,
-      );
 
-      return { id: Number(result.lastInsertRowid), hash };
+      return store.db.transaction((): ObserverLogResult => {
+        const parentHash = validateAuditTail(store, input.sessionId);
+        const hash = buildAuditHash(baseHash, parentHash);
+        const result = store.db.prepare(`
+          INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash)
+          VALUES (?, ?, ?, ?, ?)
+        `).run(
+          input.sessionId,
+          input.event,
+          metadata,
+          hash,
+          parentHash ?? null,
+        );
+
+        return { id: Number(result.lastInsertRowid), hash };
+      }).immediate();
     },
 
     async logCost(input) {
@@ -222,6 +214,36 @@ interface PendingAuditMigration {
   id: number;
   hash: string;
   parentHash: string | undefined;
+}
+
+function validateAuditTail(
+  store: ReturnType<typeof createSqliteStore>,
+  sessionId: string,
+): string | undefined {
+  const rows = store.db.prepare(
+    'SELECT id, event_type AS eventType, payload, hash, parent_hash AS parentHash, created_at AS createdAt FROM audit_trail WHERE session_id = ? ORDER BY id DESC LIMIT 2',
+  ).all(sessionId) as AuditTrailRow[];
+  const tail = rows[0];
+  if (!tail) return undefined;
+
+  const previousHash = rows[1]?.hash;
+  const actualParentHash = tail.parentHash ?? undefined;
+  const metadata = tail.payload;
+  const payload = parseMetadata(metadata);
+  const auditEvent = createAuditEvent(tail.eventType, payload, {
+    phase: 'mcp',
+    provider: 'fbeast-mcp',
+    input: metadata,
+  });
+  const baseHash = buildEventBaseHash(sessionId, tail.eventType, metadata, auditEvent.inputHash);
+  const matchesCurrent = tail.hash === buildAuditHash(baseHash, previousHash);
+  const matchesLegacy16 = buildMatchingLegacy16Hash(tail, previousHash) === tail.hash;
+
+  if (actualParentHash !== previousHash || (!matchesCurrent && !matchesLegacy16)) {
+    throw new Error('Cannot append audit row to invalid trail tail');
+  }
+
+  return tail.hash;
 }
 
 function verifyAuditTrail(

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -37,6 +37,9 @@ const SCHEMA = `
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
 
+  CREATE INDEX IF NOT EXISTS idx_audit_trail_session_id_id
+    ON audit_trail(session_id, id DESC);
+
   CREATE TABLE IF NOT EXISTS cost_ledger (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- replace full audit-chain verification on every append with indexed tail validation
- validate and insert inside one immediate SQLite transaction
- preserve legacy-row compatibility and explicit full-chain migration/verification
- cover long trails, damaged tails, and legacy tails

## Test plan
- npm test -- --run src/adapters/observer-adapter.test.ts
- npm test
- npm run typecheck
- npm run lint
- npm run build
- root npm run build
- git diff --check

Closes #3202