### PR TITLE
fix(orchestrator): bound reflected request ids

### DIFF
--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -24,8 +24,21 @@ export class HttpError extends Error {
   }
 }
 
+const MAX_REQUEST_ID_LENGTH = 128;
+const SAFE_REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+function isSafeRequestId(value: string | undefined): value is string {
+  return value !== undefined
+    && value.length > 0
+    && value.length <= MAX_REQUEST_ID_LENGTH
+    && SAFE_REQUEST_ID_PATTERN.test(value);
+}
+
 export const requestId = createMiddleware(async (c, next) => {
-  const id = c.req.header('x-request-id') ?? deterministicUuid('packages/franken-orchestrator/src/http/middleware.ts');
+  const incomingId = c.req.header('x-request-id');
+  const id = isSafeRequestId(incomingId)
+    ? incomingId
+    : deterministicUuid('packages/franken-orchestrator/src/http/middleware.ts');
   c.set('requestId', id);
   c.header('x-request-id', id);
   await next();

--- a/packages/franken-orchestrator/tests/unit/http/request-id.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/request-id.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { requestId } from '../../../src/http/middleware.js';
+
+function createApp() {
+  const app = new Hono();
+  app.use('*', requestId);
+  app.get('/', (c) => c.json({ requestId: c.get('requestId') }));
+  return app;
+}
+
+async function reflectedRequestId(incoming?: string): Promise<{ header: string; context: string }> {
+  const app = createApp();
+  const response = await app.request('http://localhost/', incoming === undefined
+    ? undefined
+    : { headers: { 'x-request-id': incoming } });
+  const body = await response.json() as { requestId: string };
+  return {
+    header: response.headers.get('x-request-id') ?? '',
+    context: body.requestId,
+  };
+}
+
+describe('request ID middleware', () => {
+  it('preserves a valid incoming request ID in the response and request context', async () => {
+    const incoming = 'trace_01J2.example:span-7';
+
+    await expect(reflectedRequestId(incoming)).resolves.toEqual({
+      header: incoming,
+      context: incoming,
+    });
+  });
+
+  it('replaces an overlong incoming request ID', async () => {
+    const incoming = 'a'.repeat(129);
+
+    const result = await reflectedRequestId(incoming);
+
+    expect(result.header).not.toBe(incoming);
+    expect(result.context).toBe(result.header);
+    expect(result.header).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  it.each([
+    ['spaces', 'unsafe request id'],
+    ['commas', 'left,right'],
+    ['non-ASCII characters', 'trace-é'],
+  ])('replaces an incoming request ID containing %s', async (_description, incoming) => {
+    const result = await reflectedRequestId(incoming);
+
+    expect(result.header).not.toBe(incoming);
+    expect(result.context).toBe(result.header);
+    expect(result.header).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+});


### PR DESCRIPTION
## Summary
- accept only non-empty request IDs up to 128 characters from a narrow ASCII allowlist
- replace overlong or unsafe incoming IDs with a generated UUID before response reflection and request-context use
- add focused middleware coverage for valid, overlong, and unsafe values

## Test plan
- `npm test --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build`

Closes #3225