### PR TITLE
ci(types): run root typecheck explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,11 @@ jobs:
       - name: Dependabot supply-chain guard
         run: npm run check:dependabot-supply-chain
 
-      - name: Run package build and typecheck
-        run: npx turbo run build typecheck
+      - name: Run package build
+        run: npm run build
+
+      - name: Run root typecheck
+        run: npm run typecheck
 
       - name: Run workspace lint gate
         run: npm run lint

--- a/tests/turborepo.test.ts
+++ b/tests/turborepo.test.ts
@@ -689,7 +689,11 @@ describe("Turborepo configuration", () => {
       );
 
       expect(rootPkg.scripts.typecheck).toBe("turbo run typecheck");
-      expect(ciWorkflow).toContain("run: npx turbo run build typecheck");
+      expect(ciWorkflow).toContain("run: npm run build");
+      expect(ciWorkflow).toContain("run: npm run typecheck");
+      expect(ciWorkflow.indexOf("run: npm run build")).toBeLessThan(
+        ciWorkflow.indexOf("run: npm run typecheck"),
+      );
       expect(ciWorkflow).not.toContain("run: npx turbo run build lint");
       expect(ciWorkflow).not.toContain(
         "run: npx turbo run build typecheck lint",

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -89,14 +89,6 @@ function expectStepByName(
   return step as Record<string, unknown>;
 }
 
-function expectBuildTypecheckStep(workflow: Record<string, unknown>): Record<string, unknown> {
-  return expectStepByRun(
-    expectSteps(expectCiJob(workflow)),
-    'npx turbo run build typecheck',
-    'a Turbo build/typecheck step',
-  );
-}
-
 describe('CI Workflow (.github/workflows/ci.yml)', () => {
   it('ci.yml file exists', () => {
     expect(existsSync(CI_PATH)).toBe(true);
@@ -174,16 +166,19 @@ on:
       expect(content.indexOf('node scripts/check-package-manager.mjs')).toBeLessThan(content.indexOf('npm ci'));
     });
 
-    it('explicitly gates build, typecheck, and the root lint coverage check before running the shared CI test target', () => {
+    it('runs the root build and typecheck scripts as explicit CI gates before lint and tests', () => {
       const steps = expectSteps(expectCiJob(workflow));
-      const buildTypecheckStep = expectBuildTypecheckStep(workflow);
+      const buildStep = expectStepByRun(steps, 'npm run build', 'the root build gate');
+      const typecheckStep = expectStepByRun(steps, 'npm run typecheck', 'the root typecheck gate');
       const workspaceLintStep = expectStepByRun(steps, 'npm run lint', 'a workspace lint gate step');
       const ciTestStep = expectStepByRun(steps, 'npm run test:ci', 'the shared root/package CI test target');
 
-      expect(buildTypecheckStep.name).toBe('Run package build and typecheck');
+      expect(buildStep.name).toBe('Run package build');
+      expect(typecheckStep.name).toBe('Run root typecheck');
       expect(workspaceLintStep.name).toBe('Run workspace lint gate');
       expect(ciTestStep.name).toBe('Run root and package CI test suite');
-      expect(steps.indexOf(buildTypecheckStep)).toBeLessThan(steps.indexOf(workspaceLintStep));
+      expect(steps.indexOf(buildStep)).toBeLessThan(steps.indexOf(typecheckStep));
+      expect(steps.indexOf(typecheckStep)).toBeLessThan(steps.indexOf(workspaceLintStep));
       expect(steps.indexOf(workspaceLintStep)).toBeLessThan(steps.indexOf(ciTestStep));
       expect(content).not.toMatch(/turbo run.*build\s+test\s+lint/);
       expect(content).not.toContain('npx turbo run build typecheck lint');
@@ -314,8 +309,9 @@ on:
       expect(content).not.toContain('run: npx turbo run test');
     });
 
-    it('documents the package build, typecheck, workspace lint, and shared root/package CI test targets in step names', () => {
-      expect(content).toMatch(/name:\s*Run package build and typecheck/);
+    it('documents the package build, root typecheck, workspace lint, and shared root/package CI test targets in step names', () => {
+      expect(content).toMatch(/name:\s*Run package build/);
+      expect(content).toMatch(/name:\s*Run root typecheck/);
       expect(content).toMatch(/name:\s*Run workspace lint gate/);
       expect(content).toMatch(/name:\s*Run root and package CI test suite/);
       expect(content).toMatch(/name:\s*Run orchestrator E2E smoke CI suite/);


### PR DESCRIPTION
## Summary
- split the package build and root typecheck into separate CI steps
- invoke the root `typecheck` package script directly so type-only regressions are operator-visible
- strengthen workflow regression coverage for both commands and their ordering

## Test plan
- `npm run test:root -- tests/unit/ci-workflow.test.ts tests/turborepo.test.ts` (92 passed)
- `npm run build`
- `npm run typecheck`
- `npm run lint` (passes with pre-existing warnings)

Closes #3058