### PR TITLE
docs(onboarding): add first PR handoff recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,8 @@ Keep the pull request title in Conventional Commit form, for example `docs(onboa
 For a copyable, non-interactive first-PR handoff, set a title and list only checks you actually ran:
 
 ```bash
+ISSUE_NUMBER="2530" # replace with the issue you are closing
+: "${ISSUE_NUMBER:?set ISSUE_NUMBER to the issue you are closing}"
 PR_TITLE="docs(onboarding): describe your issue-specific change" # replace this example
 PR_URL=$(gh pr create \
   --repo djm204/frankenbeast \
@@ -132,7 +134,7 @@ printf 'Opened %s\n' "$PR_URL"
 gh pr view "$PR_URL" --json number,title,body,baseRefName,headRefName,url
 ```
 
-Read the displayed title, body, base branch, and head branch before requesting review. If anything is wrong, correct it with `gh pr edit "$PR_URL"` rather than closing and recreating the pull request. Never list a test that you skipped or that failed.
+Read the displayed title, body, base branch, and head branch before requesting review. If the title, body, or base branch is wrong, correct it with `gh pr edit "$PR_URL"`. GitHub cannot change an existing pull request's head branch: if the displayed head is wrong, close the pull request, switch to and push the intended branch, then create a new pull request. Never list a test that you skipped or that failed.
 
 ## Before requesting review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,27 @@ Closes #<issue-number>
 
 Keep the pull request title in Conventional Commit form, for example `docs(onboarding): clarify first contribution setup`. If you are using `gh`, `gh pr create --repo djm204/frankenbeast --base main` opens the interactive form.
 
+For a copyable, non-interactive first-PR handoff, set a title and list only checks you actually ran:
+
+```bash
+PR_TITLE="docs(onboarding): describe your issue-specific change" # replace this example
+PR_URL=$(gh pr create \
+  --repo djm204/frankenbeast \
+  --base main \
+  --title "$PR_TITLE" \
+  --body "## Summary
+- describe the contributor-facing change
+
+## Verification
+- \`npm run test:root -- tests/docs-issue-${ISSUE_NUMBER}.test.ts\`
+
+Closes #${ISSUE_NUMBER}")
+printf 'Opened %s\n' "$PR_URL"
+gh pr view "$PR_URL" --json number,title,body,baseRefName,headRefName,url
+```
+
+Read the displayed title, body, base branch, and head branch before requesting review. If anything is wrong, correct it with `gh pr edit "$PR_URL"` rather than closing and recreating the pull request. Never list a test that you skipped or that failed.
+
 ## Before requesting review
 
 - [ ] The pull request addresses one issue and contains no unrelated files.

--- a/tests/docs-issue-2530.test.ts
+++ b/tests/docs-issue-2530.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('issue #2530 first pull request handoff', () => {
+  it('keeps the contributor guide reachable from public onboarding entrypoints', () => {
+    expect(readText('README.md')).toContain('[contributor guide](CONTRIBUTING.md)');
+    expect(readText('ONBOARDING.md')).toContain('[contributor guide](CONTRIBUTING.md)');
+    expect(readText('docs/onboarding/README.md')).toContain(
+      '[Contributor guide](../../CONTRIBUTING.md)',
+    );
+  });
+
+  it('provides a copyable and verifiable non-interactive PR handoff', () => {
+    const guide = readText('CONTRIBUTING.md');
+
+    for (const expected of [
+      'For a copyable, non-interactive first-PR handoff',
+      'PR_URL=$(gh pr create',
+      '--repo djm204/frankenbeast',
+      '--base main',
+      '--title "$PR_TITLE"',
+      'Closes #${ISSUE_NUMBER}',
+      'gh pr view "$PR_URL" --json number,title,body,baseRefName,headRefName,url',
+      'gh pr edit "$PR_URL"',
+      'Never list a test that you skipped or that failed',
+    ]) {
+      expect(guide).toContain(expected);
+    }
+  });
+});

--- a/tests/docs-issue-2530.test.ts
+++ b/tests/docs-issue-2530.test.ts
@@ -22,6 +22,8 @@ describe('issue #2530 first pull request handoff', () => {
 
     for (const expected of [
       'For a copyable, non-interactive first-PR handoff',
+      'ISSUE_NUMBER="2530" # replace with the issue you are closing',
+      ': "${ISSUE_NUMBER:?set ISSUE_NUMBER to the issue you are closing}"',
       'PR_URL=$(gh pr create',
       '--repo djm204/frankenbeast',
       '--base main',
@@ -29,6 +31,8 @@ describe('issue #2530 first pull request handoff', () => {
       'Closes #${ISSUE_NUMBER}',
       'gh pr view "$PR_URL" --json number,title,body,baseRefName,headRefName,url',
       'gh pr edit "$PR_URL"',
+      "GitHub cannot change an existing pull request's head branch",
+      'close the pull request, switch to and push the intended branch',
       'Never list a test that you skipped or that failed',
     ]) {
       expect(guide).toContain(expected);


### PR DESCRIPTION
## Summary
- add a copyable non-interactive `gh pr create` recipe to the contributor guide
- verify the created PR metadata before requesting review
- guard the public entrypoint and handoff steps with a focused docs regression test

## Verification
- `npm run test:root -- tests/docs-issue-2530.test.ts` (2 passed)
- `npm run test:root` (594 passed, 1 skipped)
- `git diff --check`

Closes #2530