### PR TITLE
fix(orchestrator): require MCP handshake for healthy skills

### DIFF
--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -25,6 +25,8 @@ export interface SkillHealthOptions {
 
 const UNTRUSTED_HEALTH_CHECK_MESSAGE =
   'MCP health check command was not executed because the skill is not trusted';
+const INCOMPLETE_HANDSHAKE_MESSAGE =
+  'MCP initialize handshake was not completed before the command exited';
 
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const MCP_INITIALIZE_ID = 1;
@@ -32,6 +34,11 @@ const MCP_INITIALIZE_ID = 1;
 interface HealthCheckMcpServerConfig {
   command: string;
   args?: string[] | undefined;
+}
+
+interface HealthCheckOutcome {
+  status: McpHealthStatus;
+  error?: string;
 }
 
 /**
@@ -58,11 +65,11 @@ export class SkillHealthChecker {
           }
 
           try {
-            const status = await this.checkServer(
+            const outcome = await this.checkServer(
               config.command,
               config.args ?? [],
             );
-            return { serverName, status };
+            return { serverName, ...outcome };
           } catch (err) {
             return {
               serverName,
@@ -89,7 +96,7 @@ export class SkillHealthChecker {
   private checkServer(
     command: string,
     args: string[],
-  ): Promise<McpHealthStatus> {
+  ): Promise<HealthCheckOutcome> {
     return new Promise((resolve) => {
       let proc: ChildProcessWithoutNullStreams;
       let settled = false;
@@ -98,7 +105,10 @@ export class SkillHealthChecker {
 
       const settle = (
         status: McpHealthStatus,
-        { killRunningProcess = true }: { killRunningProcess?: boolean } = {},
+        {
+          killRunningProcess = true,
+          error,
+        }: { killRunningProcess?: boolean; error?: string } = {},
       ) => {
         if (settled) {
           return;
@@ -108,7 +118,7 @@ export class SkillHealthChecker {
         if (killRunningProcess && proc.exitCode === null && !proc.killed) {
           proc.kill();
         }
-        resolve(status);
+        resolve({ status, ...(error === undefined ? {} : { error }) });
       };
 
       try {
@@ -127,14 +137,17 @@ export class SkillHealthChecker {
         });
 
         proc.on('close', (code) => {
-          settle(code === 0 ? 'connected' : 'error', { killRunningProcess: false });
+          settle(code === 0 ? 'unknown' : 'error', {
+            killRunningProcess: false,
+            ...(code === 0 ? { error: INCOMPLETE_HANDSHAKE_MESSAGE } : {}),
+          });
         });
 
         proc.stdin.on('error', () => {
           // Defer to the process error/close/timeout paths. Some commands exit
           // successfully before reading the initialize probe; in that case the
-          // stdin stream can emit EPIPE before close(0), and the clean-exit
-          // fallback should remain connected.
+          // stdin stream can emit EPIPE before close(0), which remains unknown
+          // because no MCP handshake completed.
         });
 
         proc.stdout.on('data', (chunk: Buffer | string) => {
@@ -165,7 +178,7 @@ export class SkillHealthChecker {
           },
         }));
       } catch {
-        resolve('error');
+        resolve({ status: 'error' });
       }
     });
   }

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -64,7 +64,7 @@ describe('SkillHealthChecker', () => {
     ]);
   });
 
-  it('returns connected when a trusted server exits cleanly', async () => {
+  it('returns unknown with a diagnostic when a trusted command exits cleanly without an MCP handshake', async () => {
     const config: McpConfig = {
       mcpServers: {
         github: { command: 'echo', args: ['ok'] },
@@ -72,8 +72,14 @@ describe('SkillHealthChecker', () => {
     };
     const result = await checker.getStatus('github', config, { trustMcpServerCommands: true });
     expect(result.name).toBe('github');
-    expect(result.status).toBe('connected');
-    expect(result.serverStatuses).toHaveLength(1);
+    expect(result.status).toBe('unknown');
+    expect(result.serverStatuses).toEqual([
+      {
+        serverName: 'github',
+        status: 'unknown',
+        error: 'MCP initialize handshake was not completed before the command exited',
+      },
+    ]);
   });
 
   it('returns connected when a long-running trusted MCP server responds to initialize', async () => {
@@ -117,7 +123,7 @@ describe('SkillHealthChecker', () => {
     expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('defers stdin EPIPE to the process close status', async () => {
+  it('defers stdin EPIPE to an unknown clean-exit result', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();
     proc.stdin.write.mockImplementation(() => {
@@ -137,7 +143,11 @@ describe('SkillHealthChecker', () => {
 
     const result = await checker.getStatus('epipe', config, { trustMcpServerCommands: true });
 
-    expect(result.status).toBe('connected');
+    expect(result.status).toBe('unknown');
+    expect(result.serverStatuses[0]).toMatchObject({
+      status: 'unknown',
+      error: 'MCP initialize handshake was not completed before the command exited',
+    });
   });
 
   it('parses framed initialize responses by UTF-8 byte length', async () => {


### PR DESCRIPTION
## Summary
- classify trusted commands that exit zero without completing MCP initialize as unknown
- return a clear per-server diagnostic for incomplete handshakes
- preserve connected status only for successful initialize responses

## Test plan
- `npm --workspace @franken/orchestrator test -- --run tests/unit/skills/skill-health-checker.test.ts`
- `npm --workspace @franken/orchestrator test`
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run lint`
- `npm run build`

Closes #3179