### PR TITLE
docs(onboarding): add starter issue discovery guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,38 @@
 
 Thank you for improving Frankenbeast. This guide is the shortest path from choosing one issue to opening a reviewable pull request. For environment details beyond this path, use the [onboarding checklist](ONBOARDING.md) or the [goal-based onboarding index](docs/onboarding/README.md).
 
+## Find a starter issue
+
+List open issues intended for new contributors before choosing work:
+
+```bash
+gh issue list --repo djm204/frankenbeast \
+  --state open \
+  --label "good first issue" \
+  --limit 20 \
+  --json number,title,labels,url
+```
+
+Pick an issue only when all of these are true:
+
+- You understand the requested outcome and acceptance criteria.
+- The change fits one focused pull request.
+- No open pull request already claims the issue.
+- The issue discussion does not show another contributor actively working on it.
+
+After checking for duplicate work in the next section, leave a short claim comment so other contributors can coordinate:
+
+```bash
+ISSUE_NUMBER="2541" # replace with the issue you selected
+gh issue comment "$ISSUE_NUMBER" --repo djm204/frankenbeast \
+  --body "I plan to work on this issue. I will keep the change scoped to its acceptance criteria."
+```
+
+If the scope is unclear, ask one focused question instead of claiming the issue or guessing.
+
 ## Before you start
 
-1. Choose one open issue whose scope you understand. Issues labeled `good first issue` are intended for new contributors.
+1. Read the issue body, acceptance criteria, labels, and discussion end to end before editing.
 2. Check the issue discussion and open pull requests so you do not duplicate active work:
 
    ```bash

--- a/tests/docs-issue-2541.test.ts
+++ b/tests/docs-issue-2541.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('issue #2541 starter issue discovery guidance', () => {
+  it('gives first-time contributors an actionable starter-issue workflow', () => {
+    const guide = readText('CONTRIBUTING.md');
+
+    for (const expected of [
+      '## Find a starter issue',
+      'gh issue list --repo djm204/frankenbeast',
+      '--label "good first issue"',
+      '--json number,title,labels,url',
+      'No open pull request already claims the issue',
+      'gh issue comment "$ISSUE_NUMBER"',
+      'I plan to work on this issue',
+    ]) {
+      expect(guide).toContain(expected);
+    }
+  });
+
+  it('keeps the starter-issue workflow discoverable from public onboarding entrypoints', () => {
+    expect(readText('README.md')).toContain('[contributor guide](CONTRIBUTING.md)');
+    expect(readText('ONBOARDING.md')).toContain('[contributor guide](CONTRIBUTING.md)');
+    expect(readText('docs/onboarding/README.md')).toContain('[Contributor guide](../../CONTRIBUTING.md)');
+  });
+});


### PR DESCRIPTION
## Summary
- add an exact GitHub CLI workflow for listing newcomer-friendly issues
- document scope and duplicate-work checks before claiming an issue
- add a focused regression test that keeps the workflow discoverable

## Verification
- `npm run test:root -- tests/docs-issue-1094.test.ts tests/docs-issue-2541.test.ts tests/docs-issue-2542.test.ts tests/docs-issue-2543.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `gh issue list --repo djm204/frankenbeast --state open --label "good first issue" --limit 20 --json number,title,labels,url --jq "length"`

Closes #2541