### PR TITLE
fix(web): expose module selection state via aria-pressed

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-modules.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-modules.tsx
@@ -55,22 +55,25 @@ export function StepModules() {
   return (
     <div className="p-8 space-y-6">
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-        {MODULES.map((mod) => (
-          <button
-            key={mod.key}
-            type="button"
-            aria-pressed={Boolean(values[mod.key])}
-            onClick={() => toggleModule(mod.key)}
-            className={`p-4 rounded-xl border-2 text-left transition-colors
-              ${values[mod.key]
-                ? 'border-beast-accent bg-beast-accent-soft'
-                : 'border-beast-border bg-beast-panel hover:bg-beast-elevated'
-              }`}
-          >
-            <h3 className="text-sm font-medium text-beast-text">{mod.name}</h3>
-            <p className="text-xs text-beast-subtle mt-0.5">{mod.description}</p>
-          </button>
-        ))}
+        {MODULES.map((mod) => {
+          const isSelected = values[mod.key] === true;
+          return (
+            <button
+              key={mod.key}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => toggleModule(mod.key)}
+              className={`p-4 rounded-xl border-2 text-left transition-colors
+                ${isSelected
+                  ? 'border-beast-accent bg-beast-accent-soft'
+                  : 'border-beast-border bg-beast-panel hover:bg-beast-elevated'
+                }`}
+            >
+              <h3 className="text-sm font-medium text-beast-text">{mod.name}</h3>
+              <p className="text-xs text-beast-subtle mt-0.5">{mod.description}</p>
+            </button>
+          );
+        })}
       </div>
 
       {enabledModules.length > 0 && (

--- a/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-modules.test.tsx
@@ -21,16 +21,25 @@ describe('StepModules', () => {
     expect(screen.getByText('Heartbeat')).toBeTruthy();
   });
 
-  it('announces module toggle state and stores it in Zustand', () => {
+  it('announces module toggle state for each module button', () => {
     render(<StepModules />);
-    const firewallButton = screen.getByRole('button', { name: /firewall/i });
 
-    expect(firewallButton.getAttribute('aria-pressed')).toBe('false');
-    fireEvent.click(firewallButton);
-    expect(firewallButton.getAttribute('aria-pressed')).toBe('true');
+    const moduleNames = ['Firewall', 'Skills', 'Memory', 'Planner', 'Critique', 'Governor', 'Heartbeat'];
+    moduleNames.forEach((name) => {
+      const moduleButton = screen.getByRole('button', { name: new RegExp(name, 'i') });
+      expect(moduleButton.getAttribute('aria-pressed')).toBe('false');
+      fireEvent.click(moduleButton);
+      expect(moduleButton.getAttribute('aria-pressed')).toBe('true');
+    });
 
     const modules = useBeastStore.getState().stepValues[3] as Record<string, boolean>;
     expect(modules?.firewall).toBe(true);
+    expect(modules?.skills).toBe(true);
+    expect(modules?.memory).toBe(true);
+    expect(modules?.planner).toBe(true);
+    expect(modules?.critique).toBe(true);
+    expect(modules?.governor).toBe(true);
+    expect(modules?.heartbeat).toBe(true);
   });
 
   it('does not save zero when positive planner numeric fields are cleared', () => {


### PR DESCRIPTION
## Summary
- Ensure module-selection buttons use strict boolean state for .
- Extend tests to validate toggle state reporting for all module buttons.

## Test Plan
- npm run test --workspace @franken/web -- tests/components/beasts/steps/step-modules.test.tsx

Closes #2905