### PR TITLE
docs: document npm 11 packageManager requirement in ramp-up

### DIFF
--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -9,14 +9,14 @@ A deterministic guardrails framework for AI agents organized as an **npm workspa
 ## Prerequisites
 
 - Node.js version is read from the root `package.json` `engines.node` field (`>=22.13.0 <23 || >=24.0.0 <26`).
-- npm major/minor version is pinned by the root `package.json` `packageManager` field (`npm@11.5.1`).
+- npm version is pinned by the root `package.json` `packageManager` field (`npm@11.5.1`).
 
 To align your local toolchain with these pins, run:
 
 ```bash
 corepack enable npm
-corepack prepare "$(node -p \"require('./package.json').packageManager\")" --activate
-npm --version  # should match the pinned major/minor above
+corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+npm --version  # should match the pinned version above
 ```
 
 For a full setup gate before making changes, run:

--- a/docs/RAMP_UP.md
+++ b/docs/RAMP_UP.md
@@ -6,6 +6,27 @@
 
 A deterministic guardrails framework for AI agents organized as an **npm workspaces monorepo with Turborepo** for build orchestration. The current workspace contains **10 first-party packages** under `packages/`, matching the canonical inventories in [README.md](../README.md#current-workspace-packages) and [docs/guides/quickstart.md](guides/quickstart.md#project-structure): the consolidated core packages, the current MCP suite (`@franken/mcp-suite`), and `live-bench` (`@franken/live-bench`). Cross-package dependencies use workspace references (e.g., `@franken/types`). See [ADR-011](adr/011-real-monorepo-migration.md) and ADR-031 for the earlier consolidation history; pre-consolidation package surfaces were absorbed into the active workspaces listed below.
 
+## Prerequisites
+
+- Node.js version is read from the root `package.json` `engines.node` field (`>=22.13.0 <23 || >=24.0.0 <26`).
+- npm major/minor version is pinned by the root `package.json` `packageManager` field (`npm@11.5.1`).
+
+To align your local toolchain with these pins, run:
+
+```bash
+corepack enable npm
+corepack prepare "$(node -p \"require('./package.json').packageManager\")" --activate
+npm --version  # should match the pinned major/minor above
+```
+
+For a full setup gate before making changes, run:
+
+```bash
+npm run setup:healthcheck
+# or
+npm run check:package-manager
+```
+
 ## Modules
 
 | Package | Purpose |

--- a/tests/docs-issue-2881.test.ts
+++ b/tests/docs-issue-2881.test.ts
@@ -19,9 +19,9 @@ describe('issue #2881 onboarding npm prereqs', () => {
     const rampUp = readDoc('docs/RAMP_UP.md');
 
     expect(rampUp).toContain('## Prerequisites');
-    expect(rampUp).toContain(`root \`packageManager\` field (\`${manifest.packageManager}\`)`);
-    expect(rampUp).toContain(`root \`package.json\` \`engines.node\` field (\`${manifest.engines?.node ?? ''}\`)`);
-    expect(rampUp).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
+    expect(rampUp).toContain('root `package.json` `packageManager` field (`' + manifest.packageManager + ')');
+    expect(rampUp).toContain('root `package.json` `engines.node` field (`' + `${manifest.engines?.node ?? ''}` + ')');
+    expect(rampUp).toContain("corepack prepare \"$(node -p \"require('./package.json').packageManager\")\" --activate");
     expect(rampUp).toContain('npm run check:package-manager');
     expect(rampUp).toContain('npm run setup:healthcheck');
   });

--- a/tests/docs-issue-2881.test.ts
+++ b/tests/docs-issue-2881.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readDoc(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+const manifest = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+  packageManager: string;
+  engines?: { node?: string };
+};
+
+describe('issue #2881 onboarding npm prereqs', () => {
+  it('derives toolchain requirements from root package metadata', () => {
+    const rampUp = readDoc('docs/RAMP_UP.md');
+
+    expect(rampUp).toContain('## Prerequisites');
+    expect(rampUp).toContain(`root \`packageManager\` field (\`${manifest.packageManager}\`)`);
+    expect(rampUp).toContain(`root \`package.json\` \`engines.node\` field (\`${manifest.engines?.node ?? ''}\`)`);
+    expect(rampUp).toContain('corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate');
+    expect(rampUp).toContain('npm run check:package-manager');
+    expect(rampUp).toContain('npm run setup:healthcheck');
+  });
+});


### PR DESCRIPTION
## Summary
This change updates `docs/RAMP_UP.md` with explicit onboarding requirements derived from the root package metadata and adds a regression test covering that derivation.

- Document Node version from root `package.json` `engines.node`
- Document npm version from root `package.json` `packageManager`
- Include a verification command (`npm run check:package-manager`)
- Add `tests/docs-issue-2881.test.ts` to enforce this relationship

Closes #2881
