### PR TITLE
fix(observer): harden trace server responses

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -48,6 +48,22 @@ describe('TraceServer', () => {
   })
 
   describe('GET /', () => {
+    it('prevents sniffing and caching for HTML and trace JSON responses', async () => {
+      const trace = makeTrace('Sensitive trace')
+      await adapter.flush(trace)
+
+      const responses = await Promise.all([
+        fetch(server.url + '/'),
+        fetch(server.url + '/api/traces'),
+        fetch(`${server.url}/api/traces/${trace.id}`),
+      ])
+
+      for (const res of responses) {
+        expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+        expect(res.headers.get('cache-control')).toBe('no-store')
+      }
+    })
+
     it('returns 200', async () => {
       const res = await fetch(server.url + '/')
       expect(res.status).toBe(200)

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -3,6 +3,11 @@ import type { IncomingMessage, ServerResponse, Server } from 'node:http'
 import type { ExportAdapter, TraceSummary } from '../export/ExportAdapter.js'
 import type { Trace } from '../core/types.js'
 
+const TRACE_RESPONSE_HEADERS = {
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'no-store',
+} as const
+
 export interface TraceServerOptions {
   adapter: ExportAdapter
   /** Port to listen on. Use 0 to let the OS assign a free port. Default: 4040 */
@@ -76,7 +81,10 @@ export class TraceServer {
       const path = new URL(req.url ?? '/', `http://localhost`).pathname
 
       if (path === '/' || path === '') {
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.writeHead(200, {
+          'Content-Type': 'text/html; charset=utf-8',
+          ...TRACE_RESPONSE_HEADERS,
+        })
         res.end(buildHtml())
         return
       }
@@ -136,7 +144,10 @@ function formatHostForUrl(host: string): string {
 }
 
 function json(res: ServerResponse, status: number, body: unknown): void {
-  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    ...TRACE_RESPONSE_HEADERS,
+  })
   res.end(JSON.stringify(body))
 }
 


### PR DESCRIPTION
## Summary
- add `X-Content-Type-Options: nosniff` to TraceServer HTML and JSON responses
- add `Cache-Control: no-store` to prevent caching trace data
- cover `/`, `/api/traces`, and `/api/traces/:id` with response-header regression assertions

## Test Plan
- `npm test --workspace @franken/observer` (826 tests)
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)
- `npm run build --workspace @franken/observer`

Closes #3100