### PR TITLE
fix(web): announce analytics detail errors

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -617,6 +617,7 @@ describe('AnalyticsPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'View details for Denied destructive command' }));
 
     expect(await screen.findByText('detail timeout')).toBeTruthy();
+    expect(screen.getByRole('alert').textContent).toBe('detail timeout');
     expect(screen.getByText('Partial row data')).toBeTruthy();
     expect(screen.getByText('Full event detail is not loaded; the fields below are only from the selected table row.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy JSON' })).toHaveProperty('disabled', true);

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -593,7 +593,7 @@ function DetailDrawer({
               </Dialog.Close>
             </div>
 
-            {error && <div className="analytics-alert">{error}</div>}
+            {error && <div className="analytics-alert" role="alert">{error}</div>}
 
             <div className="analytics-detail-status" aria-live="polite">
               <strong>{detailStateLabel}</strong>


### PR DESCRIPTION
## Summary
- expose analytics detail-load failures through an assertive alert role
- cover the failing detail path with an accessible-role regression

## Verification
- `npm test --workspace @franken/web` (654 passed)
- `npm run lint --workspace @franken/web` (0 errors; 17 existing warnings)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/web`
- `npm run build --workspace @franken/web`

Closes #2978