### PR TITLE
fix(web): announce beast page load errors to screen readers

### DIFF
--- a/packages/franken-web/src/pages/beasts-page.tsx
+++ b/packages/franken-web/src/pages/beasts-page.tsx
@@ -114,7 +114,10 @@ export function BeastsPage({
   return (
     <main className="flex-1 flex flex-col min-h-0 bg-beast-bg">
       {error && (
-        <div className="px-6 py-3 bg-red-900/30 border-b border-red-700 text-red-300 text-sm">
+        <div
+          role="alert"
+          className="px-6 py-3 bg-red-900/30 border-b border-red-700 text-red-300 text-sm"
+        >
           {error}
         </div>
       )}

--- a/packages/franken-web/tests/pages/beasts-page.test.tsx
+++ b/packages/franken-web/tests/pages/beasts-page.test.tsx
@@ -161,8 +161,10 @@ describe('BeastsPage', () => {
     expect(screen.queryByText('Design Interview')).toBeNull();
   });
 
-  it('shows error banner when error prop is set', () => {
+  it('shows an accessible error alert when error prop is set', () => {
     render(<BeastsPage {...baseProps} error="Something went wrong" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeTruthy();
     expect(screen.getByText('Something went wrong')).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
- Add screen-reader semantics to Beasts page load error banner via  (implicit assertive live region).
- Add regression test asserting the error banner uses an accessible alert role when error prop is set.

## Test Plan
- npm test -- beasts-page.test.tsx
- npm run typecheck

Closes #2904