### PR TITLE
fix(web): expose selected agent row state

### DIFF
--- a/packages/franken-web/src/components/beasts/agent-row.tsx
+++ b/packages/franken-web/src/components/beasts/agent-row.tsx
@@ -42,6 +42,7 @@ export function AgentRow({ agent, run, density, selected, onClick }: AgentRowPro
   return (
     <button
       type="button"
+      aria-pressed={selected}
       onClick={() => onClick(agent.id)}
       className={`w-full text-left rounded-xl border p-4 transition-colors duration-150
         bg-beast-panel hover:bg-beast-elevated cursor-pointer ${selectedClass}`}

--- a/packages/franken-web/tests/components/beasts/agent-row.test.tsx
+++ b/packages/franken-web/tests/components/beasts/agent-row.test.tsx
@@ -67,8 +67,18 @@ describe('AgentRow', () => {
     expect(onClick).toHaveBeenCalledWith('agent-1');
   });
 
-  it('shows selected highlight', () => {
-    const { container } = render(<AgentRow agent={agent} density="compact" selected={true} onClick={vi.fn()} />);
-    expect((container.firstChild as HTMLElement)?.className).toContain('bg-beast-accent-soft');
+  it('keeps visual and semantic selected state in sync', () => {
+    const { rerender } = render(
+      <AgentRow agent={agent} density="compact" selected={false} onClick={vi.fn()} />,
+    );
+    const row = screen.getByRole('button', { name: /My Test Agent/ });
+
+    expect(row.getAttribute('aria-pressed')).toBe('false');
+    expect(row.className).not.toContain('bg-beast-accent-soft');
+
+    rerender(<AgentRow agent={agent} density="compact" selected={true} onClick={vi.fn()} />);
+
+    expect(row.getAttribute('aria-pressed')).toBe('true');
+    expect(row.className).toContain('bg-beast-accent-soft');
   });
 });


### PR DESCRIPTION
## Summary
- expose each AgentRow selection state through `aria-pressed`
- keep semantic state synchronized with the existing selected-row styling
- add a regression covering both selected and unselected states

## Test plan
- `npm test --workspace @franken/web -- tests/components/beasts/agent-row.test.tsx`
- `npm test --workspace @franken/web` (653 tests)
- `npm run lint --workspace @franken/web` (0 errors; 17 pre-existing warnings)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/web`
- `npm run build --workspace @franken/web`

Closes #2980