### PR TITLE
fix(orchestrator): simplify cleanupBuild deletion counts

### DIFF
--- a/packages/franken-orchestrator/src/cli/cleanup.ts
+++ b/packages/franken-orchestrator/src/cli/cleanup.ts
@@ -58,32 +58,19 @@ export function cleanupBuild(buildDir: string, options: CleanupBuildOptions = {}
   }
 
   let removed = 0;
-  const removeRecursive = (target: string): void => {
-    const stat = lstatOptional(target);
-    if (!stat) return;
-
-    if (stat.isSymbolicLink()) {
-      rmSync(target, { force: true });
-      removed++;
-      return;
-    }
-
-    if (stat.isDirectory()) {
-      for (const entry of readdirSync(target)) {
-        removeRecursive(join(target, entry));
-      }
-      rmSync(target, { recursive: true, force: true });
-      removed++;
-      return;
-    }
-
-    rmSync(target, { force: true });
-    removed++;
-  };
 
   for (const entry of readdirSync(buildDir)) {
+    const target = join(buildDir, entry);
     try {
-      removeRecursive(join(buildDir, entry));
+      const stat = lstatOptional(target);
+      if (!stat) continue;
+
+      if (stat.isDirectory()) {
+        rmSync(target, { recursive: true, force: true });
+      } else {
+        rmSync(target, { force: true });
+      }
+      removed++;
     } catch {
       // skip entries that can't be removed
     }

--- a/packages/franken-orchestrator/test/cli/cleanup.test.ts
+++ b/packages/franken-orchestrator/test/cli/cleanup.test.ts
@@ -57,6 +57,18 @@ describe('cleanupBuild', () => {
     expect(removed).toBe(3);
   });
 
+  it('counts top-level build artifacts only, not nested file entries', () => {
+    writeFileSync(join(buildDir, 'plan-abc-2026-03-08T02-31-09-build.log'), 'log');
+    mkdirSync(join(buildDir, 'nested-session'), { recursive: true });
+    writeFileSync(join(buildDir, 'nested-session', 'payload.json'), '{}');
+    writeFileSync(join(buildDir, 'build-traces.db'), 'db');
+
+    const removed = cleanupBuild(buildDir);
+
+    expect(readdirSync(buildDir)).toEqual([]);
+    expect(removed).toBe(3);
+  });
+
   it('returns 0 when .build/ is empty', () => {
     const removed = cleanupBuild(buildDir);
     expect(removed).toBe(0);

--- a/packages/franken-orchestrator/tests/unit/cli/cleanup.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/cleanup.test.ts
@@ -13,7 +13,7 @@ describe('cleanupBuild', () => {
 
     const removed = cleanupBuild(root);
 
-    expect(removed).toBeGreaterThan(0);
+    expect(removed).toBe(1);
     expect(existsSync(nested)).toBe(false);
 
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary\n- Simplify cleanupBuild to delete only top-level .build/ entries and count removals at that granularity.\n- Add regression coverage for nested-directory cleanups so returned counts are deterministic.\n- Align tech-debt test in unit suite for nested chunk session directories.\n\n## Test plan\n- npm --prefix packages/franken-orchestrator run test -- --run test/cli/cleanup.test.ts tests/unit/cli/cleanup.test.ts\n- Note: full dependency setup for package tests is blocked in this workspace due missing private dependency resolution for @franken/brain@0.15.0.\n\nCloses #2958