### PR TITLE
fix: disambiguate critique result type exports

### DIFF
--- a/packages/franken-critique/docs/adr/ADR-002-evaluator-pipeline-architecture.md
+++ b/packages/franken-critique/docs/adr/ADR-002-evaluator-pipeline-architecture.md
@@ -11,7 +11,7 @@ MOD-06 must evaluate agent output across multiple orthogonal dimensions: factual
 We need an architecture that:
 1. Allows evaluators to run independently and in parallel where possible
 2. Makes it easy to add, remove, or reorder evaluators without touching core logic
-3. Produces a unified `CritiqueResult` regardless of which evaluators ran
+3. Produces a unified `CritiquePipelineResult` regardless of which evaluators ran
 4. Supports both deterministic checks (linting, type checking) and heuristic checks (complexity assessment)
 
 ## Decision
@@ -29,7 +29,7 @@ interface Evaluator {
 A `CritiquePipeline` orchestrates evaluators:
 1. Accepts a list of `Evaluator` instances at construction
 2. Runs all evaluators against the input (deterministic first, then heuristic)
-3. Aggregates individual `EvaluationResult`s into a single `CritiqueResult`
+3. Aggregates individual `EvaluationResult`s into a single `CritiquePipelineResult`
 4. Short-circuits on critical failures (e.g., safety violations stop further evaluation)
 
 ```

--- a/packages/franken-critique/docs/adr/ADR-006-critique-loop-engine.md
+++ b/packages/franken-critique/docs/adr/ADR-006-critique-loop-engine.md
@@ -39,7 +39,7 @@ The `run()` method follows this algorithm:
 1. Initialize `LoopState` with iteration count = 0 and empty history
 2. **Pre-check**: Run all circuit breakers. If any trip, return immediately.
 3. Run the `CritiquePipeline` against the current input
-4. Record the `CritiqueResult` in iteration history
+4. Record the `CritiquePipelineResult` in iteration history
 5. If the result is a **pass**, return success with all iteration data
 6. If the result is a **fail**, update failure history and iteration count.
 7. If this was the final allowed iteration (`iterationCount >= config.maxIterations`), construct and return a `CorrectionRequest` from the failed evaluations.

--- a/packages/franken-critique/docs/implementation-plan.md
+++ b/packages/franken-critique/docs/implementation-plan.md
@@ -7,7 +7,7 @@ franken-critique/
 ├── src/
 │   ├── index.ts                    # Public API barrel export
 │   ├── types/
-│   │   ├── evaluation.ts           # EvaluationInput, EvaluationResult, CritiqueResult
+│   │   ├── evaluation.ts           # EvaluationInput, EvaluationResult, CritiquePipelineResult
 │   │   ├── contracts.ts            # Port interfaces for MOD-01, MOD-03, MOD-05, MOD-07
 │   │   ├── loop.ts                 # LoopState, LoopConfig, CritiqueLoopResult, CorrectionRequest
 │   │   └── common.ts               # Shared primitives (Severity, Verdict, etc.)
@@ -165,7 +165,7 @@ Define all core types and port interfaces. No implementation code.
 
 ### Files
 - `src/types/common.ts` — `Severity`, `Verdict`, `Score`
-- `src/types/evaluation.ts` — `EvaluationInput`, `EvaluationResult`, `CritiquePipelineResult`, deprecated compatibility alias `CritiqueResult`, `Evaluator` interface
+- `src/types/evaluation.ts` — `EvaluationInput`, `EvaluationResult`, `CritiquePipelineResult`, `Evaluator` interface
 - `src/types/contracts.ts` — `GuardrailsPort`, `MemoryPort`, `ObservabilityPort`, `EscalationPort`
 - `src/types/loop.ts` — `LoopState`, `LoopConfig`, `CritiqueLoopResult`, `CorrectionRequest`, `CritiqueIteration`, `CircuitBreaker` interface
 
@@ -359,7 +359,7 @@ Implement the three circuit breakers:
 Implement `CritiquePipeline` that orchestrates evaluators:
 - Accepts evaluator list at construction
 - Runs deterministic evaluators first, then heuristic
-- Aggregates results into a single `CritiqueResult`
+- Aggregates results into a single `CritiquePipelineResult`
 - Short-circuits on critical safety failures
 
 ### TDD Approach

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -17,7 +17,6 @@ export type {
   EvaluationFinding,
   EvaluationResult,
   CritiquePipelineResult,
-  CritiqueResult,
   Evaluator,
 } from './types/evaluation.js';
 

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -17,6 +17,7 @@ export type {
   EvaluationFinding,
   EvaluationResult,
   CritiquePipelineResult,
+  CritiqueResult,
   Evaluator,
 } from './types/evaluation.js';
 

--- a/packages/franken-critique/src/types/evaluation.ts
+++ b/packages/franken-critique/src/types/evaluation.ts
@@ -48,12 +48,6 @@ export interface CritiquePipelineResult {
   readonly shortCircuited: boolean;
 }
 
-/**
- * @deprecated Use CritiquePipelineResult for aggregate pipeline outcomes.
- * @franken/types exports ProviderCritiqueFinding for individual provider
- * critique findings.
- */
-export type CritiqueResult = CritiquePipelineResult;
 
 /** An evaluator that can assess code or plans. */
 export interface Evaluator {

--- a/packages/franken-critique/src/types/evaluation.ts
+++ b/packages/franken-critique/src/types/evaluation.ts
@@ -48,6 +48,11 @@ export interface CritiquePipelineResult {
   readonly shortCircuited: boolean;
 }
 
+/**
+ * @deprecated Use {@link CritiquePipelineResult}.
+ */
+export type CritiqueResult = CritiquePipelineResult;
+
 
 /** An evaluator that can assess code or plans. */
 export interface Evaluator {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -21,7 +21,7 @@ import type {
   CritiqueIteration,
 } from '../../../src/types/loop.js';
 import type {
-  CritiqueResult,
+  CritiquePipelineResult,
   EvaluationFinding,
 } from '../../../src/types/evaluation.js';
 
@@ -39,7 +39,7 @@ function createIteration(
   evaluatorName = 'mock',
   findings: EvaluationFinding[] = [],
 ): CritiqueIteration {
-  const result: CritiqueResult = {
+  const result: CritiquePipelineResult = {
     verdict,
     overallScore: verdict === 'pass' ? 1 : 0.3,
     results: [
@@ -57,7 +57,7 @@ function createIteration(
 
 function createIterationFromResult(
   index: number,
-  result: CritiqueResult,
+  result: CritiquePipelineResult,
 ): CritiqueIteration {
   return {
     index,

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -5,6 +5,7 @@ import {
 import type { ProviderCritiqueFinding } from '@franken/types';
 import type {
   CritiquePipelineResult,
+  CritiqueResult,
   LessonRollbackWorkflow,
   AgentImprovementScorecard,
   LessonFeedbackWeighting,
@@ -38,8 +39,12 @@ describe('public critique type contracts', () => {
       shortCircuited: false,
     };
     const alias: CritiquePipelineResult = pipelineResult;
+    const legacyAlias: CritiqueResult = pipelineResult;
 
     expect(alias.results[0]?.findings[0]?.message).toBe(
+      providerFinding.message,
+    );
+    expect(legacyAlias.results[0]?.findings[0]?.message).toBe(
       providerFinding.message,
     );
   });

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import { createSessionId } from '@franken/types';
+import {
+  createSessionId,
+} from '@franken/types';
 import type { ProviderCritiqueFinding } from '@franken/types';
 import type {
   CritiquePipelineResult,
-  CritiqueResult as DeprecatedCritiqueResult,
   LessonRollbackWorkflow,
   AgentImprovementScorecard,
   LessonFeedbackWeighting,
@@ -36,9 +37,9 @@ describe('public critique type contracts', () => {
       ],
       shortCircuited: false,
     };
-    const compatibilityAlias: DeprecatedCritiqueResult = pipelineResult;
+    const alias: CritiquePipelineResult = pipelineResult;
 
-    expect(compatibilityAlias.results[0]?.findings[0]?.message).toBe(
+    expect(alias.results[0]?.findings[0]?.message).toBe(
       providerFinding.message,
     );
   });

--- a/packages/franken-types/docs/RAMP_UP.md
+++ b/packages/franken-types/docs/RAMP_UP.md
@@ -9,7 +9,7 @@ The package ensures architectural consistency across the monorepo by enforcing a
 - **Branded IDs**: Prevents ID confusion at compile time (e.g., you cannot pass a `SessionId` where a `ProjectId` is expected).
 - **Result Monad**: Standardized error handling without throwing exceptions in core logic.
 - **Severity Enums**: Unified severity levels used by Firewall, Critique, and Heartbeat.
-- **Provider Critique Findings**: `ProviderCritiqueFinding` is the primary provider/evaluator finding shape; the older `CritiqueResult` export remains as a deprecated compatibility alias and should not be confused with `@franken/critique` pipeline results.
+- **Provider Critique Findings**: `ProviderCritiqueFinding` is the primary provider/evaluator finding shape; use `CritiqueFinding` for the shared provider alias and `CritiquePipelineResult` for aggregate pipeline results from `@franken/critique`.
 - **LLM Interfaces**: Defines `ILlmClient` and `IResultLlmClient` to ensure interchangeable provider adapters.
 
 ## Key Exports

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -104,8 +104,10 @@ export type {
   CritiqueContext,
   ProviderCritiqueFinding,
   CritiqueFinding,
+  CritiqueResult,
   ProviderSkillConfig,
 } from './provider.js';
+
 export {
   ToolDefinitionSchema,
   TokenUsageSchema,

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -103,7 +103,7 @@ export type {
   AuthField,
   CritiqueContext,
   ProviderCritiqueFinding,
-  CritiqueResult,
+  CritiqueFinding,
   ProviderSkillConfig,
 } from './provider.js';
 export {

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -154,6 +154,11 @@ export interface ProviderCritiqueFinding {
  */
 export type CritiqueFinding = ProviderCritiqueFinding;
 
+/**
+ * @deprecated Use {@link CritiqueFinding}.
+ */
+export type CritiqueResult = ProviderCritiqueFinding;
+
 // --- Skill Loading Types (used by SkillManager provider translation + Beast Loop spawn wiring) ---
 
 export interface ProviderSkillConfig {

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -150,11 +150,9 @@ export interface ProviderCritiqueFinding {
 }
 
 /**
- * @deprecated Use ProviderCritiqueFinding for provider/evaluator findings.
- * The @franken/critique package uses CritiquePipelineResult for aggregate
- * pipeline outcomes.
+ * A single provider/evaluator finding used by provider/critiquing flows.
  */
-export type CritiqueResult = ProviderCritiqueFinding;
+export type CritiqueFinding = ProviderCritiqueFinding;
 
 // --- Skill Loading Types (used by SkillManager provider translation + Beast Loop spawn wiring) ---
 

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -21,6 +21,7 @@ import {
   type CritiqueContext,
   type ProviderCritiqueFinding,
   type CritiqueFinding,
+  type CritiqueResult,
   type ProviderSkillConfig,
 } from '../src/index.js';
 
@@ -58,6 +59,17 @@ describe('TokenUsageSchema', () => {
     expect(() =>
       TokenUsageSchema.parse({ inputTokens: 1, outputTokens: 1, totalTokens: 2.5 }),
     ).toThrow();
+  });
+
+  it('retains deprecated compatibility alias CritiqueResult', () => {
+    const deprecatedAlias: CritiqueResult = {
+      evaluator: 'legacy-alias-check',
+      severity: 6,
+      message: 'Compatibility layer stays available.',
+    };
+    const canonical: CritiqueFinding = deprecatedAlias;
+
+    expect(canonical.message).toBe('Compatibility layer stays available.');
   });
 
   it('rejects non-finite token counts', () => {

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -20,7 +20,7 @@ import {
   type ImageSource,
   type CritiqueContext,
   type ProviderCritiqueFinding,
-  type CritiqueResult,
+  type CritiqueFinding,
   type ProviderSkillConfig,
 } from '../src/index.js';
 
@@ -300,9 +300,9 @@ describe('Provider interfaces (type-level)', () => {
       message: 'Missing error handling',
       suggestion: 'Add try/catch around API calls',
     };
-    const deprecatedAlias: CritiqueResult = result;
+    const finding: CritiqueFinding = result;
     expect(ctx.phase).toBe('execution');
-    expect(deprecatedAlias.severity).toBe(7);
+    expect(finding.severity).toBe(7);
   });
 
   it('ProviderSkillConfig has required shape', () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -391,3 +391,7 @@
 
 ## Lessons
 - 2026-07-19 — Docs regression tests should assert exact pinned values from manifest and treat setup commands as gate-narrow/full setup distinctions.
+
+## 2026-07-19 — Type export renames and deprecation compatibility
+- When renaming shared public type names for clarity, keep deprecated aliases temporarily (with `@deprecated` JSDoc) for downstream consumers, update docs/tests to use new names, and add targeted tests validating both canonical and deprecated aliases.
+- Before merging such API refactors, require `tsc`, package `lint`, `build`, and focused unit tests for both packages to avoid regressions in public contracts.


### PR DESCRIPTION
## Summary
- Renames the provider-level type alias in `@franken/types` from `CritiqueResult` to `CritiqueFinding`.
- Renames the aggregate critique result in `@franken/critique` from `CritiqueResult` to `CritiquePipelineResult`.
- Re-adds deprecation-compatible `CritiqueResult` aliases in both packages to preserve backward compatibility for downstream consumers.
- Updates affected tests and docs/notes to consistently use the new canonical names.

## Tests
- `npm run test -- tests/provider.test.ts`
- `npm run test -- tests/unit/types/public-contracts.test.ts tests/unit/memory/lesson-recorder.test.ts`
- `npm run typecheck` (franken-types)
- `npm run typecheck` (franken-critique)
- `npm run lint` (franken-types)
- `npm run lint` (franken-critique)
- `npm run build` (franken-types)
- `npm run build` (franken-critique)

Closes #2971
