### PR TITLE
docs: document npm 11 packageManager requirement in ramp-up

### DIFF
--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -6,6 +6,27 @@
 
 A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`, matching the canonical inventories in [README.md](../README.md#current-workspace-packages) and [docs/guides/quickstart.md](guides/quickstart.md#project-structure): the consolidated core packages, the current MCP suite (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-real-monorepo-migration.md) and ADR-031 for the earlier consolidation history; pre-consolidation package surfaces were absorbed into the active workspaces listed below.
 
+## Prerequisites
+
+- Node.js version is read from the root `package.json` `engines.node` field (`>=22.13.0 <23 || >=24.0.0 <26`).
+- npm major/minor version is pinned by the root `package.json` `packageManager` field (`npm@11.5.1`).
+
+To align your local toolchain with these pins, run:
+
+```bash
+corepack enable npm
+corepack prepare "$(node -p \"require('./package.json').packageManager\")" --activate
+npm --version  # should match the pinned major/minor above
+```
+
+For a full setup gate before making changes, run:
+
+```bash
+npm run setup:healthcheck
+# or
+npm run check:package-manager
+```
+
 ## Modules
 
 | Package | Purpose |

--- a/tests/docs-issue-2881.test.ts
+++ b/tests/docs-issue-2881.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readDoc(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+const manifest = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+  packageManager: string;
+  engines?: { node?: string };
+};
+
+describe('issue #2881 onboarding npm prereqs', () => {
+  it('derives toolchain requirements from root package metadata', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('## Prerequisites');
+    expect(rampUp).toContain(`root \`packageManager\` field (\`${manifest.packageManager}\`)`);
+    expect(rampUp).toContain(`root \`package.json\` \`engines.node\` field (\`${manifest.engines?.node ?? ''}\`)`);
+    expect(rampUp).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
+    expect(rampUp).toContain('npm run check:package-manager');
+    expect(rampUp).toContain('npm run setup:healthcheck');
+  });
+});


### PR DESCRIPTION
## Summary
- Add prerequisite section to docs/RAMP_UP.md documenting npm toolchain requirements.
- Clarify that Node and npm requirements are sourced from the root package metadata.
- Add explicit verification command examples using corepack + setup validation scripts.
- Add regression test coverage for issue #2881.

## Test Plan
- npm run test:root -- tests/docs-issue-2881.test.ts (attempted, fails in this environment due missing local dev deps: vitest package not installed)

Closes #2881