### PR TITLE
fix(orchestrator): strip proxy operator credentials

### DIFF
--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -28,7 +28,7 @@ import {
 import { CHAT_SOCKET_TOKEN_TTL_MS, createSessionTokenSecret, issueSessionToken } from './ws-chat-auth.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { TransportSecurityService } from './security/transport-security.js';
-import { requireOperatorAuth } from './operator-auth.js';
+import { requireOperatorAuth, stripOperatorCredentialHeaders } from './operator-auth.js';
 import { ChatBeastDispatchAdapter } from '../chat/beast-dispatch-adapter.js';
 import type { CommsConfig } from '../comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../comms/core/comms-runtime-port.js';
@@ -356,6 +356,7 @@ async function proxyToBeastDaemon(
   const targetUrl = new URL(`${sourceUrl.pathname}${sourceUrl.search}`, daemon.baseUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  const headerToken = stripOperatorCredentialHeaders(headers);
   const browserOrigin = parseBrowserOrigin(headers.get('origin'));
   if (!headers.has('x-forwarded-host')) {
     headers.set('x-forwarded-host', browserOrigin?.host ?? sourceUrl.host);
@@ -364,7 +365,6 @@ async function proxyToBeastDaemon(
     headers.set('x-forwarded-proto', browserOrigin?.protocol.replace(/:$/, '') ?? sourceUrl.protocol.replace(/:$/, ''));
   }
   if (!headers.has('authorization')) {
-    const headerToken = headers.get('x-frankenbeast-operator-token')?.trim();
     const forwardedToken = operatorToken ?? (headerToken ? headerToken : undefined);
     if (forwardedToken) {
       headers.set('authorization', `Bearer ${forwardedToken}`);

--- a/packages/franken-orchestrator/src/http/operator-auth.ts
+++ b/packages/franken-orchestrator/src/http/operator-auth.ts
@@ -8,6 +8,32 @@ export interface OperatorAuthOptions {
 }
 
 export const OPERATOR_TOKEN_COOKIE = 'frankenbeast_operator_token';
+export const OPERATOR_TOKEN_HEADER = 'x-frankenbeast-operator-token';
+
+/**
+ * Remove gateway-only operator credentials before a request crosses into a
+ * downstream service. Returns the legacy header token so callers can replace
+ * it with canonical bearer authorization when needed.
+ */
+export function stripOperatorCredentialHeaders(headers: Headers): string | undefined {
+  const headerToken = headers.get(OPERATOR_TOKEN_HEADER)?.trim() || undefined;
+  headers.delete(OPERATOR_TOKEN_HEADER);
+
+  const cookieHeader = headers.get('cookie');
+  if (cookieHeader) {
+    const retainedCookies = cookieHeader
+      .split(';')
+      .map((cookie) => cookie.trim())
+      .filter((cookie) => cookie.length > 0 && cookie.split('=', 1)[0] !== OPERATOR_TOKEN_COOKIE);
+    if (retainedCookies.length > 0) {
+      headers.set('cookie', retainedCookies.join('; '));
+    } else {
+      headers.delete('cookie');
+    }
+  }
+
+  return headerToken;
+}
 
 export function extractOperatorToken(headerValue: string | undefined): string | undefined {
   if (!headerValue) return undefined;
@@ -82,7 +108,7 @@ export function isCookieOperatorAuthAllowed(options: {
 export function requireOperatorAuth(options: OperatorAuthOptions) {
   return createMiddleware(async (c, next) => {
     const headerToken = extractOperatorToken(c.req.header('authorization'))
-      ?? c.req.header('x-frankenbeast-operator-token')
+      ?? c.req.header(OPERATOR_TOKEN_HEADER)
       ?? undefined;
     const cookieToken = extractOperatorTokenCookie(c.req.header('cookie'));
     const provided = headerToken ?? cookieToken;

--- a/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
@@ -94,7 +94,28 @@ describe('chat app beast daemon proxy', () => {
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
-    expect((init.headers as Headers).get('authorization')).toBe(`Bearer ${TEST_GATEWAY_TOKEN}`);
+    const forwardedHeaders = init.headers as Headers;
+    expect(forwardedHeaders.get('authorization')).toBe(`Bearer ${TEST_GATEWAY_TOKEN}`);
+    expect(forwardedHeaders.has('x-frankenbeast-operator-token')).toBe(false);
+  });
+
+  it('strips the operator token cookie while preserving unrelated cookies', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ data: 'ok' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const app = createProxyApp();
+
+    const response = await app.request('/v1/beasts/catalog', {
+      headers: {
+        cookie: `theme=dark; frankenbeast_operator_token=${encodeURIComponent(TEST_DAEMON_TOKEN)}; session=abc`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+    const forwardedHeaders = init.headers as Headers;
+    expect(forwardedHeaders.get('authorization')).toBe(`Bearer ${TEST_DAEMON_TOKEN}`);
+    expect(forwardedHeaders.get('cookie')).toBe('theme=dark; session=abc');
   });
 
   it('strips hop-by-hop headers before forwarding daemon requests', async () => {


### PR DESCRIPTION
## Summary
- strip the internal `x-frankenbeast-operator-token` header before forwarding beast-daemon requests
- remove the operator-token cookie while preserving unrelated cookies
- preserve canonical bearer-token injection and add proxy regression coverage

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/http/chat-app-beast-daemon-proxy.test.ts`
- `npm run test --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`

Closes #2826