### PR TITLE
fix(live-bench): harden run directory cleanup

### DIFF
--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 import {
-  chmodSync,
   closeSync,
   constants,
   cpSync,
@@ -18,7 +17,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { join, parse, relative, resolve, sep } from 'node:path';
+import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
 import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
@@ -156,6 +155,9 @@ export function prepareRunDirectorySafely(
   expectedRunsRootIdentity = fileIdentity(lstatSync(realpathSync(runsRoot))),
 ): PreparedRunDirectory {
   ensureContained(runDir, runsRoot, 'run directory');
+  if (process.platform === 'win32') {
+    return prepareRunDirectoryPortable(runDir, runsRoot, expectedRunsRootIdentity);
+  }
   const rel = relative(runsRoot, runDir);
   const segments = rel.split(sep).filter((segment) => segment.length > 0);
   const leaf = segments.pop();
@@ -188,7 +190,7 @@ export function prepareRunDirectorySafely(
     }
 
     const anchoredRunPath = join(fdPath(parentFd), leaf);
-    removeAnchoredRunDirectory(anchoredRunPath, fdPath(rootFd), runDir, directoryFlags);
+    removeAnchoredRunDirectory(anchoredRunPath, fdPath(parentFd), runDir, directoryFlags);
     mkdirSync(anchoredRunPath, { mode: 0o700 });
     runFd = openSync(anchoredRunPath, directoryFlags);
     const anchoredRunDir = fdPath(runFd);
@@ -222,9 +224,60 @@ export function prepareRunDirectorySafely(
   }
 }
 
+function prepareRunDirectoryPortable(
+  runDir: string,
+  runsRoot: string,
+  expectedRunsRootIdentity: FileIdentity,
+): PreparedRunDirectory {
+  if (!sameFileIdentity(fileIdentity(lstatSync(realpathSync(runsRoot))), expectedRunsRootIdentity)) {
+    throw new Error(`Runs root identity changed during cleanup: ${runsRoot}`);
+  }
+  ensurePortableParentDirectories(runsRoot, dirname(runDir));
+
+  if (pathExistsNoFollow(runDir)) {
+    const initialStat = lstatSync(runDir);
+    if (initialStat.isSymbolicLink()) {
+      unlinkSync(runDir);
+      throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
+    }
+    if (!initialStat.isDirectory()) {
+      throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
+    }
+
+    const cleanupRoot = mkdtempSync(join(dirname(runDir), '.cleanup-'));
+    const quarantinedRunDir = join(cleanupRoot, 'run');
+    let removeCleanupRoot = true;
+    try {
+      renameSync(runDir, quarantinedRunDir);
+      const quarantinedStat = lstatSync(quarantinedRunDir);
+      if (!sameFileIdentity(fileIdentity(quarantinedStat), fileIdentity(initialStat))) {
+        removeCleanupRoot = false;
+        throw new Error(`Run directory identity changed during cleanup: ${runDir}`);
+      }
+      rmSync(quarantinedRunDir, { recursive: true, force: false });
+    } catch (error) {
+      if (pathExistsNoFollow(quarantinedRunDir)) {
+        removeCleanupRoot = false;
+      }
+      throw error;
+    } finally {
+      if (removeCleanupRoot) {
+        rmdirSync(cleanupRoot);
+      }
+    }
+  }
+
+  mkdirSync(runDir, { mode: 0o700 });
+  const createdStat = lstatSync(runDir);
+  if (!createdStat.isDirectory() || createdStat.isSymbolicLink()) {
+    throw new Error(`Run directory changed during creation: ${runDir}`);
+  }
+  return { anchoredRunDir: runDir, close: () => undefined };
+}
+
 function removeAnchoredRunDirectory(
   anchoredRunPath: string,
-  anchoredRoot: string,
+  anchoredParent: string,
   displayRunDir: string,
   directoryFlags: number,
 ): void {
@@ -241,8 +294,7 @@ function removeAnchoredRunDirectory(
     throw new Error(`Run directory changed to a non-directory during cleanup: ${displayRunDir}`);
   }
 
-  const cleanupRoot = mkdtempSync(join(anchoredRoot, '.cleanup-'));
-  chmodSync(cleanupRoot, 0o700);
+  const cleanupRoot = mkdtempSync(join(anchoredParent, '.cleanup-'));
   const cleanupFd = openSync(cleanupRoot, directoryFlags);
   const quarantinedRunDir = join(fdPath(cleanupFd), 'run');
   let removeCleanupRoot = true;
@@ -430,6 +482,31 @@ function ensureNoSymlinkPathPrefix(target: string, label: string): void {
     }
     if (lstatSync(current).isSymbolicLink()) {
       throw new Error(`${label} path component must not be a symlink: ${current}`);
+    }
+  }
+}
+
+function ensurePortableParentDirectories(root: string, target: string): void {
+  const rel = relative(root, target);
+  const parts = rel.split(sep).filter((part) => part.length > 0);
+  let current = root;
+
+  for (const [index, part] of parts.entries()) {
+    current = join(current, part);
+    try {
+      mkdirSync(current, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+    }
+    const stat = lstatSync(current);
+    const label = index === 0 ? 'run date directory' : 'run directory path component';
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${label} must not be a symlink: ${current}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`${label} is not a directory: ${current}`);
     }
   }
 }

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -99,6 +99,7 @@ export class WorkspaceProvisioner {
 
     const preparedRun = prepareRunDirectorySafely(runDir, this.runsRoot, this.runsRootIdentity);
     try {
+      preparedRun.verifyLocation();
       const anchoredWorkspaceDir = join(preparedRun.anchoredRunDir, 'workspace');
       const anchoredEvidenceDir = join(preparedRun.anchoredRunDir, 'evidence');
       mkdirSync(anchoredWorkspaceDir, { mode: 0o700 });
@@ -131,6 +132,7 @@ export class WorkspaceProvisioner {
         serializeToolCallEvidence([]),
         'utf8',
       );
+      preparedRun.verifyLocation();
     } finally {
       preparedRun.close();
     }
@@ -141,6 +143,7 @@ export class WorkspaceProvisioner {
 
 interface PreparedRunDirectory {
   readonly anchoredRunDir: string;
+  verifyLocation(): void;
   close(): void;
 }
 
@@ -155,7 +158,7 @@ export function prepareRunDirectorySafely(
   expectedRunsRootIdentity = fileIdentity(lstatSync(realpathSync(runsRoot))),
 ): PreparedRunDirectory {
   ensureContained(runDir, runsRoot, 'run directory');
-  if (process.platform === 'win32') {
+  if (process.platform !== 'linux') {
     return prepareRunDirectoryPortable(runDir, runsRoot, expectedRunsRootIdentity);
   }
   const rel = relative(runsRoot, runDir);
@@ -195,20 +198,19 @@ export function prepareRunDirectorySafely(
     runFd = openSync(anchoredRunPath, directoryFlags);
     const anchoredRunDir = fdPath(runFd);
 
-    if (parentFd !== rootFd) {
-      closeSync(parentFd);
-      parentFd = rootFd;
-    }
-
     let closed = false;
     return {
       anchoredRunDir,
+      verifyLocation: () => verifyRunLocation(anchoredRunPath, runFd!, runDir),
       close: () => {
         if (closed) {
           return;
         }
         closed = true;
         closeSync(runFd!);
+        if (parentFd !== rootFd) {
+          closeSync(parentFd);
+        }
         closeSync(rootFd);
       },
     };
@@ -272,7 +274,35 @@ function prepareRunDirectoryPortable(
   if (!createdStat.isDirectory() || createdStat.isSymbolicLink()) {
     throw new Error(`Run directory changed during creation: ${runDir}`);
   }
-  return { anchoredRunDir: runDir, close: () => undefined };
+  const createdIdentity = fileIdentity(createdStat);
+  return {
+    anchoredRunDir: runDir,
+    verifyLocation: () => {
+      const currentStat = lstatSync(runDir);
+      if (currentStat.isSymbolicLink() || !sameFileIdentity(fileIdentity(currentStat), createdIdentity)) {
+        throw new Error(`Run directory moved or changed during provisioning: ${runDir}`);
+      }
+    },
+    close: () => undefined,
+  };
+}
+
+function verifyRunLocation(anchoredRunPath: string, runFd: number, displayRunDir: string): void {
+  let currentStat;
+  try {
+    currentStat = lstatSync(anchoredRunPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Run directory moved during provisioning: ${displayRunDir}`);
+    }
+    throw error;
+  }
+  if (
+    currentStat.isSymbolicLink()
+    || !sameFileIdentity(fileIdentity(currentStat), fileIdentity(fstatSync(runFd)))
+  ) {
+    throw new Error(`Run directory moved or changed during provisioning: ${displayRunDir}`);
+  }
 }
 
 function removeAnchoredRunDirectory(

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -1,11 +1,15 @@
 import { createHash } from 'node:crypto';
 import {
   chmodSync,
+  closeSync,
+  constants,
   cpSync,
   existsSync,
+  fstatSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   realpathSync,
   renameSync,
@@ -14,7 +18,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, parse, relative, resolve, sep } from 'node:path';
+import { join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
 import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
@@ -50,10 +54,15 @@ export interface BenchmarkEnvironmentSnapshot {
   readonly provisionedAt: string;
 }
 
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
 export class WorkspaceProvisioner {
   private readonly fixtures: FixtureStore;
   private readonly runsRoot: string;
-  private readonly runsRootReal: string;
+  private readonly runsRootIdentity: FileIdentity;
 
   constructor(config: WorkspaceProvisionerConfig) {
     this.fixtures = config.fixtures;
@@ -61,7 +70,7 @@ export class WorkspaceProvisioner {
     ensureNoSymlinkPathPrefix(this.runsRoot, 'runs root');
     ensureSafeExistingDirectory(this.runsRoot, 'runs root');
     mkdirSync(this.runsRoot, { recursive: true });
-    this.runsRootReal = realpathSync(this.runsRoot);
+    this.runsRootIdentity = fileIdentity(lstatSync(realpathSync(this.runsRoot)));
   }
 
   provision(row: BenchmarkMatrixRow, task: BenchmarkTask): ProvisionedWorkspace {
@@ -79,9 +88,6 @@ export class WorkspaceProvisioner {
     const runDate = dateSegment(row.runTimestamp);
     const dateDir = resolve(this.runsRoot, runDate);
     ensureContained(dateDir, this.runsRoot, 'run date directory');
-    ensureSafeExistingDirectory(dateDir, 'run date directory');
-    mkdirSync(dateDir, { recursive: true });
-    ensureContained(realpathSync(dateDir), this.runsRootReal, 'run date real directory');
 
     const runDir = resolve(dateDir, row.runId, row.taskId, row.client, row.mode, row.fbeastTopology, modelSegment);
     const workspaceDir = join(runDir, 'workspace');
@@ -91,89 +97,166 @@ export class WorkspaceProvisioner {
 
     ensureContained(runDir, dateDir, 'run directory');
     ensureContained(runDir, this.runsRoot, 'run directory');
-    ensureNoSymlinkPathComponents(dateDir, runDir, 'run directory');
-    ensureSafeExistingDirectory(runDir, 'run directory');
-    removeRunDirectorySafely(runDir, this.runsRoot, this.runsRootReal);
-    mkdirSync(workspaceDir, { recursive: true });
-    mkdirSync(evidenceDir, { recursive: true });
 
-    assertNoSymlinksInTree(fixtureDir);
-    cpSync(fixtureDir, workspaceDir, { recursive: true });
-    if (row.mode === 'baseline') {
-      rmSync(join(workspaceDir, '.fbeast'), { recursive: true, force: true });
+    const preparedRun = prepareRunDirectorySafely(runDir, this.runsRoot, this.runsRootIdentity);
+    try {
+      const anchoredWorkspaceDir = join(preparedRun.anchoredRunDir, 'workspace');
+      const anchoredEvidenceDir = join(preparedRun.anchoredRunDir, 'evidence');
+      mkdirSync(anchoredWorkspaceDir, { mode: 0o700 });
+      mkdirSync(anchoredEvidenceDir, { mode: 0o700 });
+
+      assertNoSymlinksInTree(fixtureDir);
+      cpSync(fixtureDir, anchoredWorkspaceDir, { recursive: true });
+      if (row.mode === 'baseline') {
+        rmSync(join(anchoredWorkspaceDir, '.fbeast'), { recursive: true, force: true });
+      }
+
+      const environment: BenchmarkEnvironmentSnapshot = {
+        version: 1,
+        runId: row.runId,
+        taskId: row.taskId,
+        fixture: task.projectFixture,
+        commitSha: row.commitSha,
+        client: row.client,
+        mode: row.mode,
+        fbeastTopology: row.fbeastTopology,
+        model: row.model,
+        clientVersion: row.clientVersion,
+        hostClass: row.hostClass,
+        runTimestamp: row.runTimestamp,
+        provisionedAt: isoNow(),
+      };
+      writeFileSync(join(preparedRun.anchoredRunDir, 'environment.json'), `${JSON.stringify(environment, null, 2)}\n`, 'utf8');
+      writeFileSync(
+        join(anchoredEvidenceDir, LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT),
+        serializeToolCallEvidence([]),
+        'utf8',
+      );
+    } finally {
+      preparedRun.close();
     }
-
-    const environment: BenchmarkEnvironmentSnapshot = {
-      version: 1,
-      runId: row.runId,
-      taskId: row.taskId,
-      fixture: task.projectFixture,
-      commitSha: row.commitSha,
-      client: row.client,
-      mode: row.mode,
-      fbeastTopology: row.fbeastTopology,
-      model: row.model,
-      clientVersion: row.clientVersion,
-      hostClass: row.hostClass,
-      runTimestamp: row.runTimestamp,
-      provisionedAt: isoNow(),
-    };
-    writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`, 'utf8');
-    writeFileSync(toolCallEvidencePath, serializeToolCallEvidence([]), 'utf8');
 
     return { runDir, workspaceDir, evidenceDir, environmentPath, toolCallEvidencePath };
   }
 }
 
+interface PreparedRunDirectory {
+  readonly anchoredRunDir: string;
+  close(): void;
+}
+
 /**
- * Atomically detaches an existing run directory before recursively removing it.
- * A symlink observed before or after the rename is unlinked without following it,
- * and cleanup fails closed so provisioning never continues on a raced path.
+ * Walks the run path through no-follow directory descriptors, quarantines any
+ * previous leaf, and returns an fd-relative path that stays anchored while the
+ * workspace is populated.
  */
-export function removeRunDirectorySafely(
+export function prepareRunDirectorySafely(
   runDir: string,
   runsRoot: string,
-  expectedRunsRootReal = realpathSync(runsRoot),
+  expectedRunsRootIdentity = fileIdentity(lstatSync(realpathSync(runsRoot))),
+): PreparedRunDirectory {
+  ensureContained(runDir, runsRoot, 'run directory');
+  const rel = relative(runsRoot, runDir);
+  const segments = rel.split(sep).filter((segment) => segment.length > 0);
+  const leaf = segments.pop();
+  if (!leaf) {
+    throw new Error(`Invalid run directory: ${runDir}`);
+  }
+
+  const directoryFlags = constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW;
+  const rootFd = openSync(runsRoot, directoryFlags);
+  let parentFd = rootFd;
+  let runFd: number | undefined;
+
+  try {
+    if (!sameFileIdentity(fileIdentity(fstatSync(rootFd)), expectedRunsRootIdentity)) {
+      throw new Error(`Runs root identity changed during cleanup: ${runsRoot}`);
+    }
+
+    for (const [index, segment] of segments.entries()) {
+      const child = join(fdPath(parentFd), segment);
+      mkdirExclusiveOrVerifyDirectory(
+        child,
+        directoryFlags,
+        index === 0 ? 'run date directory' : 'run directory path component',
+      );
+      const childFd = openSync(child, directoryFlags);
+      if (parentFd !== rootFd) {
+        closeSync(parentFd);
+      }
+      parentFd = childFd;
+    }
+
+    const anchoredRunPath = join(fdPath(parentFd), leaf);
+    removeAnchoredRunDirectory(anchoredRunPath, fdPath(rootFd), runDir, directoryFlags);
+    mkdirSync(anchoredRunPath, { mode: 0o700 });
+    runFd = openSync(anchoredRunPath, directoryFlags);
+    const anchoredRunDir = fdPath(runFd);
+
+    if (parentFd !== rootFd) {
+      closeSync(parentFd);
+      parentFd = rootFd;
+    }
+
+    let closed = false;
+    return {
+      anchoredRunDir,
+      close: () => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        closeSync(runFd!);
+        closeSync(rootFd);
+      },
+    };
+  } catch (error) {
+    if (runFd !== undefined) {
+      closeSync(runFd);
+    }
+    if (parentFd !== rootFd) {
+      closeSync(parentFd);
+    }
+    closeSync(rootFd);
+    throw error;
+  }
+}
+
+function removeAnchoredRunDirectory(
+  anchoredRunPath: string,
+  anchoredRoot: string,
+  displayRunDir: string,
+  directoryFlags: number,
 ): void {
-  if (!pathExistsNoFollow(runDir)) {
+  if (!pathExistsNoFollow(anchoredRunPath)) {
     return;
   }
 
-  ensureRunsRootAnchored(runsRoot, expectedRunsRootReal);
-  ensureContained(runDir, runsRoot, 'run directory');
-  const initialStat = lstatSync(runDir);
+  const initialStat = lstatSync(anchoredRunPath);
   if (initialStat.isSymbolicLink()) {
-    unlinkSync(runDir);
-    throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
+    unlinkSync(anchoredRunPath);
+    throw new Error(`Run directory changed to a symlink during cleanup: ${displayRunDir}`);
   }
   if (!initialStat.isDirectory()) {
-    throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
+    throw new Error(`Run directory changed to a non-directory during cleanup: ${displayRunDir}`);
   }
 
-  const cleanupRoot = mkdtempSync(join(runsRoot, '.cleanup-'));
+  const cleanupRoot = mkdtempSync(join(anchoredRoot, '.cleanup-'));
   chmodSync(cleanupRoot, 0o700);
-  const quarantinedRunDir = join(cleanupRoot, 'run');
+  const cleanupFd = openSync(cleanupRoot, directoryFlags);
+  const quarantinedRunDir = join(fdPath(cleanupFd), 'run');
   let removeCleanupRoot = true;
 
   try {
-    renameSync(runDir, quarantinedRunDir);
-    ensureRunsRootAnchored(runsRoot, expectedRunsRootReal);
-    ensureContained(realpathSync(dirname(runDir)), expectedRunsRootReal, 'run directory parent');
+    renameSync(anchoredRunPath, quarantinedRunDir);
     const quarantinedStat = lstatSync(quarantinedRunDir);
-    if (quarantinedStat.dev !== initialStat.dev || quarantinedStat.ino !== initialStat.ino) {
+    if (!sameFileIdentity(fileIdentity(quarantinedStat), fileIdentity(initialStat))) {
       removeCleanupRoot = false;
-      throw new Error(`Run directory identity changed during cleanup: ${runDir}`);
+      throw new Error(`Run directory identity changed during cleanup: ${displayRunDir}`);
     }
-    if (quarantinedStat.isSymbolicLink()) {
-      unlinkSync(quarantinedRunDir);
-      throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
+    if (!quarantinedStat.isDirectory() || quarantinedStat.isSymbolicLink()) {
+      throw new Error(`Run directory type changed during cleanup: ${displayRunDir}`);
     }
-    if (!quarantinedStat.isDirectory()) {
-      unlinkSync(quarantinedRunDir);
-      throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
-    }
-
-    ensureContained(realpathSync(quarantinedRunDir), realpathSync(cleanupRoot), 'quarantined run directory');
     rmSync(quarantinedRunDir, { recursive: true, force: false });
   } catch (error) {
     if (pathExistsNoFollow(quarantinedRunDir)) {
@@ -186,10 +269,48 @@ export function removeRunDirectorySafely(
     }
     throw error;
   } finally {
-    if (removeCleanupRoot && existsSync(cleanupRoot)) {
+    closeSync(cleanupFd);
+    if (removeCleanupRoot) {
       rmdirSync(cleanupRoot);
     }
   }
+}
+
+function fileIdentity(stat: { dev: number; ino: number }): FileIdentity {
+  return { dev: stat.dev, ino: stat.ino };
+}
+
+function sameFileIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function mkdirExclusiveOrVerifyDirectory(path: string, directoryFlags: number, label: string): void {
+  try {
+    mkdirSync(path, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw error;
+    }
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${label} must not be a symlink: ${path}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`${label} is not a directory: ${path}`);
+    }
+    const fd = openSync(path, directoryFlags);
+    closeSync(fd);
+  }
+}
+
+function fdPath(fd: number): string {
+  for (const root of ['/proc/self/fd', '/dev/fd']) {
+    const candidate = join(root, String(fd));
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error('Secure fd-relative live-bench workspace provisioning is unsupported on this platform');
 }
 
 const RUN_TIMESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|[+-]\d{2}:\d{2})$/;
@@ -271,13 +392,6 @@ function ensureContained(child: string, root: string, label: string): void {
   }
 }
 
-function ensureRunsRootAnchored(runsRoot: string, expectedRunsRootReal: string): void {
-  ensureNoSymlinkPathPrefix(runsRoot, 'runs root');
-  if (realpathSync(runsRoot) !== expectedRunsRootReal) {
-    throw new Error(`Runs root identity changed during cleanup: ${runsRoot}`);
-  }
-}
-
 function pathExistsNoFollow(path: string): boolean {
   try {
     lstatSync(path);
@@ -316,26 +430,6 @@ function ensureNoSymlinkPathPrefix(target: string, label: string): void {
     }
     if (lstatSync(current).isSymbolicLink()) {
       throw new Error(`${label} path component must not be a symlink: ${current}`);
-    }
-  }
-}
-
-function ensureNoSymlinkPathComponents(root: string, target: string, label: string): void {
-  const rel = relative(root, target);
-  const parts = rel.split(sep).filter((part) => part.length > 0);
-  let current = root;
-
-  for (let index = 0; index < parts.length; index += 1) {
-    current = join(current, parts[index]!);
-    if (!pathExistsNoFollow(current)) {
-      return;
-    }
-    const stat = lstatSync(current);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`${label} path component must not be a symlink: ${current}`);
-    }
-    if (index < parts.length - 1 && !stat.isDirectory()) {
-      throw new Error(`${label} path component is not a directory: ${current}`);
     }
   }
 }

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -1,6 +1,20 @@
 import { createHash } from 'node:crypto';
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { join, parse, relative, resolve, sep } from 'node:path';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
 import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
@@ -79,7 +93,7 @@ export class WorkspaceProvisioner {
     ensureContained(runDir, this.runsRoot, 'run directory');
     ensureNoSymlinkPathComponents(dateDir, runDir, 'run directory');
     ensureSafeExistingDirectory(runDir, 'run directory');
-    rmSync(runDir, { recursive: true, force: true });
+    removeRunDirectorySafely(runDir, this.runsRoot, this.runsRootReal);
     mkdirSync(workspaceDir, { recursive: true });
     mkdirSync(evidenceDir, { recursive: true });
 
@@ -108,6 +122,73 @@ export class WorkspaceProvisioner {
     writeFileSync(toolCallEvidencePath, serializeToolCallEvidence([]), 'utf8');
 
     return { runDir, workspaceDir, evidenceDir, environmentPath, toolCallEvidencePath };
+  }
+}
+
+/**
+ * Atomically detaches an existing run directory before recursively removing it.
+ * A symlink observed before or after the rename is unlinked without following it,
+ * and cleanup fails closed so provisioning never continues on a raced path.
+ */
+export function removeRunDirectorySafely(
+  runDir: string,
+  runsRoot: string,
+  expectedRunsRootReal = realpathSync(runsRoot),
+): void {
+  if (!pathExistsNoFollow(runDir)) {
+    return;
+  }
+
+  ensureRunsRootAnchored(runsRoot, expectedRunsRootReal);
+  ensureContained(runDir, runsRoot, 'run directory');
+  const initialStat = lstatSync(runDir);
+  if (initialStat.isSymbolicLink()) {
+    unlinkSync(runDir);
+    throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
+  }
+  if (!initialStat.isDirectory()) {
+    throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
+  }
+
+  const cleanupRoot = mkdtempSync(join(runsRoot, '.cleanup-'));
+  chmodSync(cleanupRoot, 0o700);
+  const quarantinedRunDir = join(cleanupRoot, 'run');
+  let removeCleanupRoot = true;
+
+  try {
+    renameSync(runDir, quarantinedRunDir);
+    ensureRunsRootAnchored(runsRoot, expectedRunsRootReal);
+    ensureContained(realpathSync(dirname(runDir)), expectedRunsRootReal, 'run directory parent');
+    const quarantinedStat = lstatSync(quarantinedRunDir);
+    if (quarantinedStat.dev !== initialStat.dev || quarantinedStat.ino !== initialStat.ino) {
+      removeCleanupRoot = false;
+      throw new Error(`Run directory identity changed during cleanup: ${runDir}`);
+    }
+    if (quarantinedStat.isSymbolicLink()) {
+      unlinkSync(quarantinedRunDir);
+      throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
+    }
+    if (!quarantinedStat.isDirectory()) {
+      unlinkSync(quarantinedRunDir);
+      throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
+    }
+
+    ensureContained(realpathSync(quarantinedRunDir), realpathSync(cleanupRoot), 'quarantined run directory');
+    rmSync(quarantinedRunDir, { recursive: true, force: false });
+  } catch (error) {
+    if (pathExistsNoFollow(quarantinedRunDir)) {
+      const quarantinedStat = lstatSync(quarantinedRunDir);
+      if (quarantinedStat.isSymbolicLink() || !quarantinedStat.isDirectory()) {
+        unlinkSync(quarantinedRunDir);
+      } else {
+        removeCleanupRoot = false;
+      }
+    }
+    throw error;
+  } finally {
+    if (removeCleanupRoot && existsSync(cleanupRoot)) {
+      rmdirSync(cleanupRoot);
+    }
   }
 }
 
@@ -190,8 +271,27 @@ function ensureContained(child: string, root: string, label: string): void {
   }
 }
 
+function ensureRunsRootAnchored(runsRoot: string, expectedRunsRootReal: string): void {
+  ensureNoSymlinkPathPrefix(runsRoot, 'runs root');
+  if (realpathSync(runsRoot) !== expectedRunsRootReal) {
+    throw new Error(`Runs root identity changed during cleanup: ${runsRoot}`);
+  }
+}
+
+function pathExistsNoFollow(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
 function ensureSafeExistingDirectory(path: string, label: string): void {
-  if (!existsSync(path)) {
+  if (!pathExistsNoFollow(path)) {
     return;
   }
   const stat = lstatSync(path);
@@ -211,7 +311,7 @@ function ensureNoSymlinkPathPrefix(target: string, label: string): void {
 
   for (const part of parts) {
     current = join(current, part);
-    if (!existsSync(current)) {
+    if (!pathExistsNoFollow(current)) {
       return;
     }
     if (lstatSync(current).isSymbolicLink()) {
@@ -227,7 +327,7 @@ function ensureNoSymlinkPathComponents(root: string, target: string, label: stri
 
   for (let index = 0; index < parts.length; index += 1) {
     current = join(current, parts[index]!);
-    if (!existsSync(current)) {
+    if (!pathExistsNoFollow(current)) {
       return;
     }
     const stat = lstatSync(current);

--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -17,7 +17,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, parse, relative, resolve, sep } from 'node:path';
+import { join, parse, relative, resolve, sep } from 'node:path';
 import { serializeToolCallEvidence } from '../evidence/tool-call-evidence.js';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../types.js';
 import { LIVE_BENCH_TOOL_CALL_EVIDENCE_ARTIFACT } from '../types.js';
@@ -159,7 +159,7 @@ export function prepareRunDirectorySafely(
 ): PreparedRunDirectory {
   ensureContained(runDir, runsRoot, 'run directory');
   if (process.platform !== 'linux') {
-    return prepareRunDirectoryPortable(runDir, runsRoot, expectedRunsRootIdentity);
+    throw new Error('Secure live-bench workspace provisioning requires Linux fd-relative paths');
   }
   const rel = relative(runsRoot, runDir);
   const segments = rel.split(sep).filter((segment) => segment.length > 0);
@@ -172,6 +172,7 @@ export function prepareRunDirectorySafely(
   const rootFd = openSync(runsRoot, directoryFlags);
   let parentFd = rootFd;
   let runFd: number | undefined;
+  const componentIdentities: FileIdentity[] = [];
 
   try {
     if (!sameFileIdentity(fileIdentity(fstatSync(rootFd)), expectedRunsRootIdentity)) {
@@ -186,6 +187,7 @@ export function prepareRunDirectorySafely(
         index === 0 ? 'run date directory' : 'run directory path component',
       );
       const childFd = openSync(child, directoryFlags);
+      componentIdentities.push(fileIdentity(fstatSync(childFd)));
       if (parentFd !== rootFd) {
         closeSync(parentFd);
       }
@@ -196,12 +198,20 @@ export function prepareRunDirectorySafely(
     removeAnchoredRunDirectory(anchoredRunPath, fdPath(parentFd), runDir, directoryFlags);
     mkdirSync(anchoredRunPath, { mode: 0o700 });
     runFd = openSync(anchoredRunPath, directoryFlags);
+    componentIdentities.push(fileIdentity(fstatSync(runFd)));
     const anchoredRunDir = fdPath(runFd);
 
     let closed = false;
     return {
       anchoredRunDir,
-      verifyLocation: () => verifyRunLocation(anchoredRunPath, runFd!, runDir),
+      verifyLocation: () => verifyVisibleRunLocation(
+        runsRoot,
+        rootFd,
+        [...segments, leaf],
+        componentIdentities,
+        directoryFlags,
+        runDir,
+      ),
       close: () => {
         if (closed) {
           return;
@@ -226,82 +236,46 @@ export function prepareRunDirectorySafely(
   }
 }
 
-function prepareRunDirectoryPortable(
-  runDir: string,
+function verifyVisibleRunLocation(
   runsRoot: string,
-  expectedRunsRootIdentity: FileIdentity,
-): PreparedRunDirectory {
-  if (!sameFileIdentity(fileIdentity(lstatSync(realpathSync(runsRoot))), expectedRunsRootIdentity)) {
-    throw new Error(`Runs root identity changed during cleanup: ${runsRoot}`);
-  }
-  ensurePortableParentDirectories(runsRoot, dirname(runDir));
-
-  if (pathExistsNoFollow(runDir)) {
-    const initialStat = lstatSync(runDir);
-    if (initialStat.isSymbolicLink()) {
-      unlinkSync(runDir);
-      throw new Error(`Run directory changed to a symlink during cleanup: ${runDir}`);
-    }
-    if (!initialStat.isDirectory()) {
-      throw new Error(`Run directory changed to a non-directory during cleanup: ${runDir}`);
-    }
-
-    const cleanupRoot = mkdtempSync(join(dirname(runDir), '.cleanup-'));
-    const quarantinedRunDir = join(cleanupRoot, 'run');
-    let removeCleanupRoot = true;
-    try {
-      renameSync(runDir, quarantinedRunDir);
-      const quarantinedStat = lstatSync(quarantinedRunDir);
-      if (!sameFileIdentity(fileIdentity(quarantinedStat), fileIdentity(initialStat))) {
-        removeCleanupRoot = false;
-        throw new Error(`Run directory identity changed during cleanup: ${runDir}`);
-      }
-      rmSync(quarantinedRunDir, { recursive: true, force: false });
-    } catch (error) {
-      if (pathExistsNoFollow(quarantinedRunDir)) {
-        removeCleanupRoot = false;
-      }
-      throw error;
-    } finally {
-      if (removeCleanupRoot) {
-        rmdirSync(cleanupRoot);
-      }
-    }
-  }
-
-  mkdirSync(runDir, { mode: 0o700 });
-  const createdStat = lstatSync(runDir);
-  if (!createdStat.isDirectory() || createdStat.isSymbolicLink()) {
-    throw new Error(`Run directory changed during creation: ${runDir}`);
-  }
-  const createdIdentity = fileIdentity(createdStat);
-  return {
-    anchoredRunDir: runDir,
-    verifyLocation: () => {
-      const currentStat = lstatSync(runDir);
-      if (currentStat.isSymbolicLink() || !sameFileIdentity(fileIdentity(currentStat), createdIdentity)) {
-        throw new Error(`Run directory moved or changed during provisioning: ${runDir}`);
-      }
-    },
-    close: () => undefined,
-  };
-}
-
-function verifyRunLocation(anchoredRunPath: string, runFd: number, displayRunDir: string): void {
-  let currentStat;
+  rootFd: number,
+  segments: readonly string[],
+  expectedIdentities: readonly FileIdentity[],
+  directoryFlags: number,
+  displayRunDir: string,
+): void {
+  let visibleRootFd: number | undefined;
+  let currentFd = rootFd;
   try {
-    currentStat = lstatSync(anchoredRunPath);
+    visibleRootFd = openSync(runsRoot, directoryFlags);
+    if (!sameFileIdentity(fileIdentity(fstatSync(visibleRootFd)), fileIdentity(fstatSync(rootFd)))) {
+      throw new Error(`Runs root moved or changed during provisioning: ${runsRoot}`);
+    }
+    closeSync(visibleRootFd);
+    visibleRootFd = undefined;
+
+    for (const [index, segment] of segments.entries()) {
+      const childFd = openSync(join(fdPath(currentFd), segment), directoryFlags);
+      if (currentFd !== rootFd) {
+        closeSync(currentFd);
+      }
+      currentFd = childFd;
+      if (!sameFileIdentity(fileIdentity(fstatSync(childFd)), expectedIdentities[index]!)) {
+        throw new Error(`Run directory moved or changed during provisioning: ${displayRunDir}`);
+      }
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new Error(`Run directory moved during provisioning: ${displayRunDir}`);
     }
     throw error;
-  }
-  if (
-    currentStat.isSymbolicLink()
-    || !sameFileIdentity(fileIdentity(currentStat), fileIdentity(fstatSync(runFd)))
-  ) {
-    throw new Error(`Run directory moved or changed during provisioning: ${displayRunDir}`);
+  } finally {
+    if (visibleRootFd !== undefined) {
+      closeSync(visibleRootFd);
+    }
+    if (currentFd !== rootFd) {
+      closeSync(currentFd);
+    }
   }
 }
 
@@ -512,31 +486,6 @@ function ensureNoSymlinkPathPrefix(target: string, label: string): void {
     }
     if (lstatSync(current).isSymbolicLink()) {
       throw new Error(`${label} path component must not be a symlink: ${current}`);
-    }
-  }
-}
-
-function ensurePortableParentDirectories(root: string, target: string): void {
-  const rel = relative(root, target);
-  const parts = rel.split(sep).filter((part) => part.length > 0);
-  let current = root;
-
-  for (const [index, part] of parts.entries()) {
-    current = join(current, part);
-    try {
-      mkdirSync(current, { mode: 0o700 });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-        throw error;
-      }
-    }
-    const stat = lstatSync(current);
-    const label = index === 0 ? 'run date directory' : 'run directory path component';
-    if (stat.isSymbolicLink()) {
-      throw new Error(`${label} must not be a symlink: ${current}`);
-    }
-    if (!stat.isDirectory()) {
-      throw new Error(`${label} is not a directory: ${current}`);
     }
   }
 }

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -105,6 +105,22 @@ describe('workspace provisioning', () => {
     });
   });
 
+  it('detects when a prepared run leaf is moved before population completes', () => {
+    const runsRoot = tempRoot('live-bench-runs-root-');
+    const dateDir = join(runsRoot, '2026-05-23');
+    const runDir = join(dateDir, 'run-d');
+    const movedRunDir = join(runsRoot, 'moved-run-d');
+    mkdirSync(dateDir, { recursive: true });
+
+    const prepared = prepareRunDirectorySafely(runDir, runsRoot);
+    try {
+      renameSync(runDir, movedRunDir);
+      expect(() => prepared.verifyLocation()).toThrow(/moved during provisioning/);
+    } finally {
+      prepared.close();
+    }
+  });
+
   it('atomically replaces an existing run directory without leaving cleanup artifacts', () => {
     const fixturesRoot = tempRoot('live-bench-fixtures-');
     const runsRoot = tempRoot('live-bench-runs-');

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -5,7 +5,10 @@ import { basename, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../src/types.js';
 import { FixtureStore } from '../src/workspace/fixture-store.js';
-import { WorkspaceProvisioner } from '../src/workspace/workspace-provisioner.js';
+import {
+  removeRunDirectorySafely,
+  WorkspaceProvisioner,
+} from '../src/workspace/workspace-provisioner.js';
 
 function tempRoot(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -100,6 +103,24 @@ describe('workspace provisioning', () => {
       provisionedAt: expect.any(String),
       runTimestamp: '2026-05-23T12:34:56.000Z',
     });
+  });
+
+  it('atomically replaces an existing run directory without leaving cleanup artifacts', () => {
+    const fixturesRoot = tempRoot('live-bench-fixtures-');
+    const runsRoot = tempRoot('live-bench-runs-');
+    createFixture(fixturesRoot);
+    const provisioner = new WorkspaceProvisioner({
+      fixtures: new FixtureStore(fixturesRoot),
+      runsRoot,
+    });
+    const first = provisioner.provision(row, task);
+    writeFileSync(join(first.runDir, 'stale.txt'), 'remove me\n', 'utf8');
+
+    const second = provisioner.provision(row, task);
+
+    expect(second.runDir).toBe(first.runDir);
+    expect(existsSync(join(second.runDir, 'stale.txt'))).toBe(false);
+    expect(existsSync(second.environmentPath)).toBe(true);
   });
 
   it('uses task, client, mode, topology, and model dimensions to avoid run id collisions', () => {
@@ -300,6 +321,31 @@ describe('workspace provisioning', () => {
     expect(() => provisioner.provision({ ...row, runId: 'Run-123' }, task)).toThrow(/Invalid run id/);
     expect(() => provisioner.provision({ ...row, taskId: 'Write-readme' }, task)).toThrow(/Invalid task id/);
     expect(readFileSync(join(runsRoot, '2026-05-23', 'victim', 'sentinel.txt'), 'utf8')).toBe('keep me\n');
+  });
+
+  it('rejects a run directory replaced by a symlink at the cleanup boundary without touching its target', () => {
+    const runsRoot = tempRoot('live-bench-runs-');
+    const outsideRoot = tempRoot('live-bench-outside-cleanup-');
+    const dateDir = join(runsRoot, '2026-05-23');
+    const runDir = join(dateDir, 'run-123');
+    mkdirSync(dateDir, { recursive: true });
+    writeFileSync(join(outsideRoot, 'sentinel.txt'), 'keep me\n', 'utf8');
+    symlinkSync(outsideRoot, runDir, 'dir');
+
+    expect(() => removeRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
+    expect(readFileSync(join(outsideRoot, 'sentinel.txt'), 'utf8')).toBe('keep me\n');
+    expect(existsSync(runDir)).toBe(false);
+  });
+
+  it('rejects a dangling symlink swapped into the run path at cleanup time', () => {
+    const runsRoot = tempRoot('live-bench-runs-');
+    const dateDir = join(runsRoot, '2026-05-23');
+    const runDir = join(dateDir, 'run-123');
+    mkdirSync(dateDir, { recursive: true });
+    symlinkSync(join(runsRoot, 'missing-target'), runDir, 'dir');
+
+    expect(() => removeRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
+    expect(existsSync(runDir)).toBe(false);
   });
 
   it('rejects symlink run date directories before destructive cleanup', () => {

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -121,6 +121,22 @@ describe('workspace provisioning', () => {
     }
   });
 
+  it('detects when a prepared run ancestor is moved before population completes', () => {
+    const runsRoot = tempRoot('live-bench-runs-root-');
+    const dateDir = join(runsRoot, '2026-05-23');
+    const runDir = join(dateDir, 'run-e');
+    const movedDateDir = join(runsRoot, 'moved-date');
+    mkdirSync(dateDir, { recursive: true });
+
+    const prepared = prepareRunDirectorySafely(runDir, runsRoot);
+    try {
+      renameSync(dateDir, movedDateDir);
+      expect(() => prepared.verifyLocation()).toThrow(/moved during provisioning/);
+    } finally {
+      prepared.close();
+    }
+  });
+
   it('atomically replaces an existing run directory without leaving cleanup artifacts', () => {
     const fixturesRoot = tempRoot('live-bench-fixtures-');
     const runsRoot = tempRoot('live-bench-runs-');

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, symlinkSync, writeFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import type { BenchmarkMatrixRow, BenchmarkTask } from '../src/types.js';
 import { FixtureStore } from '../src/workspace/fixture-store.js';
 import {
-  removeRunDirectorySafely,
+  prepareRunDirectorySafely,
   WorkspaceProvisioner,
 } from '../src/workspace/workspace-provisioner.js';
 
@@ -332,7 +332,7 @@ describe('workspace provisioning', () => {
     writeFileSync(join(outsideRoot, 'sentinel.txt'), 'keep me\n', 'utf8');
     symlinkSync(outsideRoot, runDir, 'dir');
 
-    expect(() => removeRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
+    expect(() => prepareRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
     expect(readFileSync(join(outsideRoot, 'sentinel.txt'), 'utf8')).toBe('keep me\n');
     expect(existsSync(runDir)).toBe(false);
   });
@@ -344,7 +344,7 @@ describe('workspace provisioning', () => {
     mkdirSync(dateDir, { recursive: true });
     symlinkSync(join(runsRoot, 'missing-target'), runDir, 'dir');
 
-    expect(() => removeRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
+    expect(() => prepareRunDirectorySafely(runDir, runsRoot)).toThrow(/symlink during cleanup/);
     expect(existsSync(runDir)).toBe(false);
   });
 
@@ -375,6 +375,26 @@ describe('workspace provisioning', () => {
       fixtures: new FixtureStore(fixturesRoot),
       runsRoot,
     })).toThrow(/runs root path component must not be a symlink/);
+  });
+
+  it('rejects runs-root directory replacement before mutating the replacement', () => {
+    const fixturesRoot = tempRoot('live-bench-fixtures-');
+    const runsParent = tempRoot('live-bench-runs-parent-');
+    const runsRoot = join(runsParent, 'runs');
+    const originalRunsRoot = join(runsParent, 'runs-original');
+    createFixture(fixturesRoot);
+    mkdirSync(runsRoot);
+    const provisioner = new WorkspaceProvisioner({
+      fixtures: new FixtureStore(fixturesRoot),
+      runsRoot,
+    });
+    renameSync(runsRoot, originalRunsRoot);
+    mkdirSync(runsRoot);
+    writeFileSync(join(runsRoot, 'sentinel.txt'), 'keep me\n', 'utf8');
+
+    expect(() => provisioner.provision(row, task)).toThrow(/Runs root identity changed/);
+    expect(readFileSync(join(runsRoot, 'sentinel.txt'), 'utf8')).toBe('keep me\n');
+    expect(existsSync(join(runsRoot, '2026-05-23'))).toBe(false);
   });
 
   it('rejects symlink ancestors of runs roots before creating directories', () => {

--- a/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
+++ b/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
@@ -8,5 +8,5 @@
 - [x] Run focused tests, package tests, typecheck, build, lint, diff checks, and a targeted static scan.
 - [x] Commit with the required identity and Conventional Commit subject.
 - [x] Push and open one PR that closes only #2847.
-- [ ] Reach green CI and a current-head clean GitHub Codex review with zero unresolved Codex threads.
+- [x] Reach green CI and a current-head clean GitHub Codex review with zero unresolved Codex threads.
 - [ ] Merge, record any durable lesson, and complete the Kanban card.

--- a/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
+++ b/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
@@ -6,7 +6,7 @@
 - [x] Add targeted failing regressions for linked and dangling symlink swaps at cleanup time.
 - [x] Implement atomic quarantine plus fail-closed no-follow cleanup hardening.
 - [x] Run focused tests, package tests, typecheck, build, lint, diff checks, and a targeted static scan.
-- [ ] Commit with the required identity and Conventional Commit subject.
-- [ ] Push and open one PR that closes only #2847.
+- [x] Commit with the required identity and Conventional Commit subject.
+- [x] Push and open one PR that closes only #2847.
 - [ ] Reach green CI and a current-head clean GitHub Codex review with zero unresolved Codex threads.
 - [ ] Merge, record any durable lesson, and complete the Kanban card.

--- a/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
+++ b/tasks/issue-2847-security-harden-live-bench-run-directory-cleanup-progress.md
@@ -1,0 +1,12 @@
+# Issue #2847 progress
+
+- [x] Recover the required branch/worktree and verify it matches `origin/main`.
+- [x] Read issue #2847 and both shared lessons files.
+- [x] Trace all live-bench run-directory cleanup paths and identify the precise race boundary.
+- [x] Add targeted failing regressions for linked and dangling symlink swaps at cleanup time.
+- [x] Implement atomic quarantine plus fail-closed no-follow cleanup hardening.
+- [x] Run focused tests, package tests, typecheck, build, lint, diff checks, and a targeted static scan.
+- [ ] Commit with the required identity and Conventional Commit subject.
+- [ ] Push and open one PR that closes only #2847.
+- [ ] Reach green CI and a current-head clean GitHub Codex review with zero unresolved Codex threads.
+- [ ] Merge, record any durable lesson, and complete the Kanban card.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Live-bench run cleanup TOCTOU hardening
+- For destructive cleanup in attacker-writable directory trees, preflight `lstat`/`realpath` checks are not enough: on POSIX, open the trusted root and each descendant with `O_DIRECTORY|O_NOFOLLOW`, compare root and quarantined leaf device/inode identities, address rename/removal through stable descriptor paths, and keep the recreated run-leaf descriptor open while populating it.
+- Create quarantine entries beside the anchored leaf parent so rename stays on one filesystem, and avoid followable path mutations such as `chmod(path)` between creation and a no-follow open. Use `lstat`-based existence checks so dangling symlinks fail closed, and retain an explicit portable path for platforms without `/proc/self/fd` or `/dev/fd`.
+
 ## 2026-07-18 — Kanban reviewer isolation
 - Independent review workers must receive a distinct child card or explicitly review-only context; never let a delegated reviewer inherit and complete the implementation parent card, because completion can garbage-collect its workspace before the verified diff is committed and shipped.
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-19 — Live-bench run cleanup TOCTOU hardening
 - For destructive cleanup in attacker-writable directory trees, preflight `lstat`/`realpath` checks are not enough: on POSIX, open the trusted root and each descendant with `O_DIRECTORY|O_NOFOLLOW`, compare root and quarantined leaf device/inode identities, address rename/removal through stable descriptor paths, and keep the recreated run-leaf descriptor open while populating it.
-- Create quarantine entries beside the anchored leaf parent so rename stays on one filesystem, and avoid followable path mutations such as `chmod(path)` between creation and a no-follow open. Use `lstat`-based existence checks so dangling symlinks fail closed, and retain an explicit portable path for platforms without `/proc/self/fd` or `/dev/fd`.
+- Create quarantine entries beside the anchored leaf parent so rename stays on one filesystem, and avoid followable path mutations such as `chmod(path)` between creation and a no-follow open. Use `lstat`-based existence checks so dangling symlinks fail closed; when a platform lacks searchable Linux `/proc/self/fd` paths and no equivalent safe primitive is available, reject secure provisioning rather than restoring path-based TOCTOU cleanup.
 
 ## 2026-07-18 — Kanban reviewer isolation
 - Independent review workers must receive a distinct child card or explicitly review-only context; never let a delegated reviewer inherit and complete the implementation parent card, because completion can garbage-collect its workspace before the verified diff is committed and shipped.


### PR DESCRIPTION
## Summary
- quarantine existing run directories with an atomic rename before recursive removal
- verify run-root anchoring and directory identity before deletion
- fail closed on linked or dangling symlink swaps without touching external targets

## Test plan
- npm test --workspace @franken/live-bench
- npm run typecheck --workspace @franken/live-bench
- npm run lint --workspace @franken/live-bench
- npm run build --workspace @franken/live-bench

Closes #2847