### PR TITLE
fix(mcp): enforce tool schema bounds

### DIFF
--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -363,6 +363,26 @@ describe('proxy server', () => {
       expect(fakeHandler).not.toHaveBeenCalled();
     });
 
+    it('redacts over-bound target arguments from proxy validation-error audits', async () => {
+      mockRegistry.set('bounded_tool', {
+        name: 'bounded_tool',
+        server: 'memory',
+        description: 'Bounded test tool',
+        inputSchema: { type: 'object', properties: { query: { type: 'string', description: 'Query', maxLength: 3 } }, required: ['query'] },
+        makeHandler: vi.fn(),
+      });
+
+      const result = await executeToolDef.handler({ tool: 'bounded_tool', args: { query: 'oversized' } }) as { isError: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(auditRecord).toHaveBeenCalledWith({
+        tool: 'bounded_tool',
+        ok: false,
+        decision: 'validation_error',
+        args: { query: '[schema-bound-exceeded]' },
+      });
+    });
+
     it('rejects proxied calls with target unknown properties', async () => {
       const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
       const entry = mockRegistry.get('test_tool')!;

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createMcpServer, DEFAULT_TOOL_TIMEOUT_MS, executeToolWithDeadline, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, DEFAULT_TOOL_TIMEOUT_MS, executeToolWithDeadline, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
 import { handleStartupFailure } from '../shared/shutdown.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
@@ -101,9 +101,12 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
         // Best-effort audit of the resolved target, including its args and any
         // governance denial or rejected probe (mirrors dispatchTool); never
         // fails the call.
-        const recordAudit = async (input: { ok: boolean; decision?: string }): Promise<void> => {
+        const recordAudit = async (
+          input: { ok: boolean; decision?: string },
+          argsForAudit: Record<string, unknown> = toolArgs,
+        ): Promise<void> => {
           try {
-            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: sanitizeToolArgumentsForAuditTrail(toolName, toolArgs) });
+            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: sanitizeToolArgumentsForAuditTrail(toolName, argsForAudit) });
           } catch (err) {
             process.stderr.write(`fbeast audit failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`);
           }
@@ -126,7 +129,10 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
         // Validate the resolved target's args before governing/running it.
         const validated = validateToolArguments(entry, toolArgs);
         if (!validated.ok) {
-          await recordAudit({ ok: false, decision: 'validation_error' });
+          await recordAudit(
+            { ok: false, decision: 'validation_error' },
+            sanitizeRejectedToolArgumentsForAudit(entry, toolArgs),
+          );
           return { content: [{ type: 'text', text: `Error: ${validated.message}` }], isError: true };
         }
         // Central governance on the resolved target — fails closed on any

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -449,6 +449,67 @@ describe('createMcpServer', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('enforces string length bounds before invoking the handler', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'search',
+      description: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'query', minLength: 2, maxLength: 3 } },
+        required: ['query'],
+      },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+
+    expect((await srv.callTool('search', { query: 'x' })).content[0]!.text).toContain('at least 2 characters');
+    expect((await srv.callTool('search', { query: 'abcd' })).content[0]!.text).toContain('at most 3 characters');
+    expect(await srv.callTool('search', { query: 'abc' })).not.toHaveProperty('isError');
+    expect(await srv.callTool('search', { query: '😀😀' })).not.toHaveProperty('isError');
+    expect(calls).toEqual([{ query: 'abc' }, { query: '😀😀' }]);
+  });
+
+  it('enforces numeric bounds before invoking the handler', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'page',
+      description: 'page',
+      inputSchema: {
+        type: 'object',
+        properties: { limit: { type: 'integer', description: 'limit', minimum: 1, maximum: 100 } },
+        required: ['limit'],
+      },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+
+    expect((await srv.callTool('page', { limit: 0 })).content[0]!.text).toContain('at least 1');
+    expect((await srv.callTool('page', { limit: 101 })).content[0]!.text).toContain('at most 100');
+    expect(await srv.callTool('page', { limit: 100 })).not.toHaveProperty('isError');
+    expect(calls).toEqual([{ limit: 100 }]);
+  });
+
+  it('enforces array item bounds before invoking the handler', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'batch',
+      description: 'batch',
+      inputSchema: {
+        type: 'object',
+        properties: { items: { type: 'array', description: 'items', minItems: 1, maxItems: 2 } },
+        required: ['items'],
+      },
+      handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+
+    expect((await srv.callTool('batch', { items: [] })).content[0]!.text).toContain('at least 1 items');
+    expect((await srv.callTool('batch', { items: [1, 2, 3] })).content[0]!.text).toContain('at most 2 items');
+    expect(await srv.callTool('batch', { items: [1, 2] })).not.toHaveProperty('isError');
+    expect(calls).toEqual([{ items: [1, 2] }]);
+  });
+
   it('accepts arguments matching any listed schema type', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -363,6 +363,34 @@ describe('createMcpServer', () => {
     });
   });
 
