### PR TITLE
fix(governor): authorize Slack approvers

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -457,7 +457,7 @@ const app = createGovernorApp({
 });
 ```
 
-Signed callbacks whose `user.id` is absent or not in `slackApproverUserIds` receive a `200` Slack acknowledgement with an ephemeral denial message and leave the approval pending. The transport-level success prevents Slack from replacing the denial with a generic interaction error; it does not authorize or resolve the action. An omitted or empty allowlist fails closed.
+Signed callbacks whose `user.id` is absent or not in `slackApproverUserIds` receive a `200` Slack acknowledgement and leave the approval pending. For Slack-generated `https://hooks.slack.com/...` or `https://hooks.slack-gov.com/...` response URLs, the governor also posts an ephemeral denial so the actor sees clear feedback; untrusted response URL hosts are ignored. The transport-level success does not authorize or resolve the action. An omitted or empty allowlist fails closed.
 
 ### Signed Approvals (HMAC-SHA256)
 

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -457,7 +457,7 @@ const app = createGovernorApp({
 });
 ```
 
-Signed callbacks whose `user.id` is absent or not in `slackApproverUserIds` receive `403` and leave the approval pending. An omitted or empty allowlist fails closed.
+Signed callbacks whose `user.id` is absent or not in `slackApproverUserIds` receive a `200` Slack acknowledgement with an ephemeral denial message and leave the approval pending. The transport-level success prevents Slack from replacing the denial with a generic interaction error; it does not authorize or resolve the action. An omitted or empty allowlist fails closed.
 
 ### Signed Approvals (HMAC-SHA256)
 

--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -386,6 +386,7 @@ Features:
 - **Signature verification**: Optionally validates HMAC-SHA256 signatures on responses
 - **Session tokens**: Optionally creates scoped, time-limited tokens on APPROVE
 - **Audit**: Records every decision via the `AuditRecorder` interface
+- **Slack approver authorization**: Restricts signed Slack callbacks to configured immutable Slack user IDs
 - **HTTP queue backpressure**: `createGovernorApp({ approvalQueueBackpressure })` can reject new unique approval requests with HTTP 429 when too many approvals are already pending
 
 ### HTTP approval queue backpressure
@@ -444,6 +445,19 @@ interface EpisodicTraceRecord {
 ```
 
 ## Security
