### PR TITLE
fix(web): describe agent creation wizard

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useBeastStore } from '../../stores/beast-store';
 import { WizardStepIndicator } from './wizard-step-indicator';
@@ -32,6 +32,7 @@ interface WizardDialogProps {
 }
 
 export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRuntime, launching, launchError }: WizardDialogProps) {
+  const descriptionId = useId();
   const {
     wizardStep,
     highestCompleted,
@@ -122,11 +123,16 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
         <Dialog.Content
           className="fixed top-[10vh] left-[12vw] w-[76vw] h-[80vh] bg-beast-panel border border-beast-border
             rounded-2xl z-[70] flex flex-col shadow-2xl shadow-black/40"
-          aria-describedby={undefined}
+          aria-describedby={descriptionId}
         >
           {/* Header */}
           <div className="flex items-center justify-between px-8 py-5 border-b border-beast-border shrink-0">
-            <Dialog.Title className="text-beast-text font-semibold text-lg">Create Agent</Dialog.Title>
+            <div>
+              <Dialog.Title className="text-beast-text font-semibold text-lg">Create Agent</Dialog.Title>
+              <Dialog.Description id={descriptionId} className="sr-only">
+                Configure and launch a new agent. Use Next and Back to move between steps, review your settings, and launch the agent when ready.
+              </Dialog.Description>
+            </div>
             <div className="flex items-center gap-4">
               <button
                 type="button"

--- a/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-dialog.test.tsx
@@ -15,6 +15,19 @@ describe('WizardDialog', () => {
     expect(screen.getByText('Identity')).toBeTruthy(); // First step label in indicator
   });
 
+  it('describes the creation flow and step navigation to assistive technology', () => {
+    render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} />);
+
+    const dialog = screen.getByRole('dialog');
+    const descriptionId = dialog.getAttribute('aria-describedby');
+    const description = descriptionId ? document.getElementById(descriptionId) : null;
+
+    expect(description).toBeTruthy();
+    expect(description?.textContent).toContain('Configure and launch a new agent');
+    expect(description?.textContent).toContain('Next and Back');
+    expect(description?.textContent).toContain('review your settings');
+  });
+
   it('has Back and Next buttons', () => {
     render(<WizardDialog isOpen={true} onClose={vi.fn()} onLaunch={vi.fn()} />);
     expect(screen.getByText('Next')).toBeTruthy();


### PR DESCRIPTION
## Summary
- add an assistive description for the multi-step Create Agent dialog
- wire the dialog description through a unique `aria-describedby` target
- cover the description content and relationship with a focused regression test

## Test plan
- `npm test -- --run tests/components/beasts/wizard-dialog.test.tsx`
- `npm test` (654 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #2979