### PR TITLE
fix(mcp): close observer resources on shutdown

### DIFF
--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -100,6 +100,24 @@ For Beast controls, run the orchestrator/backend setup flow with `frankenbeast i
 
 All servers share `.fbeast/beast.db` (SQLite, WAL mode). Memory frontload is scoped to that database: use a separate database per project when project isolation is required.
 
+### Programmatic lifecycle
+
+Programmatic callers that create an observer adapter or MCP server should close the owner during shutdown. `close()` is idempotent and releases the observer's SQLite handle; MCP server shutdown also closes its owned audit/observer resources.
+
+```ts
+const observer = createObserverAdapter('.fbeast/beast.db');
+try {
+  await observer.log({ event: 'tool_call', metadata: '{}', sessionId: 'session-1' });
+} finally {
+  observer.close?.();
+}
+
+const serverObserver = createObserverAdapter('.fbeast/beast.db');
+const server = createObserverServer({ observer: serverObserver });
+await server.start();
+await server.close();
+```
+
 Memory reads support explicit per-agent scope controls on `fbeast_memory_query` and `fbeast_memory_frontload`:
 
 - omit `readScope` or set `readScope: "all"` for legacy behavior;

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -59,6 +59,16 @@ describe('ObserverAdapter', () => {
     dbPaths.length = 0;
   });
 
+  it('closes its SQLite handle through the public lifecycle', async () => {
+    const observer = createObserverAdapter(tracked(tmpDbPath()));
+
+    await observer.log({ event: 'tool_call', metadata: '{}', sessionId: 'close-test' });
+    observer.close?.();
+    expect(() => observer.close?.()).not.toThrow();
+
+    await expect(observer.trail('close-test')).rejects.toThrow(/database connection is not open/i);
+  });
+
   it('chains later audit hashes through the previous entry hash', async () => {
     const secondHashFrom = async (firstMetadata: string): Promise<string> => {
       const observer = createObserverAdapter(tracked(tmpDbPath()));

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -70,6 +70,8 @@ export interface ObserverAdapter {
   cost(input: { sessionId?: string }): Promise<ObserverCostSummary>;
   trail(sessionId: string): Promise<ObserverTrailEntry[]>;
   verify(sessionId: string): Promise<ObserverVerifyResult>;
+  /** Release the adapter's SQLite handle when its owner shuts down. */
+  close?(): void;
 }
 
 function hasDefaultPricing(model: string): boolean {
@@ -88,6 +90,7 @@ function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; m
 
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
+  let closed = false;
   const costCalculator = new CostCalculator(DEFAULT_PRICING, {
     onUnknownModel: (model) => {
       process.stderr.write(`[fbeast-observer] Unknown model "${model}" — cost will be recorded as $0.0000 until pricing is configured.\n`);
@@ -202,6 +205,12 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
 
     async verify(sessionId) {
       return verifyAuditTrail(store, sessionId, { migrate: true });
+    },
+
+    close() {
+      if (closed) return;
+      closed = true;
+      store.close();
     },
   };
 }

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -2,6 +2,24 @@ import { describe, it, expect, vi } from 'vitest';
 import { createObserverServer } from './observer.js';
 
 describe('Observer Server', () => {
+  it('closes the observer adapter when the server shuts down', async () => {
+    const close = vi.fn();
+    const server = createObserverServer({
+      observer: {
+        log: vi.fn(),
+        logCost: vi.fn(),
+        cost: vi.fn(),
+        trail: vi.fn(),
+        verify: vi.fn(),
+        close,
+      },
+    });
+
+    await server.close();
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
   it('exposes 5 tools', () => {
     const server = createObserverServer({
       observer: {

--- a/packages/franken-mcp-suite/src/servers/observer.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.ts
@@ -14,7 +14,16 @@ export interface ObserverServerDeps {
 
 export function createObserverServer(deps: ObserverServerDeps, options: CreateMcpServerOptions = {}): FbeastMcpServer {
   const tools = createToolDefsForServer('observer', deps);
-  return createMcpServer('fbeast-observer', '0.1.0', tools, options);
+  return createMcpServer('fbeast-observer', '0.1.0', tools, {
+    ...options,
+    onClose() {
+      try {
+        deps.observer.close?.();
+      } finally {
+        options.onClose?.();
+      }
+    },
+  });
 }
 
 if (isMain(import.meta.url)) {

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -182,8 +182,16 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
         return audit.record(event);
       }
     },
+    close() {
+      audit.close?.();
+    },
   };
-  return createMcpServer('fbeast-proxy', '0.1.0', tools, { audit: wrapperAudit });
+  return createMcpServer('fbeast-proxy', '0.1.0', tools, {
+    audit: wrapperAudit,
+    onClose() {
+      cachedAdapters?.observer.close?.();
+    },
+  });
 }
 
 // CLI entry point

--- a/packages/franken-mcp-suite/src/shared/central-enforcement.ts
+++ b/packages/franken-mcp-suite/src/shared/central-enforcement.ts
@@ -62,6 +62,9 @@ export function createAuditSink(source: string | ObserverAdapter): AuditSink {
         sessionId: resolveSessionId(),
       });
     },
+    close() {
+      observer?.close?.();
+    },
   };
 }
 

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createMcpServer, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type ToolDef, type GovernanceGate, type AuditSink } from './server-factory.js';
 
 describe('createMcpServer', () => {
@@ -6,6 +6,21 @@ describe('createMcpServer', () => {
     const server = createMcpServer('fbeast-memory', '0.1.0', []);
     expect(server).toBeDefined();
     expect(server.name).toBe('fbeast-memory');
+  });
+
+  it('runs close lifecycle callbacks exactly once', async () => {
+    const onClose = vi.fn();
+    const auditClose = vi.fn();
+    const server = createMcpServer('fbeast-memory', '0.1.0', [], {
+      onClose,
+      audit: { record: vi.fn(), close: auditClose },
+    });
+
+    await server.close();
+    await server.close();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(auditClose).toHaveBeenCalledTimes(1);
   });
 
   it('registers tools from definitions', () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -48,6 +48,8 @@ export interface FbeastMcpServer {
   /** Invoke a tool through the same validation gate the MCP CallTool path uses. */
   callTool(name: string, args: unknown): Promise<ToolResult>;
   start(): Promise<void>;
+  /** Close the transport and release server-owned resources. */
+  close(): Promise<void>;
 }
 
 export interface GovernanceDecision {
@@ -86,6 +88,8 @@ export interface AuditSink {
     /** Validated call arguments, so the trail records *what* was attempted. */
     args?: Record<string, unknown>;
   }): Promise<void> | void;
+  /** Release resources owned by the sink, when applicable. */
+  close?(): void;
 }
 
 export interface CreateMcpServerOptions {
@@ -101,6 +105,8 @@ export interface CreateMcpServerOptions {
    * giving the central path a server-side audit trail independent of hooks.
    */
   audit?: AuditSink;
+  /** Release resources owned by the caller when the MCP connection closes. */
+  onClose?: () => void;
   /** Default execution deadline for each tool call. Defaults to 30 seconds. */
   defaultToolTimeoutMs?: number;
 }
@@ -925,6 +931,23 @@ export function createMcpServer(
   validateToolDeadlineConfiguration(tools, options);
   const server = new Server({ name, version }, { capabilities: { tools: {} } });
   const toolMap = new Map(tools.map((t) => [t.name, t]));
+  let closed = false;
+  const closeResources = (): void => {
+    if (closed) return;
+    closed = true;
+    const errors: unknown[] = [];
+    for (const close of [options.onClose, options.audit?.close?.bind(options.audit)]) {
+      if (!close) continue;
+      try {
+        close();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, `Failed to close ${name} resources`);
+  };
+  server.onclose = closeResources;
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: tools.map((t) => ({
@@ -946,6 +969,13 @@ export function createMcpServer(
     async start() {
       const transport = new StdioServerTransport();
       await server.connect(transport);
+    },
+    async close() {
+      try {
+        await server.close();
+      } finally {
+        closeResources();
+      }
     },
   };
 }

--- a/tasks/issue-3201-observer-close-lifecycle-progress.md
+++ b/tasks/issue-3201-observer-close-lifecycle-progress.md
@@ -1,0 +1,13 @@
+# Issue #3201 Observer close lifecycle progress
+
+- [x] Inspect issue acceptance criteria and shared project lessons.
+- [x] Trace every MCP server path that creates or owns an `ObserverAdapter`.
+- [x] Add a failing adapter-level SQLite close regression test.
+- [x] Add server lifecycle callback and observer shutdown regression tests.
+- [x] Expose an idempotent optional `ObserverAdapter.close()` method.
+- [x] Wire SDK transport shutdown and explicit server shutdown to owned resources.
+- [x] Forward cleanup through combined-server audit and proxy adapter paths.
+- [x] Document programmatic lifecycle ownership.
+- [x] Run targeted tests and MCP-suite tests, typecheck, lint, and builds.
+- [ ] Open the issue PR and complete CI/Codex review gates.
+- [ ] Merge and record the terminal Kanban handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-18 — MCP-owned SQLite lifecycle
+- When an MCP server owns or lazily creates a SQLite-backed adapter, expose an idempotent adapter `close()` and connect it to the SDK server's `onclose` path as well as an explicit public server `close()`. Central audit wrappers must forward cleanup, and proxy servers must release both their audit observer and any lazily-created adapter set.
+- In fresh monorepo worktrees, build internal workspace packages before package-level TypeScript checks; otherwise missing generated `dist` declarations produce unrelated module-resolution errors.
+
 ## 2026-07-18 — MCP execution deadline review fixes
 - A `Promise.race` timer cannot preempt synchronous handler work because the event loop is blocked; deadline wrappers must re-check wall-clock time after handler resolution/rejection and convert late completion into the same structured timeout while aborting the supplied signal. Keep that timer ref'ed so in-process callers with no other active handles still receive the timeout result.
 - Nested dispatch wrappers must have a deadline strictly longer than the longest inner target deadline, including validation/governance/audit slack, or the wrapper can win the timeout race and lose resolved-target timeout auditing.


### PR DESCRIPTION
## Summary
- expose an idempotent close lifecycle on the SQLite-backed ObserverAdapter
- close observer and audit resources from explicit MCP server close and SDK transport shutdown
- wire combined/proxy server ownership paths and document programmatic lifecycle use

## Test plan
- `npm run test --workspace @franken/mcp-suite` (549 passed)
- `npm run build`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (0 errors; 27 pre-existing warnings)
- `npm run build --workspace @franken/mcp-suite`

Closes #3201