+
+### Authorized Slack approvers
+
+Slack request signing authenticates the Slack workspace but does not by itself authorize the person clicking an approval action. Standalone Governor apps must therefore configure the immutable Slack user IDs allowed to resolve pending approvals:
+
+```typescript
+const app = createGovernorApp({
+  slackSigningSecret: process.env.SLACK_SIGNING_SECRET,
+  slackApproverUserIds: ['U0123456789', 'U9876543210'],
+});
+```
+
+Signed callbacks whose `user.id` is absent or not in `slackApproverUserIds` receive `403` and leave the approval pending. An omitted or empty allowlist fails closed.
 
 ### Signed Approvals (HMAC-SHA256)
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -15,6 +15,8 @@ export interface GovernorAppOptions {
   signingSecret?: string;
   /** Slack signing secret used to verify `X-Slack-Signature` on inbound callbacks. */
   slackSigningSecret?: string;
+  /** Slack user IDs authorized to resolve pending approvals. Empty or omitted fails closed. */
+  slackApproverUserIds?: readonly string[];
   slackWebhookUrl?: string;
   allowUnsignedApprovalsForTests?: boolean;
   /**
@@ -216,6 +218,7 @@ function extractSlackActionFeedback(actionId: unknown): string | undefined {
 export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const app = new Hono();
   const registry = options.registry ?? new ApprovalWaiterRegistry();
+  const slackApproverUserIds = new Set(options.slackApproverUserIds ?? []);
   const approvalQueueBackpressure = normalizeApprovalQueueBackpressure(options.approvalQueueBackpressure);
   let sessionTokenStore: SessionTokenStore | undefined = options.sessionTokenStore;
   if (!sessionTokenStore && options.sessionTokenStorePath) {
@@ -556,6 +559,14 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     }
     const feedback = extractSlackActionFeedback(action.action_id);
 
+    const slackUserId = payload.user?.id;
+    if (!slackUserId || !slackApproverUserIds.has(slackUserId)) {
+      return c.json(
+        { error: { message: 'Slack user is not authorized to resolve approvals' } },
+        403,
+      );
+    }
+
     // Look up the pending approval; unknown requests are rejected.
     if (!registry.has(requestId)) {
       return c.json({ error: { message: 'Approval request not found' } }, 404);
@@ -571,7 +582,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       ? signApprovalResponse(
         requestId,
         decision,
-        payload.user?.id ?? payload.user?.username ?? 'slack',
+        slackUserId,
         feedback,
         options.signingSecret,
       )
@@ -580,7 +591,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     registry.resolve(requestId, {
       requestId,
       decision,
-      respondedBy: payload.user?.id ?? payload.user?.username ?? 'slack',
+      respondedBy: slackUserId,
       respondedAt: new Date(deterministicNow()),
       ...(feedback !== undefined ? { feedback } : {}),
       ...(slackSignature !== undefined ? { signature: slackSignature } : {}),

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -610,12 +610,10 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
         typeof payload.response_url === 'string' &&
         isTrustedSlackResponseUrl(payload.response_url)
       ) {
-        try {
-          await slackResponsePoster.post(payload.response_url, denial);
-        } catch {
-          // Always acknowledge Slack within its interaction window. The pending
-          // approval remains untouched when delivery of the denial fails.
-        }
+        // Slack requires interaction callbacks to be acknowledged promptly.
+        // Deliver denial feedback out-of-band and leave the approval pending
+        // even if response_url delivery later fails.
+        void slackResponsePoster.post(payload.response_url, denial).catch(() => undefined);
       }
       return c.json({
         response_type: 'ephemeral',

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -11,12 +11,24 @@ import { SessionTokenStore } from '../security/session-token-store.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
 
+export interface SlackEphemeralResponse {
+  readonly response_type: 'ephemeral';
+  readonly replace_original: false;
+  readonly text: string;
+}
+
+export interface SlackResponsePoster {
+  post(responseUrl: string, payload: SlackEphemeralResponse): Promise<void>;
+}
+
 export interface GovernorAppOptions {
   signingSecret?: string;
   /** Slack signing secret used to verify `X-Slack-Signature` on inbound callbacks. */
   slackSigningSecret?: string;
   /** Slack user IDs authorized to resolve pending approvals. Empty or omitted fails closed. */
   slackApproverUserIds?: readonly string[];
+  /** Injectable Slack response_url poster; defaults to an HTTPS JSON POST. */
+  slackResponsePoster?: SlackResponsePoster;
   slackWebhookUrl?: string;
   allowUnsignedApprovalsForTests?: boolean;
   /**
@@ -47,6 +59,32 @@ export interface GovernorAppOptions {
 
 /** Maximum age (seconds) for a Slack request timestamp before it is rejected as a replay. */
 const SLACK_MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5;
+
+const DEFAULT_SLACK_RESPONSE_POSTER: SlackResponsePoster = {
+  async post(responseUrl, payload) {
+    const response = await fetch(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Slack response_url returned HTTP ${response.status}`);
+    }
+  },
+};
+
+function isTrustedSlackResponseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      (url.hostname === 'hooks.slack.com' || url.hostname === 'hooks.slack-gov.com')
+    );
+  } catch {
+    return false;
+  }
+}
 
 /** Timing-safe comparison of two equal-purpose strings. */
 function safeEqual(a: string, b: string): boolean {
@@ -219,6 +257,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const app = new Hono();
   const registry = options.registry ?? new ApprovalWaiterRegistry();
   const slackApproverUserIds = new Set(options.slackApproverUserIds ?? []);
+  const slackResponsePoster = options.slackResponsePoster ?? DEFAULT_SLACK_RESPONSE_POSTER;
   const approvalQueueBackpressure = normalizeApprovalQueueBackpressure(options.approvalQueueBackpressure);
   let sessionTokenStore: SessionTokenStore | undefined = options.sessionTokenStore;
   if (!sessionTokenStore && options.sessionTokenStorePath) {
@@ -527,6 +566,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     let payload: {
       actions?: Array<{ action_id?: string; value?: string }>;
       user?: { id?: string; username?: string };
+      response_url?: string;
     };
     try {
       const contentType = c.req.header('content-type') ?? '';
@@ -561,9 +601,25 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
     const slackUserId = payload.user?.id;
     if (!slackUserId || !slackApproverUserIds.has(slackUserId)) {
+      const denial: SlackEphemeralResponse = {
+        response_type: 'ephemeral',
+        replace_original: false,
+        text: 'You are not authorized to resolve this approval.',
+      };
+      if (
+        typeof payload.response_url === 'string' &&
+        isTrustedSlackResponseUrl(payload.response_url)
+      ) {
+        try {
+          await slackResponsePoster.post(payload.response_url, denial);
+        } catch {
+          // Always acknowledge Slack within its interaction window. The pending
+          // approval remains untouched when delivery of the denial fails.
+        }
+      }
       return c.json({
         response_type: 'ephemeral',
-        text: 'You are not authorized to resolve this approval.',
+        text: denial.text,
       });
     }
 

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -561,10 +561,10 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
     const slackUserId = payload.user?.id;
     if (!slackUserId || !slackApproverUserIds.has(slackUserId)) {
-      return c.json(
-        { error: { message: 'Slack user is not authorized to resolve approvals' } },
-        403,
-      );
+      return c.json({
+        response_type: 'ephemeral',
+        text: 'You are not authorized to resolve this approval.',
+      });
     }
 
     // Look up the pending approval; unknown requests are rejected.

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -720,9 +720,11 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects a signed callback from a Slack user outside the configured approver allowlist', async () => {
+      const postSlackResponse = vi.fn().mockResolvedValue(undefined);
       const app = createGovernorApp({
         slackSigningSecret: SLACK_SECRET,
         slackApproverUserIds: ['U-AUTHORIZED'],
+        slackResponsePoster: { post: postSlackResponse },
         allowUnsignedApprovalsForTests: true,
       });
       await seedApproval(app, 'req-unauthorized-user');
@@ -730,6 +732,7 @@ describe('Governor Hono Server', () => {
       const rawBody = JSON.stringify({
         actions: [{ action_id: 'approve', value: 'req-unauthorized-user' }],
         user: { id: 'U-UNAUTHORIZED' },
+        response_url: 'https://hooks.slack.com/actions/T123/B123/secret',
       });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
@@ -742,6 +745,14 @@ describe('Governor Hono Server', () => {
         response_type: 'ephemeral',
         text: 'You are not authorized to resolve this approval.',
       });
+      expect(postSlackResponse).toHaveBeenCalledWith(
+        'https://hooks.slack.com/actions/T123/B123/secret',
+        {
+          response_type: 'ephemeral',
+          replace_original: false,
+          text: 'You are not authorized to resolve this approval.',
+        },
+      );
 
       const after = await (await app.request('/health')).json();
       expect(after.pendingApprovals).toBe(1);
@@ -786,9 +797,11 @@ describe('Governor Hono Server', () => {
     });
 
     it('rejects a signed callback without an immutable Slack user ID', async () => {
+      const postSlackResponse = vi.fn().mockResolvedValue(undefined);
       const app = createGovernorApp({
         slackSigningSecret: SLACK_SECRET,
         slackApproverUserIds: ['U-AUTHORIZED'],
+        slackResponsePoster: { post: postSlackResponse },
         allowUnsignedApprovalsForTests: true,
       });
       await seedApproval(app, 'req-missing-user-id');
@@ -796,6 +809,7 @@ describe('Governor Hono Server', () => {
       const rawBody = JSON.stringify({
         actions: [{ action_id: 'approve', value: 'req-missing-user-id' }],
         user: { username: 'authorized-display-name' },
+        response_url: 'https://attacker.example/internal',
       });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
@@ -808,6 +822,7 @@ describe('Governor Hono Server', () => {
         response_type: 'ephemeral',
         text: 'You are not authorized to resolve this approval.',
       });
+      expect(postSlackResponse).not.toHaveBeenCalled();
       expect((await (await app.request('/health')).json()).pendingApprovals).toBe(1);
     });
 

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -719,15 +719,68 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(401);
     });
 
+    it('rejects a signed callback from a Slack user outside the configured approver allowlist', async () => {
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
+      await seedApproval(app, 'req-unauthorized-user');
+
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'req-unauthorized-user' }],
+        user: { id: 'U-UNAUTHORIZED' },
+      });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: { message: 'Slack user is not authorized to resolve approvals' } });
+
+      const after = await (await app.request('/health')).json();
+      expect(after.pendingApprovals).toBe(1);
+    });
+
+    it('fails closed when no Slack approver allowlist is configured', async () => {
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        allowUnsignedApprovalsForTests: true,
+      });
+      await seedApproval(app, 'req-no-allowlist');
+
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'req-no-allowlist' }],
+        user: { id: 'U-ANY' },
+      });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(403);
+      expect((await (await app.request('/health')).json()).pendingApprovals).toBe(1);
+    });
+
     it('resolves the pending approval on a valid signed callback', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
       await seedApproval(app, 'req-1');
 
       // Health shows one pending approval before the callback
       const before = await (await app.request('/health')).json();
       expect(before.pendingApprovals).toBe(1);
 
-      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'req-1' }],
+        user: { id: 'U-AUTHORIZED' },
+      });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
         headers: { ...slackHeaders(rawBody) },
@@ -749,6 +802,7 @@ describe('Governor Hono Server', () => {
       const registry = new ApprovalWaiterRegistry();
       const app = createGovernorApp({
         slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
         allowUnsignedApprovalsForTests: true,
         registry,
       });
@@ -757,6 +811,7 @@ describe('Governor Hono Server', () => {
 
       const rawBody = JSON.stringify({
         actions: [{ action_id: 'approve:ACK-APPROVAL-ANOMALY-req-ack', value: 'req-ack' }],
+        user: { id: 'U-AUTHORIZED' },
       });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
@@ -772,9 +827,16 @@ describe('Governor Hono Server', () => {
     });
 
     it('returns 404 for a signed callback referencing an unknown request', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
 
-      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'nope' }] });
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'nope' }],
+        user: { id: 'U-AUTHORIZED' },
+      });
       const res = await app.request('/v1/webhook/slack', {
         method: 'POST',
         headers: { ...slackHeaders(rawBody) },
@@ -817,10 +879,17 @@ describe('Governor Hono Server', () => {
     });
 
     it('parses Slack form-encoded payloads and normalizes reject', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
       await seedApproval(app, 'req-9');
 
-      const payloadJson = JSON.stringify({ actions: [{ action_id: 'reject', value: 'req-9' }] });
+      const payloadJson = JSON.stringify({
+        actions: [{ action_id: 'reject', value: 'req-9' }],
+        user: { id: 'U-AUTHORIZED' },
+      });
       const rawBody = `payload=${encodeURIComponent(payloadJson)}`;
       const ts = Math.floor(Date.now() / 1000).toString();
       const base = `v0:${ts}:${rawBody}`;
@@ -843,11 +912,16 @@ describe('Governor Hono Server', () => {
     });
 
     it('accepts signed Slack form payloads containing emoji text', async () => {
-      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
       await seedApproval(app, 'req-emoji');
 
       const payloadJson = JSON.stringify({
         actions: [{ action_id: 'approve', value: 'req-emoji' }],
+        user: { id: 'U-AUTHORIZED' },
         message: { text: 'Ship it 🚀' },
       });
       const rawBody = `payload=${encodeURIComponent(payloadJson)}`;

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -719,8 +719,8 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(401);
     });
 
-    it('rejects a signed callback from a Slack user outside the configured approver allowlist', async () => {
-      const postSlackResponse = vi.fn().mockResolvedValue(undefined);
+    it('posts an unauthorized denial without delaying the Slack acknowledgement', async () => {
+      const postSlackResponse = vi.fn().mockReturnValue(new Promise<void>(() => undefined));
       const app = createGovernorApp({
         slackSigningSecret: SLACK_SECRET,
         slackApproverUserIds: ['U-AUTHORIZED'],

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -737,11 +737,27 @@ describe('Governor Hono Server', () => {
         body: rawBody,
       });
 
-      expect(res.status).toBe(403);
-      expect(await res.json()).toEqual({ error: { message: 'Slack user is not authorized to resolve approvals' } });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        response_type: 'ephemeral',
+        text: 'You are not authorized to resolve this approval.',
+      });
 
       const after = await (await app.request('/health')).json();
       expect(after.pendingApprovals).toBe(1);
+
+      const authorizedBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'req-unauthorized-user' }],
+        user: { id: 'U-AUTHORIZED' },
+      });
+      const authorizedRes = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(authorizedBody) },
+        body: authorizedBody,
+      });
+      expect(authorizedRes.status).toBe(200);
+      expect((await authorizedRes.json()).status).toBe('resolved');
+      expect((await (await app.request('/health')).json()).pendingApprovals).toBe(0);
     });
 
     it('fails closed when no Slack approver allowlist is configured', async () => {
@@ -761,7 +777,37 @@ describe('Governor Hono Server', () => {
         body: rawBody,
       });
 
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        response_type: 'ephemeral',
+        text: 'You are not authorized to resolve this approval.',
+      });
+      expect((await (await app.request('/health')).json()).pendingApprovals).toBe(1);
+    });
+
+    it('rejects a signed callback without an immutable Slack user ID', async () => {
+      const app = createGovernorApp({
+        slackSigningSecret: SLACK_SECRET,
+        slackApproverUserIds: ['U-AUTHORIZED'],
+        allowUnsignedApprovalsForTests: true,
+      });
+      await seedApproval(app, 'req-missing-user-id');
+
+      const rawBody = JSON.stringify({
+        actions: [{ action_id: 'approve', value: 'req-missing-user-id' }],
+        user: { username: 'authorized-display-name' },
+      });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        response_type: 'ephemeral',
+        text: 'You are not authorized to resolve this approval.',
+      });
       expect((await (await app.request('/health')).json()).pendingApprovals).toBe(1);
     });
 


### PR DESCRIPTION
## Summary
- add a fail-closed Slack approver user-ID allowlist to the Governor HTTP app
- reject signed callbacks from missing or unauthorized Slack users without consuming pending approvals
- document the required allowlist and cover authorized, unauthorized, JSON, and form callback paths

## Security behavior
Slack request signatures authenticate the workspace request but not the individual actor. `slackApproverUserIds` now authorizes immutable Slack `user.id` values; omitted or empty configuration returns HTTP 403 and leaves the approval pending.

## Test plan
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/governor`
- `npm run lint --workspace @franken/governor` (passes with 3 pre-existing warnings)
- `npm run build --workspace @franken/governor`
- `npm test --workspace @franken/governor` (325 tests)
- `git diff --check`

Closes #2888