### PR TITLE
ci: add explicit workflow job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   build-test-lint:
     runs-on: ubuntu-latest
+    # Full monorepo build, tests, coverage, and E2E smoke checks may be slow,
+    # but a stalled run must release its runner within two hours.
+    timeout-minutes: 120
     strategy:
       matrix:
         deterministic-seed: ['1337']
@@ -164,6 +167,9 @@ jobs:
   publish-smoke:
     name: publish smoke (pack + offline install + run)
     runs-on: ubuntu-latest
+    # Packing and installing every publishable workspace should finish well
+    # inside this bound, including cold npm downloads.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -41,6 +41,9 @@ jobs:
   scan:
     name: SAST + secrets + dependency audit
     runs-on: ubuntu-latest
+    # Tool installation, repository scans, report uploads, and issue
+    # reconciliation should complete within one hour even on cold runners.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   validate-release:
     runs-on: ubuntu-latest
+    # The full pre-release build, test, lint, and eval suite is bounded to the
+    # same two-hour ceiling as the main CI validation job.
+    timeout-minutes: 120
     permissions:
       contents: read
     steps:
@@ -41,6 +44,9 @@ jobs:
   release-please:
     needs: validate-release
     runs-on: ubuntu-latest
+    # Release metadata creation is API-bound and should never occupy a runner
+    # beyond this short operational window.
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -93,6 +99,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
+    # Building and publishing all released workspaces may need cold-cache time,
+    # but must terminate within 45 minutes if npm or GitHub stalls.
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    # A single actionlint pass should finish quickly; bound runner use if the
+    # action download or lint process stalls.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 import { load } from 'js-yaml';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
+const WORKFLOW_DIR = resolve(ROOT, '.github/workflows');
 const CI_PATH = resolve(ROOT, '.github/workflows/ci.yml');
 const RELEASE_PATH = resolve(ROOT, '.github/workflows/release-please.yml');
 const DAILY_SECURITY_SCAN_PATH = resolve(ROOT, '.github/workflows/daily-security-scan.yml');
@@ -88,6 +89,30 @@ function expectStepByName(
   expect(step, `CI should include ${label}`).toBeTruthy();
   return step as Record<string, unknown>;
 }
+
+describe('GitHub Actions timeout policy', () => {
+  it('sets an explicit bounded timeout for every workflow job', () => {
+    const workflowFiles = readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file));
+
+    expect(workflowFiles.length).toBeGreaterThan(0);
+    for (const file of workflowFiles) {
+      const workflow = parseWorkflowYaml(readFileSync(resolve(WORKFLOW_DIR, file), 'utf-8'));
+      const jobs = expectRecord(workflow.jobs, `${file}.jobs`);
+
+      expect(Object.keys(jobs).length, `${file} should define at least one job`).toBeGreaterThan(0);
+      for (const [jobName, jobConfig] of Object.entries(jobs)) {
+        const job = expectRecord(jobConfig, `${file}.jobs.${jobName}`);
+        const timeout = job['timeout-minutes'];
+
+        expect(timeout, `${file}.jobs.${jobName} should set timeout-minutes`).toBeTypeOf('number');
+        expect(timeout, `${file}.jobs.${jobName} timeout should be positive`).toBeGreaterThan(0);
+        expect(timeout, `${file}.jobs.${jobName} timeout should not exceed GitHub's six-hour maximum`).toBeLessThanOrEqual(
+          360,
+        );
+      }
+    }
+  });
+});
 
 describe('CI Workflow (.github/workflows/ci.yml)', () => {
   it('ci.yml file exists', () => {

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -148,6 +148,13 @@ on:
       });
     });
 
+    it('sets explicit upper bounds for every CI job', () => {
+      const jobs = expectRecord(workflow.jobs, 'workflow.jobs');
+
+      expect(expectRecord(jobs['build-test-lint'], 'jobs.build-test-lint')['timeout-minutes']).toBe(120);
+      expect(expectRecord(jobs['publish-smoke'], 'jobs.publish-smoke')['timeout-minutes']).toBe(45);
+    });
+
     it('uses the repository-pinned minimum supported Node.js version', () => {
       const setupNode = expectSteps(expectCiJob(workflow)).find((step) => step.uses === 'actions/setup-node@v7');
       expect(setupNode).toBeTruthy();
@@ -447,6 +454,12 @@ jobs:
       contents: 'write',
       'pull-requests': 'write',
     });
+  });
+
+  it('sets explicit upper bounds for every release job', () => {
+    expect(expectRecord(jobs['validate-release'], 'jobs.validate-release')['timeout-minutes']).toBe(120);
+    expect(releasePlease['timeout-minutes']).toBe(15);
+    expect(publishNpm['timeout-minutes']).toBe(45);
   });
 
   it('anchors config-file and manifest-file under the release-please action step', () => {


### PR DESCRIPTION
## Summary
- bound full CI and release validation jobs to two hours
- use shorter limits for publish smoke, release automation, and npm publishing
- add regression assertions covering every affected job

## Test plan
- `npm run test:root -- tests/unit/ci-workflow.test.ts tests/unit/release-please-config.test.ts`
- `actionlint .github/workflows/ci.yml .github/workflows/release-please.yml`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #3052