### PR TITLE
fix(live-bench): validate artifact paths

### DIFF
--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -35,6 +35,7 @@ Key exports:
 | `ToolCallEvidenceManifestSchema`, `serializeToolCallEvidence` | Validate and serialize the full tool-call evidence artifact array. |
 | `FixtureStore` | Manage fixture files used by benchmark workspaces. |
 | `WorkspaceProvisioner` | Create isolated workspaces and capture environment snapshots for benchmark runs. |
+| `resolveWorkspaceArtifactPath` | Resolve an expected artifact or file-check path beneath a workspace while rejecting traversal, absolute paths, and symlinked components. Evaluators must call this before inspecting files. |
 | `runLearningSandboxExperiment` | Run learned-strategy experiments against read-only fixture clones with a deny-by-default tool policy and persisted pass/fail evidence. |
 
 ## CLI

--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -35,7 +35,7 @@ Key exports:
 | `ToolCallEvidenceManifestSchema`, `serializeToolCallEvidence` | Validate and serialize the full tool-call evidence artifact array. |
 | `FixtureStore` | Manage fixture files used by benchmark workspaces. |
 | `WorkspaceProvisioner` | Create isolated workspaces and capture environment snapshots for benchmark runs. |
-| `resolveWorkspaceArtifactPath` | Resolve an expected artifact or file-check path beneath a workspace while rejecting traversal, absolute paths, and symlinked components. Evaluators must call this before inspecting files. |
+| `openWorkspaceArtifactFile`, `readWorkspaceArtifactFile`, `workspaceArtifactFileExists` | Inspect expected artifacts and file-check paths through a pinned file descriptor while rejecting traversal, absolute paths, symlinked components, and path swaps. |
 | `runLearningSandboxExperiment` | Run learned-strategy experiments against read-only fixture clones with a deny-by-default tool policy and persisted pass/fail evidence. |
 
 ## CLI

