### PR TITLE
docs(observer): clarify trace server bind security

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -830,7 +830,7 @@ const discordNotifier = new WebhookNotifier({
 
 ## Local trace viewer
 
-`TraceServer` serves a self-contained HTML trace viewer over a local HTTP server (Node built-ins only, no external dependencies).
+`TraceServer` serves a self-contained HTML trace viewer over a local HTTP server (Node built-ins only, no external dependencies). It binds to `127.0.0.1` by default so prompts, goals, errors, and trace metadata are not exposed on other network interfaces.
 
 ```ts
 import { TraceServer, SQLiteAdapter } from '@franken/observer'
@@ -840,10 +840,20 @@ const server  = new TraceServer({ adapter, port: 4040 })
 
 await server.start()
 process.stdout.write(`Trace viewer: ${server.url}`)
-// → http://localhost:4040
+// → http://127.0.0.1:4040
 
 // Later:
 await server.stop()
+```
+
+To opt in to access from another interface, set `host` explicitly. `server.url` reports the configured host. `TraceServer` does not provide authentication, so only use a non-loopback host behind appropriate firewall and access controls.
+
+```ts
+const sharedServer = new TraceServer({
+  adapter,
+  port: 4040,
+  host: '0.0.0.0',
+})
 ```
 
 **Routes:**

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -846,7 +846,7 @@ process.stdout.write(`Trace viewer: ${server.url}`)
 await server.stop()
 ```
 
-To opt in to access from another interface, set `host` explicitly. `server.url` reports the configured host. `TraceServer` does not provide authentication, so only use a non-loopback host behind appropriate firewall and access controls.
+To opt in to access from another interface, set `host` explicitly. `server.url` reports the configured bind host; when using the wildcard `0.0.0.0`, open the viewer with the server's reachable hostname or interface IP instead of `0.0.0.0`. `TraceServer` does not provide authentication, so only use a non-loopback host behind appropriate firewall and access controls.
 
 ```ts
 const sharedServer = new TraceServer({

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -48,13 +48,13 @@ describe('TraceServer', () => {
 
     it('uses an explicitly configured host for binding and the reported URL', async () => {
       await server.stop()
-      server = new TraceServer({ adapter, port: 0, host: 'localhost' })
+      server = new TraceServer({ adapter, port: 0, host: '0.0.0.0' })
       await server.start()
 
       const nodeServer = (server as unknown as { server: Server | null }).server
       const address = nodeServer?.address()
-      expect(address && typeof address === 'object' ? address.address : undefined).toMatch(/^(?:127\.0\.0\.1|::1)$/)
-      expect(server.url).toMatch(/^http:\/\/localhost:\d+$/)
+      expect(address && typeof address === 'object' ? address.address : undefined).toBe('0.0.0.0')
+      expect(server.url).toMatch(/^http:\/\/0\.0\.0\.0:\d+$/)
     })
   })
 

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -45,6 +45,17 @@ describe('TraceServer', () => {
       const address = nodeServer?.address()
       expect(address && typeof address === 'object' ? address.address : undefined).toBe('127.0.0.1')
     })
+
+    it('uses an explicitly configured host for binding and the reported URL', async () => {
+      await server.stop()
+      server = new TraceServer({ adapter, port: 0, host: 'localhost' })
+      await server.start()
+
+      const nodeServer = (server as unknown as { server: Server | null }).server
+      const address = nodeServer?.address()
+      expect(address && typeof address === 'object' ? address.address : undefined).toMatch(/^(?:127\.0\.0\.1|::1)$/)
+      expect(server.url).toMatch(/^http:\/\/localhost:\d+$/)
+    })
   })
 
   describe('GET /', () => {


### PR DESCRIPTION
## Summary
- document that `TraceServer` binds to `127.0.0.1` by default
- document the explicit non-loopback `host` opt-in and required firewall/access controls
- verify an explicit host controls both the listener and reported URL

## Test Plan
- `npm test --workspace @franken/observer` (827 passed)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)
- `npm run lint:any`
- `npm run lint:security`

The loopback implementation and default-host regression originally landed in #837; this closes the remaining explicit-host test and documentation acceptance criteria.

Closes #3099