### PR TITLE
perf(web): code-split route pages to fix chunk-size warning

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -164,13 +164,14 @@ describe('ChatShell route heading', () => {
     });
   });
 
-  it('uses the active route label as the primary heading and demotes project context to metadata', () => {
+  it('uses the active route label as the primary heading and demotes project context to metadata', async () => {
     render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
 
     expect(screen.getByRole('heading', { level: 1, name: 'Network' })).toBeTruthy();
     expect(screen.queryByRole('heading', { level: 1, name: 'default' })).toBeNull();
     expect(screen.getByText('Project: default')).toBeTruthy();
-    expect(screen.getByText('Service controls')).toBeTruthy();
+    // The routed page is lazy-loaded, so its content mounts asynchronously.
+    expect(await screen.findByText('Service controls')).toBeTruthy();
     expect(screen.queryByText('Chat is the only live section in this first Frankenbeast dashboard cut.')).toBeNull();
   });
 
@@ -247,7 +248,7 @@ describe('ChatShell route heading', () => {
     render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
     await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh' }));
 
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to refresh network status: HTTP 503');
   });
@@ -266,7 +267,7 @@ describe('ChatShell route heading', () => {
 
     render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
     await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
-    expect(screen.getByDisplayValue('initial-model')).toBeDefined();
+    expect(await screen.findByDisplayValue('initial-model')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
@@ -292,7 +293,7 @@ describe('ChatShell route heading', () => {
     render(<ChatShell baseUrl="http://localhost:3737" projectId="default" version="0.2.1" />);
     await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh' }));
     await waitFor(() => expect(networkApiMocks.getConfig).toHaveBeenCalledTimes(2));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
 import brandMark from '../../../../assets/img/frankenbeast-github-logo-478x72.png';
 import { useChatSession } from '../hooks/use-chat-session';
 import { TranscriptPane } from './transcript-pane';
@@ -6,7 +6,6 @@ import { Composer } from './composer';
 import { ActivityPane } from './activity-pane';
 import { ApprovalCard } from './approval-card';
 import { CostBadge } from './cost-badge';
-import { NetworkPage } from '../pages/network-page';
 import {
   BeastApiClient,
   BeastApiError,
@@ -21,12 +20,9 @@ import {
 } from '../lib/beast-api';
 import { ChatApiClient, type ChatSessionSummary, type CorruptChatSessionFile } from '../lib/api';
 import { NetworkApiClient, type NetworkConfigResponse, type NetworkStatusResponse } from '../lib/network-api';
-import { BeastsPage } from '../pages/beasts-page';
 import type { AgentLifecycleAction } from './beasts/agent-action-bar';
 import { AnalyticsApiClient } from '../lib/analytics-api';
-import { AnalyticsPage } from '../pages/analytics-page';
 import { DashboardApiClient } from '../lib/dashboard-api';
-import { DashboardPage } from '../pages/dashboard-page';
 import { ChatErrorBanners } from './chat-shell/chat-error-banners';
 import { PlaceholderPage } from './chat-shell/placeholder-page';
 import { PRIMARY_NAV_ROUTES, ROUTES, routeFromHash, type RouteId } from './chat-shell/route-model';
@@ -34,6 +30,17 @@ import { formatSessionOptionLabel } from './chat-shell/session-labels';
 import { getSidebarFocusableElements } from './chat-shell/sidebar-focus';
 import { appendUniqueLogLine, formatStreamedLogLine, getAgentEventRunId } from './chat-shell/beast-log-utils';
 import { networkErrorMessage } from './chat-shell/network-error';
+
+// Route pages are lazy so each becomes its own chunk; they carry route-specific
+// UI the initial chat view never needs, keeping the entry bundle small.
+const DashboardPage = lazy(() =>
+  import('../pages/dashboard-page').then((module) => ({ default: module.DashboardPage })));
+const BeastsPage = lazy(() =>
+  import('../pages/beasts-page').then((module) => ({ default: module.BeastsPage })));
+const NetworkPage = lazy(() =>
+  import('../pages/network-page').then((module) => ({ default: module.NetworkPage })));
+const AnalyticsPage = lazy(() =>
+  import('../pages/analytics-page').then((module) => ({ default: module.AnalyticsPage })));
 
 export interface ChatShellProps {
   baseUrl: string;
@@ -838,6 +845,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           </dl>
         </header>
 
+        <Suspense fallback={<main className="chat-page" aria-busy="true" />}>
         {route === 'dashboard' ? (
           <main className="dashboard-overview-page">
             <DashboardPage client={dashboardClient} />
@@ -1242,6 +1250,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             <PlaceholderPage routeId={route} />
           </main>
         )}
+        </Suspense>
       </div>
     </div>
   );

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1036,9 +1036,11 @@ describe('ChatShell', () => {
       />,
     );
 
+    // First lazy mount of the beasts page pays the dynamic-import cost, so
+    // allow more than waitFor's 1s default.
     await waitFor(() => {
       expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
-    });
+    }, { timeout: 5000 });
 
     expect(screen.getByRole('heading', { level: 1, name: 'Beasts' })).toBeDefined();
     expect(mockListAgents).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Fixes the Vite build warning `(!) Some chunks are larger than 500 kB after minification` in `@franken/web`.
- The four routed pages (dashboard, beasts, network, analytics) were statically imported by `ChatShell`, bundling the whole dashboard into a single 571 kB chunk. They are now `React.lazy`-loaded behind a single `Suspense` boundary, so each route ships as its own chunk, loaded on first navigation.

**Bundle before:** one `index-*.js` at 571.79 kB.
**Bundle after:** entry `index-*.js` at 343.99 kB (102.41 kB gzip), plus per-route chunks: beasts 151.95 kB, network 16.40 kB, analytics 13.85 kB, dashboard 13.44 kB. No chunk exceeds the 500 kB warning limit.

Tests asserting on routed page content now await the lazy mount (`findBy*` / a longer `waitFor` for the first beasts-page import).

## Testing

- `npm run build` — all 10 packages build, chunk-size warning gone
- `npm run typecheck` — 17/17 pass
- `@franken/web` vitest suite: 654/654 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)