### PR TITLE
ci(security): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -131,6 +131,12 @@ on:
       expect(workflow).toHaveProperty('jobs');
     });
 
+    it('grants the workflow token read-only repository contents access', () => {
+      expect(expectRecord(workflow.permissions, 'workflow.permissions')).toEqual({
+        contents: 'read',
+      });
+    });
+
     it('has a workflow name', () => {
       expect(workflow.name).toBe('CI');
     });


### PR DESCRIPTION
## Summary
- declare explicit top-level `contents: read` permissions for the CI workflow
- add focused regression coverage that rejects broader or missing workflow permissions
- preserve existing push and pull-request CI triggers and all build/test/lint jobs

## Verification
- `npx vitest run tests/unit/ci-workflow.test.ts` (42 passed)
- `npm run lint` (10/10 workspace lint tasks passed; existing warnings only)
- `git diff --check`

Closes #3161