### PR TITLE
fix(workspaces): link all local packages

### DIFF
--- a/docs/guides/fix-github-issues.md
+++ b/docs/guides/fix-github-issues.md
@@ -11,7 +11,9 @@
   npm run local:verify-cli
   ```
 
-  `local:link` builds the repo and links the workspaces that expose the `fbeast` and `frankenbeast` binaries. If you do not want global links, build the full checkout first and use `--help` as the setup smoke test:
+  `local:link` builds the repo and links every workspace, including those that
+  expose the `fbeast` and `frankenbeast` binaries. If you do not want global
+  links, build the full checkout first and use `--help` as the setup smoke test:
 
   ```bash
   npm run build

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -110,10 +110,10 @@ When a worker or contributor needs a narrower verification command, use the [tes
 ## 5. Try the orchestrator CLI
 
 The repository root is private and does not publish a root `frankenbeast` binary
-for `npx` to resolve. Link the local workspace CLIs first; the `local:link`
-script builds the packages and links both `@franken/orchestrator` and
-`@franken/mcp-suite` so `frankenbeast`, `franken`, `frkn`, and `fbeast` are on
-your PATH.
+for `npx` to resolve. Link the local workspaces first; the `local:link` script
+builds and links every workspace so their current local packages are available,
+including the `frankenbeast`, `franken`, `frkn`, `fbeast`, and
+`fbeast-live-bench` binaries on your PATH.
 
 ```bash
 # Build and link the local workspace binaries once from the repo root
@@ -142,7 +142,7 @@ frankenbeast issues --repo owner/repo --dry-run
 The `fbeast` binary ships from the `@franken/mcp-suite` package (there is no package named `fbeast`). Install it persistently so both `fbeast` and the `fbeast-*` MCP server binaries stay on PATH — `mcp init` registers servers as bare `fbeast-memory`/`fbeast-proxy` commands the AI client spawns later, so a one-shot `npx` would leave those servers unable to start:
 
 ```bash
-# Install once (global), or link both local CLIs from the monorepo with: npm run local:link
+# Install once (global), or link the local workspaces from the monorepo with: npm run local:link
 npm install -g @franken/mcp-suite
 
 # Standard MCP registration

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:any": "node scripts/audit-explicit-any.mjs",
     "lint:security": "node scripts/check-plain-http.mjs && node scripts/check-hardcoded-secrets.mjs && node scripts/audit-todo-markers.mjs",
     "audit:todos": "node scripts/audit-todo-markers.mjs",
-    "local:link": "npm run build && npm link --workspace=@franken/mcp-suite --workspace=@franken/orchestrator",
+    "local:link": "npm run build && npm link --workspaces",
     "local:seed": "tsx scripts/seed.ts",
     "local:verify-cli": "fbeast --help && fbeast mcp --help && frankenbeast --help",
     "local:verify-setup": "node scripts/verify-setup.mjs --require-services",

--- a/tests/docs-issue-1023.test.ts
+++ b/tests/docs-issue-1023.test.ts
@@ -14,7 +14,7 @@ describe('issue #1023 GitHub issues guide CLI setup docs', () => {
     const packageJson = readJson<{ scripts?: Record<string, string> }>('package.json');
     const orchestratorPackage = readJson<{ bin?: Record<string, string> }>('packages/franken-orchestrator/package.json');
 
-    expect(packageJson.scripts?.['local:link']).toContain('--workspace=@franken/orchestrator');
+    expect(packageJson.scripts?.['local:link']).toContain('--workspaces');
     expect(orchestratorPackage.bin).toHaveProperty('frankenbeast');
 
     expect(guide).toContain('npm run local:link');

--- a/tests/docs-issue-961.test.ts
+++ b/tests/docs-issue-961.test.ts
@@ -26,7 +26,7 @@ describe('issue #961 local CLI linking docs', () => {
     const packageJson = readJson<{ scripts?: Record<string, string> }>('package.json');
 
     expect(packageJson.scripts?.['local:link']).toBe(
-      'npm run build && npm link --workspace=@franken/mcp-suite --workspace=@franken/orchestrator',
+      'npm run build && npm link --workspaces',
     );
 
     for (const docPath of LOCAL_LINK_DOCS) {

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -81,6 +81,12 @@ describe("npm workspaces configuration", () => {
       expect(rootPkg.workspaces).toEqual(["packages/*"]);
     });
 
+    it("links every workspace for local development", () => {
+      expect(rootPkg.scripts?.["local:link"]).toBe(
+        "npm run build && npm link --workspaces",
+      );
+    });
+
     it("derives the complete package inventory from the workspace glob", () => {
       const packageDirs = readdirSync(join(ROOT, "packages"), {
         withFileTypes: true,


### PR DESCRIPTION
## Summary
- link every npm workspace through the root `local:link` helper
- update local setup documentation to describe the complete workspace scope
- add and update regression coverage for the canonical command

## Test plan
- `npm run test:root` (582 passed, 1 skipped)
- `npm run build`
- `npm run typecheck`
- `npm run lint` (passes with pre-existing warnings)
- `npm link --workspaces --dry-run --json` (enumerates all 10 workspaces)

Closes #3246