### PR TITLE
fix(mcp): cap brain startup hydration

### DIFF
--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -1,6 +1,7 @@
 export {
   SqliteBrain,
   WorkingMemoryLimitError,
+  WorkingMemoryHydrationLimitError,
   MemoryDeletionGuardError,
   UnsupportedMemorySchemaVersionError,
   MemoryEncryptionKeyUnavailableError,
@@ -16,6 +17,7 @@ export {
   SqliteMemoryReviewQueue,
   SqliteMemoryAccessAuditTrail,
   type WorkingMemoryLimits,
+  type WorkingMemoryHydrationLimits,
   type SqliteBrainOptions,
   type MemoryRetentionClass,
   type MemoryRetentionAction,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1230,7 +1230,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     if (hydrateFromDb) {
       this.loadFromDb(hydrationLimits);
     } else {
-      this.loadPersistedSerializedFromDb();
+      this.loadPersistedSerializedFromDb(hydrationLimits);
     }
   }
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -35,6 +35,13 @@ export interface WorkingMemoryLimits {
   maxTotalBytes: number;
 }
 
+export interface WorkingMemoryHydrationLimits {
+  /** Maximum persisted rows read into memory during startup hydration. */
+  maxRows: number;
+  /** Maximum combined persisted key/value bytes read during startup hydration. */
+  maxBytes: number;
+}
+
 export const DEFAULT_WORKING_MEMORY_LIMITS: WorkingMemoryLimits = {
   maxEntries: 10_000,
   maxValueBytes: 5 * 1024 * 1024,
@@ -85,6 +92,7 @@ export interface MemoryEncryptionOptions {
 
 export interface SqliteBrainOptions {
   hydrateWorkingMemoryFromDb?: boolean;
+  workingMemoryHydrationLimits?: Partial<WorkingMemoryHydrationLimits>;
   encryption?: MemoryEncryptionOptions;
 }
 
@@ -863,6 +871,26 @@ export class WorkingMemoryLimitError extends Error {
   }
 }
 
+export class WorkingMemoryHydrationLimitError extends Error {
+  readonly code = 'WORKING_MEMORY_HYDRATION_LIMIT_EXCEEDED';
+
+  constructor(
+    readonly rowCount: number,
+    readonly byteCount: number | undefined,
+    readonly maxRows: number,
+    readonly maxBytes: number,
+  ) {
+    const rowDiagnostic = byteCount === undefined ? `at least ${rowCount}` : `${rowCount}`;
+    const byteDiagnostic =
+      byteCount === undefined ? 'byte count skipped after row overflow' : `${byteCount} bytes`;
+    super(
+      `Persisted working memory hydration requires ${rowDiagnostic} rows and ${byteDiagnostic}, ` +
+        `exceeding startup limits of ${maxRows} rows and ${maxBytes} bytes`,
+    );
+    this.name = 'WorkingMemoryHydrationLimitError';
+  }
+}
+
 export class MemoryDeletionGuardError extends Error {
   constructor(message: string) {
     super(message);
@@ -1197,21 +1225,61 @@ class SqliteWorkingMemory implements IWorkingMemory {
     private encryption?: MemoryCipher,
     private audit?: MemoryAccessAuditRecorder,
     private onPrunedPersistedKeys?: (keys: readonly string[]) => void,
+    hydrationLimits?: WorkingMemoryHydrationLimits,
   ) {
-    this.loadPersistedSerializedFromDb();
     if (hydrateFromDb) {
-      this.loadFromDb();
+      this.loadFromDb(hydrationLimits);
+    } else {
+      this.loadPersistedSerializedFromDb();
     }
   }
 
-  private loadPersistedSerializedFromDb(): Array<{
+  private loadPersistedSerializedFromDb(
+    hydrationLimits?: WorkingMemoryHydrationLimits,
+  ): Array<{
     key: string;
     value: string;
     updatedAt: string;
   }> {
-    const rows = this.db
-      .prepare(`SELECT key, value, updated_at AS updatedAt FROM working_memory ORDER BY key ASC`)
-      .all() as Array<{ key: string; value: string; updatedAt: string }>;
+    const selectRows = this.db.prepare(
+      `SELECT key, value, updated_at AS updatedAt FROM working_memory ORDER BY key ASC`,
+    );
+    const readRows = () => {
+      if (hydrationLimits) {
+        const rowOverflow = this.db
+          .prepare(`SELECT 1 AS present FROM working_memory LIMIT 1 OFFSET ?`)
+          .get(hydrationLimits.maxRows) as { present: 1 } | undefined;
+        if (rowOverflow) {
+          throw new WorkingMemoryHydrationLimitError(
+            hydrationLimits.maxRows + 1,
+            undefined,
+            hydrationLimits.maxRows,
+            hydrationLimits.maxBytes,
+          );
+        }
+        const stats = this.db
+          .prepare(
+            `SELECT COUNT(*) AS rowCount,
+                    COALESCE(SUM(length(CAST(key AS BLOB)) + length(CAST(value AS BLOB))), 0) AS byteCount
+               FROM (SELECT key, value FROM working_memory LIMIT ?)`,
+          )
+          .get(hydrationLimits.maxRows) as { rowCount: number; byteCount: number };
+        if (stats.byteCount > hydrationLimits.maxBytes) {
+          throw new WorkingMemoryHydrationLimitError(
+            stats.rowCount,
+            stats.byteCount,
+            hydrationLimits.maxRows,
+            hydrationLimits.maxBytes,
+          );
+        }
+      }
+      return selectRows.all() as Array<{ key: string; value: string; updatedAt: string }>;
+    };
+    // Keep the preflight and snapshot read atomic with respect to writers.
+    const rows =
+      hydrationLimits && !this.db.inTransaction
+        ? this.db.transaction(readRows).immediate()
+        : readRows();
     const decryptedRows = rows.map((row) => ({
       key: row.key,
       value: this.encryption?.decrypt(row.value) ?? row.value,
@@ -1224,8 +1292,8 @@ class SqliteWorkingMemory implements IWorkingMemory {
   }
 
   /** Hydrate in-memory state from persisted SQLite working_memory rows. */
-  private loadFromDb(): void {
-    const rows = this.loadPersistedSerializedFromDb();
+  private loadFromDb(hydrationLimits?: WorkingMemoryHydrationLimits): void {
+    const rows = this.loadPersistedSerializedFromDb(hydrationLimits);
 
     let prepared: Array<{
       key: string;
@@ -5245,6 +5313,24 @@ export class SqliteBrain implements IBrain {
     workingMemoryLimits?: Partial<WorkingMemoryLimits>,
     options: SqliteBrainOptions = {},
   ) {
+    const requestedHydrationLimits = options.workingMemoryHydrationLimits;
+    const hydrationLimits = requestedHydrationLimits
+      ? {
+          maxRows:
+            requestedHydrationLimits.maxRows ?? DEFAULT_WORKING_MEMORY_LIMITS.maxEntries,
+          maxBytes:
+            requestedHydrationLimits.maxBytes ?? DEFAULT_WORKING_MEMORY_LIMITS.maxTotalBytes,
+        }
+      : undefined;
+    if (hydrationLimits) {
+      for (const [name, value] of Object.entries(hydrationLimits)) {
+        if (!Number.isSafeInteger(value) || value < 1) {
+          throw new RangeError(
+            `workingMemoryHydrationLimits.${name} must be a positive safe integer`,
+          );
+        }
+      }
+    }
     this.dbPath = normalizeSqliteDbPath(dbPath);
     this.db = new Database(dbPath);
     this.db.pragma('busy_timeout = 5000');
@@ -5259,17 +5345,23 @@ export class SqliteBrain implements IBrain {
     assertMemoryEncryptionState(this.db, dbPath, encryption);
     this.auditRecorder = (event) => insertMemoryAccessAuditEvent(this.db, event, encryption);
     this.accessAudit = new SqliteMemoryAccessAuditTrail(this.db, encryption);
-    this.working = new SqliteWorkingMemory(
-      this.db,
-      {
-        ...DEFAULT_WORKING_MEMORY_LIMITS,
-        ...workingMemoryLimits,
-      },
-      options.hydrateWorkingMemoryFromDb ?? true,
-      encryption,
-      (event) => this.auditRecorder(event),
-      (keys) => SqliteBrain.expireLivePrunedWorkingKeys(this.dbPath, keys),
-    );
+    try {
+      this.working = new SqliteWorkingMemory(
+        this.db,
+        {
+          ...DEFAULT_WORKING_MEMORY_LIMITS,
+          ...workingMemoryLimits,
+        },
+        options.hydrateWorkingMemoryFromDb ?? true,
+        encryption,
+        (event) => this.auditRecorder(event),
+        (keys) => SqliteBrain.expireLivePrunedWorkingKeys(this.dbPath, keys),
+        hydrationLimits,
+      );
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
     this.episodic = new SqliteEpisodicMemory(
       this.db,
       encryption,

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
   SqliteBrain,
   WorkingMemoryLimitError,
+  WorkingMemoryHydrationLimitError,
   UnsupportedMemorySchemaVersionError,
   MemoryEncryptionKeyUnavailableError,
   MemoryEncryptionMigrationRequiredError,
@@ -1612,6 +1613,88 @@ describe('SqliteBrain', () => {
         WorkingMemoryLimitError,
       );
       bounded.close();
+    });
+
+    it('fails before hydrating persisted rows beyond startup row or byte budgets', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-hydration-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath);
+        seeded.working.set('first', 'x'.repeat(32));
+        seeded.working.set('second', 'y'.repeat(32));
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        let rowError: unknown;
+        try {
+          new SqliteBrain(dbPath, undefined, {
+            workingMemoryHydrationLimits: { maxRows: 1, maxBytes: 10_000 },
+          });
+        } catch (error) {
+          rowError = error;
+        }
+        expect(rowError).toMatchObject({
+          code: 'WORKING_MEMORY_HYDRATION_LIMIT_EXCEEDED',
+          rowCount: 2,
+          byteCount: undefined,
+          maxRows: 1,
+        });
+
+        let byteError: unknown;
+        try {
+          new SqliteBrain(dbPath, undefined, {
+            workingMemoryHydrationLimits: { maxRows: 10, maxBytes: 1 },
+          });
+        } catch (error) {
+          byteError = error;
+        }
+        expect(byteError).toBeInstanceOf(WorkingMemoryHydrationLimitError);
+        expect(byteError).toMatchObject({
+          code: 'WORKING_MEMORY_HYDRATION_LIMIT_EXCEEDED',
+          rowCount: 2,
+          maxBytes: 1,
+        });
+
+        db = new Database(dbPath);
+        expect(db.prepare(`SELECT key FROM working_memory ORDER BY key ASC`).all()).toEqual([
+          { key: 'first' },
+          { key: 'second' },
+        ]);
+      } finally {
+        db?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps startup hydration budgets separate from working-memory write limits', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-hydration-write-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath);
+        seeded.working.set('first', 1);
+        seeded.working.set('second', 2);
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        reopened = new SqliteBrain(dbPath, undefined, {
+          workingMemoryHydrationLimits: { maxRows: 2, maxBytes: 10_000 },
+        });
+        expect(() => reopened?.working.set('third', 3)).not.toThrow();
+        expect(reopened.working.keys().sort()).toEqual(['first', 'second', 'third']);
+      } finally {
+        reopened?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('prunes oldest persisted rows on startup when maxEntries is reduced', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1644,6 +1644,13 @@ describe('SqliteBrain', () => {
           maxRows: 1,
         });
 
+        expect(() =>
+          new SqliteBrain(dbPath, undefined, {
+            hydrateWorkingMemoryFromDb: false,
+            workingMemoryHydrationLimits: { maxRows: 1, maxBytes: 10_000 },
+          }),
+        ).toThrow(WorkingMemoryHydrationLimitError);
+
         let byteError: unknown;
         try {
           new SqliteBrain(dbPath, undefined, {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -5,6 +5,7 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
   const databaseInstances: Array<{
     pragma: ReturnType<typeof vi.fn>;
     prepare: ReturnType<typeof vi.fn>;
+    transaction: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
     dbPath: string;
     options: unknown;
@@ -47,6 +48,16 @@ vi.mock("better-sqlite3", () => ({
       pragma: vi.fn(),
       prepare: vi.fn((sql: string) => ({
         get: vi.fn((tableName?: string) => {
+          if (sql.includes("COUNT(*)") && sql.includes("working_memory")) {
+            const rows = workingMemoryRowsByPath.get(_dbPath) ?? [];
+            return {
+              rowCount: rows.length,
+              byteCount: rows.reduce(
+                (total, row) => total + Buffer.byteLength(row.key) + Buffer.byteLength(row.value),
+                0,
+              ),
+            };
+          }
           if (sql.includes("sqlite_master") && (tableName === "governor_log" || tableName === "audit_trail")) {
             return { name: tableName };
           }
@@ -406,6 +417,7 @@ vi.mock("better-sqlite3", () => ({
           return workingMemoryRowsByPath.get(_dbPath) ?? [];
         }),
       })),
+      transaction: vi.fn((callback: () => unknown) => callback),
       close: vi.fn(),
       dbPath: _dbPath,
       options,
@@ -681,7 +693,7 @@ describe("createBrainAdapter", () => {
     vi.clearAllMocks();
   });
 
-  it("configures WAL and a busy timeout on the adapter read connection before rehydrating memory", () => {
+  it("configures WAL and a busy timeout and measures hydration before loading rows", () => {
     createBrainAdapter("/tmp/beast.db");
 
     expect(databaseInstances).toHaveLength(1);
@@ -689,10 +701,56 @@ describe("createBrainAdapter", () => {
     expect(readDb.options).toBeUndefined();
     expect(readDb.pragma).toHaveBeenNthCalledWith(1, "journal_mode = WAL");
     expect(readDb.pragma).toHaveBeenNthCalledWith(2, "busy_timeout = 5000");
-    expect(readDb.prepare).toHaveBeenCalledWith(
-      "SELECT key, value FROM working_memory",
-    );
+    expect(readDb.prepare).toHaveBeenCalledWith(expect.stringContaining("COUNT(*)"));
+    expect(readDb.prepare).toHaveBeenCalledWith("SELECT key, value FROM working_memory");
+    expect(readDb.transaction).toHaveBeenCalledOnce();
     expect(readDb.close).toHaveBeenCalledOnce();
+  });
+
+  it("fails startup with a recoverable diagnostic before hydrating too many rows", () => {
+    workingMemoryRowsByPath.set("/tmp/oversized.db", [
+      { key: "one", value: JSON.stringify("first") },
+      { key: "two", value: JSON.stringify("second") },
+      { key: "three", value: JSON.stringify("third") },
+    ]);
+
+    expect(() =>
+      createBrainAdapter("/tmp/oversized.db", {
+        hydration: { maxRows: 2, maxBytes: 1_000 },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        name: "BrainAdapterHydrationLimitError",
+        code: "BRAIN_ADAPTER_HYDRATION_LIMIT_EXCEEDED",
+        rowCount: 3,
+        maxRows: 2,
+      }),
+    );
+    expect(brainInstances).toHaveLength(0);
+    expect(databaseInstances[0]!.close).toHaveBeenCalledOnce();
+  });
+
+  it("fails startup before hydration when the working-memory byte budget is exceeded", () => {
+    workingMemoryRowsByPath.set("/tmp/oversized-bytes.db", [
+      { key: "large", value: JSON.stringify("💾".repeat(20)) },
+    ]);
+
+    expect(() =>
+      createBrainAdapter("/tmp/oversized-bytes.db", {
+        hydration: { maxRows: 10, maxBytes: 32 },
+      }),
+    ).toThrow(/byte budget 32/);
+    expect(brainInstances).toHaveLength(0);
+  });
+
+  it("rejects invalid hydration budgets before opening the database", () => {
+    expect(() =>
+      createBrainAdapter("/tmp/beast.db", {
+        hydration: { maxRows: 0 },
+      }),
+    ).toThrow("hydration.maxRows must be a positive safe integer");
+    expect(databaseInstances).toHaveLength(0);
+    expect(brainInstances).toHaveLength(0);
   });
 
   it("keeps direct API memory reads isolated by profile database path", async () => {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -11,7 +11,7 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
   }> = [];
   const brainInstances: Array<{
     dbPath: string;
-    limits: { maxEntries?: number; maxTotalBytes?: number } | undefined;
+    limits: { maxRows?: number; maxBytes?: number } | undefined;
     working: {
       restore: ReturnType<typeof vi.fn>;
       snapshot: ReturnType<typeof vi.fn>;
@@ -427,7 +427,10 @@ vi.mock("@franken/brain", () => ({
   SqliteBrain: vi.fn(function MockSqliteBrain(
     this: unknown,
     dbPath: string,
-    limits?: { maxEntries?: number; maxTotalBytes?: number },
+    _workingMemoryLimits?: unknown,
+    options?: {
+      workingMemoryHydrationLimits?: { maxRows?: number; maxBytes?: number };
+    },
   ) {
     let workingSnapshot: Record<string, unknown> = {
       "task-1": "working entry",
@@ -690,7 +693,11 @@ vi.mock("@franken/brain", () => ({
       },
       flush: vi.fn(),
     };
-    brainInstances.push({ ...brain, dbPath, limits });
+    brainInstances.push({
+      ...brain,
+      dbPath,
+      limits: options?.workingMemoryHydrationLimits,
+    });
     Object.assign(this as object, brain);
   }),
 }));
@@ -712,7 +719,7 @@ describe("createBrainAdapter", () => {
     expect(brainInstances).toHaveLength(1);
     expect(brainInstances[0]).toMatchObject({
       dbPath: "/tmp/beast.db",
-      limits: { maxEntries: 10_000, maxTotalBytes: 64 * 1024 * 1024 },
+      limits: { maxRows: 10_000, maxBytes: 64 * 1024 * 1024 },
     });
     expect(brainInstances[0]!.working.restore).not.toHaveBeenCalled();
   });
@@ -724,7 +731,7 @@ describe("createBrainAdapter", () => {
 
     expect(brainInstances[0]).toMatchObject({
       dbPath: "/tmp/bounded.db",
-      limits: { maxEntries: 2, maxTotalBytes: 1_000 },
+      limits: { maxRows: 2, maxBytes: 1_000 },
     });
   });
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -5,12 +5,13 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
   const databaseInstances: Array<{
     pragma: ReturnType<typeof vi.fn>;
     prepare: ReturnType<typeof vi.fn>;
-    transaction: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
     dbPath: string;
     options: unknown;
   }> = [];
   const brainInstances: Array<{
+    dbPath: string;
+    limits: { maxEntries?: number; maxTotalBytes?: number } | undefined;
     working: {
       restore: ReturnType<typeof vi.fn>;
       snapshot: ReturnType<typeof vi.fn>;
@@ -24,6 +25,7 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
       record: ReturnType<typeof vi.fn>;
     };
     rightToForget: ReturnType<typeof vi.fn>;
+    memoryRetentionReport: ReturnType<typeof vi.fn>;
     memoryReview: {
       propose: ReturnType<typeof vi.fn>;
       approve: ReturnType<typeof vi.fn>;
@@ -48,16 +50,6 @@ vi.mock("better-sqlite3", () => ({
       pragma: vi.fn(),
       prepare: vi.fn((sql: string) => ({
         get: vi.fn((tableName?: string) => {
-          if (sql.includes("COUNT(*)") && sql.includes("working_memory")) {
-            const rows = workingMemoryRowsByPath.get(_dbPath) ?? [];
-            return {
-              rowCount: rows.length,
-              byteCount: rows.reduce(
-                (total, row) => total + Buffer.byteLength(row.key) + Buffer.byteLength(row.value),
-                0,
-              ),
-            };
-          }
           if (sql.includes("sqlite_master") && (tableName === "governor_log" || tableName === "audit_trail")) {
             return { name: tableName };
           }
@@ -417,7 +409,6 @@ vi.mock("better-sqlite3", () => ({
           return workingMemoryRowsByPath.get(_dbPath) ?? [];
         }),
       })),
-      transaction: vi.fn((callback: () => unknown) => callback),
       close: vi.fn(),
       dbPath: _dbPath,
       options,
@@ -428,7 +419,16 @@ vi.mock("better-sqlite3", () => ({
 }));
 
 vi.mock("@franken/brain", () => ({
-  SqliteBrain: vi.fn(function MockSqliteBrain(this: unknown) {
+  DEFAULT_WORKING_MEMORY_LIMITS: {
+    maxEntries: 10_000,
+    maxValueBytes: 5 * 1024 * 1024,
+    maxTotalBytes: 64 * 1024 * 1024,
+  },
+  SqliteBrain: vi.fn(function MockSqliteBrain(
+    this: unknown,
+    dbPath: string,
+    limits?: { maxEntries?: number; maxTotalBytes?: number },
+  ) {
     let workingSnapshot: Record<string, unknown> = {
       "task-1": "working entry",
       "agents/oncall/runbook": "shared runbook",
@@ -478,6 +478,18 @@ vi.mock("@franken/brain", () => ({
         value: "beta entry",
       },
     };
+    const persistedRows = workingMemoryRowsByPath.get(dbPath);
+    if (persistedRows !== undefined) {
+      workingSnapshot = Object.fromEntries(
+        persistedRows.map((row) => {
+          try {
+            return [row.key, JSON.parse(row.value)];
+          } catch {
+            return [row.key, row.value];
+          }
+        }),
+      );
+    }
     const brain = {
       working: {
         restore: vi.fn((snapshot: Record<string, unknown>) => {
@@ -678,7 +690,7 @@ vi.mock("@franken/brain", () => ({
       },
       flush: vi.fn(),
     };
-    brainInstances.push(brain);
+    brainInstances.push({ ...brain, dbPath, limits });
     Object.assign(this as object, brain);
   }),
 }));
@@ -693,54 +705,27 @@ describe("createBrainAdapter", () => {
     vi.clearAllMocks();
   });
 
-  it("configures WAL and a busy timeout and measures hydration before loading rows", () => {
+  it("delegates startup hydration to SqliteBrain with its bounded defaults", () => {
     createBrainAdapter("/tmp/beast.db");
 
-    expect(databaseInstances).toHaveLength(1);
-    const readDb = databaseInstances[0];
-    expect(readDb.options).toBeUndefined();
-    expect(readDb.pragma).toHaveBeenNthCalledWith(1, "journal_mode = WAL");
-    expect(readDb.pragma).toHaveBeenNthCalledWith(2, "busy_timeout = 5000");
-    expect(readDb.prepare).toHaveBeenCalledWith(expect.stringContaining("COUNT(*)"));
-    expect(readDb.prepare).toHaveBeenCalledWith("SELECT key, value FROM working_memory");
-    expect(readDb.transaction).toHaveBeenCalledOnce();
-    expect(readDb.close).toHaveBeenCalledOnce();
+    expect(databaseInstances).toHaveLength(0);
+    expect(brainInstances).toHaveLength(1);
+    expect(brainInstances[0]).toMatchObject({
+      dbPath: "/tmp/beast.db",
+      limits: { maxEntries: 10_000, maxTotalBytes: 64 * 1024 * 1024 },
+    });
+    expect(brainInstances[0]!.working.restore).not.toHaveBeenCalled();
   });
 
-  it("fails startup with a recoverable diagnostic before hydrating too many rows", () => {
-    workingMemoryRowsByPath.set("/tmp/oversized.db", [
-      { key: "one", value: JSON.stringify("first") },
-      { key: "two", value: JSON.stringify("second") },
-      { key: "three", value: JSON.stringify("third") },
-    ]);
+  it("passes configurable hydration budgets to SqliteBrain's bounded startup path", () => {
+    createBrainAdapter("/tmp/bounded.db", {
+      hydration: { maxRows: 2, maxBytes: 1_000 },
+    });
 
-    expect(() =>
-      createBrainAdapter("/tmp/oversized.db", {
-        hydration: { maxRows: 2, maxBytes: 1_000 },
-      }),
-    ).toThrow(
-      expect.objectContaining({
-        name: "BrainAdapterHydrationLimitError",
-        code: "BRAIN_ADAPTER_HYDRATION_LIMIT_EXCEEDED",
-        rowCount: 3,
-        maxRows: 2,
-      }),
-    );
-    expect(brainInstances).toHaveLength(0);
-    expect(databaseInstances[0]!.close).toHaveBeenCalledOnce();
-  });
-
-  it("fails startup before hydration when the working-memory byte budget is exceeded", () => {
-    workingMemoryRowsByPath.set("/tmp/oversized-bytes.db", [
-      { key: "large", value: JSON.stringify("💾".repeat(20)) },
-    ]);
-
-    expect(() =>
-      createBrainAdapter("/tmp/oversized-bytes.db", {
-        hydration: { maxRows: 10, maxBytes: 32 },
-      }),
-    ).toThrow(/byte budget 32/);
-    expect(brainInstances).toHaveLength(0);
+    expect(brainInstances[0]).toMatchObject({
+      dbPath: "/tmp/bounded.db",
+      limits: { maxEntries: 2, maxTotalBytes: 1_000 },
+    });
   });
 
   it("rejects invalid hydration budgets before opening the database", () => {
@@ -783,16 +768,10 @@ describe("createBrainAdapter", () => {
     expect(doctorRows).toEqual([
       { key: "profile-note", value: "doctor profile memory", type: "working" },
     ]);
-    expect(databaseInstances.map((db) => db.dbPath)).toEqual([
+    expect(brainInstances.map((brain) => brain.dbPath)).toEqual([
       "/tmp/profiles/default/beast.db",
       "/tmp/profiles/doctor/beast.db",
     ]);
-    expect(brainInstances[0]!.working.restore).toHaveBeenCalledWith({
-      "profile-note": "default profile memory",
-    });
-    expect(brainInstances[1]!.working.restore).toHaveBeenCalledWith({
-      "profile-note": "doctor profile memory",
-    });
     expect(JSON.stringify(defaultRows)).not.toContain("doctor profile memory");
     expect(JSON.stringify(doctorRows)).not.toContain("default profile memory");
   });

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1132,12 +1132,14 @@ export function createBrainAdapter(
   options: BrainAdapterOptions = {},
 ): BrainAdapter {
   const hydrationBudget = resolveHydrationBudget(options);
-  // SqliteBrain owns working-memory hydration, expiry, startup pruning, and
-  // concurrent-row safety. Passing the limits into that single hydration path
-  // avoids the adapter's former unbounded second SELECT/restore cycle.
-  const brain = new SqliteBrain(dbPath, {
-    maxEntries: hydrationBudget.maxRows,
-    maxTotalBytes: hydrationBudget.maxBytes,
+  // SqliteBrain owns the single startup hydration read and its concurrency
+  // safety. Startup-only limits avoid the adapter's former unbounded second
+  // SELECT/restore cycle without changing normal working-memory write limits.
+  const brain = new SqliteBrain(dbPath, undefined, {
+    workingMemoryHydrationLimits: {
+      maxRows: hydrationBudget.maxRows,
+      maxBytes: hydrationBudget.maxBytes,
+    },
   });
 
   const resolveMemoryType = (

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  DEFAULT_WORKING_MEMORY_LIMITS,
   SqliteBrain,
   type MemoryAttributionListOptions,
   type MemoryCandidate,
@@ -190,9 +191,6 @@ const MAX_MEMORY_ACCESS_AUDIT_SCAN_LIMIT = 10_000;
 const AGENT_WORKING_KEY_PREFIX = "__fbeast_agent_memory__/";
 const AGENT_MEMORY_SCOPE_MARKER = "fbeast:agent-memory";
 const MAX_OPERATIONAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
-const DEFAULT_HYDRATION_MAX_ROWS = 10_000;
-const DEFAULT_HYDRATION_MAX_BYTES = 16 * 1024 * 1024;
-
 export interface BrainAdapterOptions {
   hydration?: {
     /** Maximum working-memory rows restored during adapter construction. */
@@ -202,33 +200,14 @@ export interface BrainAdapterOptions {
   };
 }
 
-export class BrainAdapterHydrationLimitError extends Error {
-  readonly code = "BRAIN_ADAPTER_HYDRATION_LIMIT_EXCEEDED";
-
-  constructor(
-    readonly rowCount: number,
-    readonly byteCount: number,
-    readonly maxRows: number,
-    readonly maxBytes: number,
-  ) {
-    const exceeded = [
-      rowCount > maxRows ? `row budget ${maxRows} (found ${rowCount})` : undefined,
-      byteCount > maxBytes ? `byte budget ${maxBytes} (found ${byteCount})` : undefined,
-    ].filter((value): value is string => value !== undefined);
-    super(
-      `BrainAdapter startup hydration exceeded ${exceeded.join(" and ")}. ` +
-        "Increase the hydration budget or compact the working_memory table before retrying.",
-    );
-    this.name = "BrainAdapterHydrationLimitError";
-  }
-}
-
 function resolveHydrationBudget(options: BrainAdapterOptions): {
   maxRows: number;
   maxBytes: number;
 } {
-  const maxRows = options.hydration?.maxRows ?? DEFAULT_HYDRATION_MAX_ROWS;
-  const maxBytes = options.hydration?.maxBytes ?? DEFAULT_HYDRATION_MAX_BYTES;
+  const maxRows =
+    options.hydration?.maxRows ?? DEFAULT_WORKING_MEMORY_LIMITS.maxEntries;
+  const maxBytes =
+    options.hydration?.maxBytes ?? DEFAULT_WORKING_MEMORY_LIMITS.maxTotalBytes;
   for (const [name, value] of [
     ["maxRows", maxRows],
     ["maxBytes", maxBytes],
@@ -238,13 +217,6 @@ function resolveHydrationBudget(options: BrainAdapterOptions): {
     }
   }
   return { maxRows, maxBytes };
-}
-
-function isMissingWorkingMemoryTable(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    /no such table:\s*working_memory\b/i.test(error.message)
-  );
 }
 
 type SupportedMemoryType = (typeof SUPPORTED_MEMORY_TYPES)[number];
@@ -1160,6 +1132,13 @@ export function createBrainAdapter(
   options: BrainAdapterOptions = {},
 ): BrainAdapter {
   const hydrationBudget = resolveHydrationBudget(options);
+  // SqliteBrain owns working-memory hydration, expiry, startup pruning, and
+  // concurrent-row safety. Passing the limits into that single hydration path
+  // avoids the adapter's former unbounded second SELECT/restore cycle.
+  const brain = new SqliteBrain(dbPath, {
+    maxEntries: hydrationBudget.maxRows,
+    maxTotalBytes: hydrationBudget.maxBytes,
+  });
 
   const resolveMemoryType = (
     type: string | undefined,
@@ -1172,58 +1151,6 @@ export function createBrainAdapter(
       `Unsupported memory type: ${type}. Supported types: ${SUPPORTED_MEMORY_TYPES.join(", ")}`,
     );
   };
-
-  // Rehydrate working memory from SQLite so entries survive process restarts.
-  // SqliteBrain's constructor starts with an empty in-memory Map; flush() writes
-  // to the working_memory table but construction doesn't read it back.
-  const readDb = new Database(dbPath);
-  configureBrainAdapterDb(readDb);
-  let hydrationSnapshot: Record<string, unknown> = {};
-  try {
-    const readSnapshot = readDb.transaction(() => {
-      const stats = readDb
-        .prepare(
-          "SELECT COUNT(*) AS rowCount, " +
-            "COALESCE(SUM(length(CAST(key AS BLOB)) + length(CAST(value AS BLOB))), 0) AS byteCount " +
-            "FROM working_memory",
-        )
-        .get() as { rowCount: number; byteCount: number };
-      if (
-        stats.rowCount > hydrationBudget.maxRows ||
-        stats.byteCount > hydrationBudget.maxBytes
-      ) {
-        throw new BrainAdapterHydrationLimitError(
-          stats.rowCount,
-          stats.byteCount,
-          hydrationBudget.maxRows,
-          hydrationBudget.maxBytes,
-        );
-      }
-      return readDb
-        .prepare("SELECT key, value FROM working_memory")
-        .all() as Array<{ key: string; value: string }>;
-    });
-    const rows = readSnapshot();
-    hydrationSnapshot = Object.fromEntries(
-      rows.map((row) => {
-        try {
-          return [row.key, JSON.parse(row.value)];
-        } catch {
-          return [row.key, row.value];
-        }
-      }),
-    );
-  } catch (error) {
-    // SqliteBrain creates the table on first use, so a missing table is an empty snapshot.
-    if (!isMissingWorkingMemoryTable(error)) throw error;
-  } finally {
-    readDb.close();
-  }
-
-  const brain = new SqliteBrain(dbPath);
-  if (Object.keys(hydrationSnapshot).length > 0) {
-    brain.working.restore(hydrationSnapshot);
-  }
 
   return {
     async query(input) {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -190,6 +190,62 @@ const MAX_MEMORY_ACCESS_AUDIT_SCAN_LIMIT = 10_000;
 const AGENT_WORKING_KEY_PREFIX = "__fbeast_agent_memory__/";
 const AGENT_MEMORY_SCOPE_MARKER = "fbeast:agent-memory";
 const MAX_OPERATIONAL_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+const DEFAULT_HYDRATION_MAX_ROWS = 10_000;
+const DEFAULT_HYDRATION_MAX_BYTES = 16 * 1024 * 1024;
+
+export interface BrainAdapterOptions {
+  hydration?: {
+    /** Maximum working-memory rows restored during adapter construction. */
+    maxRows?: number;
+    /** Maximum combined UTF-8 bytes of working-memory keys and values restored. */
+    maxBytes?: number;
+  };
+}
+
+export class BrainAdapterHydrationLimitError extends Error {
+  readonly code = "BRAIN_ADAPTER_HYDRATION_LIMIT_EXCEEDED";
+
+  constructor(
+    readonly rowCount: number,
+    readonly byteCount: number,
+    readonly maxRows: number,
+    readonly maxBytes: number,
+  ) {
+    const exceeded = [
+      rowCount > maxRows ? `row budget ${maxRows} (found ${rowCount})` : undefined,
+      byteCount > maxBytes ? `byte budget ${maxBytes} (found ${byteCount})` : undefined,
+    ].filter((value): value is string => value !== undefined);
+    super(
+      `BrainAdapter startup hydration exceeded ${exceeded.join(" and ")}. ` +
+        "Increase the hydration budget or compact the working_memory table before retrying.",
+    );
+    this.name = "BrainAdapterHydrationLimitError";
+  }
+}
+
+function resolveHydrationBudget(options: BrainAdapterOptions): {
+  maxRows: number;
+  maxBytes: number;
+} {
+  const maxRows = options.hydration?.maxRows ?? DEFAULT_HYDRATION_MAX_ROWS;
+  const maxBytes = options.hydration?.maxBytes ?? DEFAULT_HYDRATION_MAX_BYTES;
+  for (const [name, value] of [
+    ["maxRows", maxRows],
+    ["maxBytes", maxBytes],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new Error(`hydration.${name} must be a positive safe integer`);
+    }
+  }
+  return { maxRows, maxBytes };
+}
+
+function isMissingWorkingMemoryTable(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /no such table:\s*working_memory\b/i.test(error.message)
+  );
+}
 
 type SupportedMemoryType = (typeof SUPPORTED_MEMORY_TYPES)[number];
 
@@ -1099,8 +1155,11 @@ function redactEpisodicSummary(
   return fullStringRedaction;
 }
 
-export function createBrainAdapter(dbPath: string): BrainAdapter {
-  const brain = new SqliteBrain(dbPath);
+export function createBrainAdapter(
+  dbPath: string,
+  options: BrainAdapterOptions = {},
+): BrainAdapter {
+  const hydrationBudget = resolveHydrationBudget(options);
 
   const resolveMemoryType = (
     type: string | undefined,
@@ -1119,25 +1178,51 @@ export function createBrainAdapter(dbPath: string): BrainAdapter {
   // to the working_memory table but construction doesn't read it back.
   const readDb = new Database(dbPath);
   configureBrainAdapterDb(readDb);
+  let hydrationSnapshot: Record<string, unknown> = {};
   try {
-    const rows = readDb
-      .prepare("SELECT key, value FROM working_memory")
-      .all() as Array<{ key: string; value: string }>;
-    const snap: Record<string, unknown> = {};
-    for (const row of rows) {
-      try {
-        snap[row.key] = JSON.parse(row.value);
-      } catch {
-        snap[row.key] = row.value;
+    const readSnapshot = readDb.transaction(() => {
+      const stats = readDb
+        .prepare(
+          "SELECT COUNT(*) AS rowCount, " +
+            "COALESCE(SUM(length(CAST(key AS BLOB)) + length(CAST(value AS BLOB))), 0) AS byteCount " +
+            "FROM working_memory",
+        )
+        .get() as { rowCount: number; byteCount: number };
+      if (
+        stats.rowCount > hydrationBudget.maxRows ||
+        stats.byteCount > hydrationBudget.maxBytes
+      ) {
+        throw new BrainAdapterHydrationLimitError(
+          stats.rowCount,
+          stats.byteCount,
+          hydrationBudget.maxRows,
+          hydrationBudget.maxBytes,
+        );
       }
-    }
-    if (Object.keys(snap).length > 0) {
-      brain.working.restore(snap);
-    }
-  } catch {
-    // Table may not exist yet on first run — that's fine
+      return readDb
+        .prepare("SELECT key, value FROM working_memory")
+        .all() as Array<{ key: string; value: string }>;
+    });
+    const rows = readSnapshot();
+    hydrationSnapshot = Object.fromEntries(
+      rows.map((row) => {
+        try {
+          return [row.key, JSON.parse(row.value)];
+        } catch {
+          return [row.key, row.value];
+        }
+      }),
+    );
+  } catch (error) {
+    // SqliteBrain creates the table on first use, so a missing table is an empty snapshot.
+    if (!isMissingWorkingMemoryTable(error)) throw error;
   } finally {
     readDb.close();
+  }
+
+  const brain = new SqliteBrain(dbPath);
+  if (Object.keys(hydrationSnapshot).length > 0) {
+    brain.working.restore(hydrationSnapshot);
   }
 
   return {

--- a/packages/franken-mcp-suite/src/index.ts
+++ b/packages/franken-mcp-suite/src/index.ts
@@ -16,7 +16,6 @@ export { createAuditSink, createCentralOptions } from './shared/central-enforcem
 
 // Adapters
 export {
-  BrainAdapterHydrationLimitError,
   createBrainAdapter,
   type BrainAdapter,
   type BrainAdapterOptions,

--- a/packages/franken-mcp-suite/src/index.ts
+++ b/packages/franken-mcp-suite/src/index.ts
@@ -15,7 +15,12 @@ export { createGovernanceGate } from './shared/governance-gate.js';
 export { createAuditSink, createCentralOptions } from './shared/central-enforcement.js';
 
 // Adapters
-export { createBrainAdapter, type BrainAdapter } from './adapters/brain-adapter.js';
+export {
+  BrainAdapterHydrationLimitError,
+  createBrainAdapter,
+  type BrainAdapter,
+  type BrainAdapterOptions,
+} from './adapters/brain-adapter.js';
 export { createObserverAdapter, type ObserverAdapter } from './adapters/observer-adapter.js';
 export { createGovernorAdapter, type GovernorAdapter } from './adapters/governor-adapter.js';
 export { createPlannerAdapter, type PlannerAdapter } from './adapters/planner-adapter.js';

--- a/packages/franken-mcp-suite/src/index.ts
+++ b/packages/franken-mcp-suite/src/index.ts
@@ -20,6 +20,7 @@ export {
   type BrainAdapter,
   type BrainAdapterOptions,
 } from './adapters/brain-adapter.js';
+export { WorkingMemoryHydrationLimitError } from '@franken/brain';
 export { createObserverAdapter, type ObserverAdapter } from './adapters/observer-adapter.js';
 export { createGovernorAdapter, type GovernorAdapter } from './adapters/governor-adapter.js';
 export { createPlannerAdapter, type PlannerAdapter } from './adapters/planner-adapter.js';


### PR DESCRIPTION
## Summary
- bound BrainAdapter startup hydration by configurable row and UTF-8 byte budgets
- fail before constructing the in-memory brain with a typed, recoverable diagnostic when either budget is exceeded
- measure and load under one SQLite read transaction and preserve first-run behavior
- export the hydration options and limit error for callers

## Test plan
- `npm run test --workspace @franken/mcp-suite` (549 passed)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite -- --quiet`
- `npm run build` (10 packages)

Closes #3200