### PR TITLE
fix(brain): reject corrupt working memory hydration

### DIFF
--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -2,6 +2,7 @@ export {
   SqliteBrain,
   WorkingMemoryLimitError,
   WorkingMemoryHydrationLimitError,
+  CorruptWorkingMemoryRowError,
   MemoryDeletionGuardError,
   UnsupportedMemorySchemaVersionError,
   MemoryEncryptionKeyUnavailableError,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -891,6 +891,17 @@ export class WorkingMemoryHydrationLimitError extends Error {
   }
 }
 
+export class CorruptWorkingMemoryRowError extends Error {
+  readonly code = 'CORRUPT_WORKING_MEMORY_ROW';
+
+  constructor(readonly key: string) {
+    super(
+      `Persisted working memory row "${key}" contains invalid JSON and was not hydrated; the row was preserved for recovery`,
+    );
+    this.name = 'CorruptWorkingMemoryRowError';
+  }
+}
+
 export class MemoryDeletionGuardError extends Error {
   constructor(message: string) {
     super(message);
@@ -1307,7 +1318,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const expiredRows: Array<{ key: string; serialized: string }> = [];
     let total = 0;
     const prepareRow = (row: { key: string; serialized: string; updatedAt: string }) => {
-      const parsed = parseStoredWorkingMemoryValue(row.serialized);
+      const parsed = parseHydratedWorkingMemoryValue(row.key, row.serialized);
       if (isExpiredWorkingMemoryValue(parsed)) return undefined;
       const { normalized, serialized, size } = this.prepareEntry(
         row.key,
@@ -1328,7 +1339,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       };
     };
     for (const row of rows) {
-      const parsed = parseStoredWorkingMemoryValue(row.value);
+      const parsed = parseHydratedWorkingMemoryValue(row.key, row.value);
       if (isExpiredWorkingMemoryValue(parsed)) {
         expiredRows.push({ key: row.key, serialized: row.value });
         continue;
@@ -7992,6 +8003,18 @@ function parseStoredWorkingMemoryValue(value: string): unknown {
   try {
     return JSON.parse(value) as unknown;
   } catch {
+    return value;
+  }
+}
+
+function parseHydratedWorkingMemoryValue(key: string, value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    const trimmed = value.trimStart();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      throw new CorruptWorkingMemoryRowError(key);
+    }
     return value;
   }
 }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -14,6 +14,7 @@ import {
   SqliteBrain,
   WorkingMemoryLimitError,
   WorkingMemoryHydrationLimitError,
+  CorruptWorkingMemoryRowError,
   UnsupportedMemorySchemaVersionError,
   MemoryEncryptionKeyUnavailableError,
   MemoryEncryptionMigrationRequiredError,
@@ -1673,6 +1674,60 @@ describe('SqliteBrain', () => {
         ]);
       } finally {
         db?.close();
+        seeded?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects corrupt persisted JSON during hydration without deleting the recoverable row', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-corrupt-hydration-'));
+      const dbPath = join(dir, 'brain.db');
+      let seeded: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        seeded = new SqliteBrain(dbPath);
+        seeded.working.set('healthy', { enabled: true });
+        seeded.working.set('corrupt', { recoverable: true });
+        seeded.flush();
+        seeded.close();
+        seeded = undefined;
+
+        db = new Database(dbPath);
+        db.prepare(`UPDATE working_memory SET value = ? WHERE key = ?`).run('{not-json', 'corrupt');
+        db.close();
+        db = undefined;
+
+        let hydrationError: unknown;
+        try {
+          reopened = new SqliteBrain(dbPath);
+        } catch (error) {
+          hydrationError = error;
+        }
+        expect(hydrationError).toBeInstanceOf(CorruptWorkingMemoryRowError);
+        expect(hydrationError).toMatchObject({
+          code: 'CORRUPT_WORKING_MEMORY_ROW',
+          key: 'corrupt',
+        });
+
+        db = new Database(dbPath);
+        expect(
+          db.prepare(`SELECT value FROM working_memory WHERE key = ?`).get('corrupt'),
+        ).toEqual({ value: '{not-json' });
+        db.prepare(`UPDATE working_memory SET value = ? WHERE key = ?`).run(
+          JSON.stringify({ recovered: true }),
+          'corrupt',
+        );
+        db.close();
+        db = undefined;
+
+        reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('healthy')).toEqual({ enabled: true });
+        expect(reopened.working.get('corrupt')).toEqual({ recovered: true });
+      } finally {
+        db?.close();
+        reopened?.close();
         seeded?.close();
         rmSync(dir, { recursive: true, force: true });
       }

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-18 — Working-memory hydration corruption
+- Fail closed on malformed persisted values that are shaped like structured JSON (`{` or `[` after leading whitespace), while retaining the documented plain-text fallback for genuinely legacy rows. Typed hydration errors should identify the affected key without deleting the row, so operators can repair it and reopen the store.
+
 ## 2026-07-18 — MCP-owned SQLite lifecycle
 - When an MCP server owns or lazily creates a SQLite-backed adapter, expose an idempotent adapter `close()` and connect it to the SDK server's `onclose` path as well as an explicit public server `close()`. Central audit wrappers must forward cleanup, and proxy servers must release both their audit observer and any lazily-created adapter set.
 - In fresh monorepo worktrees, build internal workspace packages before package-level TypeScript checks; otherwise missing generated `dist` declarations produce unrelated module-resolution errors.


### PR DESCRIPTION
## Summary
- reject malformed structured JSON during SQLite working-memory hydration with a typed diagnostic
- preserve corrupt rows for operator recovery and retain legacy plain-text compatibility
- add a regression test covering failure, row preservation, repair, and successful rehydration

## Test Plan
- `npm run test --workspace @franken/brain` (304 passed)
- `npm run typecheck --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm run build --workspace @franken/brain`

Closes #3175