### PR TITLE
fix(web): explain disabled model selector

### DIFF
--- a/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
+++ b/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 export interface ProviderOption {
   id: string;
   name: string;
@@ -14,6 +16,7 @@ interface ProviderModelSelectProps {
 }
 
 export function ProviderModelSelect({ providers, value, onChange, showUseDefault, useDefault, onUseDefaultChange }: ProviderModelSelectProps) {
+  const modelGuidanceId = useId();
   const selectedProvider = providers.find((p) => p.id === value.provider);
   const hasProviders = providers.length > 0;
 
@@ -63,6 +66,7 @@ export function ProviderModelSelect({ providers, value, onChange, showUseDefault
           value={value.model}
           onChange={(e) => onChange({ ...value, model: e.target.value })}
           aria-label="Model"
+          aria-describedby={!selectedProvider ? modelGuidanceId : undefined}
           disabled={!selectedProvider}
           className="flex-1 bg-beast-control border border-beast-border rounded-lg px-3 py-2 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent disabled:opacity-50"
         >
@@ -72,6 +76,11 @@ export function ProviderModelSelect({ providers, value, onChange, showUseDefault
           ))}
         </select>
       </div>
+      {!selectedProvider && (
+        <p id={modelGuidanceId} className="text-xs text-beast-muted">
+          Select a provider to choose a model.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
@@ -29,6 +29,16 @@ describe('ProviderModelSelect', () => {
     expect(options.length).toBeGreaterThan(1); // includes placeholder
   });
 
+  it('explains how to enable the disabled model select', () => {
+    render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={vi.fn()} />);
+
+    const modelSelect = screen.getByLabelText(/model/i);
+    const guidance = screen.getByText('Select a provider to choose a model.');
+
+    expect(modelSelect.hasAttribute('disabled')).toBe(true);
+    expect(modelSelect.getAttribute('aria-describedby')).toBe(guidance.id);
+  });
+
   it('calls onChange when provider changes', () => {
     const onChange = vi.fn();
     render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={onChange} />);


### PR DESCRIPTION
## Summary
- show inline guidance while the model selector is disabled
- connect the disabled selector to its guidance with `aria-describedby`
- add focused accessibility regression coverage

## Test plan
- `npm run test --workspace @franken/web` (652 passed)
- `npm run lint --workspace @franken/web` (0 errors; 17 pre-existing warnings)
- `npm run typecheck --workspace @franken/web`
- `npm run build`

Closes #3127