### PR TITLE
fix(web): adopt accessible non-modal detail drawer

### DIFF
--- a/docs/adr/022-adopt-radix-ui-primitives.md
+++ b/docs/adr/022-adopt-radix-ui-primitives.md
@@ -17,8 +17,8 @@ Adopt Radix UI primitives (`@radix-ui/react-*`) as the component foundation for 
 - `react-tooltip`, `react-alert-dialog`, `react-popover`, `react-scroll-area`
 - `react-separator`
 
-### Not using Radix for:
-- **Slide-in detail panel** — bespoke `<aside>` with CSS transitions (Dialog's modal semantics conflict with non-modal side panels)
+### Non-modal drawer pattern
+- **Slide-in detail panel** — Radix Dialog with `modal={false}` provides dialog semantics, open/close focus management, focus return, and Escape handling without trapping focus or making the rest of the dashboard inert.
 - **Wizard step indicator** — custom component (Tabs allows free navigation, incompatible with validation-gated step progression)
 
 ## Consequences

--- a/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
+++ b/packages/franken-web/src/components/beasts/agent-detail-panel.tsx
@@ -75,7 +75,11 @@ export function AgentDetailPanel({
 
   return (
     <>
-      <SlideInPanel isOpen={isOpen} onClose={handleClose}>
+      <SlideInPanel
+        isOpen={isOpen}
+        onClose={handleClose}
+        title={`${agent.name?.trim() ? agent.name : agent.id} details`}
+      >
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-beast-border shrink-0">
           <StatusLight status={agent.status} />

--- a/packages/franken-web/src/components/beasts/log-viewer-modal.tsx
+++ b/packages/franken-web/src/components/beasts/log-viewer-modal.tsx
@@ -66,7 +66,10 @@ export function LogViewerModal({ isOpen, onClose, logs, events }: LogViewerModal
     <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[70]" />
-        <Dialog.Content className="fixed top-[5vh] left-[5vw] w-[90vw] h-[90vh] bg-beast-panel border border-beast-border rounded-xl z-[70] flex flex-col">
+        <Dialog.Content
+          data-beast-dialog-layer="content"
+          className="fixed top-[5vh] left-[5vw] w-[90vw] h-[90vh] bg-beast-panel border border-beast-border rounded-xl z-[70] flex flex-col"
+        >
           <div className="flex items-center gap-3 p-4 border-b border-beast-border">
             <Dialog.Title className="text-beast-text font-semibold flex-1">Events & Logs</Dialog.Title>
             <input

--- a/packages/franken-web/src/components/beasts/slide-in-panel.tsx
+++ b/packages/franken-web/src/components/beasts/slide-in-panel.tsx
@@ -1,12 +1,14 @@
+import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useRef, type ReactNode } from 'react';
 
 interface SlideInPanelProps {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
+  title?: string;
 }
 
-function isPortalClick(target: Node | null): boolean {
+function isPortalClick(target: EventTarget | null): boolean {
   if (!(target instanceof Node)) return false;
 
   const targetElement = target instanceof Element
@@ -16,43 +18,83 @@ function isPortalClick(target: Node | null): boolean {
   return Boolean(targetElement?.closest('[data-beast-panel-portal="true"], [data-beast-dialog-layer]'));
 }
 
-export function SlideInPanel({ isOpen, onClose, children }: SlideInPanelProps) {
-  const panelRef = useRef<HTMLElement>(null);
+function hasFocusMovedOutside(panel: HTMLElement | null): boolean {
+  const activeElement = document.activeElement;
+  return activeElement instanceof HTMLElement
+    && activeElement !== document.body
+    && !panel?.contains(activeElement);
+}
+
+export function SlideInPanel({ isOpen, onClose, children, title = 'Details' }: SlideInPanelProps) {
+  const openerRef = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const shouldRestoreFocusRef = useRef(true);
+  const wasOpenRef = useRef(false);
+
+  if (isOpen !== wasOpenRef.current) {
+    wasOpenRef.current = isOpen;
+    if (isOpen) {
+      openerRef.current = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    }
+  }
 
   useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && isOpen && !document.querySelector('[data-beast-panel-portal="true"], [data-beast-dialog-layer]')) {
-        onClose();
+    if (!isOpen) return;
+
+    shouldRestoreFocusRef.current = true;
+
+    return () => {
+      const opener = openerRef.current;
+      if (shouldRestoreFocusRef.current && !hasFocusMovedOutside(panelRef.current) && opener?.isConnected) {
+        opener.focus();
       }
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      const target = e.target;
-      if (!(target instanceof Node)) return;
-      if (isPortalClick(target)) return;
-
-      if (isOpen && panelRef.current && !panelRef.current.contains(target)) {
-        onClose();
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
+      openerRef.current = null;
+    };
+  }, [isOpen]);
 
   return (
-    <aside
-      ref={panelRef}
-      className="fixed top-0 right-0 h-screen w-[45vw] min-w-[400px] max-w-[720px]
-        bg-beast-panel border-l border-beast-border shadow-2xl z-50
-        flex flex-col animate-in slide-in-from-right duration-200"
+    <Dialog.Root
+      modal={false}
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
     >
-      {children}
-    </aside>
+      <Dialog.Portal>
+        <Dialog.Content
+          ref={panelRef}
+          aria-describedby={undefined}
+          className="fixed top-0 right-0 h-screen w-[45vw] min-w-[400px] max-w-[720px]
+            bg-beast-panel border-l border-beast-border shadow-2xl z-50
+            flex flex-col animate-in slide-in-from-right duration-200"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            if (shouldRestoreFocusRef.current && !hasFocusMovedOutside(panelRef.current)) {
+              openerRef.current?.focus();
+            }
+          }}
+          onEscapeKeyDown={(event) => {
+            if (document.querySelector('[data-beast-panel-portal="true"], [data-beast-dialog-layer]')) {
+              event.preventDefault();
+            }
+          }}
+          onFocusOutside={(event) => {
+            event.preventDefault();
+          }}
+          onPointerDownOutside={(event) => {
+            if (isPortalClick(event.target)) {
+              event.preventDefault();
+            } else {
+              shouldRestoreFocusRef.current = false;
+            }
+          }}
+        >
+          <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          {children}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-detail-panel.test.tsx
@@ -42,6 +42,12 @@ describe('AgentDetailPanel', () => {
     expect(screen.getByText('Overview')).toBeTruthy();
   });
 
+  it('names the non-modal detail drawer for screen readers', () => {
+    render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
+    const drawer = screen.getByRole('dialog', { name: 'agent-1 details' });
+    expect(drawer.getAttribute('aria-modal')).not.toBe('true');
+  });
+
   it('shows agent id in header', () => {
     render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
     expect(screen.getByText('agent-1')).toBeTruthy();
@@ -56,6 +62,17 @@ describe('AgentDetailPanel', () => {
   it('shows action bar with status-appropriate buttons', () => {
     render(<AgentDetailPanel isOpen={true} detail={detail} logs={[]} {...handlers} />);
     expect(screen.getByText('Stop')).toBeTruthy();
+  });
+
+  it('keeps the drawer open when the portaled log viewer takes focus', async () => {
+    render(<AgentDetailPanel isOpen={true} detail={detail} logs={['hello']} {...handlers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Events & Logs' })).toBeTruthy());
+    expect(handlers.onClose).not.toHaveBeenCalled();
+    const drawer = document.querySelector('[role="dialog"][aria-labelledby]');
+    expect(drawer?.textContent).toContain('agent-1 details');
   });
 
   it('keeps portaled action confirmations from closing the slide-in panel before confirm click', () => {
@@ -280,6 +297,6 @@ describe('AgentDetailPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
-    expect(screen.getByText(/agent-blank-name/)).toBeTruthy();
+    expect(screen.getByText(/Delete agent-blank-name\?/)).toBeTruthy();
   });
 });

--- a/packages/franken-web/tests/components/beasts/slide-in-panel.test.tsx
+++ b/packages/franken-web/tests/components/beasts/slide-in-panel.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useLayoutEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { SlideInPanel } from '../../../src/components/beasts/slide-in-panel';
 
 afterEach(cleanup);
@@ -22,6 +24,121 @@ describe('SlideInPanel', () => {
     );
     expect(container.querySelector('aside')).toBeNull();
     expect(screen.queryByText('Hidden')).toBeNull();
+  });
+
+  it('exposes a non-modal dialog and moves focus into it', async () => {
+    render(
+      <SlideInPanel isOpen={true} onClose={vi.fn()}>
+        <button type="button">Panel action</button>
+      </SlideInPanel>
+    );
+
+    const drawer = screen.getByRole('dialog');
+    expect(drawer.getAttribute('aria-modal')).not.toBe('true');
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Panel action' })));
+  });
+
+  it('returns focus to the opener after closing', async () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open details';
+    document.body.append(opener);
+    opener.focus();
+
+    const { rerender } = render(
+      <SlideInPanel isOpen={true} onClose={vi.fn()}>
+        <button type="button">Panel action</button>
+      </SlideInPanel>
+    );
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Panel action' })));
+
+    rerender(
+      <SlideInPanel isOpen={false} onClose={vi.fn()}>
+        <button type="button">Panel action</button>
+      </SlideInPanel>
+    );
+
+    await waitFor(() => expect(document.activeElement).toBe(opener));
+    opener.remove();
+  });
+
+  it('captures the opener before child layout autofocus runs', async () => {
+    function LayoutAutofocusButton() {
+      const buttonRef = useRef<HTMLButtonElement>(null);
+      useLayoutEffect(() => buttonRef.current?.focus(), []);
+      return <button ref={buttonRef} type="button">Panel action</button>;
+    }
+
+    const opener = document.createElement('button');
+    opener.textContent = 'Open details';
+    document.body.append(opener);
+    opener.focus();
+
+    const { rerender } = render(
+      <SlideInPanel isOpen={true} onClose={vi.fn()}>
+        <LayoutAutofocusButton />
+      </SlideInPanel>
+    );
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Panel action' })));
+
+    rerender(
+      <SlideInPanel isOpen={false} onClose={vi.fn()}>
+        <LayoutAutofocusButton />
+      </SlideInPanel>
+    );
+
+    await waitFor(() => expect(document.activeElement).toBe(opener));
+    opener.remove();
+  });
+
+  it('keeps the drawer open when keyboard focus moves outside it', async () => {
+    const onClose = vi.fn();
+    const outsideControl = document.createElement('button');
+    outsideControl.textContent = 'Outside control';
+    document.body.append(outsideControl);
+
+    render(
+      <SlideInPanel isOpen={true} onClose={onClose}>
+        <button type="button">Panel action</button>
+      </SlideInPanel>
+    );
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Panel action' })));
+
+    outsideControl.focus();
+
+    expect(onClose).not.toHaveBeenCalled();
+    outsideControl.remove();
+  });
+
+  it('does not steal focus back after an outside interaction closes it', async () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open details';
+    document.body.append(opener);
+    opener.focus();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <SlideInPanel isOpen={true} onClose={onClose}>
+        <button type="button">Panel action</button>
+      </SlideInPanel>
+    );
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Panel action' })));
+
+    rerender(
+      <SlideInPanel isOpen={true} onClose={onClose}>
+        <button type="button">Panel action</button>
+        {createPortal(<button type="button" autoFocus>Outside control</button>, document.body)}
+      </SlideInPanel>
+    );
+    const outsideControl = screen.getByRole('button', { name: 'Outside control' });
+    outsideControl.focus();
+    rerender(
+      <SlideInPanel isOpen={false} onClose={onClose}>
+        {createPortal(<button type="button" autoFocus>Outside control</button>, document.body)}
+      </SlideInPanel>
+    );
+
+    await waitFor(() => expect(document.activeElement).not.toBe(opener));
+    opener.remove();
   });
 
   it('calls onClose when Escape is pressed', () => {


### PR DESCRIPTION
## Summary
- replace the bespoke slide-in `<aside>` with a Radix Dialog configured as a non-modal drawer
- give the drawer a screen-reader name, move focus into it, restore focus to its opener, and preserve nested confirmation behavior
- add focused accessibility regressions and update ADR-022

## Test plan
- `npm run test --workspace @franken/web` (644 tests)
- `npm run lint --workspace @franken/web` (0 errors; 18 pre-existing warnings)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/web`
- `npm run build --workspace @franken/web`

Closes #3253