### PR TITLE
fix: import shared ServerSocketEvent in web hook

### DIFF
--- a/packages/franken-web/src/hooks/chat-session-state.ts
+++ b/packages/franken-web/src/hooks/chat-session-state.ts
@@ -1,7 +1,6 @@
 import {
   type ApproveResult,
   type ChatSession,
-  type PendingApproval,
   type TokenTotals,
   type TranscriptMessage,
 } from '../lib/api';
@@ -9,47 +8,9 @@ import {
   deterministicUuid,
   isoNow,
   seededRandom,
+  type ServerSocketEvent,
 } from '@franken/types';
 import type { ActivityEvent, ChatErrorAction, ChatErrorBanner, ChatMessage, MessageReceipt } from './use-chat-session';
-
-type SocketEventBase = { eventId?: string };
-
-export type ServerSocketPayload = SocketEventBase & (
-  | {
-      type: 'session.ready';
-      sessionId: string;
-      projectId: string;
-      transcript: TranscriptMessage[];
-      state: string;
-      pendingApproval?: PendingApproval | null;
-    }
-  | { type: 'message.accepted'; clientMessageId: string; sessionId: string; timestamp: string }
-  | { type: 'message.delivered'; clientMessageId: string; timestamp: string }
-  | { type: 'message.read'; clientMessageId?: string; messageId?: string; timestamp: string }
-  | { type: 'assistant.typing.start'; timestamp: string }
-  | { type: 'assistant.message.delta'; messageId: string; chunk: string; modelTier?: string }
-  | { type: 'assistant.message.complete'; messageId: string; content: string; modelTier?: string; timestamp: string }
-  | { type: 'turn.execution.start'; data?: Record<string, unknown>; timestamp: string }
-  | { type: 'turn.execution.progress'; data?: Record<string, unknown>; timestamp: string }
-  | { type: 'turn.execution.complete'; data?: Record<string, unknown>; timestamp: string }
-  | {
-      type: 'turn.approval.requested';
-      description: string;
-      timestamp: string;
-      tool?: string;
-      command?: string;
-      risk?: string;
-      affectedFiles?: string[];
-      sessionId?: string;
-      approvalToken?: string;
-      requester?: string;
-      workerId?: string;
-      workdir?: string;
-    }
-  | { type: 'turn.approval.resolved'; approved: boolean; timestamp: string }
-  | { type: 'turn.error'; code: string; message: string; timestamp: string }
-  | { type: 'pong'; timestamp: string }
-);
 
 export const EMPTY_TOKEN_TOTALS: TokenTotals = {
   cheap: 0,
@@ -156,7 +117,7 @@ function normalizeTranscript(messages: TranscriptMessage[]): ChatMessage[] {
 
 export function appendOrUpdateAssistantMessage(
   messages: ChatMessage[],
-  event: Extract<ServerSocketPayload, { type: 'assistant.message.delta' | 'assistant.message.complete' }>,
+  event: Extract<ServerSocketEvent, { type: 'assistant.message.delta' | 'assistant.message.complete' }>,
 ): ChatMessage[] {
   const existingIndex = messages.findIndex((message) => message.id === event.messageId);
   const nextMessage: ChatMessage = {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -7,6 +7,7 @@ import {
 } from '../lib/api';
 import {
   ServerSocketEventSchema,
+  type ServerSocketEvent,
   isoNow,
 } from '@franken/types';
 import {
@@ -28,7 +29,6 @@ import {
   shouldApplySocketEvent,
   updateReceipt,
   type PendingSend,
-  type ServerSocketPayload,
 } from './chat-session-state';
 
 export type SessionStatus = 'idle' | 'connecting' | 'sending' | 'streaming' | 'error';
@@ -420,7 +420,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         return;
       }
 
-      const payload = parsed.data as ServerSocketPayload;
+      const payload = parsed.data as ServerSocketEvent;
       if (!shouldApplySocketEvent(
         payload,
         processedSocketEventIdsRef.current,

--- a/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session-source.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 const sourcePath = resolve(process.cwd(), 'src/hooks/use-chat-session.ts');
 const source = readFileSync(sourcePath, 'utf8');
+const stateSourcePath = resolve(process.cwd(), 'src/hooks/chat-session-state.ts');
+const stateSource = readFileSync(stateSourcePath, 'utf8');
 
 describe('useChatSession source hygiene', () => {
   const patchAdditionMarker = new RegExp(`^\\s*${'\\+'}\\s*(?:\\/\\/|const|if|try|catch|socket|set\\w*|return|throw|await|for|function)\\b`, 'm');
@@ -40,5 +42,12 @@ describe('useChatSession source hygiene', () => {
     expect(existsSync(helperModulePath)).toBe(true);
     expect(source.split('\n').length).toBeLessThan(900);
     expect(readFileSync(helperModulePath, 'utf8')).toContain('export function preserveLocalRecoveryMessages');
+  });
+
+  it('types websocket payloads from the shared @franken/types contract', () => {
+    expect(stateSource).toContain("type ServerSocketEvent");
+    expect(stateSource).toContain('from \'@franken/types\'');
+    expect(stateSource).not.toMatch(/type SocketEventBase/);
+    expect(stateSource).not.toMatch(/ServerSocketPayload/);
   });
 });

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -349,6 +349,12 @@ describe('useChatSession', () => {
   it.each([
     ['invalid JSON', (socket: MockWebSocket) => socket.rawMessage('{not json')],
     ['malformed known event', (socket: MockWebSocket) => socket.message({ type: 'assistant.message.delta', messageId: 'assistant-1' })],
+    ['malformed session.ready', (socket: MockWebSocket) => socket.message({
+      type: 'session.ready',
+      sessionId: 'chat-1',
+      projectId: 'test-project',
+      state: 'active',
+    })],
     ['unknown event type', (socket: MockWebSocket) => socket.message({ type: 'session.unknown', timestamp: '2026-03-09T00:00:01Z' })],
   ])('surfaces %s as a recoverable websocket protocol error without mutating chat state', async (_name, sendInvalidEvent) => {
     const { result } = renderHook(() => useChatSession(opts));

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -4,6 +4,9 @@
 - Prefer deterministic abort fixtures over timing sleeps: for HTTP disconnect behavior, verify both in-band and immediate-abort paths by asserting that `AbortSignal` is already aborted when `request.destroyed`/`request.aborted` is true before app handler execution.
 - Use a pre-aborted request object (or equivalent event-driven signal path) in unit tests when asserting handler abort behavior, and keep timeouts only as a bounded safety net, not as fixture synchronization.
 
+## 2026-07-19 — Shared schema typing for websocket event payloads
+- Prefer importing socket event unions from shared contract packages and remove local duplicate unions in UI/runtime state modules; add a small source-inspection regression if the duplicate types are the failure mode so future refactors cannot silently reintroduce drift between schema and state handlers.
+
 ## 2026-07-19 — Artifact-path TOCTOU hardening
 - Returning a validated pathname is not a secure file-inspection API: pin both the workspace directory and artifact as file descriptors, traverse through `/proc/self/fd` or `/dev/fd` where available, and compare descriptor/path identities after opening so rename/symlink swaps fail closed.
 - Use `lstat` rather than `existsSync` when dangling symlinks must be rejected, translate only candidate-component `ENOENT` into an ordinary missing artifact, and open untrusted artifact targets with nonblocking/no-follow flags before requiring a regular file.


### PR DESCRIPTION
## Summary\n- Replace web-side local websocket event payload re-definition with shared contract type from @franken/types.\n- Keep session message handling behavior unchanged while tightening parsing via shared schema typings.\n- Add regression coverage for schema-driven failure on malformed socket payloads (including malformed session.ready).\n\n## Test plan\n- npm run typecheck --workspace @franken/web\n- npm run test --workspace @franken/web -- src/hooks/use-chat-session-source.test.ts src/hooks/use-chat-session.test.ts\n- npm run lint --workspace @franken/web\n- npm run build --workspace @franken/web\n\nCloses #2972