### PR TITLE
fix(web): validate package metadata parsing

### DIFF
--- a/packages/franken-web/src/config/package-metadata.ts
+++ b/packages/franken-web/src/config/package-metadata.ts
@@ -1,0 +1,34 @@
+export type PackageMetadata = {
+  version: string;
+};
+
+const VERSION_KEY = 'version';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asPackageMetadata(value: unknown): PackageMetadata {
+  if (!isRecord(value)) {
+    throw new Error('Root package metadata must be a JSON object');
+  }
+
+  const candidate = value[VERSION_KEY];
+  if (typeof candidate !== 'string' || candidate.trim().length === 0) {
+    throw new Error('Root package metadata must include a non-empty string "version" field');
+  }
+
+  return { version: candidate };
+}
+
+export function parsePackageMetadata(raw: string): PackageMetadata {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return asPackageMetadata(parsed);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to parse package metadata JSON: ${error.message}`);
+    }
+    throw new Error('Failed to parse package metadata JSON');
+  }
+}

--- a/packages/franken-web/tests/package-metadata.test.ts
+++ b/packages/franken-web/tests/package-metadata.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parsePackageMetadata } from '../src/config/package-metadata';
+
+describe('parsePackageMetadata', () => {
+  it('extracts a valid version from package metadata JSON', () => {
+    const metadata = parsePackageMetadata('{"name":"frankenbeast","version":"9.9.9"}');
+
+    expect(metadata.version).toBe('9.9.9');
+  });
+
+  it('throws for non-object metadata', () => {
+    expect(() => parsePackageMetadata('[]')).toThrow(/must be a JSON object/i);
+    expect(() => parsePackageMetadata('"string"')).toThrow(/must be a JSON object/i);
+  });
+
+  it('throws for missing version', () => {
+    expect(() => parsePackageMetadata('{"name":"frankenbeast"}')).toThrow(/must include a non-empty string "version" field/i);
+  });
+
+  it('throws for invalid JSON', () => {
+    expect(() => parsePackageMetadata('{broken')).toThrow(/Failed to parse package metadata JSON/i);
+  });
+});

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
 import { fileURLToPath } from 'node:url';
+import { parsePackageMetadata } from './src/config/package-metadata';
 import { assertNoBrowserOperatorToken, assertSecureProxyTarget, loadProxyEnv, loadProxyOperatorToken } from './vite-env';
 
 type ServerSideProxyConfig = Record<string, string | ProxyOptions>;
@@ -15,9 +16,9 @@ const dashboardSecurityHeaders = {
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'same-origin',
 } as const;
-const rootPackageJson = JSON.parse(
+const rootPackageJson = parsePackageMetadata(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
-) as { version: string };
+);
 
 function isLoopbackRemoteAddress(address: string | undefined): boolean {
   return address === '127.0.0.1'


### PR DESCRIPTION
## Bug Description

Vite config loads root package metadata via  directly and used the result without validating shape. That can produce runtime/typing issues if malformed or unexpected package metadata is encountered.

## Root Cause

Unchecked parsing in  assumed the parsed JSON always includes a valid  string.

## Fix

- Add  helper in  to validate metadata shape.
- Use the helper in  instead of a direct cast.
- Add regression tests for valid/invalid JSON and missing version in .

## Test Plan

- [x] Added regression test for invalid/missing version and invalid JSON cases
- [ ] Existing package test/typecheck/build suite verification (tooling currently fails in local environment)

## How to Verify

1. 
> @franken/web@0.6.0 test
> vitest run --fileParallelism=false --run tests/package-metadata.test.ts
2. 
> @franken/web@0.6.0 typecheck
> tsc --noEmit

../../../../frankenbeast/node_modules/@vitest/expect/dist/index.d.ts(128,30): error TS1010: '*/' expected.
3. 
> @franken/web@0.6.0 build
> tsc && vite build

../../../../frankenbeast/node_modules/@vitest/expect/dist/index.d.ts(128,30): error TS1010: '*/' expected.
4. Confirm PR closes this issue when merged

## Risk Assessment

Low — change is scoped to config parsing and guarded by targeted tests.

Closes #2922