### PR TITLE
test: harden HTTP abort fixture timing

### DIFF
--- a/packages/franken-orchestrator/tests/unit/http/http-server-utils.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/http-server-utils.test.ts
@@ -1,9 +1,62 @@
-import { createServer } from 'node:http';
+import { createServer, get } from 'node:http';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 import { closeHttpServer, handleHonoHttpRequest } from '../../../src/http/http-server-utils.js';
 
 describe('http-server-utils', () => {
+  it('uses an already-aborted request as an immediate abort signal', async () => {
+    const app = new Hono();
+    let resolveAbort!: () => void;
+    const aborted = new Promise<void>((resolve) => {
+      resolveAbort = resolve;
+    });
+
+    app.get('/stream', (c) => {
+      if (c.req.raw.signal.aborted) {
+        resolveAbort();
+      } else {
+        c.req.raw.signal.addEventListener('abort', () => {
+          resolveAbort();
+        }, { once: true });
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    const fakeRequest = {
+      headers: {},
+      method: 'GET',
+      url: '/stream',
+      socket: { remoteAddress: '127.0.0.1' },
+      aborted: true,
+      destroyed: true,
+      on: () => undefined,
+    } as Parameters<typeof handleHonoHttpRequest>[0];
+
+    let statusCode = 0;
+    const fakeResponse = {
+      setHeader: () => undefined,
+      set: () => undefined,
+      end: () => undefined,
+    } as unknown as Parameters<typeof handleHonoHttpRequest>[1] & { statusCode: number; statusMessage: string };
+
+    Object.defineProperties(fakeResponse, {
+      statusCode: {
+        get: () => statusCode,
+        set: (value: number) => {
+          statusCode = value;
+        },
+      },
+    });
+
+    await handleHonoHttpRequest(app, fakeRequest, fakeResponse);
+
+    await expect(Promise.race([
+      aborted.then(() => 'aborted'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 500)),
+    ])).resolves.toBe('aborted');
+    expect(statusCode).toBe(204);
+  });
+
   it('aborts the Hono request signal when the client disconnects', async () => {
     const app = new Hono();
     let resolveAbort!: () => void;
@@ -33,7 +86,7 @@ describe('http-server-utils', () => {
     }
 
     try {
-      const request = await import('node:http').then(({ get }) => get(`http://127.0.0.1:${address.port}/stream`));
+      const request = get(`http://127.0.0.1:${address.port}/stream`);
       request.on('error', () => {
         // Expected after destroying the client side of the long-lived request.
       });

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Deterministic abort handling regression
+- Prefer deterministic abort fixtures over timing sleeps: for HTTP disconnect behavior, verify both in-band and immediate-abort paths by asserting that `AbortSignal` is already aborted when `request.destroyed`/`request.aborted` is true before app handler execution.
+- Use a pre-aborted request object (or equivalent event-driven signal path) in unit tests when asserting handler abort behavior, and keep timeouts only as a bounded safety net, not as fixture synchronization.
+
 ## 2026-07-19 — Artifact-path TOCTOU hardening
 - Returning a validated pathname is not a secure file-inspection API: pin both the workspace directory and artifact as file descriptors, traverse through `/proc/self/fd` or `/dev/fd` where available, and compare descriptor/path identities after opening so rename/symlink swaps fail closed.
 - Use `lstat` rather than `existsSync` when dangling symlinks must be rejected, translate only candidate-component `ENOENT` into an ordinary missing artifact, and open untrusted artifact targets with nonblocking/no-follow flags before requiring a regular file.


### PR DESCRIPTION
## Summary
- Add a deterministic pre-aborted request-path test to cover immediate-abort signal behavior in http-server-utils.
- Keep disconnect-dispose sync deterministic by waiting for handler readiness before destroying the request and retaining bounded fallback timeout only as deadlock guard.
- Preserve issue-specific shared lessons with guidance against timing-dependent fixtures.

Closes #2960