### PR TITLE
docs(security): document secret backend argv safeguards

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -348,12 +348,15 @@ It maps ChromaDB, Grafana, Tempo, provider credentials, and secret backends to t
     node packages/franken-orchestrator/dist/cli/run.js run --config .fbeast/config.json
     ```
 
-- [ ] For `os-keychain`, set the backend in `.fbeast/config.json`, then run `frankenbeast init`; no passphrase prompt is required.
+- [ ] For `os-keychain` on Linux, install `secret-tool` for Linux Secret Service, set the backend in `.fbeast/config.json`, then run `frankenbeast init`; no passphrase prompt is required and secret values are supplied over stdin.
+  - macOS and Windows writes fail closed because their built-in noninteractive keychain CLIs require secret values in process arguments. Use `local-encrypted`, `1password`, or `bitwarden` on those platforms.
 - [ ] For `1password`:
+  - Install 1Password CLI 2.23.0 or newer so writes can use stdin instead of command-line arguments.
   - Create or use a vault literally named `frankenbeast`.
   - Authenticate the `op` CLI before init.
   - Init-created items use titles like `frankenbeast/network.operatorTokenRef`.
 - [ ] For `bitwarden`:
+  - Install the Bitwarden CLI; credential payloads are supplied over stdin instead of command-line arguments.
   - Run `bw login` / `bw unlock`.
   - Export `BW_SESSION` before init.
   - Init-created secure notes use the `frankenbeast/` title prefix.

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Frankenbeast stores secrets outside the config file. The config references secre
 | Backend | Key | Best for |
 |---------|-----|----------|
 | Local encrypted file | `local-encrypted` | Default backend; zero-install local dev, CI/CD, offline, or minimal environments |
-| OS keychain (Keychain/GNOME/DPAPI) | `os-keychain` | Explicit opt-in for single-machine local dev when you want OS-managed storage and no passphrase prompt |
+| OS keychain (Linux Secret Service) | `os-keychain` | Explicit opt-in for Linux single-machine local dev when you want OS-managed storage and no passphrase prompt |
 | 1Password | `1password` | Teams using 1Password vaults |
 | Bitwarden | `bitwarden` | Teams using Bitwarden |
 
@@ -710,7 +710,7 @@ When `network.secureBackend` is unset, init defaults to `local-encrypted`: the p
 ```json
 { "network": { "secureBackend": "os-keychain" } }
 ```
-Set this in `.fbeast/config.json` before running `frankenbeast init` when you want local secrets in the native macOS Keychain, GNOME Secret Service, or Windows Credential Manager instead of the default encrypted file. The token is generated and stored in the OS keychain automatically (no passphrase prompt). Use `os-keychain` only when you explicitly select it; it is convenient for single-machine local development, but it is not the default backend.
+Set this in `.fbeast/config.json` before running `frankenbeast init` when you want local secrets in Linux Secret Service instead of the default encrypted file. The token is generated and stored through `secret-tool` stdin (no passphrase prompt), so secret values never enter process arguments. macOS and Windows writes fail closed because their built-in noninteractive CLIs require secret values in process arguments; use `local-encrypted`, `1password`, or `bitwarden` on those platforms. Use `os-keychain` only when you explicitly select it; it is convenient for Linux single-machine local development, but it is not the default backend.
 
 **1Password / Bitwarden:**
 ```json
@@ -721,7 +721,7 @@ Set this in `.fbeast/config.json` before running `frankenbeast init` when you wa
 ```
 Set one of those values in `.fbeast/config.json`, then run `frankenbeast init`. You can also use the current CLI shortcut `frankenbeast init --backend 1password` or `frankenbeast init --backend bitwarden`; it applies the same `network.secureBackend` choice before the wizard writes `.fbeast/config.json`.
 
-For 1Password, create or use a vault literally named `frankenbeast`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, run `bw login`/`bw unlock` and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. The CLI uses the official 1Password/Bitwarden CLI under the hood.
+For 1Password, install 1Password CLI 2.23.0 or newer, create or use a vault literally named `frankenbeast`, and authenticate `op`; init-created items use titles like `frankenbeast/network.operatorTokenRef`. For Bitwarden, install the Bitwarden CLI, run `bw login`/`bw unlock`, and export `BW_SESSION` first; init-created secure notes use the same `frankenbeast/` title prefix. Both backends send credential payloads through stdin instead of command-line arguments and fail closed when a stdin-capable runner is unavailable.
 
 ### Operator token setup
 

--- a/tests/docs-issue-2857.test.ts
+++ b/tests/docs-issue-2857.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('issue #2857 secret-store argv safety documentation', () => {
+  it('documents the OS keychain write limitations at both onboarding entrypoints', () => {
+    for (const relativePath of ['README.md', 'ONBOARDING.md']) {
+      const document = readText(relativePath);
+
+      expect(document).toContain('Linux Secret Service');
+      expect(document).toContain('macOS and Windows writes fail closed');
+      expect(document).toContain('secret values in process arguments');
+    }
+  });
+
+  it('documents the CLI requirements for stdin-safe 1Password and Bitwarden writes', () => {
+    const readme = readText('README.md');
+
+    expect(readme).toContain('1Password CLI 2.23.0 or newer');
+    expect(readme).toContain('stdin instead of command-line arguments');
+    expect(readme).toContain('Bitwarden CLI');
+  });
+});


### PR DESCRIPTION
## Summary
- documents that OS keychain writes are stdin-safe only on Linux Secret Service
- records the fail-closed macOS and Windows limitation instead of claiming unsupported automatic writes
- documents the stdin-safe CLI requirements for 1Password and Bitwarden
- adds a focused documentation regression test

## Context
The production argv hardening and backend unit coverage landed in #2636. This PR closes the remaining documentation acceptance gap without duplicating that implementation.

## Test Plan
- `npm run test:root -- tests/docs-issue-2857.test.ts tests/docs-issue-2543.test.ts`
- `npm run test --workspace @franken/orchestrator -- tests/unit/network/secret-backends/one-password-store.test.ts tests/unit/network/secret-backends/bitwarden-store.test.ts tests/unit/network/secret-backends/os-keychain-store.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run build`

Closes #2857