### PR TITLE
fix(observer): handle missing trace details

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -103,6 +103,7 @@ describe('TraceServer', () => {
           })
         }
         return Promise.resolve({
+          ok: true,
           json: () => Promise.resolve({ id: maliciousId, goal: 'g', status: 'completed', spans: [] }),
         })
       }
@@ -127,6 +128,61 @@ describe('TraceServer', () => {
       await context.loadDetail!(maliciousId)
       expect(panel.innerHTML).not.toContain('<img')
       expect(panel.innerHTML).toContain('&lt;img')
+    })
+
+    it('renders an escaped recoverable error when a trace detail request returns 404', async () => {
+      const html = await fetch(server.url + '/').then(r => r.text())
+      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+      expect(script).toBeDefined()
+
+      const panel = { innerHTML: '' }
+      const context = createContext({
+        document: {
+          getElementById: (id: string) => id === 'panel'
+            ? panel
+            : { innerHTML: '', addEventListener: () => {} },
+          querySelectorAll: () => [] as unknown[],
+        },
+        fetch: () => Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({ error: 'trace not found <img src=x onerror=alert(1)>' }),
+        }),
+        Date,
+      }) as { loadDetail?: (id: string) => Promise<void> }
+      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+
+      await expect(context.loadDetail!('stale-trace')).resolves.toBeUndefined()
+      expect(panel.innerHTML).toContain('trace not found')
+      expect(panel.innerHTML).toContain('&lt;img')
+      expect(panel.innerHTML).not.toContain('<img')
+    })
+
+    it('renders a recoverable error when successful trace JSON has no spans array', async () => {
+      const html = await fetch(server.url + '/').then(r => r.text())
+      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+      expect(script).toBeDefined()
+
+      const panel = { innerHTML: '' }
+      const context = createContext({
+        document: {
+          getElementById: (id: string) => id === 'panel'
+            ? panel
+            : { innerHTML: '', addEventListener: () => {} },
+          querySelectorAll: () => [] as unknown[],
+        },
+        fetch: () => Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'malformed-trace', goal: 'incomplete trace' }),
+        }),
+        Date,
+      }) as { loadDetail?: (id: string) => Promise<void> }
+      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+
+      await expect(context.loadDetail!('malformed-trace')).resolves.toBeUndefined()
+      expect(panel.innerHTML).toContain('Trace details are unavailable')
+      expect(panel.innerHTML).toContain('empty')
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -225,7 +225,26 @@ sidebar.addEventListener('click', e=>{
 
 async function loadDetail(id){
   document.querySelectorAll('.trace-item').forEach(el=>el.classList.toggle('active',el.dataset.id===id))
-  const t = await fetch('/api/traces/'+encodeURIComponent(id)).then(r=>r.json())
+  let response
+  let t
+  try {
+    response = await fetch('/api/traces/'+encodeURIComponent(id))
+    t = await response.json()
+  } catch {
+    panel.innerHTML = '<p class="empty" role="alert">Trace details are unavailable.</p>'
+    return
+  }
+  if(!response.ok){
+    const message = t && typeof t.error==='string'
+      ? t.error
+      : 'Unable to load trace details ('+response.status+').'
+    panel.innerHTML = '<p class="empty" role="alert">'+esc(message)+'</p>'
+    return
+  }
+  if(!t || !Array.isArray(t.spans)){
+    panel.innerHTML = '<p class="empty" role="alert">Trace details are unavailable.</p>'
+    return
+  }
   const totalTokens = t.spans.reduce((n,s)=>(n+(s.metadata.totalTokens??0)),0)
   panel.innerHTML = \`
     <h2>\${esc(t.goal)}</h2>


### PR DESCRIPTION
## Summary
- handle trace-detail HTTP and JSON failures without throwing from the embedded UI
- validate that successful detail payloads contain a spans array before rendering
- escape API-provided error text and show a recoverable alert in the detail pane
- add regression coverage for 404 responses and malformed successful payloads

## Test plan
- `npm test --workspace @franken/observer -- src/ui/TraceServer.test.ts`
- `npm test --workspace @franken/observer`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer`

Closes #3187