### PR TITLE
test: add RAMP_UP package drift guard for issue #2880

### DIFF
--- a/tests/docs-issue-2880.test.ts
+++ b/tests/docs-issue-2880.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+const workspacePackages = () => readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .filter((entry) => existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')))
+  .map((entry) => entry.name)
+  .sort();
+
+const packageRows = () => readDoc('docs/RAMP_UP.md')
+  .split('\n')
+  .map((line) => line.match(/^\| `packages\/(?<dir>[^/`]+)\/`/u)?.groups?.dir)
+  .filter((dir): dir is string => dir !== undefined)
+  .sort();
+
+describe('issue #2880 package metadata alignment', () => {
+  it('keeps RAMP_UP package list and count aligned with workspace metadata', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+    const workspacePackageDirs = workspacePackages();
+    const listedPackageDirs = packageRows();
+
+    expect(rampUp).toContain(`contains **${workspacePackageDirs.length} first-party packages**`);
+    expect(listedPackageDirs).toEqual(workspacePackageDirs);
+  });
+
+  it('includes explicit entries for recently added packages', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('packages/franken-mcp-suite/');
+    expect(rampUp).toContain('packages/live-bench/');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a targeted docs drift test for issue #2880.
- Verifies the `docs/RAMP_UP.md` package count string and module table entries match live `packages/*` workspace directories.
- Explicitly checks for explicit `packages/franken-mcp-suite/` and `packages/live-bench/` entries.
- Complements existing ramp-up alignment checks with a low-friction future-proof guard.

## Test Plan
- [x] npx vitest run tests/docs-issue-2880.test.ts
- [x] npx vitest run tests/docs-issue-511.test.ts

Closes #2880