### PR TITLE
fix(brain): validate working memory keys

### DIFF
--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -1,6 +1,7 @@
 export {
   SqliteBrain,
   WorkingMemoryLimitError,
+  WorkingMemoryKeyError,
   WorkingMemoryHydrationLimitError,
   MemoryDeletionGuardError,
   UnsupportedMemorySchemaVersionError,
@@ -10,6 +11,7 @@ export {
   MemoryEncryptionWrongKeyError,
   MemoryConfidenceDecayError,
   DEFAULT_WORKING_MEMORY_LIMITS,
+  MAX_WORKING_MEMORY_KEY_BYTES,
   DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS,
   CURRENT_MEMORY_SCHEMA_VERSION,
   calculateMemoryConfidenceDecay,
@@ -17,6 +19,7 @@ export {
   SqliteMemoryReviewQueue,
   SqliteMemoryAccessAuditTrail,
   type WorkingMemoryLimits,
+  type WorkingMemoryKeyErrorReason,
   type WorkingMemoryHydrationLimits,
   type SqliteBrainOptions,
   type MemoryRetentionClass,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -48,6 +48,14 @@ export const DEFAULT_WORKING_MEMORY_LIMITS: WorkingMemoryLimits = {
   maxTotalBytes: 64 * 1024 * 1024,
 };
 
+/**
+ * Working-memory keys must be non-empty printable Unicode strings whose UTF-8
+ * representation does not exceed this bound. Spaces and punctuation remain
+ * valid for backwards compatibility, while Unicode "Other" code points are
+ * rejected because they make logs, snapshots, and selectors ambiguous.
+ */
+export const MAX_WORKING_MEMORY_KEY_BYTES = 1024;
+
 export const CURRENT_MEMORY_SCHEMA_VERSION = 2;
 
 export interface MemorySchemaStoreMetadata {
@@ -871,6 +879,43 @@ export class WorkingMemoryLimitError extends Error {
   }
 }
 
+export type WorkingMemoryKeyErrorReason =
+  | 'empty'
+  | 'control_character'
+  | 'too_long';
+
+export class WorkingMemoryKeyError extends Error {
+  readonly code = 'INVALID_WORKING_MEMORY_KEY';
+
+  constructor(
+    readonly reason: WorkingMemoryKeyErrorReason,
+    readonly byteLength: number,
+    readonly maxBytes: number = MAX_WORKING_MEMORY_KEY_BYTES,
+  ) {
+    super(
+      reason === 'empty'
+        ? 'Working memory key must not be empty'
+        : reason === 'control_character'
+          ? 'Working memory key must contain only printable Unicode characters'
+          : `Working memory key is ${byteLength} bytes, exceeding the ${maxBytes}-byte limit`,
+    );
+    this.name = 'WorkingMemoryKeyError';
+  }
+}
+
+function validateWorkingMemoryKey(key: string): void {
+  const byteLength = Buffer.byteLength(key, 'utf8');
+  if (key.length === 0) {
+    throw new WorkingMemoryKeyError('empty', byteLength);
+  }
+  if (/\p{C}/u.test(key)) {
+    throw new WorkingMemoryKeyError('control_character', byteLength);
+  }
+  if (byteLength > MAX_WORKING_MEMORY_KEY_BYTES) {
+    throw new WorkingMemoryKeyError('too_long', byteLength);
+  }
+}
+
 export class WorkingMemoryHydrationLimitError extends Error {
   readonly code = 'WORKING_MEMORY_HYDRATION_LIMIT_EXCEEDED';
 
@@ -1280,11 +1325,18 @@ class SqliteWorkingMemory implements IWorkingMemory {
       hydrationLimits && !this.db.inTransaction
         ? this.db.transaction(readRows).immediate()
         : readRows();
-    const decryptedRows = rows.map((row) => ({
-      key: row.key,
-      value: this.encryption?.decrypt(row.value) ?? row.value,
-      updatedAt: row.updatedAt,
-    }));
+    const decryptedRows = rows.map((row) => {
+      const value = this.encryption?.decrypt(row.value) ?? row.value;
+      // Fail closed without rewriting legacy data. Operators can migrate or
+      // remove the offending row explicitly instead of startup silently
+      // dropping memory whose key no longer satisfies the contract.
+      validateWorkingMemoryKey(row.key);
+      return {
+        key: row.key,
+        value,
+        updatedAt: row.updatedAt,
+      };
+    });
     this.persistedSerialized = new Map(
       decryptedRows.map((row) => [row.key, row.value]),
     );
@@ -1882,6 +1934,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     key: string,
     value: unknown,
   ): { normalized: unknown; serialized: string; size: number } {
+    validateWorkingMemoryKey(key);
     const serialized = stringifyWorkingMemoryValue(key, value);
     const valueBytes = Buffer.byteLength(serialized, 'utf8');
     if (valueBytes > this.limits.maxValueBytes) {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
   SqliteBrain,
   WorkingMemoryLimitError,
+  WorkingMemoryKeyError,
   WorkingMemoryHydrationLimitError,
   UnsupportedMemorySchemaVersionError,
   MemoryEncryptionKeyUnavailableError,
@@ -21,6 +22,7 @@ import {
   MemoryEncryptionWrongKeyError,
   CURRENT_MEMORY_SCHEMA_VERSION,
   DEFAULT_WORKING_MEMORY_LIMITS,
+  MAX_WORKING_MEMORY_KEY_BYTES,
   DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS,
   MemoryConfidenceDecayError,
   calculateMemoryConfidenceDecay,
@@ -621,6 +623,90 @@ describe('SqliteBrain', () => {
     it('stores and retrieves values', () => {
       brain.working.set('key', 'value');
       expect(brain.working.get('key')).toBe('value');
+    });
+
+    it('accepts bounded printable working-memory keys', () => {
+      const key = 'project:tenant/α β_1-@';
+
+      expect(() => brain.working.set(key, 'value')).not.toThrow();
+      expect(brain.working.get(key)).toBe('value');
+    });
+
+    it.each([
+      { key: '', reason: 'empty', byteLength: 0 },
+      { key: 'line\nbreak', reason: 'control_character', byteLength: 10 },
+      {
+        key: 'k'.repeat(MAX_WORKING_MEMORY_KEY_BYTES + 1),
+        reason: 'too_long',
+        byteLength: MAX_WORKING_MEMORY_KEY_BYTES + 1,
+      },
+    ])('rejects invalid working-memory keys before set mutation ($reason)', ({ key, reason, byteLength }) => {
+      brain.working.set('existing', 'preserved');
+
+      let error: unknown;
+      try {
+        brain.working.set(key, 'invalid');
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(WorkingMemoryKeyError);
+      expect(error).toMatchObject({
+        code: 'INVALID_WORKING_MEMORY_KEY',
+        reason,
+        byteLength,
+        maxBytes: MAX_WORKING_MEMORY_KEY_BYTES,
+      });
+      expect(brain.working.snapshot()).toEqual({ existing: 'preserved' });
+    });
+
+    it('rejects invalid restore keys atomically before persistence', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-invalid-key-'));
+      const dbPath = join(dir, 'brain.db');
+      const persistent = new SqliteBrain(dbPath);
+
+      try {
+        persistent.working.set('existing', 'preserved');
+        persistent.flush();
+
+        expect(() => persistent.working.restore({ valid: 1, 'bad\u0000key': 2 })).toThrow(
+          WorkingMemoryKeyError,
+        );
+        persistent.flush();
+
+        expect(persistent.working.snapshot()).toEqual({ existing: 'preserved' });
+        const db = new Database(dbPath, { readonly: true });
+        expect(db.prepare(`SELECT key FROM working_memory ORDER BY key`).all()).toEqual([
+          { key: 'existing' },
+        ]);
+        db.close();
+      } finally {
+        persistent.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed without mutating legacy persisted rows that have invalid keys', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-legacy-invalid-key-'));
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const initialized = new SqliteBrain(dbPath);
+        initialized.close();
+        const db = new Database(dbPath);
+        db.prepare(
+          `INSERT INTO working_memory (key, value, updated_at, schema_version) VALUES (?, ?, ?, ?)`,
+        ).run('legacy\nkey', '"value"', new Date().toISOString(), CURRENT_MEMORY_SCHEMA_VERSION);
+        db.close();
+
+        expect(() => new SqliteBrain(dbPath)).toThrow(WorkingMemoryKeyError);
+
+        const verify = new Database(dbPath, { readonly: true });
+        expect(verify.prepare(`SELECT key FROM working_memory`).pluck().get()).toBe('legacy\nkey');
+        verify.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('snapshot() returns all key-value pairs', () => {


### PR DESCRIPTION
## Summary
- define and export a bounded printable-Unicode key contract for SQLite working memory
- reject empty, Unicode Other/control, and overlong keys with a structured `WorkingMemoryKeyError` before mutation or persistence
- fail closed on legacy persisted invalid keys without silently rewriting data
- cover set, restore atomicity, persistence, valid keys, and legacy-row behavior with regression tests

## Test plan
- `npm test --workspace @franken/brain` (309 passed)
- `npm run build`
- `npm run typecheck`
- `npm run lint`

Closes #3174