### PR TITLE
ci(testing): publish coverage artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,21 @@ jobs:
       - name: Run root and package CI test suite
         run: npm run test:ci
 
+      - name: Run root and workspace coverage suite
+        continue-on-error: true
+        run: npm run test:coverage
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-reports
+          path: |
+            coverage
+            packages/*/coverage
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Run orchestrator E2E smoke CI suite
         run: npm run ci:test:e2e
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:ci-retry-fail-fixture": "node tests/fixtures/ci-retry-fail-fixture.cjs",
     "test:docker:sandbox": "node scripts/run-docker-sandbox-smoke.mjs",
     "test:root:watch": "vitest",
-    "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1",
+    "test:coverage": "npm run test:coverage:root && turbo run test:coverage --filter=\"./packages/*\" --concurrency=1 --continue",
     "test:coverage:root": "vitest run --coverage",
     "dr:restore-rehearsal": "tsx scripts/restore-rehearsal.mjs",
     "ci:dr:restore-rehearsal": "npm run dr:restore-rehearsal"

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -189,6 +189,35 @@ on:
       expect(content).not.toContain('npx turbo run build typecheck lint');
     });
 
+    it('runs coverage and publishes all root and workspace reports as an artifact', () => {
+      const steps = expectSteps(expectCiJob(workflow));
+      const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>;
+      };
+      const coverageStep = expectStepByRun(
+        steps,
+        'npm run test:coverage',
+        'the root and workspace coverage suite',
+      );
+      const uploadStep = expectStepByName(
+        steps,
+        'Upload coverage reports',
+        'the coverage artifact upload',
+      );
+      const uploadWith = expectRecord(uploadStep.with, 'coverage upload inputs');
+
+      expect(coverageStep.name).toBe('Run root and workspace coverage suite');
+      expect(coverageStep['continue-on-error']).toBe(true);
+      expect(packageJson.scripts?.['test:coverage']).toContain('--continue');
+      expect(uploadStep.uses).toBe('actions/upload-artifact@v7');
+      expect(uploadStep.if).toBe('always()');
+      expect(uploadWith.name).toBe('coverage-reports');
+      expect(uploadWith.path).toBe('coverage\npackages/*/coverage\n');
+      expect(uploadWith['if-no-files-found']).toBe('error');
+      expect(uploadWith['retention-days']).toBe(30);
+      expect(steps.indexOf(coverageStep)).toBeLessThan(steps.indexOf(uploadStep));
+    });
+
     it('runs the deterministic root Vitest suite through the shared CI test script', () => {
       const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
         scripts?: Record<string, string>;

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -633,7 +633,7 @@ describe("npm workspaces configuration", () => {
       });
 
       expect(missingRadixLocations).toEqual([]);
-    });
+    }, 30_000);
 
     it("uses filesystem-safe module URL conversion in the lint coverage audit", () => {
       const auditScript = readFileSync(


### PR DESCRIPTION
## Summary
- run the existing root and workspace coverage suite in CI without replacing the deterministic test gate
- continue across workspace coverage failures and upload all generated reports for 30 days
- add focused workflow regression coverage and a bounded timeout for the source-scanning root test

## Test Plan
- `npm run test:root`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npx turbo run test:coverage --filter="./packages/*" --concurrency=1 --continue --dry=json`
- `actionlint .github/workflows/ci.yml`

## Coverage behavior
Coverage remains informational because existing workspace thresholds can fail; the step is non-blocking and the artifact upload runs with `always()` so reports remain available for failed or suspicious runs.

Closes #3055