### PR TITLE
test(orchestrator): cover invalid comms auth tokens

### DIFF
--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -115,6 +115,46 @@ describe('control-plane operator auth', () => {
     }
   });
 
+  describe('rejects invalid operator tokens with 401', () => {
+    const cases: Array<{ name: string; path: string; body: unknown }> = [
+      {
+        name: 'comms inbound',
+        path: '/v1/comms/inbound',
+        body: {
+          channelType: 'slack',
+          externalUserId: 'U1',
+          externalChannelId: 'C1',
+          externalMessageId: 'M1',
+          text: 'hello',
+          receivedAt: new Date().toISOString(),
+          rawEvent: {},
+        },
+      },
+      {
+        name: 'comms action',
+        path: '/v1/comms/action',
+        body: { channelType: 'slack', sessionId: 's', actionId: 'a' },
+      },
+    ];
+
+    for (const { name, path, body } of cases) {
+      it(`${name} -> 401 with an invalid operator token`, async () => {
+        const app = buildApp();
+        const res = await app.request(path, {
+          method: 'POST',
+          headers: {
+            'x-frankenbeast-operator-token': INVALID_OPERATOR_TOKEN,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        });
+
+        expect(res.status).toBe(401);
+        await expect(res.json()).resolves.toMatchObject({ error: { code: 'UNAUTHORIZED' } });
+      });
+    }
+  });
+
   describe('rejects browser cookie mutations without same-origin proof', () => {
     it('denies network mutations when cookie auth lacks an Origin header', async () => {
       const app = buildApp();


### PR DESCRIPTION
## Summary
- verifies the generic comms inbound endpoint rejects an invalid operator token before dispatch
- verifies the generic comms action endpoint rejects an invalid operator token before dispatch
- records endpoint-specific regression coverage for the authentication already enforced by merged PR #1365

## Test Plan
- npm run test --workspace @franken/orchestrator -- tests/integration/http/control-plane-auth.test.ts (31 passed)
- npm run test --workspace @franken/orchestrator (4003 passed)
- npm run typecheck --workspace @franken/orchestrator
- npm run lint --workspace @franken/orchestrator (0 errors; pre-existing warnings only)
- npm run build

Closes #2984