### PR TITLE
fix(web): surface initial network config load failures

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -307,6 +307,17 @@ describe('ChatShell route heading', () => {
     expect(screen.queryByDisplayValue('stale-model')).toBeNull();
   });
 
+  it('surfaces an initial config load failure without rendering fabricated defaults', async () => {
+    networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
+    networkApiMocks.getConfig.mockRejectedValueOnce(new Error('HTTP 503'));
+
+    render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to load network config: HTTP 503');
+    expect(screen.queryByRole('button', { name: 'Save config' })).toBeNull();
+    expect(screen.queryByDisplayValue('claude-sonnet-4-6')).toBeNull();
+  });
+
   it('surfaces failed config refreshes from the Network page', async () => {
     networkApiMocks.getStatus.mockResolvedValue({ mode: 'secure', secureBackend: 'local-encrypted', services: [] });
     networkApiMocks.getConfig

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -132,10 +132,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     secureBackend: 'local-encrypted',
     services: [],
   });
-  const [networkConfig, setNetworkConfig] = useState<NetworkConfigResponse>({
-    network: { mode: 'secure', secureBackend: 'local-encrypted' },
-    chat: { model: 'claude-sonnet-4-6', enabled: true, host: '127.0.0.1', port: 3737 },
-  });
+  const [networkConfig, setNetworkConfig] = useState<NetworkConfigResponse | null>(null);
   const [networkLogs, setNetworkLogs] = useState<string[]>([]);
   const [selectedNetworkLogServiceId, setSelectedNetworkLogServiceId] = useState<string | undefined>(undefined);
   const [networkLogsLoading, setNetworkLogsLoading] = useState(false);
@@ -207,6 +204,8 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
 
   useEffect(() => {
     const client = new NetworkApiClient(baseUrl);
+    setNetworkConfig(null);
+    setNetworkConfigError(null);
     const statusRequestId = ++networkStatusRequestIdRef.current;
     void client.getStatus()
       .then((nextStatus) => {
@@ -228,9 +227,14 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       .then((nextConfig) => {
         if (configRequestId === networkConfigRequestIdRef.current) {
           setNetworkConfig(nextConfig);
+          setNetworkConfigError(null);
         }
       })
-      .catch(() => undefined);
+      .catch((error: unknown) => {
+        if (configRequestId === networkConfigRequestIdRef.current) {
+          setNetworkConfigError(`Unable to load network config: ${networkErrorMessage(error, 'Request failed.')}`);
+        }
+      });
   }, [baseUrl]);
 
   const composerSessionKey = preserveComposerDraft
@@ -1103,6 +1107,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
         ) : route === 'network' ? (
           <NetworkPage
             config={networkConfig}
+            configError={networkConfigError}
             error={networkError ?? networkConfigError}
             logs={networkLogs}
             logsError={networkLogsError}

--- a/packages/franken-web/src/pages/network-page.tsx
+++ b/packages/franken-web/src/pages/network-page.tsx
@@ -12,7 +12,8 @@ interface NetworkPageProps {
   selectedLogServiceId?: string;
   logsLoading?: boolean;
   logsError?: string | null;
-  config: NetworkConfigResponse;
+  config: NetworkConfigResponse | null;
+  configError?: string | null;
   onRefresh(): void;
   onStart(serviceId: string): Promise<void> | void;
   onStop(serviceId: string): Promise<void> | void;
@@ -30,6 +31,7 @@ export function NetworkPage({
   logsLoading,
   logsError,
   config,
+  configError = null,
   onRefresh,
   onStart,
   onStop,
@@ -62,7 +64,16 @@ export function NetworkPage({
         </div>
 
         <div className="network-page__rail">
-          <NetworkConfigEditor config={config} onSave={onSaveConfig} />
+          {config ? (
+            <NetworkConfigEditor config={config} onSave={onSaveConfig} />
+          ) : (
+            <section className="rail-card network-config-editor" aria-busy={!configError}>
+              <div className="rail-card__header">
+                <p className="eyebrow">Config</p>
+              </div>
+              <p>{configError ? 'Network config unavailable. Refresh to retry.' : 'Loading network config…'}</p>
+            </section>
+          )}
           <NetworkLogsPanel
             error={logsError}
             isLoading={logsLoading}


### PR DESCRIPTION
## Summary
- represent network config as unloaded until the API returns real server data
- surface initial config fetch failures and keep the config editor unavailable instead of showing fabricated defaults
- add regression coverage for the initial failure path

## Test plan
- `npm test` (packages/franken-web; 641 passed)
- `npm run typecheck` (packages/franken-web)
- `npm run lint` (packages/franken-web; 0 errors, 18 pre-existing warnings)
- `npm run build` (packages/franken-web)

Closes #3195