### PR TITLE
fix(web): prevent skill switches from submitting forms

### DIFF
--- a/packages/franken-web/src/components/skills/skill-card.tsx
+++ b/packages/franken-web/src/components/skills/skill-card.tsx
@@ -12,6 +12,7 @@ export function SkillCard({ name, enabled, hasContext, mcpServerCount, onToggle 
       <div className="skill-card__header">
         <span className="skill-card__name">{name}</span>
         <button
+          type="button"
           role="switch"
           aria-checked={enabled}
           className={`skill-card__toggle ${enabled ? 'skill-card__toggle--on' : ''}`}

--- a/packages/franken-web/tests/components/skills/skill-card.test.tsx
+++ b/packages/franken-web/tests/components/skills/skill-card.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { FormEvent } from 'react';
 import { SkillCard } from '../../../src/components/skills/skill-card';
 
 afterEach(cleanup);
@@ -29,6 +30,20 @@ describe('SkillCard', () => {
     render(<SkillCard name="github" enabled={true} hasContext={false} mcpServerCount={1} onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('switch', { name: /github/i }));
     expect(onToggle).toHaveBeenCalledWith('github', false);
+  });
+
+  it('does not submit a parent form when toggled', () => {
+    const onSubmit = vi.fn((event: FormEvent) => event.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <SkillCard name="github" enabled={true} hasContext={false} mcpServerCount={1} onToggle={vi.fn()} />
+      </form>,
+    );
+
+    const toggle = screen.getByRole('switch', { name: /github/i });
+    expect(toggle.getAttribute('type')).toBe('button');
+    fireEvent.click(toggle);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('shows MCP server count when > 0', () => {


### PR DESCRIPTION
## Summary
- mark SkillCard switch controls as explicit non-submit buttons
- add a form-wrapper regression proving toggles do not submit parent forms
- preserve existing switch semantics and toggle behavior

## Test plan
- `npm test -- --run tests/components/skills/skill-card.test.tsx`
- `npm test` (packages/franken-web; 649 tests)
- `npm run typecheck` (packages/franken-web)
- `npm run lint` (packages/franken-web; 0 errors, 18 pre-existing warnings)
- `npm run build` (packages/franken-web)

Closes #3155