### PR TITLE
fix(web): announce module toggle state

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-modules.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-modules.tsx
@@ -59,6 +59,7 @@ export function StepModules() {
           <button
             key={mod.key}
             type="button"
+            aria-pressed={Boolean(values[mod.key])}
             onClick={() => toggleModule(mod.key)}
             className={`p-4 rounded-xl border-2 text-left transition-colors
               ${values[mod.key]

--- a/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
@@ -21,9 +21,14 @@ describe('StepModules', () => {
     expect(screen.getByText('Heartbeat')).toBeTruthy();
   });
 
-  it('toggling a module stores state in Zustand', () => {
+  it('announces module toggle state and stores it in Zustand', () => {
     render(<StepModules />);
-    fireEvent.click(screen.getByText('Firewall'));
+    const firewallButton = screen.getByRole('button', { name: /firewall/i });
+
+    expect(firewallButton.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(firewallButton);
+    expect(firewallButton.getAttribute('aria-pressed')).toBe('true');
+
     const modules = useBeastStore.getState().stepValues[3] as Record<string, boolean>;
     expect(modules?.firewall).toBe(true);
   });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-18 — Kanban reviewer isolation
+- Independent review workers must receive a distinct child card or explicitly review-only context; never let a delegated reviewer inherit and complete the implementation parent card, because completion can garbage-collect its workspace before the verified diff is committed and shipped.
+
 ## 2026-07-18 — Working-memory hydration corruption
 - Fail closed on malformed persisted values that are shaped like structured JSON (`{` or `[` after leading whitespace), while retaining the documented plain-text fallback for genuinely legacy rows. Typed hydration errors should identify the affected key without deleting the row, so operators can repair it and reopen the store.
 


### PR DESCRIPTION
## Summary
- expose each module card toggle state with `aria-pressed`
- verify the accessible state changes from false to true while preserving Zustand updates
- record the recovery lesson for isolated Kanban reviewers

## Verification
- `npm run build --workspace @franken/types`
- `npm run test --workspace @franken/web` (649 passed)
- `npm run typecheck --workspace @franken/web`
- `npm run lint --workspace @franken/web` (0 errors, 18 pre-existing warnings)
- `npm run build --workspace @franken/web`

Closes #3130