### PR TITLE
fix(orchestrator): cap Gemini retry delays

### DIFF
--- a/packages/franken-orchestrator/src/skills/providers/gemini-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/gemini-provider.ts
@@ -13,6 +13,18 @@ import { sanitizeRunConfigIntegrityEnv } from '../../cli/run-config-integrity.js
 const RATE_LIMIT_PATTERNS =
   /RESOURCE_EXHAUSTED|rate.?limit|429|too many requests|retry.?after|overloaded|capacity|temporarily unavailable|out of extra usage|usage limit|resets?\s+\d|resets?\s+in\s+\d+\s*s/i;
 
+// Match MartinLoop's safe fallback instead of allowing provider stderr to request a longer pause.
+const MAX_GEMINI_RETRY_AFTER_MS = 120_000;
+
+function parseBoundedRetryAfterMs(secondsText: string): number {
+  const seconds = Number.parseInt(secondsText, 10);
+  const maxSeconds = MAX_GEMINI_RETRY_AFTER_MS / 1000;
+  if (!Number.isFinite(seconds) || seconds >= maxSeconds) {
+    return MAX_GEMINI_RETRY_AFTER_MS;
+  }
+  return seconds * 1000;
+}
+
 export class GeminiProvider implements ICliProvider {
   readonly name = 'gemini';
   readonly command = 'gemini';
@@ -64,19 +76,19 @@ export class GeminiProvider implements ICliProvider {
     // "retry-after: 60"
     const retryAfterMatch = stderr.match(/retry.?after:?\s*(\d+)\s*s?/i);
     if (retryAfterMatch?.[1]) {
-      return parseInt(retryAfterMatch[1], 10) * 1000;
+      return parseBoundedRetryAfterMs(retryAfterMatch[1]);
     }
 
     // "retry after 25s"
     const retryAfterPatternMatch = stderr.match(/retry.?after\s+(\d+)\s*s?/i);
     if (retryAfterPatternMatch?.[1]) {
-      return parseInt(retryAfterPatternMatch[1], 10) * 1000;
+      return parseBoundedRetryAfterMs(retryAfterPatternMatch[1]);
     }
 
     // "resets in 30s"
     const resetsInMatch = stderr.match(/resets?\s+in\s+(\d+)\s*s/i);
     if (resetsInMatch?.[1]) {
-      return parseInt(resetsInMatch[1], 10) * 1000;
+      return parseBoundedRetryAfterMs(resetsInMatch[1]);
     }
 
     return undefined;

--- a/packages/franken-orchestrator/tests/unit/skills/providers/gemini-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/gemini-provider.test.ts
@@ -115,6 +115,23 @@ describe('GeminiProvider', () => {
     expect(ms).toBe(60_000);
   });
 
+  it('parseRetryAfter parses resets-in messages', () => {
+    expect(provider.parseRetryAfter('quota resets in 30s')).toBe(30_000);
+  });
+
+  it.each([
+    'retry-after: 121',
+    'retry after 121s',
+    'quota resets in 121s',
+    `retry-after: ${'9'.repeat(400)}`,
+  ])('parseRetryAfter caps oversized delay from %s', (stderr) => {
+    expect(provider.parseRetryAfter(stderr)).toBe(120_000);
+  });
+
+  it('parseRetryAfter preserves a delay at the cap', () => {
+    expect(provider.parseRetryAfter('retry-after: 120')).toBe(120_000);
+  });
+
   it('parseRetryAfter returns undefined when no pattern matches', () => {
     expect(provider.parseRetryAfter('unknown error')).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- cap Gemini retry-after and reset hints at 120 seconds
- preserve ordinary retry delays below the cap
- cover all supported Gemini retry formats and very large numeric values

## Test plan
- `npm run test --workspace @franken/orchestrator` (3987 passed)
- `npm run test --workspace @franken/orchestrator -- tests/unit/skills/providers/gemini-provider.test.ts` (26 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings)
- `npm run build`

Closes #3178