### PR TITLE
fix(compose): tolerate slow Chroma startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
           '-ec',
           'exec 3<>/dev/tcp/127.0.0.1/8000 && printf "GET /api/v2/heartbeat HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3 && grep -q "200 OK" <&3',
         ]
+      # ChromaDB can take longer to initialize on slow or resource-constrained hosts.
       interval: 10s
-      timeout: 5s
-      retries: 3
+      timeout: 15s
+      retries: 5
+      start_period: 30s
 
   # Grafana — dashboards for observability
   grafana:

--- a/tests/local-setup-scripts.test.ts
+++ b/tests/local-setup-scripts.test.ts
@@ -757,6 +757,13 @@ describe('local setup scripts', () => {
     expect(compose).not.toContain('http://localhost:8000/api/v1/heartbeat');
   });
 
+  it('allows Chroma enough time to become healthy on slow hosts', () => {
+    const compose = read('docker-compose.yml');
+
+    expect(compose).toContain('# ChromaDB can take longer to initialize on slow or resource-constrained hosts.');
+    expect(compose).toMatch(/healthcheck:[\s\S]*?interval: 10s\n\s+timeout: 15s\n\s+retries: 5\n\s+start_period: 30s/u);
+  });
+
   it('pins local compose images and mounts an explicit Tempo config', () => {
     const compose = read('docker-compose.yml');
     const tempoConfig = read('tempo.yaml');


### PR DESCRIPTION
## Summary
- give Chroma health probes a 15-second response timeout
- add a 30-second startup grace period and five retries for slower hosts
- document and regression-test the startup budget

## Validation
- `npm run test:root -- --run tests/local-setup-scripts.test.ts` (31 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- parsed `docker-compose.yml` with `js-yaml` and asserted the healthcheck values

`docker compose config --quiet` could not run because Docker is not installed on this worker.

Closes #3281