+  it('redacts observer metadata from direct and proxy audit records', () => {
+    expect(sanitizeToolArgumentsForAuditTrail('fbeast_observer_log', {
+      event: 'tool_call',
+      metadata: 'x'.repeat(1_000_001),
+      sessionId: 'session-1',
+    })).toEqual({
+      event: 'tool_call',
+      metadata: '[observer-metadata-redacted]',
+      sessionId: 'session-1',
+    });
+
+    expect(sanitizeToolArgumentsForAuditTrail('execute_tool', {
+      tool: 'fbeast_observer_log',
+      args: {
+        event: 'tool_call',
+        metadata: 'x'.repeat(1_000_001),
+        sessionId: 'session-1',
+      },
+    })).toEqual({
+      tool: 'fbeast_observer_log',
+      args: {
+        event: 'tool_call',
+        metadata: '[observer-metadata-redacted]',
+        sessionId: 'session-1',
+      },
+    });
+  });
+
   it('redacts memory access audit report rejected selectors from direct and proxy audit records', () => {
     expect(sanitizeToolArgumentsForAuditTrail('fbeast_memory_access_audit_report', {
       operation: 'delete',

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -389,6 +389,30 @@ describe('createMcpServer', () => {
         sessionId: 'session-1',
       },
     });
+
+    expect(sanitizeToolArgumentsForAuditTrail('execute_tool', {
+      tool: 'fbeast_observer_log',
+      args: 'invalid envelope',
+      metadata: 'x'.repeat(1_000_001),
+    })).toEqual({
+      tool: 'fbeast_observer_log',
+      args: '[observer-metadata-redacted]',
+      metadata: '[observer-metadata-redacted]',
+    });
+
+    expect(sanitizeToolArgumentsForAuditTrail('fbeast_governor_check', {
+      action: 'fbeast_observer_log',
+      context: {
+        event: 'tool_call',
+        metadata: 'x'.repeat(1_000_001),
+      },
+    })).toEqual({
+      action: 'fbeast_observer_log',
+      context: {
+        event: 'tool_call',
+        metadata: '[observer-metadata-redacted]',
+      },
+    });
   });
 
   it('redacts memory access audit report rejected selectors from direct and proxy audit records', () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -374,6 +374,18 @@ describe('createMcpServer', () => {
       sessionId: 'session-1',
     });
 
+    expect(sanitizeToolArgumentsForAuditTrail('fbeast_observer_log', {
+      event: 'tool_call',
+      metadata: 'x'.repeat(1_000_001),
+      sessionId: 'session-1',
+      tool: 'untrusted-payload-name',
+    })).toEqual({
+      event: 'tool_call',
+      metadata: '[observer-metadata-redacted]',
+      sessionId: 'session-1',
+      tool: 'untrusted-payload-name',
+    });
+
     expect(sanitizeToolArgumentsForAuditTrail('execute_tool', {
       tool: 'fbeast_observer_log',
       args: {
@@ -503,6 +515,7 @@ describe('createMcpServer', () => {
 
   it('enforces string length bounds before invoking the handler', async () => {
     const calls: unknown[] = [];
+    const recorded: Array<{ decision?: string; args?: Record<string, unknown> }> = [];
     const tool: ToolDef = {
       name: 'search',
       description: 'search',
@@ -513,13 +526,14 @@ describe('createMcpServer', () => {
       },
       handler: async (a) => { calls.push(a); return { content: [{ type: 'text' as const, text: 'ok' }] }; },
     };
-    const srv = createMcpServer('t', '1', [tool]);
+    const srv = createMcpServer('t', '1', [tool], { audit: { record: async (entry) => { recorded.push(entry); } } });
 
     expect((await srv.callTool('search', { query: 'x' })).content[0]!.text).toContain('at least 2 characters');
     expect((await srv.callTool('search', { query: 'abcd' })).content[0]!.text).toContain('at most 3 characters');
     expect(await srv.callTool('search', { query: 'abc' })).not.toHaveProperty('isError');
     expect(await srv.callTool('search', { query: '😀😀' })).not.toHaveProperty('isError');
     expect(calls).toEqual([{ query: 'abc' }, { query: '😀😀' }]);
+    expect(recorded.find((entry) => entry.decision === 'validation_error' && entry.args?.['query'] === '[schema-bound-exceeded]')).toBeDefined();
   });
 
   it('enforces numeric bounds before invoking the handler', async () => {
@@ -560,6 +574,12 @@ describe('createMcpServer', () => {
     expect((await srv.callTool('batch', { items: [1, 2, 3] })).content[0]!.text).toContain('at most 2 items');
     expect(await srv.callTool('batch', { items: [1, 2] })).not.toHaveProperty('isError');
     expect(calls).toEqual([{ items: [1, 2] }]);
+
+    const oversizedWithAccessor = [1, 2, 3];
+    Object.defineProperty(oversizedWithAccessor, '0', { get: () => { throw new Error('must not be read'); } });
+    const boundedBeforeTraversal = validateToolArguments(tool, { items: oversizedWithAccessor });
+    expect(boundedBeforeTraversal.ok).toBe(false);
+    if (!boundedBeforeTraversal.ok) expect(boundedBeforeTraversal.message).toContain('at most 2 items');
   });
 
   it('accepts arguments matching any listed schema type', async () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -359,6 +359,7 @@ const MEMORY_REVIEW_DECIDE_SAFE_ACTIONS = new Set(['approve', 'reject', 'never_s
 const MEMORY_REVIEW_DECIDE_SAFE_RESOLUTIONS = new Set(['keep_existing', 'replace_existing', 'keep_both_scoped', 'reject_candidate', 'expire_existing']);
 const MEMORY_STORE_TOOL = 'fbeast_memory_store';
 const MEMORY_STORE_SAFE_AUDIT_KEYS = new Set(['key', 'type', 'agentId', 'ttlMs']);
+const OBSERVER_LOG_TOOL = 'fbeast_observer_log';
 
 function normalizeAuditDateString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -666,6 +667,23 @@ function redactMemoryStoreEnvelope(sanitized: Record<string, unknown>, redaction
   return sanitized;
 }
 
+function redactObserverLogArgs(sanitized: Record<string, unknown>, redaction = '[observer-metadata-redacted]'): Record<string, unknown> {
+  if (Object.prototype.hasOwnProperty.call(sanitized, 'metadata')) {
+    sanitized['metadata'] = redaction;
+  }
+  return sanitized;
+}
+
+function redactObserverLogEnvelope(sanitized: Record<string, unknown>, redaction = '[observer-metadata-redacted]'): Record<string, unknown> {
+  if (Object.prototype.hasOwnProperty.call(sanitized, 'args')) {
+    const args = sanitized['args'];
+    sanitized['args'] = isObjectLike(args) && !Array.isArray(args)
+      ? redactObserverLogArgs(args as Record<string, unknown>, redaction)
+      : redaction;
+  }
+  return sanitized;
+}
+
 export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unknown): Record<string, unknown> {
   const sanitized = sanitizeToolArgumentsForAudit(args);
   const unqualifiedToolName = unqualifyMcpToolName(toolName);
@@ -767,6 +785,15 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
     }
     return sanitized;
   }
+  if (auditedTool === OBSERVER_LOG_TOOL || auditedAction === OBSERVER_LOG_TOOL) {
+    if (unqualifiedToolName === 'execute_tool') {
+      return redactObserverLogEnvelope(sanitized);
+    }
+    if (unqualifiedToolName === OBSERVER_LOG_TOOL) {
+      return redactObserverLogArgs(sanitized);
+    }
+    return sanitized;
+  }
   if (auditedTool !== 'fbeast_memory_right_to_forget' && auditedAction !== 'fbeast_memory_right_to_forget') return sanitized;
   if (auditedAction === 'fbeast_memory_right_to_forget' && Object.prototype.hasOwnProperty.call(sanitized, 'context')) {
     sanitized['context'] = '[right-to-forget-args-redacted]';
@@ -845,12 +872,16 @@ export function validateToolArguments(
       return { ok: false, message: `Tool ${tool.name} property ${key} must be a finite number` };
     }
     if (typeof value === 'string') {
-      const length = Array.from(value).length;
+      let length = 0;
+      const codePoints = value[Symbol.iterator]();
+      while (!codePoints.next().done) {
+        length += 1;
+        if (prop.maxLength !== undefined && length > prop.maxLength) {
+          return { ok: false, message: `Tool ${tool.name} property ${key} must be at most ${prop.maxLength} characters` };
+        }
+      }
       if (prop.minLength !== undefined && length < prop.minLength) {
         return { ok: false, message: `Tool ${tool.name} property ${key} must be at least ${prop.minLength} characters` };
-      }
-      if (prop.maxLength !== undefined && length > prop.maxLength) {
-        return { ok: false, message: `Tool ${tool.name} property ${key} must be at most ${prop.maxLength} characters` };
       }
     }
     if (typeof value === 'number' && prop.minimum !== undefined && value < prop.minimum) {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -15,9 +15,21 @@ export interface ToolResult {
   isError?: boolean;
 }
 
+export interface ToolPropertySchema {
+  type: string | readonly string[];
+  description: string;
+  enum?: readonly unknown[];
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  minItems?: number;
+  maxItems?: number;
+}
+
 export interface ToolInputSchema {
   type: 'object';
-  properties: Record<string, { type: string | readonly string[]; description: string; enum?: readonly unknown[] }>;
+  properties: Record<string, ToolPropertySchema>;
   required?: string[];
 }
 
@@ -831,6 +843,27 @@ export function validateToolArguments(
     }
     if ((prop.type === 'number' || (Array.isArray(prop.type) && prop.type.includes('number'))) && typeof value === 'number' && !Number.isFinite(value)) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be a finite number` };
+    }
+    if (typeof value === 'string') {
+      const length = Array.from(value).length;
+      if (prop.minLength !== undefined && length < prop.minLength) {
+        return { ok: false, message: `Tool ${tool.name} property ${key} must be at least ${prop.minLength} characters` };
+      }
+      if (prop.maxLength !== undefined && length > prop.maxLength) {
+        return { ok: false, message: `Tool ${tool.name} property ${key} must be at most ${prop.maxLength} characters` };
+      }
+    }
+    if (typeof value === 'number' && prop.minimum !== undefined && value < prop.minimum) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be at least ${prop.minimum}` };
+    }
+    if (typeof value === 'number' && prop.maximum !== undefined && value > prop.maximum) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must be at most ${prop.maximum}` };
+    }
+    if (Array.isArray(value) && prop.minItems !== undefined && value.length < prop.minItems) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must contain at least ${prop.minItems} items` };
+    }
+    if (Array.isArray(value) && prop.maxItems !== undefined && value.length > prop.maxItems) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must contain at most ${prop.maxItems} items` };
     }
     if (prop.enum && !prop.enum.includes(value)) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be one of: ${prop.enum.join(', ')}` };

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -675,10 +675,19 @@ function redactObserverLogArgs(sanitized: Record<string, unknown>, redaction = '
 }
 
 function redactObserverLogEnvelope(sanitized: Record<string, unknown>, redaction = '[observer-metadata-redacted]'): Record<string, unknown> {
+  if (Object.prototype.hasOwnProperty.call(sanitized, 'metadata')) {
+    sanitized['metadata'] = redaction;
+  }
   if (Object.prototype.hasOwnProperty.call(sanitized, 'args')) {
     const args = sanitized['args'];
     sanitized['args'] = isObjectLike(args) && !Array.isArray(args)
       ? redactObserverLogArgs(args as Record<string, unknown>, redaction)
+      : redaction;
+  }
+  if (Object.prototype.hasOwnProperty.call(sanitized, 'context')) {
+    const context = sanitized['context'];
+    sanitized['context'] = isObjectLike(context) && !Array.isArray(context)
+      ? redactObserverLogArgs(context as Record<string, unknown>, redaction)
       : redaction;
   }
   return sanitized;
@@ -786,13 +795,10 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
     return sanitized;
   }
   if (auditedTool === OBSERVER_LOG_TOOL || auditedAction === OBSERVER_LOG_TOOL) {
-    if (unqualifiedToolName === 'execute_tool') {
-      return redactObserverLogEnvelope(sanitized);
-    }
     if (unqualifiedToolName === OBSERVER_LOG_TOOL) {
       return redactObserverLogArgs(sanitized);
     }
-    return sanitized;
+    return redactObserverLogEnvelope(sanitized);
   }
   if (auditedTool !== 'fbeast_memory_right_to_forget' && auditedAction !== 'fbeast_memory_right_to_forget') return sanitized;
   if (auditedAction === 'fbeast_memory_right_to_forget' && Object.prototype.hasOwnProperty.call(sanitized, 'context')) {
@@ -871,7 +877,7 @@ export function validateToolArguments(
     if ((prop.type === 'number' || (Array.isArray(prop.type) && prop.type.includes('number'))) && typeof value === 'number' && !Number.isFinite(value)) {
       return { ok: false, message: `Tool ${tool.name} property ${key} must be a finite number` };
     }
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && (prop.minLength !== undefined || prop.maxLength !== undefined)) {
       let length = 0;
       const codePoints = value[Symbol.iterator]();
       while (!codePoints.next().done) {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -703,8 +703,9 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
   const isDirectMemoryReviewDecide = unqualifiedToolName === MEMORY_REVIEW_DECIDE_TOOL;
   const isDirectMemorySourceAttribution = unqualifiedToolName === MEMORY_SOURCE_ATTRIBUTION_TOOL;
   const isDirectMemoryStore = unqualifiedToolName === MEMORY_STORE_TOOL;
+  const isDirectObserverLog = unqualifiedToolName === OBSERVER_LOG_TOOL;
   const isDirectRightToForget = unqualifiedToolName === 'fbeast_memory_right_to_forget';
-  const auditedTool = isDirectMemoryExport || isDirectMemoryRetentionReport || isDirectMemoryAccessAuditReport || isDirectMemoryReviewDecide || isMemoryReviewPropose || isDirectMemoryStore || isDirectMemorySourceAttribution || isDirectRightToForget
+  const auditedTool = isDirectMemoryExport || isDirectMemoryRetentionReport || isDirectMemoryAccessAuditReport || isDirectMemoryReviewDecide || isMemoryReviewPropose || isDirectMemoryStore || isDirectMemorySourceAttribution || isDirectObserverLog || isDirectRightToForget
     ? unqualifiedToolName
     : typeof sanitized['tool'] === 'string'
       ? unqualifyMcpToolName(sanitized['tool'])
@@ -841,6 +842,41 @@ function typeDescription(type: string | readonly string[]): string {
   return typeof type === 'string' ? type : type.join(' or ');
 }
 
+function exceedsStringCodePointLimit(value: string, maximum: number): boolean {
+  let length = 0;
+  const codePoints = value[Symbol.iterator]();
+  while (!codePoints.next().done) {
+    length += 1;
+    if (length > maximum) return true;
+  }
+  return false;
+}
+
+function sanitizeRejectedToolArgumentsForAudit(tool: ToolSchemaDef, args: unknown): Record<string, unknown> {
+  if (!isObjectLike(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
+  if (!isPlainJsonObject(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
+  const bounded: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  const descriptors = Object.getOwnPropertyDescriptors(args);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string') continue;
+    const descriptor = descriptors[key];
+    if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
+      bounded[key] = '[accessor]';
+      continue;
+    }
+    const value = descriptor.value;
+    const property = tool.inputSchema.properties[key];
+    if (property?.maxLength !== undefined && typeof value === 'string' && exceedsStringCodePointLimit(value, property.maxLength)) {
+      bounded[key] = '[schema-bound-exceeded]';
+    } else if (property?.maxItems !== undefined && Array.isArray(value) && value.length > property.maxItems) {
+      bounded[key] = '[schema-bound-exceeded]';
+    } else {
+      bounded[key] = value;
+    }
+  }
+  return sanitizeToolArgumentsForAuditTrail(tool.name, bounded);
+}
+
 export function validateToolArguments(
   tool: ToolSchemaDef,
   args: unknown,
@@ -849,6 +885,14 @@ export function validateToolArguments(
     return { ok: false, message: `Tool ${tool.name} expects an object argument` };
   }
   const obj = args as Record<string, unknown>;
+  const schema = tool.inputSchema;
+  const descriptors = Object.getOwnPropertyDescriptors(obj);
+  for (const [key, property] of Object.entries(schema.properties)) {
+    const descriptor = descriptors[key];
+    if (descriptor && 'value' in descriptor && Array.isArray(descriptor.value) && property.maxItems !== undefined && descriptor.value.length > property.maxItems) {
+      return { ok: false, message: `Tool ${tool.name} property ${key} must contain at most ${property.maxItems} items` };
+    }
+  }
   // The proxy wrapper validates only its envelope here. Its nested `args`
   // payload is validated after target resolution so governance/audit can record
   // the real target tool instead of the generic execute_tool wrapper.
@@ -856,8 +900,7 @@ export function validateToolArguments(
   if (!shape.ok) {
     return { ok: false, message: `Tool ${tool.name} rejected unsafe argument shape: ${shape.message}` };
   }
-  const descriptors = Object.getOwnPropertyDescriptors(obj);
-  const schema = tool.inputSchema;
+
   for (const req of schema.required ?? []) {
     const descriptor = descriptors[req];
     if (!descriptor || descriptor.value === undefined) {
@@ -933,12 +976,11 @@ async function dispatchTool(
       process.stderr.write(`fbeast audit failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`);
     }
   };
-  // Normalize the raw payload to an object so a malformed (null/array/scalar)
-  // probe is still captured in the audit record rather than dropped.
-  const rawArgs = sanitizeToolArgumentsForAuditTrail(toolName, args);
-
   const tool = toolMap.get(toolName);
   if (!tool) {
+    // Normalize the raw payload to an object so a malformed
+    // (null/array/scalar) unknown-tool probe is still captured.
+    const rawArgs = sanitizeToolArgumentsForAuditTrail(toolName, args);
     await recordAudit({ ok: false, decision: 'unknown_tool', args: rawArgs });
     return { content: [{ type: 'text' as const, text: `Unknown tool: ${toolName}` }], isError: true };
   }
@@ -946,7 +988,7 @@ async function dispatchTool(
   // non-object) on the wire must reach the validator and be rejected.
   const validated = validateToolArguments(tool, args === undefined ? {} : args);
   if (!validated.ok) {
-    await recordAudit({ ok: false, decision: 'validation_error', args: rawArgs });
+    await recordAudit({ ok: false, decision: 'validation_error', args: sanitizeRejectedToolArgumentsForAudit(tool, args) });
     return { content: [{ type: 'text' as const, text: `Error: ${validated.message}` }], isError: true };
   }
   // Central governance gate: enforced server-side regardless of client hooks.

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -852,7 +852,7 @@ function exceedsStringCodePointLimit(value: string, maximum: number): boolean {
   return false;
 }
 
-function sanitizeRejectedToolArgumentsForAudit(tool: ToolSchemaDef, args: unknown): Record<string, unknown> {
+export function sanitizeRejectedToolArgumentsForAudit(tool: ToolSchemaDef, args: unknown): Record<string, unknown> {
   if (!isObjectLike(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
   if (!isPlainJsonObject(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
   const bounded: Record<string, unknown> = Object.create(null) as Record<string, unknown>;

--- a/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.test.ts
@@ -33,6 +33,26 @@ describe('TOOL_REGISTRY', () => {
     }
   });
 
+  it('publishes explicit bounds for high-risk memory and observer inputs', () => {
+    const memoryQuery = TOOL_REGISTRY.get('fbeast_memory_query')!.inputSchema.properties;
+    expect(memoryQuery['query']).toMatchObject({ minLength: 1, maxLength: 4096 });
+    expect(memoryQuery['limit']).toMatchObject({
+      type: 'string',
+      minLength: 1,
+      maxLength: 16,
+    });
+
+    const observerLog = TOOL_REGISTRY.get('fbeast_observer_log')!.inputSchema.properties;
+    expect(observerLog['event']).toMatchObject({ minLength: 1, maxLength: 256 });
+    expect(observerLog['metadata']).toMatchObject({ maxLength: 1_000_000 });
+    expect(observerLog['sessionId']).toMatchObject({ minLength: 1, maxLength: 256 });
+
+    const observerCost = TOOL_REGISTRY.get('fbeast_observer_log_cost')!.inputSchema.properties;
+    expect(observerCost['promptTokens']).toMatchObject({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER });
+    expect(observerCost['completionTokens']).toMatchObject({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER });
+    expect(observerCost['costUsd']).toMatchObject({ minimum: 0 });
+  });
+
   it('all tools have a makeHandler function', () => {
     for (const [name, tool] of TOOL_REGISTRY) {
       expect(typeof tool.makeHandler, `${name} makeHandler is not a function`).toBe('function');

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -458,9 +458,9 @@ const TOOLS: ToolFull[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        query: { type: 'string', description: 'Search query (substring match on key and value)' },
+        query: { type: 'string', description: 'Search query (substring match on key and value)', minLength: 1, maxLength: 4096 },
         type: { type: 'string', description: 'Filter by type: working or episodic', enum: ['working', 'episodic'] },
-        limit: { type: 'string', description: 'Max results as a positive integer from 1 to 1000 (default 20)' },
+        limit: { type: 'string', description: 'Max results as a positive integer from 1 to 1000 (default 20)', minLength: 1, maxLength: 16 },
         readScope: { type: 'string', description: 'Read scope: all (legacy), shared (hide agent-scoped entries), or agent (shared plus entries for agentId)', enum: ['all', 'shared', 'agent'] },
         agentId: { type: 'string', description: 'Agent id required when readScope is agent' },
       },
@@ -1098,9 +1098,9 @@ const TOOLS: ToolFull[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        event: { type: 'string', description: 'Event type (e.g., file_edit, tool_call, decision)' },
-        metadata: { type: 'string', description: 'JSON metadata for this event' },
-        sessionId: { type: 'string', description: 'Session identifier' },
+        event: { type: 'string', description: 'Event type (e.g., file_edit, tool_call, decision)', minLength: 1, maxLength: 256 },
+        metadata: { type: 'string', description: 'JSON metadata for this event', maxLength: 1_000_000 },
+        sessionId: { type: 'string', description: 'Session identifier', minLength: 1, maxLength: 256 },
       },
       required: ['event', 'metadata', 'sessionId'],
     },
@@ -1131,11 +1131,11 @@ const TOOLS: ToolFull[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        sessionId: { type: 'string', description: 'Session identifier' },
-        model: { type: 'string', description: 'Model name (e.g. gpt-4o, claude-opus-4-5)' },
-        promptTokens: { type: 'number', description: 'Input/prompt token count' },
-        completionTokens: { type: 'number', description: 'Output/completion token count' },
-        costUsd: { type: 'number', description: 'Actual cost in USD if known — omit to auto-calculate from pricing table' },
+        sessionId: { type: 'string', description: 'Session identifier', minLength: 1, maxLength: 256 },
+        model: { type: 'string', description: 'Model name (e.g. gpt-4o, claude-opus-4-5)', minLength: 1, maxLength: 256 },
+        promptTokens: { type: 'number', description: 'Input/prompt token count', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+        completionTokens: { type: 'number', description: 'Output/completion token count', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+        costUsd: { type: 'number', description: 'Actual cost in USD if known — omit to auto-calculate from pricing table', minimum: 0 },
       },
       required: ['sessionId', 'model', 'promptTokens', 'completionTokens'],
     },
@@ -1157,7 +1157,7 @@ const TOOLS: ToolFull[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        sessionId: { type: 'string', description: 'Session ID to filter (omit for all sessions)' },
+        sessionId: { type: 'string', description: 'Session ID to filter (omit for all sessions)', minLength: 1, maxLength: 256 },
       },
     },
     makeHandler: ({ observer }) => async (args) => {


### PR DESCRIPTION
## Summary
- add JSON Schema-style string, number, and array bounds to shared MCP tool schemas
- enforce bounds centrally before tool handlers run
- bound memory query and observer tool inputs

## Validation
- `npx vitest run --reporter=dot` (550 tests)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite`
- `npm run build`

Closes #3199