### PR TITLE
fix(orchestrator): bound MCP health probes

### DIFF
--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -31,6 +31,7 @@ const INCOMPLETE_HANDSHAKE_MESSAGE =
   'MCP initialize handshake was not completed before the command exited';
 
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
+const HEALTH_CHECK_TERMINATION_GRACE_MS = 250;
 /** Maximum number of MCP child-process health probes running at once. */
 const MAX_CONCURRENT_MCP_HEALTH_PROBES = 4;
 /** Maximum number of child processes spawned by one trusted status check. */
@@ -135,10 +136,48 @@ export class SkillHealthChecker {
         }
         settled = true;
         clearTimeout(timer);
-        if (killRunningProcess && proc.exitCode === null && !proc.killed) {
-          proc.kill();
+        const outcome = { status, ...(error === undefined ? {} : { error }) };
+
+        if (killRunningProcess && proc.exitCode === null) {
+          let forceKillTimer: NodeJS.Timeout | undefined = undefined;
+          let terminated = false;
+          const finishAfterTermination = () => {
+            if (terminated) {
+              return;
+            }
+            terminated = true;
+            if (forceKillTimer) {
+              clearTimeout(forceKillTimer);
+            }
+            proc.off('exit', finishAfterTermination);
+            proc.off('close', finishAfterTermination);
+            resolve(outcome);
+          };
+
+          proc.once('exit', finishAfterTermination);
+          proc.once('close', finishAfterTermination);
+          try {
+            proc.kill();
+          } catch {
+            finishAfterTermination();
+            return;
+          }
+          if (terminated) {
+            return;
+          }
+          forceKillTimer = setTimeout(() => {
+            if (proc.exitCode === null) {
+              try {
+                proc.kill('SIGKILL');
+              } catch {
+                finishAfterTermination();
+              }
+            }
+          }, HEALTH_CHECK_TERMINATION_GRACE_MS);
+          return;
         }
-        resolve({ status, ...(error === undefined ? {} : { error }) });
+
+        resolve(outcome);
       };
 
       try {

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -38,6 +38,47 @@ const MAX_CONCURRENT_MCP_HEALTH_PROBES = 4;
 const MAX_MCP_HEALTH_PROBES_PER_CHECK = 20;
 const MCP_INITIALIZE_ID = 1;
 
+class AsyncSemaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(limit: number) {
+    this.available = limit;
+  }
+
+  async run<Result>(operation: () => Promise<Result>): Promise<Result> {
+    await this.acquire();
+    try {
+      return await operation();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available -= 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.available += 1;
+    }
+  }
+}
+
+const MCP_HEALTH_PROBE_SEMAPHORE = new AsyncSemaphore(
+  MAX_CONCURRENT_MCP_HEALTH_PROBES,
+);
+
 interface HealthCheckMcpServerConfig {
   command: string;
   args?: string[] | undefined;
@@ -77,9 +118,8 @@ export class SkillHealthChecker {
         }
 
         try {
-          const outcome = await this.checkServer(
-            config.command,
-            config.args ?? [],
+          const outcome = await MCP_HEALTH_PROBE_SEMAPHORE.run(() =>
+            this.checkServer(config.command, config.args ?? []),
           );
           return { serverName, ...outcome };
         } catch (err) {
@@ -157,7 +197,10 @@ export class SkillHealthChecker {
           proc.once('exit', finishAfterTermination);
           proc.once('close', finishAfterTermination);
           try {
-            proc.kill();
+            if (!proc.kill()) {
+              finishAfterTermination();
+              return;
+            }
           } catch {
             finishAfterTermination();
             return;
@@ -168,7 +211,9 @@ export class SkillHealthChecker {
           forceKillTimer = setTimeout(() => {
             if (proc.exitCode === null) {
               try {
-                proc.kill('SIGKILL');
+                if (!proc.kill('SIGKILL')) {
+                  finishAfterTermination();
+                }
               } catch {
                 finishAfterTermination();
               }

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -25,10 +25,16 @@ export interface SkillHealthOptions {
 
 const UNTRUSTED_HEALTH_CHECK_MESSAGE =
   'MCP health check command was not executed because the skill is not trusted';
+const SKIPPED_HEALTH_CHECK_MESSAGE =
+  'MCP health probe skipped because the per-check limit of 20 servers was exceeded';
 const INCOMPLETE_HANDSHAKE_MESSAGE =
   'MCP initialize handshake was not completed before the command exited';
 
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
+/** Maximum number of MCP child-process health probes running at once. */
+const MAX_CONCURRENT_MCP_HEALTH_PROBES = 4;
+/** Maximum number of child processes spawned by one trusted status check. */
+const MAX_MCP_HEALTH_PROBES_PER_CHECK = 20;
 const MCP_INITIALIZE_ID = 1;
 
 interface HealthCheckMcpServerConfig {
@@ -53,33 +59,47 @@ export class SkillHealthChecker {
     options: SkillHealthOptions = {},
   ): Promise<SkillHealthResult> {
     const mcpServers = mcpConfig.mcpServers as Record<string, HealthCheckMcpServerConfig>;
-    const serverStatuses = await Promise.all(
-      Object.entries(mcpServers).map(
-        async ([serverName, config]: [string, HealthCheckMcpServerConfig]) => {
-          if (!options.trustMcpServerCommands) {
-            return {
-              serverName,
-              status: 'unknown' as const,
-              error: UNTRUSTED_HEALTH_CHECK_MESSAGE,
-            };
-          }
+    const entries = Object.entries(mcpServers);
+    const entriesToCheck = options.trustMcpServerCommands
+      ? entries.slice(0, MAX_MCP_HEALTH_PROBES_PER_CHECK)
+      : entries;
+    const serverStatuses = await mapWithConcurrency(
+      entriesToCheck,
+      MAX_CONCURRENT_MCP_HEALTH_PROBES,
+      async ([serverName, config]: [string, HealthCheckMcpServerConfig]) => {
+        if (!options.trustMcpServerCommands) {
+          return {
+            serverName,
+            status: 'unknown' as const,
+            error: UNTRUSTED_HEALTH_CHECK_MESSAGE,
+          };
+        }
 
-          try {
-            const outcome = await this.checkServer(
-              config.command,
-              config.args ?? [],
-            );
-            return { serverName, ...outcome };
-          } catch (err) {
-            return {
-              serverName,
-              status: 'error' as const,
-              error: err instanceof Error ? err.message : String(err),
-            };
-          }
-        },
-      ),
+        try {
+          const outcome = await this.checkServer(
+            config.command,
+            config.args ?? [],
+          );
+          return { serverName, ...outcome };
+        } catch (err) {
+          return {
+            serverName,
+            status: 'error' as const,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      },
     );
+
+    if (options.trustMcpServerCommands) {
+      serverStatuses.push(
+        ...entries.slice(MAX_MCP_HEALTH_PROBES_PER_CHECK).map(([serverName]) => ({
+          serverName,
+          status: 'unknown' as const,
+          error: SKIPPED_HEALTH_CHECK_MESSAGE,
+        })),
+      );
+    }
 
     const allConnected = serverStatuses.every(
       (s) => s.status === 'connected',
@@ -182,6 +202,31 @@ export class SkillHealthChecker {
       }
     });
   }
+}
+
+async function mapWithConcurrency<Item, Result>(
+  items: readonly Item[],
+  concurrency: number,
+  mapper: (item: Item, index: number) => Promise<Result>,
+): Promise<Result[]> {
+  const results = new Array<Result>(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index] as Item, index);
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, items.length) },
+      () => worker(),
+    ),
+  );
+  return results;
 }
 
 interface JsonRpcMessage {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -309,6 +309,44 @@ describe('SkillHealthChecker', () => {
     expect(maxActiveProbes).toBeLessThanOrEqual(4);
   });
 
+  it('shares the four-probe limit across concurrent status checks', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    let activeProbes = 0;
+    let maxActiveProbes = 0;
+
+    (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const proc = makeMockProcess();
+      activeProbes += 1;
+      maxActiveProbes = Math.max(maxActiveProbes, activeProbes);
+      setTimeout(() => {
+        activeProbes -= 1;
+        proc.exitCode = 0;
+        proc.emit('close', 0);
+      }, 100);
+      return proc;
+    });
+    const makeConfig = (prefix: string): McpConfig => ({
+      mcpServers: Object.fromEntries(
+        Array.from({ length: 6 }, (_, index) => [
+          `${prefix}-${index}`,
+          { command: 'echo' },
+        ]),
+      ),
+    });
+
+    const resultsPromise = Promise.all([
+      checker.getStatus('first', makeConfig('first'), { trustMcpServerCommands: true }),
+      checker.getStatus('second', makeConfig('second'), { trustMcpServerCommands: true }),
+    ]);
+    await vi.runAllTimersAsync();
+    const results = await resultsPromise;
+
+    expect(results[0].serverStatuses).toHaveLength(6);
+    expect(results[1].serverStatuses).toHaveLength(6);
+    expect(maxActiveProbes).toBeLessThanOrEqual(4);
+  });
+
   it('keeps a concurrency slot until a probe process exits', async () => {
     vi.useFakeTimers();
     const { spawn } = await import('node:child_process');
@@ -360,6 +398,38 @@ describe('SkillHealthChecker', () => {
 
     expect(result.serverStatuses).toHaveLength(12);
     expect(maxActiveProbes).toBeLessThanOrEqual(4);
+  });
+
+  it('settles a probe when process termination cannot be signaled', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      setTimeout(() => {
+        proc.stdout.emit('data', formatMcpMessage({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {},
+        }));
+      }, 1);
+      return true;
+    });
+    proc.kill.mockReturnValue(false);
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+    const settled = vi.fn();
+
+    void checker.getStatus('unsignalable', {
+      mcpServers: { server: { command: 'node' } },
+    }, { trustMcpServerCommands: true }).then(settled);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(settled).toHaveBeenCalledWith({
+      name: 'unsignalable',
+      status: 'connected',
+      serverStatuses: [{ serverName: 'server', status: 'connected' }],
+    });
+    expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
   it('skips trusted MCP probes beyond the aggregate limit', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -309,6 +309,59 @@ describe('SkillHealthChecker', () => {
     expect(maxActiveProbes).toBeLessThanOrEqual(4);
   });
 
+  it('keeps a concurrency slot until a probe process exits', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    let activeProbes = 0;
+    let maxActiveProbes = 0;
+
+    (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const proc = makeMockProcess();
+      activeProbes += 1;
+      maxActiveProbes = Math.max(maxActiveProbes, activeProbes);
+      proc.stdin.write.mockImplementation(() => {
+        setTimeout(() => {
+          proc.stdout.emit('data', formatMcpMessage({
+            jsonrpc: '2.0',
+            id: 1,
+            result: {},
+          }));
+        }, 1);
+        return true;
+      });
+      proc.kill.mockImplementation((signal?: NodeJS.Signals) => {
+        proc.killed = true;
+        if (signal === 'SIGKILL') {
+          setTimeout(() => {
+            activeProbes -= 1;
+            proc.emit('exit', null, 'SIGKILL');
+            proc.emit('close', null, 'SIGKILL');
+          }, 1);
+        }
+        return true;
+      });
+      return proc;
+    });
+
+    const config: McpConfig = {
+      mcpServers: Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `server-${index}`,
+          { command: 'node' },
+        ]),
+      ),
+    };
+
+    const resultPromise = checker.getStatus('stubborn', config, {
+      trustMcpServerCommands: true,
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.serverStatuses).toHaveLength(12);
+    expect(maxActiveProbes).toBeLessThanOrEqual(4);
+  });
+
   it('skips trusted MCP probes beyond the aggregate limit', async () => {
     vi.useFakeTimers();
     const { spawn } = await import('node:child_process');
@@ -371,8 +424,16 @@ function makeMockProcess() {
     stdout: new EventEmitter(),
     stderr: new EventEmitter(),
     stdin,
-    kill: vi.fn(function kill(this: { killed: boolean }) {
+    kill: vi.fn(function kill(
+      this: EventEmitter & { killed: boolean },
+      signal: NodeJS.Signals = 'SIGTERM',
+    ) {
       this.killed = true;
+      queueMicrotask(() => {
+        this.emit('exit', null, signal);
+        this.emit('close', null, signal);
+      });
+      return true;
     }),
     pid: 123,
     exitCode: null as number | null,

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -272,6 +272,80 @@ describe('SkillHealthChecker', () => {
     expect(result.serverStatuses).toHaveLength(2);
   });
 
+  it('runs at most four trusted MCP probes concurrently', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    let activeProbes = 0;
+    let maxActiveProbes = 0;
+
+    (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const proc = makeMockProcess();
+      activeProbes += 1;
+      maxActiveProbes = Math.max(maxActiveProbes, activeProbes);
+      setTimeout(() => {
+        activeProbes -= 1;
+        proc.exitCode = 0;
+        proc.emit('close', 0);
+      }, 100);
+      return proc;
+    });
+
+    const config: McpConfig = {
+      mcpServers: Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `server-${index}`,
+          { command: 'echo' },
+        ]),
+      ),
+    };
+
+    const resultPromise = checker.getStatus('bounded', config, {
+      trustMcpServerCommands: true,
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.serverStatuses).toHaveLength(12);
+    expect(maxActiveProbes).toBeLessThanOrEqual(4);
+  });
+
+  it('skips trusted MCP probes beyond the aggregate limit', async () => {
+    vi.useFakeTimers();
+    const { spawn } = await import('node:child_process');
+    (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const proc = makeMockProcess();
+      setTimeout(() => {
+        proc.exitCode = 0;
+        proc.emit('close', 0);
+      }, 10);
+      return proc;
+    });
+    const config: McpConfig = {
+      mcpServers: Object.fromEntries(
+        Array.from({ length: 25 }, (_, index) => [
+          `server-${index}`,
+          { command: 'echo' },
+        ]),
+      ),
+    };
+
+    const resultPromise = checker.getStatus('budgeted', config, {
+      trustMcpServerCommands: true,
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(spawn).toHaveBeenCalledTimes(20);
+    expect(result.serverStatuses).toHaveLength(25);
+    expect(result.serverStatuses.slice(20)).toEqual(
+      Array.from({ length: 5 }, (_, index) => ({
+        serverName: `server-${index + 20}`,
+        status: 'unknown',
+        error: 'MCP health probe skipped because the per-check limit of 20 servers was exceeded',
+      })),
+    );
+  });
+
   it('returns error when trusted spawn fails', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();


### PR DESCRIPTION
## Summary
- cap trusted MCP health probes at four globally concurrent child processes across status checks
- keep probe slots occupied through child termination, escalating from SIGTERM to SIGKILL after a grace period
- cap each trusted status check at 20 spawned probes and report excess servers as unknown
- add regressions for per-check, cross-check, termination, and aggregate-limit behavior

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/skills/skill-health-checker.test.ts` (15 passed)
- `npm run lint --workspace @franken/orchestrator -- --quiet`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- GitHub CI: build-test-lint and publish smoke passed
- Codex review: current-head clean with zero unresolved Codex threads

Closes #3191