### PR TITLE
docs(onboarding): add pull request self-review checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ If a pull-request check fails, follow the [first-PR CI failure triage guide](doc
 
 ## Commit and open a pull request
 
-Review the exact diff, then create a Conventional Commit:
+Review the exact diff, then create a Conventional Commit. First-time contributors can follow the [pull request self-review checklist](docs/onboarding/pull-request-self-review.md) to inspect the complete base-to-head patch, accidental or sensitive files, verification evidence, and the GitHub pull request before requesting review.
 
 If `git status --short` shows an intentional new file with the `??` prefix, first run `git add --intent-to-add <new-path>` for that path. This lets patch mode present the new file without staging unrelated untracked files.
 
@@ -144,6 +144,7 @@ Read the displayed title, body, base branch, and head branch before requesting r
 
 ## Before requesting review
 
+- [ ] The complete base-to-head diff was checked with the [pull request self-review checklist](docs/onboarding/pull-request-self-review.md).
 - [ ] The pull request addresses one issue and contains no unrelated files.
 - [ ] Documentation and commands match the current repository state.
 - [ ] Relevant tests, typechecks, lint, and builds pass, or the pull request explicitly explains why a gate could not run.

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,21 +11,22 @@ For a complete clean-checkout setup, use the root [onboarding checklist](../../O
 
 ## Choose by goal
 
-| Goal | Start here | Continue with |
-| --- | --- | --- |
-| Run Frankenbeast locally | [Persona quickstart tracks](persona-quickstart-tracks.md) — Operator track | [Local service dependencies](local-service-dependencies.md), then the [setup troubleshooting matrix](setup-troubleshooting-matrix.md) if a check fails |
-| Make a first code or docs contribution | [Persona quickstart tracks](persona-quickstart-tracks.md) — Contributor track | [Test command decision tree](test-command-decision-tree.md) |
-| Make a documentation-only contribution | [Docs-only contribution quickstart](docs-only-contribution.md) | [Contributor guide](../../CONTRIBUTING.md) for the full code-and-docs workflow |
-| Improve the browser dashboard UX | [Dashboard UX contribution checklist](dashboard-ux-contribution.md) | [Architecture map](architecture-map.md) and [test command decision tree](test-command-decision-tree.md) |
-| Recover an outdated fork, wrong branch, or rejected push | [Fork and branch recovery](fork-and-branch-recovery.md) | [Getting help with a first contribution](getting-help.md) before resetting or rewriting shared history |
-| Diagnose a failing first-PR check | [First-PR CI failure triage](ci-failure-triage.md) | [Test command decision tree](test-command-decision-tree.md), then [getting help](getting-help.md) if the failure remains unclear |
-| Get help with a first-contribution blocker | [Getting help with a first contribution](getting-help.md) | The setup, testing, security, and review references selected by that guide |
-| Take one issue through a first PR | [First-PR agent runbook](first-pr-agent-runbook.md) | [Coding-agent PR etiquette](coding-agent-pr-etiquette.md) and the [issue complexity rubric](issue-complexity-rubric.md) |
-| Clean up after a first PR merges | [After your first pull request](after-your-first-pr.md) | [Contributor guide](../../CONTRIBUTING.md) when you are ready to select the next issue |
-| Practice before editing production code | [Sample agent practice issue](sample-agent-practice-issue.md) | The linked practice fixture and reset workflow |
-| Find the package that owns a change | [Architecture map](architecture-map.md) | [Repository ownership](repository-ownership.md) |
-| Assign or recover agent work | [Agent role responsibility map](agent-role-responsibility-map.md) | [Agent coordination runtime glossary](agent-coordination-runtime-glossary.md) |
-| Understand merge, release, and deployment ownership | [Release and deployment mental model](release-deployment-mental-model.md) | The release and rollback references linked from that guide |
+| Goal                                                     | Start here                                                                    | Continue with                                                                                                                                          |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Run Frankenbeast locally                                 | [Persona quickstart tracks](persona-quickstart-tracks.md) — Operator track    | [Local service dependencies](local-service-dependencies.md), then the [setup troubleshooting matrix](setup-troubleshooting-matrix.md) if a check fails |
+| Make a first code or docs contribution                   | [Persona quickstart tracks](persona-quickstart-tracks.md) — Contributor track | [Test command decision tree](test-command-decision-tree.md)                                                                                            |
+| Make a documentation-only contribution                   | [Docs-only contribution quickstart](docs-only-contribution.md)                | [Contributor guide](../../CONTRIBUTING.md) for the full code-and-docs workflow                                                                         |
+| Improve the browser dashboard UX                         | [Dashboard UX contribution checklist](dashboard-ux-contribution.md)           | [Architecture map](architecture-map.md) and [test command decision tree](test-command-decision-tree.md)                                                |
+| Recover an outdated fork, wrong branch, or rejected push | [Fork and branch recovery](fork-and-branch-recovery.md)                       | [Getting help with a first contribution](getting-help.md) before resetting or rewriting shared history                                                 |
+| Diagnose a failing first-PR check                        | [First-PR CI failure triage](ci-failure-triage.md)                            | [Test command decision tree](test-command-decision-tree.md), then [getting help](getting-help.md) if the failure remains unclear                       |
+| Get help with a first-contribution blocker               | [Getting help with a first contribution](getting-help.md)                     | The setup, testing, security, and review references selected by that guide                                                                             |
+| Take one issue through a first PR                        | [First-PR agent runbook](first-pr-agent-runbook.md)                           | [Coding-agent PR etiquette](coding-agent-pr-etiquette.md) and the [issue complexity rubric](issue-complexity-rubric.md)                                |
+| Self-review a pull request before review                 | [Pull request self-review checklist](pull-request-self-review.md)             | [Contributor guide](../../CONTRIBUTING.md) for opening the PR and responding to feedback                                                               |
+| Clean up after a first PR merges                         | [After your first pull request](after-your-first-pr.md)                       | [Contributor guide](../../CONTRIBUTING.md) when you are ready to select the next issue                                                                 |
+| Practice before editing production code                  | [Sample agent practice issue](sample-agent-practice-issue.md)                 | The linked practice fixture and reset workflow                                                                                                         |
+| Find the package that owns a change                      | [Architecture map](architecture-map.md)                                       | [Repository ownership](repository-ownership.md)                                                                                                        |
+| Assign or recover agent work                             | [Agent role responsibility map](agent-role-responsibility-map.md)             | [Agent coordination runtime glossary](agent-coordination-runtime-glossary.md)                                                                          |
+| Understand merge, release, and deployment ownership      | [Release and deployment mental model](release-deployment-mental-model.md)     | The release and rollback references linked from that guide                                                                                             |
 
 ## All onboarding references
 
@@ -43,6 +44,7 @@ For a complete clean-checkout setup, use the root [onboarding checklist](../../O
 - [Issue complexity rubric](issue-complexity-rubric.md) — assigns risk level, worker lane, and verification depth.
 - [Local service dependencies](local-service-dependencies.md) — explains when ChromaDB, Grafana, Tempo, Docker, providers, and secret stores are required.
 - [Persona quickstart tracks](persona-quickstart-tracks.md) — narrow operator, contributor, and agent-developer setup paths.
+- [Pull request self-review checklist](pull-request-self-review.md) — checks complete branch scope, accidental files, verification evidence, and the GitHub PR before review.
 - [Release and deployment mental model](release-deployment-mental-model.md) — ownership from PR merge through Release Please, deployment, and rollback.
 - [Repository ownership](repository-ownership.md) — primary and escalation owners by repository surface.
 - [Sample agent practice issue](sample-agent-practice-issue.md) — copyable safe training exercise for first-time agents.

--- a/docs/onboarding/pull-request-self-review.md
+++ b/docs/onboarding/pull-request-self-review.md
@@ -1,0 +1,145 @@
+---
+title: Pull request self-review checklist
+description: Review the exact files, commits, verification evidence, and GitHub pull request a maintainer will see before requesting review.
+---
+
+# Pull request self-review checklist
+
+Use this guide after implementing and testing one issue, but before requesting review. A focused self-review catches accidental files, stale evidence, branch mistakes, and missing context while they are still easy to fix.
+
+## 1. Confirm the issue and branch scope
+
+Set the issue and repository, reread the acceptance criteria, and confirm that another open pull request did not claim the same work while you were implementing:
+
+```bash
+REPO="djm204/frankenbeast"
+ISSUE_NUMBER="2526" # replace with your issue
+
+gh issue view "$ISSUE_NUMBER" --repo "$REPO"
+gh pr list --repo "$REPO" --state open --limit 100 \
+  --search "$ISSUE_NUMBER OR issue-$ISSUE_NUMBER" \
+  --json number,title,headRefName,url
+git branch --show-current
+git status --short --branch
+```
+
+Stop if the issue is closed, another active pull request covers it, you are on `main`, or the branch contains work for a second issue. Ask in the issue or pull request instead of creating duplicate work.
+
+Choose the base that matches your checkout and fetch it before comparing:
+
+```bash
+# Fork checkout: origin is your fork and upstream is djm204/frankenbeast.
+git fetch upstream main
+BASE_REF="upstream/main"
+
+# Direct upstream checkout: use these two lines instead.
+# git fetch origin main
+# BASE_REF="origin/main"
+```
+
+Do not reset, rebase, or force-push just because the base moved. If the branch needs recovery, use the [fork and branch recovery guide](fork-and-branch-recovery.md).
+
+## 2. Review every local change
+
+Review uncommitted changes first. Stage only the intended paths or hunks, then review the staged patch before committing:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+git diff
+git add -p
+git diff --cached --check
+git diff --cached --stat
+git diff --cached
+```
+
+Do not use `git add .` for convenience. It can stage generated output, local configuration, or another task's work. For an intentional untracked file, use `git add --intent-to-add path/to/file` before `git add -p`, or stage that exact path after reviewing it.
+
+After committing, review the complete branch rather than only the last commit:
+
+```bash
+git diff --check "$BASE_REF...HEAD"
+git diff --stat "$BASE_REF...HEAD"
+git diff "$BASE_REF...HEAD"
+git log --oneline "$BASE_REF..HEAD"
+git diff --name-status "$BASE_REF...HEAD"
+```
+
+For every changed file, be able to explain why it is needed for this issue. Remove drive-by formatting, unrelated refactors, debug output, editor files, and generated artifacts. Confirm each commit subject follows the repository's Conventional Commit format.
+
+## 3. Check for unsafe or accidental files
+
+Inspect the changed-path list for local state and sensitive material. Do not commit files such as:
+
+- `.env` or other credential-bearing environment files;
+- `.fbeast/` runtime state, local databases, logs, traces, or coverage output;
+- provider keys, tokens, cookies, private issue text, or customer data;
+- editor caches, dependency folders, build output, screenshots with secrets, or personal audit artifacts.
+
+A clean secret scanner does not make an unexpected file safe. Read every changed file and verify that examples use obvious placeholders rather than realistic credentials. If sensitive data was committed or pushed, stop and follow the repository's security guidance; deleting it in a later commit does not remove it from history.
+
+Also check the shape of the change:
+
+- public behavior, commands, configuration, and workflows have matching docs;
+- behavior changes have focused regression coverage;
+- new documentation pages have `title` and `description` frontmatter and are linked from the nearest index;
+- renamed or deleted files do not leave broken imports or links;
+- test fixtures are minimal and contain no real production data.
+
+## 4. Rerun and record verification
+
+Use the [test command decision tree](test-command-decision-tree.md) to choose the narrowest meaningful checks, then run the package or root gates required by the change. Run checks against the final committed content, not an earlier draft.
+
+Record the exact command and real outcome as you run it:
+
+```text
+- `npm run test:root -- tests/docs-issue-2526.test.ts` — passed
+- `npm run typecheck` — passed
+- `npm run lint` — passed
+- `npm run build` — passed
+```
+
+Replace the examples with your actual commands. Do not claim a skipped or failed check passed. If a relevant gate cannot run, state the exact blocker and any narrower check that did run. Never paste secrets, private logs, or unredacted environment output as evidence.
+
+After the final verification, confirm that tests did not modify the branch:
+
+```bash
+git status --short --branch
+git diff --check "$BASE_REF...HEAD"
+```
+
+## 5. Inspect the pull request GitHub will review
+
+Push the reviewed branch and open the pull request using the [contributor guide](../../CONTRIBUTING.md). The body should explain the gap, summarize the focused solution, list only real verification results, and include the closing line:
+
+```text
+Closes #<issue-number>
+```
+
+Before requesting review, inspect the GitHub representation rather than assuming the local branch and form were correct:
+
+```bash
+PR_NUMBER="123" # replace with your pull request
+
+gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json title,body,baseRefName,headRefName,headRefOid,files,url
+gh pr diff "$PR_NUMBER" --repo "$REPO"
+gh pr checks "$PR_NUMBER" --repo "$REPO"
+```
+
+Verify that the base is `main`, the head is the intended issue branch, the title is a Conventional Commit, the file list matches your local review, and the body closes only the selected issue. If the title or body is wrong, update it. If the head branch is wrong, close the pull request and recreate it from the correct branch; GitHub cannot change a pull request's head branch.
+
+CI and reviews apply to the current head. After any push, rerun affected local checks, update the evidence when needed, inspect the complete pull-request diff again, and wait for current-head CI and required review before merge.
+
+## Ready-for-review checklist
+
+- [ ] The issue is still the correct source of scope and no duplicate pull request exists.
+- [ ] The branch contains one issue's work and no unrelated files or commits.
+- [ ] Every changed file was reviewed in the complete base-to-head diff.
+- [ ] No credentials, local runtime state, generated output, or private data is included.
+- [ ] Tests and docs cover the changed behavior or workflow.
+- [ ] Verification evidence lists exact commands and honest outcomes.
+- [ ] The pull request targets `main`, uses the intended head branch, and has a Conventional Commit title.
+- [ ] The pull-request body explains why, summarizes what changed, and includes `Closes #<issue-number>`.
+- [ ] CI and required review are green for the current head commit.

--- a/docs/onboarding/pull-request-self-review.md
+++ b/docs/onboarding/pull-request-self-review.md
@@ -19,6 +19,9 @@ gh issue view "$ISSUE_NUMBER" --repo "$REPO"
 gh pr list --repo "$REPO" --state open --limit 100 \
   --search "$ISSUE_NUMBER OR issue-$ISSUE_NUMBER" \
   --json number,title,headRefName,url
+gh pr list --repo "$REPO" --state open --limit 100 \
+  --json number,title,headRefName,url \
+  --jq ".[] | select(.headRefName | contains(\"issue-$ISSUE_NUMBER-\"))"
 git branch --show-current
 git status --short --branch
 ```

--- a/tests/docs-issue-2526.test.ts
+++ b/tests/docs-issue-2526.test.ts
@@ -26,6 +26,7 @@ describe("issue #2526 pull-request self-review path", () => {
       "## 1. Confirm the issue and branch scope",
       'gh issue view "$ISSUE_NUMBER"',
       'gh pr list --repo "$REPO" --state open',
+      '--jq ".[] | select(.headRefName | contains(\\"issue-$ISSUE_NUMBER-\\"))"',
       "## 2. Review every local change",
       "git status --short",
       "git diff --check",

--- a/tests/docs-issue-2526.test.ts
+++ b/tests/docs-issue-2526.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const GUIDE_PATH = "docs/onboarding/pull-request-self-review.md";
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), "utf8");
+}
+
+describe("issue #2526 pull-request self-review path", () => {
+  it("is discoverable from contributor onboarding entrypoints", () => {
+    expect(readText("CONTRIBUTING.md")).toContain(`(${GUIDE_PATH})`);
+    expect(readText("docs/onboarding/README.md")).toContain(
+      "(pull-request-self-review.md)",
+    );
+  });
+
+  it("provides a complete and safe first-time self-review workflow", () => {
+    const guide = readText(GUIDE_PATH);
+
+    for (const expected of [
+      "title: Pull request self-review checklist",
+      "# Pull request self-review checklist",
+      "## 1. Confirm the issue and branch scope",
+      'gh issue view "$ISSUE_NUMBER"',
+      'gh pr list --repo "$REPO" --state open',
+      "## 2. Review every local change",
+      "git status --short",
+      "git diff --check",
+      'git diff --stat "$BASE_REF...HEAD"',
+      'git diff "$BASE_REF...HEAD"',
+      'git log --oneline "$BASE_REF..HEAD"',
+      "Do not use `git add .`",
+      "## 3. Check for unsafe or accidental files",
+      ".env",
+      ".fbeast/",
+      "## 4. Rerun and record verification",
+      "Do not claim a skipped or failed check passed",
+      "## 5. Inspect the pull request GitHub will review",
+      'gh pr view "$PR_NUMBER"',
+      'gh pr diff "$PR_NUMBER"',
+      'gh pr checks "$PR_NUMBER"',
+      "Closes #<issue-number>",
+      "## Ready-for-review checklist",
+      "current head",
+    ]) {
+      expect(guide).toContain(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a first-time-contributor self-review guide covering issue/branch scope, complete diffs, accidental or sensitive files, and honest verification evidence
- link the guide from the onboarding index and contributor review checklist
- add a focused documentation regression test for the issue requirements

## Verification
- `npm run test:root -- tests/docs-issue-2526.test.ts` — passed (2 tests)
- `npm run test:root` — passed (607 passed, 1 skipped)
- `npm run typecheck` — passed
- `npm run lint` — passed (pre-existing cached warnings only)
- `npm run build` — passed (existing Vite chunk-size warning only)
- `npx prettier --check CONTRIBUTING.md docs/onboarding/README.md docs/onboarding/pull-request-self-review.md tests/docs-issue-2526.test.ts` — passed

Closes #2526