### PR TITLE
fix: explain invalid CLI approval responses

### DIFF
--- a/packages/franken-governor/README.md
+++ b/packages/franken-governor/README.md
@@ -309,10 +309,10 @@ Key mappings:
 
 | Key | Response Code | Description |
 |-----|--------------|-------------|
-| `a` | `APPROVE` | Approve the action, agent proceeds |
-| `r` | `REGEN` | Reject and request regeneration (prompts for feedback) |
-| `x` | `ABORT` | Abort the action entirely |
-| `d` | `DEBUG` | Approve in debug/inspect mode |
+| `a`, `approve`, `y`, `yes` | `APPROVE` | Approve the action, agent proceeds |
+| `r`, `regenerate` | `REGEN` | Reject and request regeneration (prompts for feedback) |
+| `x`, `abort`, `n`, `no` | `ABORT` | Abort the action entirely |
+| `d`, `debug` | `DEBUG` | Approve in debug/inspect mode |
 
 ### SlackChannel
 

--- a/packages/franken-governor/src/channels/cli-channel.ts
+++ b/packages/franken-governor/src/channels/cli-channel.ts
@@ -14,10 +14,21 @@ export interface CliChannelDeps {
 
 const INPUT_MAP: Record<string, ResponseCode> = {
   a: 'APPROVE',
+  approve: 'APPROVE',
+  y: 'APPROVE',
+  yes: 'APPROVE',
   r: 'REGEN',
+  regenerate: 'REGEN',
   x: 'ABORT',
+  abort: 'ABORT',
+  n: 'ABORT',
+  no: 'ABORT',
   d: 'DEBUG',
+  debug: 'DEBUG',
 };
+
+const INVALID_INPUT_HELP =
+  'Please answer a/approve/y/yes, r/regenerate, x/abort/n/no, or d/debug.';
 
 export class CliChannel implements ApprovalChannel {
   readonly channelId = 'cli';
@@ -54,25 +65,32 @@ export class CliChannel implements ApprovalChannel {
     readonly decision: ResponseCode;
     readonly feedback?: string;
   }> {
-    const prompt = this.formatPrompt(request);
+    const basePrompt = this.formatPrompt(request);
+    let prompt = basePrompt;
 
     while (true) {
-      const input = await this.readline.question(prompt);
+      const input = await this.readline.question(`${prompt}\n> `);
       const trimmed = input.trim();
       const [command = '', ...feedbackParts] = trimmed.split(/\s+/u);
       const decision = INPUT_MAP[command.toLowerCase()];
-      if (decision !== undefined) {
-        const feedback = feedbackParts.join(' ').trim();
-        return feedback.length > 0 ? { decision, feedback } : { decision };
+
+      if (decision === undefined) {
+        prompt = `${basePrompt}\n\n${trimmed ? `"${trimmed}" is not recognized. ` : ''}${INVALID_INPUT_HELP}`;
+        continue;
       }
+
+      const feedback = feedbackParts.join(' ').trim();
+      return feedback.length > 0 ? { decision, feedback } : { decision };
     }
   }
+
 
   private formatPrompt(request: ApprovalRequest): string {
     const lines = [
       '',
       formatApprovalPromptWithBoundaries(request, { includePlanDiff: true }),
-      `\n[a]pprove  [r]egenerate  a[x]bort  [d]ebug\nAppend an acknowledgement token after the decision when a SECURITY NOTICE requires one.\n> `,
+      `[a]pprove  [r]egenerate  a[x]bort  [d]ebug`,
+      'Append an acknowledgement token after the decision when a SECURITY NOTICE requires one.',
     ].filter(Boolean);
 
     return lines.join('\n');

--- a/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
+++ b/packages/franken-governor/tests/unit/channels/cli-channel.test.ts
@@ -70,6 +70,26 @@ describe('CliChannel', () => {
     expect(response.decision).toBe('DEBUG');
   });
 
+  it('accepts "yes" and "y" as APPROVE aliases', async () => {
+    const channel = new CliChannel({ readline: makeFakeReadline(['yes']), operatorName: 'dev' });
+    const response = await channel.requestApproval(makeRequest());
+    expect(response.decision).toBe('APPROVE');
+
+    const channelWithY = new CliChannel({ readline: makeFakeReadline(['y']), operatorName: 'dev' });
+    const responseWithY = await channelWithY.requestApproval(makeRequest({ requestId: 'req-y' }));
+    expect(responseWithY.decision).toBe('APPROVE');
+  });
+
+  it('accepts "no" and "n" as ABORT aliases', async () => {
+    const channel = new CliChannel({ readline: makeFakeReadline(['no']), operatorName: 'dev' });
+    const response = await channel.requestApproval(makeRequest());
+    expect(response.decision).toBe('ABORT');
+
+    const channelWithN = new CliChannel({ readline: makeFakeReadline(['n']), operatorName: 'dev' });
+    const responseWithN = await channelWithN.requestApproval(makeRequest({ requestId: 'req-n' }));
+    expect(responseWithN.decision).toBe('ABORT');
+  });
+
   it('prompts for feedback when REGEN is selected', async () => {
     const readline = makeFakeReadline(['r', 'use a different approach']);
     const channel = new CliChannel({ readline, operatorName: 'dev' });
@@ -151,5 +171,8 @@ describe('CliChannel', () => {
     const response = await channel.requestApproval(makeRequest());
     expect(response.decision).toBe('APPROVE');
     expect(readline.question).toHaveBeenCalledTimes(3);
+    expect(readline.question).toHaveBeenCalledWith(
+      expect.stringContaining('Please answer a/approve/y/yes, r/regenerate, x/abort/n/no, or d/debug.'),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add explicit validation guidance when an invalid approval token is entered in CliChannel.
- Map additional operator-friendly aliases (`yes`, `no`, `y`, `n`) to APPROVE/ABORT while preserving existing `a/r/x/d` shortcuts.
- Update README to document accepted aliases.
- Add unit tests for alias inputs and invalid-input recovery messaging.

## Files changed
- packages/franken-governor/src/channels/cli-channel.ts
- packages/franken-governor/tests/unit/channels/cli-channel.test.ts
- packages/franken-governor/README.md

## Test plan
- npm run test --workspace @franken/governor -- tests/unit/channels/cli-channel.test.ts

Closes #2895
