### PR TITLE
fix: improve wizard step indicator accessibility

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -71,7 +71,7 @@ describe('WizardDialog validation', () => {
     const nextButton = screen.getByRole('button', { name: 'Next' });
     expect(nextButton).toHaveProperty('disabled', true);
     expect(screen.getByRole('alert').textContent).toContain('Agent name is required');
-    expect(screen.getByLabelText('Identity has validation errors').textContent).toContain('!');
+    expect(screen.getByLabelText(/identity.*validation errors/i).textContent).toContain('!');
 
     fireEvent.change(screen.getByLabelText(/Agent Name/), { target: { value: 'Docs Agent' } });
 

--- a/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
@@ -15,6 +15,13 @@ export function WizardStepIndicator({ steps, currentStep, highestCompleted, step
         const isCompleted = i <= highestCompleted && !hasError;
         const isCurrent = i === currentStep;
         const isClickable = isCompleted || isCurrent || hasError;
+        const ariaLabel = hasError
+          ? `${label}, validation errors`
+          : isCurrent
+            ? `${label}, current step`
+            : isCompleted
+              ? `${label}, completed`
+              : `${label}, upcoming step`;
 
         return (
           <button
@@ -23,7 +30,7 @@ export function WizardStepIndicator({ steps, currentStep, highestCompleted, step
             onClick={() => isClickable && onStepClick(i)}
             disabled={!isClickable}
             aria-current={isCurrent ? 'step' : undefined}
-            aria-label={hasError ? `${label} has validation errors` : label}
+            aria-label={ariaLabel}
             className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-colors
               ${isCurrent && !hasError ? 'text-beast-accent-strong bg-beast-accent-soft' : ''}
               ${hasError ? 'text-beast-danger bg-red-900/20 border border-red-700/60' : ''}

--- a/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
@@ -18,6 +18,26 @@ describe('WizardStepIndicator', () => {
     expect(current?.className).toContain('text-beast-accent');
   });
 
+  it('marks current step with aria-current', () => {
+    render(<WizardStepIndicator steps={STEPS} currentStep={2} highestCompleted={1} onStepClick={vi.fn()} />);
+    const current = screen.getByRole('button', { name: /LLM Targets, current step/i });
+    expect(current.getAttribute('aria-current')).toBe('step');
+  });
+
+  it('announces completed and upcoming states in accessible labels', () => {
+    render(
+      <WizardStepIndicator
+        steps={STEPS}
+        currentStep={2}
+        highestCompleted={1}
+        onStepClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Identity, completed/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Modules, upcoming step/i })).toBeTruthy();
+  });
+
   it('completed steps are clickable', () => {
     const onClick = vi.fn();
     render(<WizardStepIndicator steps={STEPS} currentStep={3} highestCompleted={2} onStepClick={onClick} />);

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Codex-triggered commit re-review on issue #2907
+- When a commit is pushed to an existing PR and there was a prior `@codex review`, always trigger a new review on the new head and collect a fresh `@codex review` clean signal before merging. In this case, a `screen-reader` aria-label update changed, a stale strict assertion in `wizard-dialog.test.tsx` broke once; switching it to a regex was sufficient and CI stayed green on the new commit.
+
 ## 2026-07-19 — Artifact-path TOCTOU hardening
 - Returning a validated pathname is not a secure file-inspection API: pin both the workspace directory and artifact as file descriptors, traverse through `/proc/self/fd` or `/dev/fd` where available, and compare descriptor/path identities after opening so rename/symlink swaps fail closed.
 - Use `lstat` rather than `existsSync` when dangling symlinks must be rejected, translate only candidate-component `ENOENT` into an ordinary missing artifact, and open untrusted artifact targets with nonblocking/no-follow flags before requiring a regular file.


### PR DESCRIPTION
## Summary
- Relax wizard-step validation indicator test assertion to match label semantics while still asserting validation errors are surfaced.
- Update shared issue-resolution lesson file with Codex re-review and lesson consolidation notes.

## Test Plan
- npm run test --workspace @franken/web -- wizard-step-indicator.test.tsx wizard-dialog.test.tsx

Closes #2907