### PR TITLE
test(orchestrator): cover missing Slack interaction payload

### DIFF
--- a/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-router.test.ts
@@ -129,6 +129,25 @@ describe('slackRouter', () => {
     expect(gateway.handleAction).toHaveBeenCalledWith('slack', 'session-123', 'approve');
   });
 
+  it('returns 400 when the interactive payload is missing without invoking handlers', async () => {
+    const appWithoutSig = slackRouter({
+      gateway,
+      sessionMapper,
+      signingSecret: secret,
+      verifySignature: false,
+    });
+
+    const res = await appWithoutSig.request('/interactive', {
+      method: 'POST',
+      body: new FormData(),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Missing payload' });
+    expect(sessionMapper.mapToSessionId).not.toHaveBeenCalled();
+    expect(gateway.handleAction).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for malformed interactive JSON without invoking handlers', async () => {
     const appWithoutSig = slackRouter({
       gateway,


### PR DESCRIPTION
## Summary
- verify Slack interactive requests without a `payload` form field return a controlled 400
- assert missing requests do not reach session mapping or action dispatch
- retain the existing valid, malformed-JSON, and schema-invalid route coverage

## Context
The production malformed-JSON and schema-validation fix already exists on `main` from PRs #812 and #830. This closes the remaining explicit acceptance-criteria gap in #3224: focused coverage for a missing interactive payload.

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/comms/slack-router.test.ts` (9 passed)
- `npm run test --workspace @franken/orchestrator` (4016 passed)
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build`

Closes #3224