--- a/packages/live-bench/src/corpus/schema.ts
+++ b/packages/live-bench/src/corpus/schema.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import { isNormalizedWorkspaceRelativePath } from '../workspace/artifact-path.js';
+
+const WorkspaceRelativePathSchema = z.string().min(1).refine(isNormalizedWorkspaceRelativePath, {
+  message: 'artifact path must be a normalized relative path',
+});
 
 function structurallyEqual(left: unknown, right: unknown): boolean {
   if (Object.is(left, right)) {
@@ -46,8 +51,8 @@ const BenchmarkCheckSchema = z.preprocess((value) => {
   }
   return value;
 }, z.discriminatedUnion('type', [
-  z.object({ type: z.literal('file-exists'), path: z.string().min(1) }).strict(),
-  z.object({ type: z.literal('file-contains'), path: z.string().min(1), text: z.string() }).strict(),
+  z.object({ type: z.literal('file-exists'), path: WorkspaceRelativePathSchema }).strict(),
+  z.object({ type: z.literal('file-contains'), path: WorkspaceRelativePathSchema, text: z.string() }).strict(),
   z.object({ type: z.literal('exit-code'), code: z.number().int() }).strict(),
   z.object({
     type: z.literal('tool-call'),
@@ -62,7 +67,7 @@ const BenchmarkTaskShape = z.object({
   taskClass: z.enum(['tool-critical', 'workflow-critical', 'artifact-critical']),
   projectFixture: z.string().min(1),
   prompt: z.string().min(1),
-  expectedArtifacts: z.array(z.string().min(1)).min(1, 'benchmark tasks must expect at least one artifact'),
+  expectedArtifacts: z.array(WorkspaceRelativePathSchema).min(1, 'benchmark tasks must expect at least one artifact'),
   requiredChecks: z.array(BenchmarkCheckSchema).min(1, 'benchmark tasks must require at least one check'),
   timeoutMs: z.number().int().positive(),
   allowedNondeterminism: z.array(z.string()),

--- a/packages/live-bench/src/index.ts
+++ b/packages/live-bench/src/index.ts
@@ -53,7 +53,9 @@ export {
   assertNormalizedWorkspaceRelativePath,
   assertSafeBenchmarkTaskPaths,
   isNormalizedWorkspaceRelativePath,
-  resolveWorkspaceArtifactPath,
+  openWorkspaceArtifactFile,
+  readWorkspaceArtifactFile,
+  workspaceArtifactFileExists,
 } from './workspace/artifact-path.js';
 export {
   WorkspaceProvisioner,

--- a/packages/live-bench/src/index.ts
+++ b/packages/live-bench/src/index.ts
@@ -50,6 +50,12 @@ export {
 } from './learning/sandbox.js';
 export { FixtureStore } from './workspace/fixture-store.js';
 export {
+  assertNormalizedWorkspaceRelativePath,
+  assertSafeBenchmarkTaskPaths,
+  isNormalizedWorkspaceRelativePath,
+  resolveWorkspaceArtifactPath,
+} from './workspace/artifact-path.js';
+export {
   WorkspaceProvisioner,
   type WorkspaceProvisionerConfig,
   type ProvisionedWorkspace,

--- a/packages/live-bench/src/workspace/artifact-path.ts
+++ b/packages/live-bench/src/workspace/artifact-path.ts
@@ -1,7 +1,6 @@
 import {
   closeSync,
   constants,
-  existsSync,
   fstatSync,
   lstatSync,
   openSync,
@@ -63,39 +62,59 @@ export function openWorkspaceArtifactFile(workspaceRoot: string, artifactPath: s
   }
   assertNoSymlinkAncestors(root);
 
-  const rootReal = realpathSync(root);
-  const candidate = resolve(root, artifactPath);
-  assertContained(candidate, root, 'artifact path');
-
-  let current = root;
-  const parts = artifactPath.split('/');
-  for (let index = 0; index < parts.length; index += 1) {
-    current = join(current, parts[index]!);
-    if (!existsSync(current)) {
-      throw new Error(`artifact file does not exist: ${artifactPath}`);
-    }
-
-    const stat = lstatSync(current);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`artifact path must not contain symlinks: ${artifactPath}`);
-    }
-    if (index < parts.length - 1 && !stat.isDirectory()) {
-      throw new Error(`artifact path component must be a directory: ${artifactPath}`);
-    }
-    assertContained(realpathSync(current), rootReal, 'artifact path');
-  }
-
   const noFollow = 'O_NOFOLLOW' in constants ? constants.O_NOFOLLOW : 0;
-  const fd = openSync(candidate, constants.O_RDONLY | constants.O_NONBLOCK | noFollow);
+  const directoryOnly = 'O_DIRECTORY' in constants ? constants.O_DIRECTORY : 0;
+  const rootFd = openSync(root, constants.O_RDONLY | constants.O_NONBLOCK | noFollow | directoryOnly);
   try {
-    // Revalidate after opening. The descriptor pins the file that callers will
-    // inspect, while this identity comparison detects a path-component swap
-    // between the initial validation and openSync().
-    assertSafeOpenedArtifact(root, rootReal, candidate, artifactPath, fd);
-    return fd;
-  } catch (error) {
-    closeSync(fd);
-    throw error;
+    if (!fstatSync(rootFd).isDirectory()) {
+      throw new Error(`workspace root must be a directory: ${workspaceRoot}`);
+    }
+
+    // On POSIX, traversing through the descriptor path makes artifact lookup
+    // relative to the pinned directory even if workspaceRoot is later replaced.
+    // Other platforms retain the before/after root identity checks below.
+    const pinnedRoot = descriptorPath(rootFd) ?? root;
+    const rootReal = realpathSync(pinnedRoot);
+    assertSameFile(rootFd, root, 'workspace root changed while it was being opened');
+    const candidate = resolve(pinnedRoot, artifactPath);
+    assertContained(candidate, pinnedRoot, 'artifact path');
+
+    let current = pinnedRoot;
+    const parts = artifactPath.split('/');
+    for (let index = 0; index < parts.length; index += 1) {
+      current = join(current, parts[index]!);
+      let stat;
+      try {
+        stat = lstatSync(current);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(`artifact file does not exist: ${artifactPath}`);
+        }
+        throw error;
+      }
+
+      if (stat.isSymbolicLink()) {
+        throw new Error(`artifact path must not contain symlinks: ${artifactPath}`);
+      }
+      if (index < parts.length - 1 && !stat.isDirectory()) {
+        throw new Error(`artifact path component must be a directory: ${artifactPath}`);
+      }
+      assertContained(realpathSync(current), rootReal, 'artifact path');
+    }
+
+    const fd = openSync(candidate, constants.O_RDONLY | constants.O_NONBLOCK | noFollow);
+    try {
+      // Revalidate after opening. The descriptor pins the file that callers
+      // inspect, while identity checks detect path-component swaps.
+      assertSameFile(rootFd, root, 'workspace root changed while opening an artifact');
+      assertSafeOpenedArtifact(pinnedRoot, rootReal, candidate, artifactPath, fd);
+      return fd;
+    } catch (error) {
+      closeSync(fd);
+      throw error;
+    }
+  } finally {
+    closeSync(rootFd);
   }
 }
 
@@ -105,10 +124,7 @@ export function workspaceArtifactFileExists(workspaceRoot: string, artifactPath:
     closeSync(fd);
     return true;
   } catch (error) {
-    if (
-      (error instanceof Error && error.message.startsWith('artifact file does not exist:'))
-      || (error as NodeJS.ErrnoException).code === 'ENOENT'
-    ) {
+    if (error instanceof Error && error.message.startsWith('artifact file does not exist:')) {
       return false;
     }
     throw error;
@@ -121,6 +137,28 @@ export function readWorkspaceArtifactFile(workspaceRoot: string, artifactPath: s
     return readFileSync(fd);
   } finally {
     closeSync(fd);
+  }
+}
+
+function descriptorPath(fd: number): string | undefined {
+  for (const path of [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]) {
+    try {
+      lstatSync(path);
+      return path;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+  return undefined;
+}
+
+function assertSameFile(fd: number, path: string, message: string): void {
+  const opened = fstatSync(fd);
+  const current = statSync(path);
+  if (opened.dev !== current.dev || opened.ino !== current.ino) {
+    throw new Error(message);
   }
 }
 

--- a/packages/live-bench/src/workspace/artifact-path.ts
+++ b/packages/live-bench/src/workspace/artifact-path.ts
@@ -86,7 +86,7 @@ export function openWorkspaceArtifactFile(workspaceRoot: string, artifactPath: s
   }
 
   const noFollow = 'O_NOFOLLOW' in constants ? constants.O_NOFOLLOW : 0;
-  const fd = openSync(candidate, constants.O_RDONLY | noFollow);
+  const fd = openSync(candidate, constants.O_RDONLY | constants.O_NONBLOCK | noFollow);
   try {
     // Revalidate after opening. The descriptor pins the file that callers will
     // inspect, while this identity comparison detects a path-component swap

--- a/packages/live-bench/src/workspace/artifact-path.ts
+++ b/packages/live-bench/src/workspace/artifact-path.ts
@@ -11,6 +11,8 @@ import {
 import { dirname, join, posix, relative, resolve, sep, win32 } from 'node:path';
 import type { BenchmarkTask } from '../types.js';
 
+class ArtifactUnavailableError extends Error {}
+
 export function assertNormalizedWorkspaceRelativePath(value: string, label = 'artifact path'): void {
   if (
     value.length === 0
@@ -88,7 +90,7 @@ export function openWorkspaceArtifactFile(workspaceRoot: string, artifactPath: s
         stat = lstatSync(current);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-          throw new Error(`artifact file does not exist: ${artifactPath}`);
+          throw new ArtifactUnavailableError(`artifact file does not exist: ${artifactPath}`);
         }
         throw error;
       }
@@ -97,7 +99,10 @@ export function openWorkspaceArtifactFile(workspaceRoot: string, artifactPath: s
         throw new Error(`artifact path must not contain symlinks: ${artifactPath}`);
       }
       if (index < parts.length - 1 && !stat.isDirectory()) {
-        throw new Error(`artifact path component must be a directory: ${artifactPath}`);
+        throw new ArtifactUnavailableError(`artifact path component must be a directory: ${artifactPath}`);
+      }
+      if (index === parts.length - 1 && !stat.isFile()) {
+        throw new ArtifactUnavailableError(`artifact path must identify a regular file: ${artifactPath}`);
       }
       assertContained(realpathSync(current), rootReal, 'artifact path');
     }
@@ -124,7 +129,7 @@ export function workspaceArtifactFileExists(workspaceRoot: string, artifactPath:
     closeSync(fd);
     return true;
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('artifact file does not exist:')) {
+    if (error instanceof ArtifactUnavailableError) {
       return false;
     }
     throw error;
@@ -185,7 +190,7 @@ function assertSafeOpenedArtifact(
     throw new Error(`artifact path changed while it was being opened: ${artifactPath}`);
   }
   if (!opened.isFile()) {
-    throw new Error(`artifact path must identify a regular file: ${artifactPath}`);
+    throw new ArtifactUnavailableError(`artifact path must identify a regular file: ${artifactPath}`);
   }
 }
 

--- a/packages/live-bench/src/workspace/artifact-path.ts
+++ b/packages/live-bench/src/workspace/artifact-path.ts
@@ -1,0 +1,96 @@
+import { existsSync, lstatSync, realpathSync } from 'node:fs';
+import { dirname, join, posix, relative, resolve, sep, win32 } from 'node:path';
+import type { BenchmarkTask } from '../types.js';
+
+export function assertNormalizedWorkspaceRelativePath(value: string, label = 'artifact path'): void {
+  if (
+    value.length === 0
+    || value.includes('\0')
+    || value.includes('\\')
+    || value.includes(':')
+    || posix.isAbsolute(value)
+    || win32.isAbsolute(value)
+    || /^[a-zA-Z]:/.test(value)
+    || posix.normalize(value) !== value
+    || value === '.'
+    || value === '..'
+    || value.startsWith('../')
+  ) {
+    throw new Error(`${label} must be a normalized relative path: ${value}`);
+  }
+}
+
+export function isNormalizedWorkspaceRelativePath(value: string): boolean {
+  try {
+    assertNormalizedWorkspaceRelativePath(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertSafeBenchmarkTaskPaths(task: BenchmarkTask): void {
+  for (const artifactPath of task.expectedArtifacts) {
+    assertNormalizedWorkspaceRelativePath(artifactPath, 'expected artifact path');
+  }
+  for (const check of task.requiredChecks) {
+    if (check.type === 'file-exists' || check.type === 'file-contains') {
+      assertNormalizedWorkspaceRelativePath(check.path, `${check.type} check path`);
+    }
+  }
+}
+
+export function resolveWorkspaceArtifactPath(workspaceRoot: string, artifactPath: string): string {
+  assertNormalizedWorkspaceRelativePath(artifactPath);
+
+  const root = resolve(workspaceRoot);
+  const rootStat = lstatSync(root);
+  if (rootStat.isSymbolicLink()) {
+    throw new Error(`workspace root must not be a symlink: ${workspaceRoot}`);
+  }
+  if (!rootStat.isDirectory()) {
+    throw new Error(`workspace root must be a directory: ${workspaceRoot}`);
+  }
+  assertNoSymlinkAncestors(root);
+
+  const rootReal = realpathSync(root);
+  const candidate = resolve(root, artifactPath);
+  assertContained(candidate, root, 'artifact path');
+
+  let current = root;
+  const parts = artifactPath.split('/');
+  for (let index = 0; index < parts.length; index += 1) {
+    current = join(current, parts[index]!);
+    if (!existsSync(current)) {
+      return candidate;
+    }
+
+    const stat = lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`artifact path must not contain symlinks: ${artifactPath}`);
+    }
+    if (index < parts.length - 1 && !stat.isDirectory()) {
+      throw new Error(`artifact path component must be a directory: ${artifactPath}`);
+    }
+    assertContained(realpathSync(current), rootReal, 'artifact path');
+  }
+
+  return candidate;
+}
+
+function assertContained(child: string, root: string, label: string): void {
+  const rel = relative(root, child);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.includes(':')) {
+    throw new Error(`${label} escapes workspace root`);
+  }
+}
+
+function assertNoSymlinkAncestors(target: string): void {
+  let current = dirname(target);
+  while (dirname(current) !== current) {
+    if (lstatSync(current).isSymbolicLink()) {
+      throw new Error(`workspace root path component must not be a symlink: ${current}`);
+    }
+    current = dirname(current);
+  }
+}

--- a/packages/live-bench/src/workspace/artifact-path.ts
+++ b/packages/live-bench/src/workspace/artifact-path.ts
@@ -1,4 +1,14 @@
-import { existsSync, lstatSync, realpathSync } from 'node:fs';
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from 'node:fs';
 import { dirname, join, posix, relative, resolve, sep, win32 } from 'node:path';
 import type { BenchmarkTask } from '../types.js';
 
@@ -40,7 +50,7 @@ export function assertSafeBenchmarkTaskPaths(task: BenchmarkTask): void {
   }
 }
 
-export function resolveWorkspaceArtifactPath(workspaceRoot: string, artifactPath: string): string {
+export function openWorkspaceArtifactFile(workspaceRoot: string, artifactPath: string): number {
   assertNormalizedWorkspaceRelativePath(artifactPath);
 
   const root = resolve(workspaceRoot);
@@ -62,7 +72,7 @@ export function resolveWorkspaceArtifactPath(workspaceRoot: string, artifactPath
   for (let index = 0; index < parts.length; index += 1) {
     current = join(current, parts[index]!);
     if (!existsSync(current)) {
-      return candidate;
+      throw new Error(`artifact file does not exist: ${artifactPath}`);
     }
 
     const stat = lstatSync(current);
@@ -75,7 +85,70 @@ export function resolveWorkspaceArtifactPath(workspaceRoot: string, artifactPath
     assertContained(realpathSync(current), rootReal, 'artifact path');
   }
 
-  return candidate;
+  const noFollow = 'O_NOFOLLOW' in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(candidate, constants.O_RDONLY | noFollow);
+  try {
+    // Revalidate after opening. The descriptor pins the file that callers will
+    // inspect, while this identity comparison detects a path-component swap
+    // between the initial validation and openSync().
+    assertSafeOpenedArtifact(root, rootReal, candidate, artifactPath, fd);
+    return fd;
+  } catch (error) {
+    closeSync(fd);
+    throw error;
+  }
+}
+
+export function workspaceArtifactFileExists(workspaceRoot: string, artifactPath: string): boolean {
+  try {
+    const fd = openWorkspaceArtifactFile(workspaceRoot, artifactPath);
+    closeSync(fd);
+    return true;
+  } catch (error) {
+    if (
+      (error instanceof Error && error.message.startsWith('artifact file does not exist:'))
+      || (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export function readWorkspaceArtifactFile(workspaceRoot: string, artifactPath: string): Buffer {
+  const fd = openWorkspaceArtifactFile(workspaceRoot, artifactPath);
+  try {
+    return readFileSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function assertSafeOpenedArtifact(
+  root: string,
+  rootReal: string,
+  candidate: string,
+  artifactPath: string,
+  fd: number,
+): void {
+  let current = root;
+  for (const part of artifactPath.split('/')) {
+    current = join(current, part);
+    const stat = lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`artifact path must not contain symlinks: ${artifactPath}`);
+    }
+    assertContained(realpathSync(current), rootReal, 'artifact path');
+  }
+
+  const opened = fstatSync(fd);
+  const currentTarget = statSync(candidate);
+  if (opened.dev !== currentTarget.dev || opened.ino !== currentTarget.ino) {
+    throw new Error(`artifact path changed while it was being opened: ${artifactPath}`);
+  }
+  if (!opened.isFile()) {
+    throw new Error(`artifact path must identify a regular file: ${artifactPath}`);
+  }
 }
 
 function assertContained(child: string, root: string, label: string): void {

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -4,6 +4,7 @@ import { join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
 import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
+import { assertSafeBenchmarkTaskPaths } from './artifact-path.js';
 import type { FixtureStore } from './fixture-store.js';
 import { isoNow } from '@franken/types';
 
@@ -60,6 +61,7 @@ export class WorkspaceProvisioner {
     if (row.taskId !== task.taskId) {
       throw new Error(`Benchmark row taskId ${row.taskId} does not match task ${task.taskId}`);
     }
+    assertSafeBenchmarkTaskPaths(task);
 
     const fixtureDir = this.fixtures.resolveFixture(task.projectFixture);
     const runDate = dateSegment(row.runTimestamp);

--- a/packages/live-bench/tests/artifact-path.test.ts
+++ b/packages/live-bench/tests/artifact-path.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveWorkspaceArtifactPath } from '../src/workspace/artifact-path.js';
+
+function tempRoot(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+describe('workspace artifact paths', () => {
+  it('resolves normalized paths beneath the workspace, including missing artifacts', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    mkdirSync(join(workspace, 'artifacts'));
+    writeFileSync(join(workspace, 'artifacts', 'result.txt'), 'ok\n', 'utf8');
+
+    expect(resolveWorkspaceArtifactPath(workspace, 'artifacts/result.txt')).toBe(join(workspace, 'artifacts', 'result.txt'));
+    expect(resolveWorkspaceArtifactPath(workspace, 'artifacts/missing.txt')).toBe(join(workspace, 'artifacts', 'missing.txt'));
+  });
+
+  it('rejects symlinked path components before an evaluator can inspect an artifact', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    const outside = tempRoot('live-bench-artifacts-outside-');
+    writeFileSync(join(outside, 'secret.txt'), 'outside\n', 'utf8');
+    symlinkSync(outside, join(workspace, 'linked'), 'dir');
+
+    expect(() => resolveWorkspaceArtifactPath(workspace, 'linked/secret.txt')).toThrow(/must not contain symlinks/);
+  });
+
+  it('rejects a symlinked workspace root', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    const linkParent = tempRoot('live-bench-artifacts-link-');
+    const workspaceLink = join(linkParent, 'workspace');
+    symlinkSync(workspace, workspaceLink, 'dir');
+
+    expect(() => resolveWorkspaceArtifactPath(workspaceLink, 'result.txt')).toThrow(/workspace root must not be a symlink/);
+  });
+
+  it('rejects symlinked ancestors of the workspace root', () => {
+    const realParent = tempRoot('live-bench-artifacts-real-parent-');
+    const workspace = join(realParent, 'workspace');
+    mkdirSync(workspace);
+    const linkParent = tempRoot('live-bench-artifacts-link-parent-');
+    const parentLink = join(linkParent, 'parent');
+    symlinkSync(realParent, parentLink, 'dir');
+
+    expect(() => resolveWorkspaceArtifactPath(join(parentLink, 'workspace'), 'result.txt')).toThrow(/workspace root path component must not be a symlink/);
+  });
+});

--- a/packages/live-bench/tests/artifact-path.test.ts
+++ b/packages/live-bench/tests/artifact-path.test.ts
@@ -1,21 +1,26 @@
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { closeSync, mkdtempSync, mkdirSync, readFileSync, renameSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveWorkspaceArtifactPath } from '../src/workspace/artifact-path.js';
+import {
+  openWorkspaceArtifactFile,
+  readWorkspaceArtifactFile,
+  workspaceArtifactFileExists,
+} from '../src/workspace/artifact-path.js';
 
 function tempRoot(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
 }
 
 describe('workspace artifact paths', () => {
-  it('resolves normalized paths beneath the workspace, including missing artifacts', () => {
+  it('opens and reads normalized artifact files beneath the workspace', () => {
     const workspace = tempRoot('live-bench-artifacts-');
     mkdirSync(join(workspace, 'artifacts'));
     writeFileSync(join(workspace, 'artifacts', 'result.txt'), 'ok\n', 'utf8');
 
-    expect(resolveWorkspaceArtifactPath(workspace, 'artifacts/result.txt')).toBe(join(workspace, 'artifacts', 'result.txt'));
-    expect(resolveWorkspaceArtifactPath(workspace, 'artifacts/missing.txt')).toBe(join(workspace, 'artifacts', 'missing.txt'));
+    expect(readWorkspaceArtifactFile(workspace, 'artifacts/result.txt').toString('utf8')).toBe('ok\n');
+    expect(workspaceArtifactFileExists(workspace, 'artifacts/result.txt')).toBe(true);
+    expect(workspaceArtifactFileExists(workspace, 'artifacts/missing.txt')).toBe(false);
   });
 
   it('rejects symlinked path components before an evaluator can inspect an artifact', () => {
@@ -24,7 +29,7 @@ describe('workspace artifact paths', () => {
     writeFileSync(join(outside, 'secret.txt'), 'outside\n', 'utf8');
     symlinkSync(outside, join(workspace, 'linked'), 'dir');
 
-    expect(() => resolveWorkspaceArtifactPath(workspace, 'linked/secret.txt')).toThrow(/must not contain symlinks/);
+    expect(() => openWorkspaceArtifactFile(workspace, 'linked/secret.txt')).toThrow(/must not contain symlinks/);
   });
 
   it('rejects a symlinked workspace root', () => {
@@ -33,7 +38,7 @@ describe('workspace artifact paths', () => {
     const workspaceLink = join(linkParent, 'workspace');
     symlinkSync(workspace, workspaceLink, 'dir');
 
-    expect(() => resolveWorkspaceArtifactPath(workspaceLink, 'result.txt')).toThrow(/workspace root must not be a symlink/);
+    expect(() => openWorkspaceArtifactFile(workspaceLink, 'result.txt')).toThrow(/workspace root must not be a symlink/);
   });
 
   it('rejects symlinked ancestors of the workspace root', () => {
@@ -44,6 +49,25 @@ describe('workspace artifact paths', () => {
     const parentLink = join(linkParent, 'parent');
     symlinkSync(realParent, parentLink, 'dir');
 
-    expect(() => resolveWorkspaceArtifactPath(join(parentLink, 'workspace'), 'result.txt')).toThrow(/workspace root path component must not be a symlink/);
+    expect(() => openWorkspaceArtifactFile(join(parentLink, 'workspace'), 'result.txt')).toThrow(/workspace root path component must not be a symlink/);
+  });
+
+  it('pins the validated file so a later symlink swap cannot redirect the read', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    const outside = tempRoot('live-bench-artifacts-outside-');
+    mkdirSync(join(workspace, 'artifacts'));
+    writeFileSync(join(workspace, 'artifacts', 'result.txt'), 'inside\n', 'utf8');
+    writeFileSync(join(outside, 'result.txt'), 'outside\n', 'utf8');
+
+    const fd = openWorkspaceArtifactFile(workspace, 'artifacts/result.txt');
+    try {
+      renameSync(join(workspace, 'artifacts'), join(workspace, 'original-artifacts'));
+      symlinkSync(outside, join(workspace, 'artifacts'), 'dir');
+
+      expect(readFileSync(fd, 'utf8')).toBe('inside\n');
+      expect(() => readWorkspaceArtifactFile(workspace, 'artifacts/result.txt')).toThrow(/must not contain symlinks/);
+    } finally {
+      closeSync(fd);
+    }
   });
 });

--- a/packages/live-bench/tests/artifact-path.test.ts
+++ b/packages/live-bench/tests/artifact-path.test.ts
@@ -32,6 +32,19 @@ describe('workspace artifact paths', () => {
     expect(() => openWorkspaceArtifactFile(workspace, 'linked/secret.txt')).toThrow(/must not contain symlinks/);
   });
 
+  it('rejects dangling symlinks instead of reporting an ordinary missing artifact', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    symlinkSync(join(workspace, 'missing-target'), join(workspace, 'dangling'));
+
+    expect(() => workspaceArtifactFileExists(workspace, 'dangling')).toThrow(/must not contain symlinks/);
+  });
+
+  it('does not disguise a missing workspace as a missing artifact', () => {
+    const parent = tempRoot('live-bench-artifacts-');
+
+    expect(() => workspaceArtifactFileExists(join(parent, 'missing-workspace'), 'result.txt')).toThrow(/ENOENT/);
+  });
+
   it('rejects a symlinked workspace root', () => {
     const workspace = tempRoot('live-bench-artifacts-');
     const linkParent = tempRoot('live-bench-artifacts-link-');

--- a/packages/live-bench/tests/artifact-path.test.ts
+++ b/packages/live-bench/tests/artifact-path.test.ts
@@ -45,6 +45,15 @@ describe('workspace artifact paths', () => {
     expect(() => workspaceArtifactFileExists(join(parent, 'missing-workspace'), 'result.txt')).toThrow(/ENOENT/);
   });
 
+  it('returns false for contained outputs with the wrong filesystem shape', () => {
+    const workspace = tempRoot('live-bench-artifacts-');
+    writeFileSync(join(workspace, 'artifacts'), 'not a directory\n', 'utf8');
+    mkdirSync(join(workspace, 'result-directory'));
+
+    expect(workspaceArtifactFileExists(workspace, 'artifacts/result.txt')).toBe(false);
+    expect(workspaceArtifactFileExists(workspace, 'result-directory')).toBe(false);
+  });
+
   it('rejects a symlinked workspace root', () => {
     const workspace = tempRoot('live-bench-artifacts-');
     const linkParent = tempRoot('live-bench-artifacts-link-');

--- a/packages/live-bench/tests/corpus-loader.test.ts
+++ b/packages/live-bench/tests/corpus-loader.test.ts
@@ -84,6 +84,26 @@ describe('corpus loader', () => {
     expect(() => loadTaskFile(emptyToolParamsPath)).toThrow(/Invalid benchmark task/);
   });
 
+  it.each([
+    ['absolute expected artifact', '/tmp/out.txt', 'README.md'],
+    ['parent-traversing expected artifact', '../out.txt', 'README.md'],
+    ['non-normalized expected artifact', 'artifacts/../out.txt', 'README.md'],
+    ['Windows absolute expected artifact', 'C:\\temp\\out.txt', 'README.md'],
+    ['absolute file check', 'README.md', '/tmp/out.txt'],
+    ['parent-traversing file check', 'README.md', '../out.txt'],
+    ['non-normalized file check', 'README.md', 'artifacts/../out.txt'],
+    ['Windows-separated file check', 'README.md', 'artifacts\\out.txt'],
+  ])('rejects unsafe artifact paths: %s', (_description, expectedArtifact, checkPath) => {
+    const root = tempCorpus();
+    const taskPath = writeTask(root, 'core/unsafe-path.task.json', {
+      ...validTask,
+      expectedArtifacts: [expectedArtifact],
+      requiredChecks: [{ type: 'file-exists', path: checkPath }],
+    });
+
+    expect(() => loadTaskFile(taskPath)).toThrow(/normalized relative path/);
+  });
+
   it('rejects unknown normalized task and check fields', () => {
     const root = tempCorpus();
     const taskPath = writeTask(root, 'core/unknown-fields.task.json', {

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -225,6 +225,23 @@ describe('workspace provisioning', () => {
     expect(() => provisioner.provision({ ...row, taskId: 'other-task' }, task)).toThrow(/does not match task/);
   });
 
+  it.each([
+    ['expected artifact', { ...task, expectedArtifacts: ['../outside.txt'] }],
+    ['file check', { ...task, requiredChecks: [{ type: 'file-exists' as const, path: '/tmp/outside.txt' }] }],
+  ])('rejects an unsafe %s on programmatically constructed tasks before provisioning', (_description, unsafeTask) => {
+    const fixturesRoot = tempRoot('live-bench-fixtures-');
+    const runsRoot = tempRoot('live-bench-runs-');
+    createFixture(fixturesRoot);
+
+    const provisioner = new WorkspaceProvisioner({
+      fixtures: new FixtureStore(fixturesRoot),
+      runsRoot,
+    });
+
+    expect(() => provisioner.provision(row, unsafeTask)).toThrow(/normalized relative path/);
+    expect(existsSync(join(runsRoot, '2026-05-23'))).toBe(false);
+  });
+
   it('refuses fixture names containing path traversal or separators', () => {
     const fixtures = new FixtureStore(tempRoot('live-bench-fixtures-'));
 

--- a/tasks/issue-2843-progress.md
+++ b/tasks/issue-2843-progress.md
@@ -8,6 +8,6 @@
 - [x] Add a symlink-swap regression proving later pathname replacement cannot redirect an opened artifact read.
 - [x] Run targeted regression tests.
 - [x] Run package tests, typecheck, build, lint, and security/secret checks.
-- [ ] Review the final diff and obtain code review.
+- [x] Review the final diff and obtain code review.
 - [ ] Commit, push, open one PR linked to #2843, and verify CI/Codex.
 - [ ] Merge, record reusable lessons, and close the Kanban card with evidence.

--- a/tasks/issue-2843-progress.md
+++ b/tasks/issue-2843-progress.md
@@ -1,0 +1,12 @@
+# Issue #2843 Progress
+
+- [x] Inspect issue, task context, shared lessons, and live-bench artifact path surfaces.
+- [x] Add failing corpus tests for absolute, traversal, non-normalized, and Windows-style paths.
+- [x] Validate expected artifact and file-check paths during schema parsing.
+- [x] Validate paths on programmatically constructed tasks before workspace provisioning.
+- [x] Add a runtime workspace artifact resolver that rejects symlink roots/components and containment escapes.
+- [x] Run targeted regression tests.
+- [x] Run package tests, typecheck, build, lint, and security/secret checks.
+- [ ] Review the final diff and obtain code review.
+- [ ] Commit, push, open one PR linked to #2843, and verify CI/Codex.
+- [ ] Merge, record reusable lessons, and close the Kanban card with evidence.

--- a/tasks/issue-2843-progress.md
+++ b/tasks/issue-2843-progress.md
@@ -4,7 +4,8 @@
 - [x] Add failing corpus tests for absolute, traversal, non-normalized, and Windows-style paths.
 - [x] Validate expected artifact and file-check paths during schema parsing.
 - [x] Validate paths on programmatically constructed tasks before workspace provisioning.
-- [x] Add a runtime workspace artifact resolver that rejects symlink roots/components and containment escapes.
+- [x] Add descriptor-pinned artifact inspection helpers that reject symlink roots/components and revalidate file identity after open.
+- [x] Add a symlink-swap regression proving later pathname replacement cannot redirect an opened artifact read.
 - [x] Run targeted regression tests.
 - [x] Run package tests, typecheck, build, lint, and security/secret checks.
 - [ ] Review the final diff and obtain code review.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Artifact-path TOCTOU hardening
+- Returning a validated pathname is not a secure file-inspection API: pin both the workspace directory and artifact as file descriptors, traverse through `/proc/self/fd` or `/dev/fd` where available, and compare descriptor/path identities after opening so rename/symlink swaps fail closed.
+- Use `lstat` rather than `existsSync` when dangling symlinks must be rejected, translate only candidate-component `ENOENT` into an ordinary missing artifact, and open untrusted artifact targets with nonblocking/no-follow flags before requiring a regular file.
+
 ## 2026-07-18 — Kanban reviewer isolation
 - Independent review workers must receive a distinct child card or explicitly review-only context; never let a delegated reviewer inherit and complete the implementation parent card, because completion can garbage-collect its workspace before the verified diff is committed and shipped.
 


### PR DESCRIPTION
## Summary
- validate expected artifact and file-check paths as normalized workspace-relative paths
- reject unsafe paths again when programmatically constructed tasks reach workspace provisioning
- inspect artifact files through pinned descriptors, with post-open identity validation that rejects symlink and path-swap escapes

## Test Plan
- `npm test --workspace=@franken/live-bench -- --run tests/artifact-path.test.ts tests/corpus-loader.test.ts tests/workspace-provisioner.test.ts` (47 passed)
- `npm test --workspace=@franken/live-bench` (111 passed, 1 live test skipped by design)
- `npm run typecheck --workspace=@franken/live-bench`
- `npm run lint --workspace=@franken/live-bench`
- `npm run build --workspace=@franken/live-bench`

Closes #2843