### PR TITLE
fix(orchestrator): persist skill toggles atomically

### DIFF
--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -429,12 +429,6 @@ export function atomicWriteFileSync(
       try {
         writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'preparing' });
         fd = openSync(tmpPath, 'wx', options.mode);
-        if (options.mode !== undefined) {
-          // open(2) applies the process umask to its mode argument. Reapply the
-          // requested mode before rename so replacement files preserve the
-          // caller's exact permissions without a post-rename exposure window.
-          fchmodSync(fd, options.mode);
-        }
         break;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
@@ -444,6 +438,14 @@ export function atomicWriteFileSync(
       }
     }
     try {
+      if (options.mode !== undefined) {
+        // open(2) applies the process umask to its mode argument. Reapply the
+        // requested mode before rename so replacement files preserve the
+        // caller's exact permissions without a post-rename exposure window.
+        // Keep this inside the descriptor finally so chmod failures cannot
+        // leak the newly opened temp-file descriptor.
+        fchmodSync(fd, options.mode);
+      }
       const writingJournal = { ...journalBase, tempPath: resolve(tmpPath), phase: 'writing-temp' as const };
       let lastJournalRefreshMs = Date.now();
       const refreshWritingJournal = (): void => {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -1,6 +1,7 @@
 import {
   closeSync,
   existsSync,
+  fchmodSync,
   fsyncSync,
   openSync,
   readFileSync,
@@ -428,6 +429,12 @@ export function atomicWriteFileSync(
       try {
         writeStateWriteJournal(filePath, { ...journalBase, tempPath: resolve(tmpPath), phase: 'preparing' });
         fd = openSync(tmpPath, 'wx', options.mode);
+        if (options.mode !== undefined) {
+          // open(2) applies the process umask to its mode argument. Reapply the
+          // requested mode before rename so replacement files preserve the
+          // caller's exact permissions without a post-rename exposure window.
+          fchmodSync(fd, options.mode);
+        }
         break;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -43,6 +43,23 @@ export class SkillConfigStore {
   save(enabledSkills: Set<string>): void {
     mkdirSync(dirname(this.configPath), { recursive: true });
 
+    const existing = this.readExistingForSave();
+    existing.skills = {
+      ...((existing.skills as Record<string, unknown>) ?? {}),
+      enabled: [...enabledSkills].sort(),
+    };
+
+    const mode = existsSync(this.configPath)
+      ? statSync(this.configPath).mode & 0o777
+      : 0o600;
+    atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n', { mode });
+  }
+
+  assertSaveable(): void {
+    this.readExistingForSave();
+  }
+
+  private readExistingForSave(): Record<string, unknown> {
     let existing: Record<string, unknown> = {};
     if (existsSync(this.configPath)) {
       try {
@@ -57,15 +74,6 @@ export class SkillConfigStore {
         });
       }
     }
-
-    existing.skills = {
-      ...((existing.skills as Record<string, unknown>) ?? {}),
-      enabled: [...enabledSkills].sort(),
-    };
-
-    const mode = existsSync(this.configPath)
-      ? statSync(this.configPath).mode & 0o777
-      : 0o600;
-    atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n', { mode });
+    return existing;
   }
 }

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync, mkdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { atomicWriteFileSync } from '../session/atomic-file.js';
+import {
+  atomicWriteFileSync,
+  recoverStateWriteTransaction,
+} from '../session/atomic-file.js';
 
 /**
  * Persistent store for skill toggle state.
@@ -57,6 +60,10 @@ export class SkillConfigStore {
 
   assertSaveable(): void {
     this.readExistingForSave();
+    const recovery = recoverStateWriteTransaction(this.configPath);
+    if (recovery?.action === 'retained-active-journal') {
+      throw new Error(recovery.reason);
+    }
   }
 
   private readExistingForSave(): Record<string, unknown> {

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, statSync, unlinkSync, lstatSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import {
   atomicWriteFileSync,
@@ -98,6 +98,9 @@ export class SkillConfigStore {
   private readExistingForSave(): Record<string, unknown> {
     let existing: Record<string, unknown> = {};
     if (existsSync(this.configPath)) {
+      if (lstatSync(this.configPath).isSymbolicLink()) {
+        throw new Error('Cannot save skill toggles because symlinked config files are not supported');
+      }
       try {
         const parsed = JSON.parse(readFileSync(this.configPath, 'utf-8'));
         // Normalize: only use parsed value if it's a plain object

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import {
   atomicWriteFileSync,
@@ -16,6 +16,7 @@ import {
  *   run config `skills:` field > persisted defaults > empty
  */
 export class SkillConfigStore {
+  private static probeCounter = 0;
   private readonly configPath: string;
 
   constructor(configDir: string) {
@@ -52,18 +53,46 @@ export class SkillConfigStore {
       enabled: [...enabledSkills].sort(),
     };
 
-    const mode = existsSync(this.configPath)
-      ? statSync(this.configPath).mode & 0o777
-      : 0o600;
+    const mode = this.configModeForWrite();
     atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n', { mode });
   }
 
   assertSaveable(): void {
+    mkdirSync(dirname(this.configPath), { recursive: true });
     this.readExistingForSave();
+    this.configModeForWrite();
     const recovery = recoverStateWriteTransaction(this.configPath);
     if (recovery?.action === 'retained-active-journal') {
       throw new Error(recovery.reason);
     }
+
+    // remove() deletes skill files before persisting their disabled state. Probe
+    // the complete sidecar/temp/rename path in the same directory first so a
+    // directory that cannot support atomic writes fails before those files are
+    // touched. The real save still performs its own recovery for race safety.
+    const probePath = `${this.configPath}.write-probe.${process.pid}.${SkillConfigStore.probeCounter++}`;
+    try {
+      this.probeAtomicWrite(probePath);
+    } finally {
+      try {
+        unlinkSync(probePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+  }
+
+  protected probeAtomicWrite(probePath: string): void {
+    atomicWriteFileSync(probePath, '', { mode: 0o600 });
+  }
+
+  private configModeForWrite(): number {
+    if (!existsSync(this.configPath)) return 0o600;
+    const mode = statSync(this.configPath).mode & 0o777;
+    if ((mode & 0o222) === 0) {
+      throw new Error('Cannot save skill toggles because the existing config is read-only');
+    }
+    return mode;
   }
 
   private readExistingForSave(): Record<string, unknown> {

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -97,10 +97,18 @@ export class SkillConfigStore {
 
   private readExistingForSave(): Record<string, unknown> {
     let existing: Record<string, unknown> = {};
-    if (existsSync(this.configPath)) {
-      if (lstatSync(this.configPath).isSymbolicLink()) {
+    let configExists = false;
+    try {
+      const configStat = lstatSync(this.configPath);
+      if (configStat.isSymbolicLink()) {
         throw new Error('Cannot save skill toggles because symlinked config files are not supported');
       }
+      configExists = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+
+    if (configExists) {
       try {
         const parsed = JSON.parse(readFileSync(this.configPath, 'utf-8'));
         // Normalize: only use parsed value if it's a plain object

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { atomicWriteFileSync } from '../session/atomic-file.js';
 
 /**
  * Persistent store for skill toggle state.
@@ -43,16 +44,18 @@ export class SkillConfigStore {
     mkdirSync(dirname(this.configPath), { recursive: true });
 
     let existing: Record<string, unknown> = {};
-    try {
-      if (existsSync(this.configPath)) {
+    if (existsSync(this.configPath)) {
+      try {
         const parsed = JSON.parse(readFileSync(this.configPath, 'utf-8'));
         // Normalize: only use parsed value if it's a plain object
         if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
           existing = parsed as Record<string, unknown>;
         }
+      } catch (error) {
+        throw new Error('Cannot save skill toggles because the existing config is corrupt or unreadable', {
+          cause: error,
+        });
       }
-    } catch {
-      /* start fresh if corrupt */
     }
 
     existing.skills = {
@@ -60,6 +63,6 @@ export class SkillConfigStore {
       enabled: [...enabledSkills].sort(),
     };
 
-    writeFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n');
+    atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n');
   }
 }

--- a/packages/franken-orchestrator/src/skills/skill-config-store.ts
+++ b/packages/franken-orchestrator/src/skills/skill-config-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { atomicWriteFileSync } from '../session/atomic-file.js';
 
@@ -63,6 +63,9 @@ export class SkillConfigStore {
       enabled: [...enabledSkills].sort(),
     };
 
-    atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n');
+    const mode = existsSync(this.configPath)
+      ? statSync(this.configPath).mode & 0o777
+      : 0o600;
+    atomicWriteFileSync(this.configPath, JSON.stringify(existing, null, 2) + '\n', { mode });
   }
 }

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -303,16 +303,17 @@ export class SkillManager {
     this.assertSkillsRootStable();
     const nextEnabledSkills = new Set(this.enabledSkills);
     nextEnabledSkills.delete(name);
-    this.configStore?.save(nextEnabledSkills);
-    this.enabledSkills.delete(name);
+    this.configStore?.assertSaveable();
     if (existsSync(skillDir)) {
       if (lstatSync(skillDir).isSymbolicLink()) {
         rmSync(skillDir);
-        return;
+      } else {
+        assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
+        rmSync(skillDir, { recursive: true });
       }
-      assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
-      rmSync(skillDir, { recursive: true });
     }
+    this.configStore?.save(nextEnabledSkills);
+    this.enabledSkills.delete(name);
   }
 
   exists(name: string): boolean {

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -284,31 +284,35 @@ export class SkillManager {
     this.validateName(name);
     if (!this.exists(name))
       throw new Error(`Skill '${name}' is not installed`);
+    const nextEnabledSkills = new Set(this.enabledSkills);
+    nextEnabledSkills.add(name);
+    this.configStore?.save(nextEnabledSkills);
     this.enabledSkills.add(name);
-    this.configStore?.save(this.enabledSkills);
   }
 
   disable(name: string): void {
+    const nextEnabledSkills = new Set(this.enabledSkills);
+    nextEnabledSkills.delete(name);
+    this.configStore?.save(nextEnabledSkills);
     this.enabledSkills.delete(name);
-    this.configStore?.save(this.enabledSkills);
   }
 
   remove(name: string): void {
     this.validateName(name);
     const skillDir = this.skillDirectoryPath(name);
     this.assertSkillsRootStable();
+    const nextEnabledSkills = new Set(this.enabledSkills);
+    nextEnabledSkills.delete(name);
+    this.configStore?.save(nextEnabledSkills);
+    this.enabledSkills.delete(name);
     if (existsSync(skillDir)) {
       if (lstatSync(skillDir).isSymbolicLink()) {
         rmSync(skillDir);
-        this.enabledSkills.delete(name);
-        this.configStore?.save(this.enabledSkills);
         return;
       }
       assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
       rmSync(skillDir, { recursive: true });
     }
-    this.enabledSkills.delete(name);
-    this.configStore?.save(this.enabledSkills);
   }
 
   exists(name: string): boolean {

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -128,6 +128,13 @@ export class SkillManager {
     }
   }
 
+  protected removeSkillPath(
+    path: string,
+    options?: { recursive?: boolean; force?: boolean },
+  ): void {
+    rmSync(path, options);
+  }
+
   private skillDirectoryPath(name: string): string {
     this.validateName(name);
     const skillDir = resolve(this.skillsDirRoot, name);
@@ -306,10 +313,10 @@ export class SkillManager {
     this.configStore?.assertSaveable();
     if (existsSync(skillDir)) {
       if (lstatSync(skillDir).isSymbolicLink()) {
-        rmSync(skillDir);
+        this.removeSkillPath(skillDir);
       } else {
         assertContainedPath(realpathSync(skillDir), this.skillsDirReal, 'skill directory');
-        rmSync(skillDir, { recursive: true });
+        this.removeSkillPath(skillDir, { recursive: true });
       }
     }
     this.configStore?.save(nextEnabledSkills);

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -314,6 +314,23 @@ describe('SkillManager + SkillConfigStore integration', () => {
     expect(manager.getEnabledSkills()).toContain('github');
   });
 
+  it('does not persist or mutate toggle state when file removal fails', async () => {
+    store.save(new Set(['github']));
+    const manager = new SkillManager(skillsDir, new Set(['github']), store);
+    await installSkill(manager, 'github');
+    chmodSync(skillsDir, 0o500);
+
+    try {
+      expect(() => manager.remove('github')).toThrow();
+      expect(manager.getEnabledSkills()).toContain('github');
+      expect(store.getEnabledSkills()).toContain('github');
+    } finally {
+      chmodSync(skillsDir, 0o700);
+    }
+
+    expect(manager.exists('github')).toBe(true);
+  });
+
   it('works without configStore (backward compatible)', async () => {
     const manager = new SkillManager(skillsDir, new Set());
     await installSkill(manager, 'github');

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -100,6 +100,18 @@ describe('SkillConfigStore', () => {
       });
     });
 
+    it('refuses to replace a dangling symlink with a local config', () => {
+      mkdirSync(configDir, { recursive: true });
+      const configPath = join(configDir, 'config.json');
+      const missingTargetPath = join(tempDir, 'missing-config.json');
+      symlinkSync(missingTargetPath, configPath);
+
+      expect(() => store.save(new Set(['github']))).toThrow(/symlinked config/i);
+
+      expect(lstatSync(configPath).isSymbolicLink()).toBe(true);
+      expect(existsSync(missingTargetPath)).toBe(false);
+    });
+
     it('refuses to overwrite a corrupt existing config', () => {
       mkdirSync(configDir, { recursive: true });
       const configPath = join(configDir, 'config.json');

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -153,6 +153,22 @@ describe('SkillConfigStore', () => {
       expect(raw.skills.enabled).toEqual(['github']);
     });
 
+    it('preserves an existing mode even when the process umask would mask it', () => {
+      mkdirSync(configDir, { recursive: true });
+      const configPath = join(configDir, 'config.json');
+      writeFileSync(configPath, JSON.stringify({ skills: { enabled: ['old'] } }));
+      chmodSync(configPath, 0o660);
+      const previousUmask = process.umask(0o077);
+
+      try {
+        store.save(new Set(['github']));
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect(statSync(configPath).mode & 0o777).toBe(0o660);
+    });
+
     it('recovers from non-object JSON root on save (e.g. null)', () => {
       mkdirSync(configDir, { recursive: true });
       writeFileSync(join(configDir, 'config.json'), 'null');
@@ -314,20 +330,42 @@ describe('SkillManager + SkillConfigStore integration', () => {
     expect(manager.getEnabledSkills()).toContain('github');
   });
 
-  it('does not persist or mutate toggle state when file removal fails', async () => {
-    store.save(new Set(['github']));
+  it('does not delete skill files while an atomic config write journal is active', async () => {
     const manager = new SkillManager(skillsDir, new Set(['github']), store);
     await installSkill(manager, 'github');
-    chmodSync(skillsDir, 0o500);
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, 'config.json');
+    const now = new Date().toISOString();
+    writeFileSync(
+      `${configPath}.journal`,
+      JSON.stringify({
+        schemaVersion: 1,
+        targetPath: configPath,
+        tempPath: `${configPath}.tmp.1.00000000-0000-4000-8000-000000000000`,
+        phase: 'preparing',
+        startedAt: now,
+        updatedAt: now,
+      }),
+    );
 
-    try {
-      expect(() => manager.remove('github')).toThrow();
-      expect(manager.getEnabledSkills()).toContain('github');
-      expect(store.getEnabledSkills()).toContain('github');
-    } finally {
-      chmodSync(skillsDir, 0o700);
+    expect(() => manager.remove('github')).toThrow(/still preparing/i);
+    expect(manager.exists('github')).toBe(true);
+    expect(manager.getEnabledSkills()).toContain('github');
+  });
+
+  it('does not persist or mutate toggle state when file removal fails', async () => {
+    store.save(new Set(['github']));
+    class FailingRemoveSkillManager extends SkillManager {
+      protected override removeSkillPath(): void {
+        throw new Error('injected removal failure');
+      }
     }
+    const manager = new FailingRemoveSkillManager(skillsDir, new Set(['github']), store);
+    await installSkill(manager, 'github');
 
+    expect(() => manager.remove('github')).toThrow(/injected removal failure/);
+    expect(manager.getEnabledSkills()).toContain('github');
+    expect(store.getEnabledSkills()).toContain('github');
     expect(manager.exists('github')).toBe(true);
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -8,6 +8,8 @@ import {
   existsSync,
   lstatSync,
   symlinkSync,
+  chmodSync,
+  statSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -84,12 +86,14 @@ describe('SkillConfigStore', () => {
         linkedConfigPath,
         JSON.stringify({ theme: 'dark', skills: { enabled: ['old'] } }, null, 2) + '\n',
       );
+      chmodSync(linkedConfigPath, 0o600);
       const configPath = join(configDir, 'config.json');
       symlinkSync(linkedConfigPath, configPath);
 
       store.save(new Set(['github']));
 
       expect(lstatSync(configPath).isSymbolicLink()).toBe(false);
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
       expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({
         theme: 'dark',
         skills: { enabled: ['github'] },
@@ -268,6 +272,23 @@ describe('SkillManager + SkillConfigStore integration', () => {
     expect(persisted).not.toContain('github');
   });
 
+  it('keeps in-memory toggle state unchanged when persistence fails', async () => {
+    const manager = new SkillManager(skillsDir, new Set(), store);
+    await installSkill(manager, 'github');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{"skills":');
+
+    expect(() => manager.enable('github')).toThrow(/corrupt/i);
+    expect(manager.getEnabledSkills()).not.toContain('github');
+
+    rmSync(join(configDir, 'config.json'));
+    manager.enable('github');
+    writeFileSync(join(configDir, 'config.json'), '{"skills":');
+
+    expect(() => manager.disable('github')).toThrow(/corrupt/i);
+    expect(manager.getEnabledSkills()).toContain('github');
+  });
+
   it('remove() persists via configStore', async () => {
     const manager = new SkillManager(skillsDir, new Set(), store);
     await installSkill(manager, 'github');
@@ -280,6 +301,17 @@ describe('SkillManager + SkillConfigStore integration', () => {
     // Removal should also persist — 'github' no longer in config
     const persisted = store.getEnabledSkills();
     expect(persisted).not.toContain('github');
+  });
+
+  it('does not delete skill files when persistence fails', async () => {
+    const manager = new SkillManager(skillsDir, new Set(['github']), store);
+    await installSkill(manager, 'github');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{"skills":');
+
+    expect(() => manager.remove('github')).toThrow(/corrupt/i);
+    expect(manager.exists('github')).toBe(true);
+    expect(manager.getEnabledSkills()).toContain('github');
   });
 
   it('works without configStore (backward compatible)', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -80,7 +80,7 @@ describe('SkillConfigStore', () => {
   });
 
   describe('save()', () => {
-    it('atomically replaces config.json instead of writing through it', () => {
+    it('refuses to copy a symlink target into a local config', () => {
       mkdirSync(configDir, { recursive: true });
       const linkedConfigPath = join(tempDir, 'linked-config.json');
       writeFileSync(
@@ -91,14 +91,9 @@ describe('SkillConfigStore', () => {
       const configPath = join(configDir, 'config.json');
       symlinkSync(linkedConfigPath, configPath);
 
-      store.save(new Set(['github']));
+      expect(() => store.save(new Set(['github']))).toThrow(/symlinked config/i);
 
-      expect(lstatSync(configPath).isSymbolicLink()).toBe(false);
-      expect(statSync(configPath).mode & 0o777).toBe(0o600);
-      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({
-        theme: 'dark',
-        skills: { enabled: ['github'] },
-      });
+      expect(lstatSync(configPath).isSymbolicLink()).toBe(true);
       expect(JSON.parse(readFileSync(linkedConfigPath, 'utf-8'))).toEqual({
         theme: 'dark',
         skills: { enabled: ['old'] },

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -10,6 +10,7 @@ import {
   symlinkSync,
   chmodSync,
   statSync,
+  readdirSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -167,6 +168,18 @@ describe('SkillConfigStore', () => {
       }
 
       expect(statSync(configPath).mode & 0o777).toBe(0o660);
+    });
+
+    it('refuses to replace an existing read-only config', () => {
+      mkdirSync(configDir, { recursive: true });
+      const configPath = join(configDir, 'config.json');
+      const original = JSON.stringify({ skills: { enabled: ['old'] } });
+      writeFileSync(configPath, original);
+      chmodSync(configPath, 0o444);
+
+      expect(() => store.save(new Set(['github']))).toThrow(/read-only/i);
+      expect(readFileSync(configPath, 'utf-8')).toBe(original);
+      expect(statSync(configPath).mode & 0o777).toBe(0o444);
     });
 
     it('recovers from non-object JSON root on save (e.g. null)', () => {
@@ -351,6 +364,48 @@ describe('SkillManager + SkillConfigStore integration', () => {
     expect(() => manager.remove('github')).toThrow(/still preparing/i);
     expect(manager.exists('github')).toBe(true);
     expect(manager.getEnabledSkills()).toContain('github');
+  });
+
+  it('preflights the complete atomic write path without leaving probe files', async () => {
+    const manager = new SkillManager(skillsDir, new Set(['github']), store);
+    await installSkill(manager, 'github');
+    store.save(new Set(['github']));
+
+    store.assertSaveable();
+
+    expect(readdirSync(configDir).filter((name) => name.includes('write-probe'))).toEqual([]);
+    expect(manager.exists('github')).toBe(true);
+    expect(store.getEnabledSkills()).toContain('github');
+  });
+
+  it('does not delete skill files when the atomic write probe fails', async () => {
+    class FailingProbeConfigStore extends SkillConfigStore {
+      protected override probeAtomicWrite(): void {
+        throw new Error('injected atomic write probe failure');
+      }
+    }
+    const failingStore = new FailingProbeConfigStore(configDir);
+    failingStore.save(new Set(['github']));
+    const manager = new SkillManager(skillsDir, new Set(['github']), failingStore);
+    await installSkill(manager, 'github');
+
+    expect(() => manager.remove('github')).toThrow(/injected atomic write probe failure/);
+    expect(manager.exists('github')).toBe(true);
+    expect(manager.getEnabledSkills()).toContain('github');
+    expect(failingStore.getEnabledSkills()).toContain('github');
+  });
+
+  it('does not delete skill files when the existing config is read-only', async () => {
+    const manager = new SkillManager(skillsDir, new Set(['github']), store);
+    await installSkill(manager, 'github');
+    store.save(new Set(['github']));
+    const configPath = join(configDir, 'config.json');
+    chmodSync(configPath, 0o444);
+
+    expect(() => manager.remove('github')).toThrow(/read-only/i);
+    expect(manager.exists('github')).toBe(true);
+    expect(manager.getEnabledSkills()).toContain('github');
+    expect(store.getEnabledSkills()).toContain('github');
   });
 
   it('does not persist or mutate toggle state when file removal fails', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-config-store.test.ts
@@ -6,6 +6,8 @@ import {
   readFileSync,
   mkdirSync,
   existsSync,
+  lstatSync,
+  symlinkSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -75,6 +77,39 @@ describe('SkillConfigStore', () => {
   });
 
   describe('save()', () => {
+    it('atomically replaces config.json instead of writing through it', () => {
+      mkdirSync(configDir, { recursive: true });
+      const linkedConfigPath = join(tempDir, 'linked-config.json');
+      writeFileSync(
+        linkedConfigPath,
+        JSON.stringify({ theme: 'dark', skills: { enabled: ['old'] } }, null, 2) + '\n',
+      );
+      const configPath = join(configDir, 'config.json');
+      symlinkSync(linkedConfigPath, configPath);
+
+      store.save(new Set(['github']));
+
+      expect(lstatSync(configPath).isSymbolicLink()).toBe(false);
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual({
+        theme: 'dark',
+        skills: { enabled: ['github'] },
+      });
+      expect(JSON.parse(readFileSync(linkedConfigPath, 'utf-8'))).toEqual({
+        theme: 'dark',
+        skills: { enabled: ['old'] },
+      });
+    });
+
+    it('refuses to overwrite a corrupt existing config', () => {
+      mkdirSync(configDir, { recursive: true });
+      const configPath = join(configDir, 'config.json');
+      const truncatedConfig = '{"theme":"dark","skills":{"enabled":["github"]';
+      writeFileSync(configPath, truncatedConfig);
+
+      expect(() => store.save(new Set(['linear']))).toThrow(/corrupt/i);
+      expect(readFileSync(configPath, 'utf-8')).toBe(truncatedConfig);
+    });
+
     it('creates config.json with skills.enabled array', () => {
       store.save(new Set(['github', 'linear']));
       const configPath = join(configDir, 'config.json');


### PR DESCRIPTION
## Summary
- write skill toggle config through the existing durable temp-file, fsync, rename, and directory-fsync helper
- refuse to overwrite malformed existing config so prior persisted state is not silently erased
- add regressions for atomic path replacement and truncated-config preservation

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/skills/skill-config-store.test.ts` (23 passed)
- `npm run build` (10 packages passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)
- full orchestrator suite: 4,016 passed; one unrelated timeout passed in isolation

Closes #3192