### PR TITLE
fix: expose skill selection state with aria-pressed

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-skills.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-skills.tsx
@@ -30,6 +30,15 @@ export function StepSkills() {
     setStepValues(4, { ...values, selectedSkills: selected.filter((s) => s !== id) });
   }
 
+  function toggleSkill(id: string, isSelected: boolean) {
+    if (isSelected) {
+      removeSkill(id);
+      return;
+    }
+
+    addSkill(id);
+  }
+
   return (
     <div className="p-8 space-y-6">
       {/* Selected chips */}
@@ -42,7 +51,18 @@ export function StepSkills() {
               return (
                 <span key={id} className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-beast-accent-soft text-beast-accent text-xs font-medium border border-beast-accent/30">
                   {skill?.name ?? id}
-                  <button type="button" onClick={() => removeSkill(id)} className="hover:text-beast-danger p-0.5" aria-label={`Remove ${skill?.name ?? id}`}>
+                  <button
+                    type="button"
+                    onClick={() => removeSkill(id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        removeSkill(id);
+                      }
+                    }}
+                    className="hover:text-beast-danger p-0.5"
+                    aria-label={`Remove ${skill?.name ?? id}`}
+                  >
                     <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                     </svg>
@@ -74,7 +94,13 @@ export function StepSkills() {
               key={skill.id}
               type="button"
               aria-pressed={isSelected}
-              onClick={() => isSelected ? removeSkill(skill.id) : addSkill(skill.id)}
+              onClick={() => toggleSkill(skill.id, isSelected)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  toggleSkill(skill.id, isSelected);
+                }
+              }}
               className={`p-4 rounded-xl border-2 text-left transition-all min-h-[5rem]
                 ${isSelected
                   ? 'border-beast-accent bg-beast-accent-soft ring-1 ring-beast-accent/30'

--- a/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
@@ -10,25 +10,49 @@ describe('StepSkills', () => {
     useBeastStore.getState().resetWizard();
   });
 
-  it('renders skill list from static data', () => {
+  it('renders available skill cards and search input', () => {
     render(<StepSkills />);
-    // Should show some skills via search input placeholder or a skill name
     expect(screen.getByPlaceholderText(/search skills/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /code review/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /test generation/i })).toBeTruthy();
   });
 
-  it('can add a skill to selected chips', () => {
+  it('adds and removes a skill via pointer interaction', () => {
     render(<StepSkills />);
-    // Find and click a skill to add it
-    const firstSkill = screen.getAllByRole('button').find(btn => !btn.textContent?.includes('Search'));
-    if (firstSkill) {
-      fireEvent.click(firstSkill);
-      // Should now appear in selected area
-      const chips = useBeastStore.getState().stepValues[4] as { selectedSkills?: string[] } | undefined;
-      expect(chips?.selectedSkills?.length).toBeGreaterThan(0);
-    }
+    const codeReview = screen.getByRole('button', { name: /code review/i });
+
+    fireEvent.click(codeReview);
+    expect(codeReview.getAttribute('aria-pressed')).toBe('true');
+    const selectedChipRemove = screen.getByLabelText('Remove Code Review');
+    expect(selectedChipRemove).toBeTruthy();
+
+    fireEvent.click(selectedChipRemove);
+    expect(codeReview.getAttribute('aria-pressed')).toBe('false');
   });
 
-  it('keeps the semantic pressed state in sync when a skill is toggled', () => {
+  it('supports keyboard activation and accessible removal flow for selected skills', () => {
+    render(<StepSkills />);
+    const codeReview = screen.getByRole('button', { name: /code review/i });
+
+    expect(codeReview.getAttribute('aria-pressed')).toBe('false');
+    codeReview.focus();
+    fireEvent.keyDown(codeReview, { key: 'Enter', code: 'Enter' });
+    expect(codeReview.getAttribute('aria-pressed')).toBe('true');
+
+    const selectedChipRemove = screen.getByLabelText('Remove Code Review');
+    expect(selectedChipRemove).toBeTruthy();
+    selectedChipRemove.focus();
+    fireEvent.keyDown(selectedChipRemove, { key: 'Enter', code: 'Enter' });
+    expect(codeReview.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.keyDown(codeReview, { key: ' ', code: 'Space', charCode: 32 });
+    expect(codeReview.getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.keyDown(codeReview, { key: ' ', code: 'Space', charCode: 32 });
+    expect(codeReview.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('keeps aria-pressed in sync when a skill is toggled', () => {
     render(<StepSkills />);
     const skill = screen.getByRole('button', { name: /code review/i });
 


### PR DESCRIPTION
## Summary
- Add explicit keyboard handlers for skill cards so Enter/Space activation is deterministic in tests and UI behavior.
- Add keyboard-accessible removal for selected skill chips.
- Keep  synced for selected skill cards.
- Add regression tests for add/remove skill flows and keyboard activation plus  assertions.

## Test plan
- npm run test -- --run tests/components/beasts/steps/step-skills.test.tsx
- npm run lint
- npm run typecheck (repo-level, currently reports existing pre-existing @franken/types workspace errors)

Closes #2906