### PR TITLE
fix(orchestrator): normalize provider stream events

### DIFF
--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -9,6 +9,23 @@ export interface StreamProgressHandle {
   stop: () => void;
 }
 
+export type NormalizedProviderStreamEvent =
+  | { type: 'reasoning' }
+  | { type: 'tool'; name?: string; input?: unknown; partialInput?: string }
+  | { type: 'text'; content: string }
+  | { type: 'usage'; inputTokens?: number; outputTokens?: number; totalTokens?: number }
+  | { type: 'result'; durationMs?: number; costUsd?: number; turns?: number }
+  | { type: 'retry' }
+  | { type: 'error' }
+  | { type: 'unknown'; sourceType: string };
+
+export interface StreamProgressOptions {
+  /** Emit redacted diagnostics for unrecognized provider frames. */
+  verbose?: boolean;
+  /** Receive provider-neutral, redacted events for terminal or persistent sinks. */
+  onEvent?: (event: NormalizedProviderStreamEvent) => void;
+}
+
 /**
  * Creates a stream progress handler with an integrated spinner.
  * The spinner shows elapsed time from the start; progress lines
@@ -16,7 +33,7 @@ export interface StreamProgressHandle {
  * Call `stop()` after the LLM call resolves to clear the spinner.
  */
 export function createStreamProgressWithSpinner(
-  options: { write?: (text: string) => void; label?: string } = {},
+  options: StreamProgressOptions & { write?: (text: string) => void; label?: string } = {},
 ): StreamProgressHandle {
   const write = options.write ?? ((t: string) => process.stderr.write(t));
   const label = options.label ?? 'LLM working...';
@@ -34,13 +51,12 @@ export function createStreamProgressWithSpinner(
   const interval = setInterval(renderSpinner, SPINNER_INTERVAL_MS);
   renderSpinner();
 
-  // Progress lines clear the spinner, write the line, then the spinner re-renders on next tick
   const writeProgress = (text: string): void => {
     write('\r\x1b[K');
     write(text);
   };
 
-  const handler = createStreamProgressHandler(writeProgress);
+  const handler = createStreamProgressHandler(writeProgress, options);
 
   return {
     onLine: handler,
@@ -52,12 +68,160 @@ export function createStreamProgressWithSpinner(
 }
 
 /**
- * Parses stream-json lines from the Claude CLI and renders
- * meaningful progress to the terminal: thinking status, tool use,
- * chunk IDs detected in text output, and completion stats.
+ * Normalizes one parsed Claude, Codex, or Gemini CLI stream frame. The
+ * contract deliberately excludes raw reasoning and error text so consumers
+ * can persist these events without exposing chain-of-thought or secrets.
  */
+export function normalizeProviderStreamEvent(
+  obj: Record<string, unknown>,
+): NormalizedProviderStreamEvent[] {
+  if ('hookSpecificOutput' in obj) return [];
+
+  const type = stringValue(obj['type']);
+  if (!type) return [{ type: 'unknown', sourceType: 'missing-type' }];
+
+  if (type === 'assistant') {
+    const message = asRecord(obj['message']);
+    const events: NormalizedProviderStreamEvent[] = [];
+    const usage = normalizeUsage(message?.['usage']);
+    if (usage) events.push(usage);
+
+    const content = message?.['content'] ?? obj['content'];
+    if (Array.isArray(content)) {
+      for (const value of content) {
+        const block = asRecord(value);
+        if (!block) continue;
+        const blockType = stringValue(block['type']);
+        if (blockType === 'thinking' || blockType === 'reasoning') {
+          events.push({ type: 'reasoning' });
+        } else if (blockType === 'tool_use' || blockType === 'tool_call') {
+          const name = stringValue(block['name']);
+          events.push({ type: 'tool', ...(name ? { name } : {}), input: block['input'] ?? {} });
+        } else if (blockType === 'text') {
+          const text = stringValue(block['text']);
+          if (text !== undefined) events.push({ type: 'text', content: text });
+        }
+      }
+    } else {
+      const text = extractText(content);
+      if (text !== undefined) events.push({ type: 'text', content: text });
+    }
+    return events;
+  }
+
+  if (type === 'content_block_start') {
+    const block = asRecord(obj['content_block']);
+    const blockType = stringValue(block?.['type']);
+    if (blockType === 'thinking' || blockType === 'reasoning') return [{ type: 'reasoning' }];
+    if (blockType === 'tool_use' || blockType === 'tool_call') {
+      const name = stringValue(block?.['name']);
+      return [{ type: 'tool', ...(name ? { name } : {}), input: block?.['input'] ?? {} }];
+    }
+    return [];
+  }
+
+  if (type === 'content_block_delta') {
+    const delta = asRecord(obj['delta']);
+    const deltaType = stringValue(delta?.['type']);
+    if (deltaType === 'text_delta') {
+      const text = stringValue(delta?.['text']);
+      return text === undefined ? [] : [{ type: 'text', content: text }];
+    }
+    if (deltaType === 'thinking_delta') return [{ type: 'reasoning' }];
+    if (deltaType === 'input_json_delta') {
+      const partialInput = stringValue(delta?.['partial_json']);
+      return partialInput === undefined ? [] : [{ type: 'tool', partialInput }];
+    }
+    return [];
+  }
+
+  if (type === 'item.started' || type === 'item.completed' || type === 'item.updated') {
+    const item = asRecord(obj['item']);
+    const itemType = stringValue(item?.['type']);
+    if (itemType === 'reasoning') return [{ type: 'reasoning' }];
+    if (itemType === 'agent_message' || itemType === 'message') {
+      const text = extractText(item?.['text'] ?? item?.['content']);
+      return text === undefined ? [] : [{ type: 'text', content: text }];
+    }
+    if (itemType === 'command_execution') {
+      return [{ type: 'tool', name: 'Bash', input: {} }];
+    }
+    if (itemType === 'mcp_tool_call') {
+      const server = stringValue(item?.['server']);
+      const tool = stringValue(item?.['tool']) ?? stringValue(item?.['name']);
+      const name = [server, tool].filter(Boolean).join('.') || 'MCP tool';
+      return [{ type: 'tool', name, input: item?.['arguments'] ?? {} }];
+    }
+    if (itemType === 'web_search') return [{ type: 'tool', name: 'Search', input: {} }];
+    return [{ type: 'unknown', sourceType: `${type}:${itemType ?? 'missing-item-type'}` }];
+  }
+
+  if (type === 'message' || type === 'content') {
+    if (obj['role'] === 'user') return [];
+    const text = extractText(obj['content'] ?? obj['text']);
+    return text === undefined ? [] : [{ type: 'text', content: text }];
+  }
+
+  if (type === 'tool_use' || type === 'tool_call' || type === 'function_call') {
+    const name = stringValue(obj['tool_name']) ?? stringValue(obj['name']);
+    const input = obj['parameters'] ?? obj['arguments'] ?? obj['input'] ?? {};
+    return [{ type: 'tool', ...(name ? { name } : {}), input }];
+  }
+
+  if (type === 'turn.completed') {
+    const events: NormalizedProviderStreamEvent[] = [];
+    const usage = normalizeUsage(obj['usage']);
+    if (usage) events.push(usage);
+    events.push({ type: 'result' });
+    return events;
+  }
+
+  if (type === 'usage') {
+    const usage = normalizeUsage(obj['usage'] ?? obj);
+    return usage ? [usage] : [];
+  }
+
+  if (type === 'result' || type === 'done') {
+    const stats = asRecord(obj['stats']);
+    const events: NormalizedProviderStreamEvent[] = [];
+    const usage = normalizeUsage(stats ?? obj['usage'] ?? obj);
+    if (usage) events.push(usage);
+    const durationMs = numberValue(stats?.['duration_ms']) ?? numberValue(obj['duration_ms']);
+    const costUsd = numberValue(obj['cost_usd']);
+    const turns = numberValue(obj['num_turns']);
+    events.push({
+      type: 'result',
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(costUsd !== undefined ? { costUsd } : {}),
+      ...(turns !== undefined ? { turns } : {}),
+    });
+    return events;
+  }
+
+  if (type === 'retry' || type === 'rate_limit' || type === 'rate_limit_event') return [{ type: 'retry' }];
+  if (type === 'error' || type === 'turn.failed') return [{ type: 'error' }];
+
+  if (KNOWN_IGNORED_TYPES.has(type)) return [];
+  return [{ type: 'unknown', sourceType: type }];
+}
+
+const KNOWN_IGNORED_TYPES = new Set([
+  'init',
+  'system',
+  'user',
+  'thread.started',
+  'turn.started',
+  'content_block_stop',
+  'message_start',
+  'message_delta',
+  'message_stop',
+  'tool_result',
+]);
+
+/** Render normalized provider events as safe, low-volume planning progress. */
 export function createStreamProgressHandler(
   write: (text: string) => void = (t) => process.stderr.write(t),
+  options: StreamProgressOptions = {},
 ): (line: string) => void {
   let lastToolName = '';
   let showedThinking = false;
@@ -73,95 +237,149 @@ export function createStreamProgressHandler(
     try {
       obj = JSON.parse(trimmed) as Record<string, unknown>;
     } catch {
-      return; // Not JSON — skip
+      if (options.verbose) writeUnknown('non-json', write, options);
+      return;
     }
 
-    // Skip hook output
     if ('hookSpecificOutput' in obj) return;
 
-    const type = obj['type'] as string | undefined;
-
-    // content_block_start: detect thinking or tool_use blocks
-    if (type === 'content_block_start') {
-      const block = obj['content_block'] as Record<string, unknown> | undefined;
-      if (!block) return;
-
-      if (block['type'] === 'thinking' && !showedThinking) {
-        showedThinking = true;
-        write(`  ${ANSI.dim}Reasoning...${ANSI.reset}\n`);
-      }
-
-      if (block['type'] === 'tool_use') {
-        lastToolName = block['name'] as string;
-        toolInputAccumulator = '';
-      } else {
+    const rawType = stringValue(obj['type']);
+    const isPartialToolStart = rawType === 'content_block_start';
+    if (rawType === 'content_block_start') {
+      const blockType = stringValue(asRecord(obj['content_block'])?.['type']);
+      if (blockType === 'text') textAccumulator = '';
+      if (blockType !== 'tool_use' && blockType !== 'tool_call') {
         lastToolName = '';
         toolInputAccumulator = '';
       }
-
-      // Reset text accumulator for new text blocks
-      if (block['type'] === 'text') {
-        textAccumulator = '';
-      }
     }
 
-    // content_block_delta: tool input or text output
-    if (type === 'content_block_delta') {
-      const delta = obj['delta'] as Record<string, unknown> | undefined;
-      if (!delta) return;
+    for (const event of normalizeProviderStreamEvent(obj)) {
+      options.onEvent?.(event);
 
-      // Tool input — show file paths
-      if (delta['type'] === 'input_json_delta' && lastToolName) {
-        const partial = delta['partial_json'] as string | undefined;
-        if (partial) {
-          toolInputAccumulator += partial;
-          const pathMatch = toolInputAccumulator.match(/"file_path"\s*:\s*"([^"]+)"/);
-          if (pathMatch?.[1]) {
-            const action = toolAction(lastToolName);
-            const shortPath = shortenPath(pathMatch[1]);
-            write(`  ${ANSI.dim}${action} ${shortPath}${ANSI.reset}\n`);
-            lastToolName = ''; // Only show once per tool use
+      if (event.type === 'reasoning') {
+        if (!showedThinking) {
+          showedThinking = true;
+          write(`  ${ANSI.dim}Reasoning...${ANSI.reset}\n`);
+        }
+      } else if (event.type === 'tool') {
+        if (event.name) {
+          lastToolName = event.name;
+          toolInputAccumulator = '';
+          if (!isPartialToolStart) renderTool(event.name, event.input, write);
+        }
+        if (event.partialInput && lastToolName) {
+          toolInputAccumulator += event.partialInput;
+          const path = extractToolPathFromPartialJson(toolInputAccumulator);
+          if (path) {
+            renderTool(lastToolName, { file_path: path }, write);
+            lastToolName = '';
             toolInputAccumulator = '';
           }
         }
-      }
-
-      // Text delta — accumulate and detect chunk IDs
-      if (delta['type'] === 'text_delta') {
-        const text = delta['text'] as string | undefined;
-        if (text) {
-          textAccumulator += text;
-          detectChunkIds(textAccumulator, seenChunkIds, write);
-        }
-      }
-    }
-
-    // result event: show completion stats
-    if (type === 'result') {
-      const cost = obj['cost_usd'] as number | undefined;
-      const duration = obj['duration_ms'] as number | undefined;
-      const numTurns = obj['num_turns'] as number | undefined;
-      const parts: string[] = [];
-      if (duration !== undefined) parts.push(`${(duration / 1000).toFixed(1)}s`);
-      if (cost !== undefined) parts.push(`$${cost.toFixed(4)}`);
-      if (numTurns !== undefined && numTurns > 1) parts.push(`${numTurns} turns`);
-      if (parts.length > 0) {
-        write(`  ${ANSI.dim}LLM done (${parts.join(', ')})${ANSI.reset}\n`);
+      } else if (event.type === 'text') {
+        textAccumulator += event.content;
+        detectChunkIds(textAccumulator, seenChunkIds, write);
+      } else if (event.type === 'result') {
+        const parts: string[] = [];
+        if (event.durationMs !== undefined) parts.push(`${(event.durationMs / 1000).toFixed(1)}s`);
+        if (event.costUsd !== undefined) parts.push(`$${event.costUsd.toFixed(4)}`);
+        if (event.turns !== undefined && event.turns > 1) parts.push(`${event.turns} turns`);
+        write(`  ${ANSI.dim}LLM done${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
+      } else if (event.type === 'retry') {
+        write(`  ${ANSI.dim}Provider retrying...${ANSI.reset}\n`);
+      } else if (event.type === 'error') {
+        write(`  ${ANSI.dim}Provider stream error${ANSI.reset}\n`);
+      } else if (event.type === 'unknown' && options.verbose) {
+        writeUnknown(event.sourceType, write, options, false);
       }
     }
   };
 }
 
-/**
- * Scan accumulated text for JSON chunk `"id": "..."` patterns.
- * Each new chunk ID found triggers a progress line.
- */
+function writeUnknown(
+  sourceType: string,
+  write: (text: string) => void,
+  options: StreamProgressOptions,
+  notify = true,
+): void {
+  const event: NormalizedProviderStreamEvent = { type: 'unknown', sourceType };
+  if (notify) options.onEvent?.(event);
+  write(`  ${ANSI.dim}Unknown provider stream event: ${sanitizeEventType(sourceType)}${ANSI.reset}\n`);
+}
+
+function renderTool(name: string, input: unknown, write: (text: string) => void): void {
+  const action = toolAction(name);
+  const path = extractToolPath(input);
+  const suffix = path ? ` ${shortenPath(path)}` : '';
+  write(`  ${ANSI.dim}${action}${suffix}${ANSI.reset}\n`);
+}
+
+function extractToolPath(input: unknown): string | undefined {
+  const record = asRecord(input);
+  return stringValue(record?.['file_path'])
+    ?? stringValue(record?.['path'])
+    ?? stringValue(record?.['absolute_path']);
+}
+
+function extractToolPathFromPartialJson(input: string): string | undefined {
+  return input.match(/"(?:file_path|path|absolute_path)"\s*:\s*"([^"]+)"/)?.[1];
+}
+
+function normalizeUsage(value: unknown): NormalizedProviderStreamEvent | undefined {
+  const usage = asRecord(value);
+  if (!usage) return undefined;
+  const inputTokens = numberValue(usage['input_tokens']) ?? numberValue(usage['inputTokens'])
+    ?? numberValue(usage['total_input_tokens']);
+  const outputTokens = numberValue(usage['output_tokens']) ?? numberValue(usage['outputTokens'])
+    ?? numberValue(usage['total_output_tokens']);
+  const totalTokens = numberValue(usage['total_tokens']) ?? numberValue(usage['totalTokens'])
+    ?? (inputTokens !== undefined && outputTokens !== undefined ? inputTokens + outputTokens : undefined);
+  if (inputTokens === undefined && outputTokens === undefined && totalTokens === undefined) return undefined;
+  return {
+    type: 'usage',
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  };
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return undefined;
+  const parts: string[] = [];
+  for (const entry of value) {
+    const record = asRecord(entry);
+    const text = stringValue(record?.['text']) ?? stringValue(record?.['content']);
+    if (text !== undefined) parts.push(text);
+  }
+  return parts.length > 0 ? parts.join('') : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function sanitizeEventType(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.:-]/g, '?').slice(0, 120);
+}
+
+/** Scan accumulated text for JSON chunk `"id": "..."` patterns. */
 function detectChunkIds(
   text: string,
   seen: Set<string>,
   write: (text: string) => void,
 ): void {
-  // Match "id": "some-chunk-id" patterns in JSON array output
   const pattern = /"id"\s*:\s*"([^"]+)"/g;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {
@@ -180,6 +398,7 @@ function toolAction(name: string): string {
     case 'Edit': return 'Editing';
     case 'Glob': return 'Searching';
     case 'Grep': return 'Searching';
+    case 'Search': return 'Searching';
     case 'Bash': return 'Running';
     default: return `Using ${name}:`;
   }

--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -156,7 +156,7 @@ export function normalizeProviderStreamEvent(
     return [{ type: 'unknown', sourceType: `${type}:${itemType ?? 'missing-item-type'}` }];
   }
 
-  if (type === 'message' || type === 'content') {
+  if (type === 'message' || type === 'content' || type === 'event') {
     const message = asRecord(obj['message']);
     const role = message?.['role'] ?? obj['role'];
     if (role === 'user') return [];
@@ -196,11 +196,17 @@ export function normalizeProviderStreamEvent(
     const events: NormalizedProviderStreamEvent[] = [];
     const usage = normalizeUsage(stats ?? obj['usage'] ?? obj);
     if (usage) events.push(usage);
+    const subtype = stringValue(obj['subtype']);
+    const status = stringValue(obj['status']);
+    if (obj['is_error'] === true || subtype === 'error' || status === 'error' || status === 'failed') {
+      events.push({ type: 'error' });
+      return events;
+    }
     const message = asRecord(obj['message']);
     const text = extractText(obj['result'] ?? message?.['content'] ?? obj['content'] ?? obj['text']);
     if (text !== undefined) events.push({ type: 'text', content: text });
     const durationMs = numberValue(stats?.['duration_ms']) ?? numberValue(obj['duration_ms']);
-    const costUsd = numberValue(obj['cost_usd']);
+    const costUsd = numberValue(obj['cost_usd']) ?? numberValue(obj['total_cost_usd']);
     const turns = numberValue(obj['num_turns']);
     events.push({
       type: 'result',

--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -11,7 +11,7 @@ export interface StreamProgressHandle {
 
 export type NormalizedProviderStreamEvent =
   | { type: 'reasoning' }
-  | { type: 'tool'; name?: string; input?: unknown; partialInput?: string }
+  | { type: 'tool'; name?: string; path?: string }
   | { type: 'text'; content: string }
   | { type: 'usage'; inputTokens?: number; outputTokens?: number; totalTokens?: number }
   | { type: 'result'; durationMs?: number; costUsd?: number; turns?: number }
@@ -96,7 +96,8 @@ export function normalizeProviderStreamEvent(
           events.push({ type: 'reasoning' });
         } else if (blockType === 'tool_use' || blockType === 'tool_call') {
           const name = stringValue(block['name']);
-          events.push({ type: 'tool', ...(name ? { name } : {}), input: block['input'] ?? {} });
+          const path = extractToolPath(block['input']);
+          events.push({ type: 'tool', ...(name ? { name } : {}), ...(path ? { path } : {}) });
         } else if (blockType === 'text') {
           const text = stringValue(block['text']);
           if (text !== undefined) events.push({ type: 'text', content: text });
@@ -115,7 +116,8 @@ export function normalizeProviderStreamEvent(
     if (blockType === 'thinking' || blockType === 'reasoning') return [{ type: 'reasoning' }];
     if (blockType === 'tool_use' || blockType === 'tool_call') {
       const name = stringValue(block?.['name']);
-      return [{ type: 'tool', ...(name ? { name } : {}), input: block?.['input'] ?? {} }];
+      const path = extractToolPath(block?.['input']);
+      return [{ type: 'tool', ...(name ? { name } : {}), ...(path ? { path } : {}) }];
     }
     return [];
   }
@@ -123,15 +125,12 @@ export function normalizeProviderStreamEvent(
   if (type === 'content_block_delta') {
     const delta = asRecord(obj['delta']);
     const deltaType = stringValue(delta?.['type']);
-    if (deltaType === 'text_delta') {
+    if (deltaType === 'text_delta' || (deltaType === undefined && typeof delta?.['text'] === 'string')) {
       const text = stringValue(delta?.['text']);
       return text === undefined ? [] : [{ type: 'text', content: text }];
     }
     if (deltaType === 'thinking_delta') return [{ type: 'reasoning' }];
-    if (deltaType === 'input_json_delta') {
-      const partialInput = stringValue(delta?.['partial_json']);
-      return partialInput === undefined ? [] : [{ type: 'tool', partialInput }];
-    }
+    if (deltaType === 'input_json_delta') return [];
     return [];
   }
 
@@ -144,28 +143,39 @@ export function normalizeProviderStreamEvent(
       return text === undefined ? [] : [{ type: 'text', content: text }];
     }
     if (itemType === 'command_execution') {
-      return [{ type: 'tool', name: 'Bash', input: {} }];
+      return [{ type: 'tool', name: 'Bash' }];
     }
     if (itemType === 'mcp_tool_call') {
       const server = stringValue(item?.['server']);
       const tool = stringValue(item?.['tool']) ?? stringValue(item?.['name']);
       const name = [server, tool].filter(Boolean).join('.') || 'MCP tool';
-      return [{ type: 'tool', name, input: item?.['arguments'] ?? {} }];
+      const path = extractToolPath(item?.['arguments']);
+      return [{ type: 'tool', name, ...(path ? { path } : {}) }];
     }
-    if (itemType === 'web_search') return [{ type: 'tool', name: 'Search', input: {} }];
+    if (itemType === 'web_search') return [{ type: 'tool', name: 'Search' }];
     return [{ type: 'unknown', sourceType: `${type}:${itemType ?? 'missing-item-type'}` }];
   }
 
   if (type === 'message' || type === 'content') {
-    if (obj['role'] === 'user') return [];
-    const text = extractText(obj['content'] ?? obj['text']);
+    const message = asRecord(obj['message']);
+    const role = message?.['role'] ?? obj['role'];
+    if (role === 'user') return [];
+    const text = extractText(message?.['content'] ?? obj['content'] ?? obj['parts'] ?? obj['text']);
     return text === undefined ? [] : [{ type: 'text', content: text }];
   }
 
   if (type === 'tool_use' || type === 'tool_call' || type === 'function_call') {
     const name = stringValue(obj['tool_name']) ?? stringValue(obj['name']);
     const input = obj['parameters'] ?? obj['arguments'] ?? obj['input'] ?? {};
-    return [{ type: 'tool', ...(name ? { name } : {}), input }];
+    const path = extractToolPath(input);
+    return [{ type: 'tool', ...(name ? { name } : {}), ...(path ? { path } : {}) }];
+  }
+
+  if (type === 'message_start' || type === 'message_delta') {
+    const message = asRecord(obj['message']);
+    const delta = asRecord(obj['delta']);
+    const usage = normalizeUsage(message?.['usage'] ?? obj['usage'] ?? delta?.['usage']);
+    return usage ? [usage] : [];
   }
 
   if (type === 'turn.completed') {
@@ -186,6 +196,9 @@ export function normalizeProviderStreamEvent(
     const events: NormalizedProviderStreamEvent[] = [];
     const usage = normalizeUsage(stats ?? obj['usage'] ?? obj);
     if (usage) events.push(usage);
+    const message = asRecord(obj['message']);
+    const text = extractText(obj['result'] ?? message?.['content'] ?? obj['content'] ?? obj['text']);
+    if (text !== undefined) events.push({ type: 'text', content: text });
     const durationMs = numberValue(stats?.['duration_ms']) ?? numberValue(obj['duration_ms']);
     const costUsd = numberValue(obj['cost_usd']);
     const turns = numberValue(obj['num_turns']);
@@ -212,8 +225,6 @@ const KNOWN_IGNORED_TYPES = new Set([
   'thread.started',
   'turn.started',
   'content_block_stop',
-  'message_start',
-  'message_delta',
   'message_stop',
   'tool_result',
 ]);
@@ -254,6 +265,22 @@ export function createStreamProgressHandler(
       }
     }
 
+    if (rawType === 'content_block_delta' && lastToolName) {
+      const delta = asRecord(obj['delta']);
+      if (stringValue(delta?.['type']) === 'input_json_delta') {
+        const partialInput = stringValue(delta?.['partial_json']);
+        if (partialInput) {
+          toolInputAccumulator += partialInput;
+          const path = extractToolPathFromPartialJson(toolInputAccumulator);
+          if (path) {
+            renderTool(lastToolName, path, write);
+            lastToolName = '';
+            toolInputAccumulator = '';
+          }
+        }
+      }
+    }
+
     for (const event of normalizeProviderStreamEvent(obj)) {
       options.onEvent?.(event);
 
@@ -266,16 +293,7 @@ export function createStreamProgressHandler(
         if (event.name) {
           lastToolName = event.name;
           toolInputAccumulator = '';
-          if (!isPartialToolStart) renderTool(event.name, event.input, write);
-        }
-        if (event.partialInput && lastToolName) {
-          toolInputAccumulator += event.partialInput;
-          const path = extractToolPathFromPartialJson(toolInputAccumulator);
-          if (path) {
-            renderTool(lastToolName, { file_path: path }, write);
-            lastToolName = '';
-            toolInputAccumulator = '';
-          }
+          if (!isPartialToolStart) renderTool(event.name, event.path, write);
         }
       } else if (event.type === 'text') {
         textAccumulator += event.content;
@@ -308,15 +326,21 @@ function writeUnknown(
   write(`  ${ANSI.dim}Unknown provider stream event: ${sanitizeEventType(sourceType)}${ANSI.reset}\n`);
 }
 
-function renderTool(name: string, input: unknown, write: (text: string) => void): void {
+function renderTool(name: string, path: string | undefined, write: (text: string) => void): void {
   const action = toolAction(name);
-  const path = extractToolPath(input);
   const suffix = path ? ` ${shortenPath(path)}` : '';
   write(`  ${ANSI.dim}${action}${suffix}${ANSI.reset}\n`);
 }
 
 function extractToolPath(input: unknown): string | undefined {
-  const record = asRecord(input);
+  let record = asRecord(input);
+  if (!record && typeof input === 'string') {
+    try {
+      record = asRecord(JSON.parse(input));
+    } catch {
+      return undefined;
+    }
+  }
   return stringValue(record?.['file_path'])
     ?? stringValue(record?.['path'])
     ?? stringValue(record?.['absolute_path']);
@@ -330,9 +354,9 @@ function normalizeUsage(value: unknown): NormalizedProviderStreamEvent | undefin
   const usage = asRecord(value);
   if (!usage) return undefined;
   const inputTokens = numberValue(usage['input_tokens']) ?? numberValue(usage['inputTokens'])
-    ?? numberValue(usage['total_input_tokens']);
+    ?? numberValue(usage['total_input_tokens']) ?? numberValue(usage['promptTokenCount']);
   const outputTokens = numberValue(usage['output_tokens']) ?? numberValue(usage['outputTokens'])
-    ?? numberValue(usage['total_output_tokens']);
+    ?? numberValue(usage['total_output_tokens']) ?? numberValue(usage['candidatesTokenCount']);
   const totalTokens = numberValue(usage['total_tokens']) ?? numberValue(usage['totalTokens'])
     ?? (inputTokens !== undefined && outputTokens !== undefined ? inputTokens + outputTokens : undefined);
   if (inputTokens === undefined && outputTokens === undefined && totalTokens === undefined) return undefined;

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -358,7 +358,10 @@ export class Session {
     // from loading in the spawned CLI. Plugins poison the session by injecting skill
     // instructions that make the CLI explore the codebase instead of returning JSON.
     depOptions.adapterWorkingDir = tmpdir();
-    const progress = createStreamProgressWithSpinner({ label: 'Planning...' });
+    const progress = createStreamProgressWithSpinner({
+      label: 'Planning...',
+      verbose: this.config.verbose,
+    });
     depOptions.onStreamLine = progress.onLine;
     const { cliLlmAdapter, logger, finalize } = await createCliDeps(depOptions);
 

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createStreamProgressHandler, createStreamProgressWithSpinner } from '../../../src/adapters/stream-progress.js';
+import type { NormalizedProviderStreamEvent } from '../../../src/adapters/stream-progress.js';
 
 describe('createStreamProgressHandler', () => {
   it('shows "Reasoning..." on first thinking content_block_start', () => {
@@ -206,6 +207,83 @@ describe('createStreamProgressHandler', () => {
     expect(lines.some((line) => line.includes('gemini-plan'))).toBe(true);
     expect(lines.some((line) => line.includes('Using read_file:') && line.includes('gemini.ts'))).toBe(true);
     expect(lines.some((line) => line.includes('LLM done') && line.includes('2.5s'))).toBe(true);
+  });
+
+  it('redacts tool payloads from normalized events', () => {
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler(() => {}, {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          name: 'Write',
+          input: { file_path: '/workspace/safe.ts', content: 'sensitive file contents' },
+        }],
+      },
+    }));
+
+    expect(events).toEqual([{ type: 'tool', name: 'Write', path: '/workspace/safe.ts' }]);
+    expect(JSON.stringify(events)).not.toContain('sensitive file contents');
+  });
+
+  it('normalizes nested Gemini messages, result text, and Gemini token fields', () => {
+    const lines: string[] = [];
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler((line) => lines.push(line), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'message',
+      message: { role: 'assistant', content: [{ text: '[{"id":"nested-gemini"}]' }] },
+    }));
+    handler(JSON.stringify({
+      type: 'result',
+      result: '[{"id":"result-gemini"}]',
+      stats: { promptTokenCount: 21, candidatesTokenCount: 8 },
+    }));
+
+    expect(events.map((event) => event.type)).toEqual(['text', 'usage', 'text', 'result']);
+    expect(events[1]).toEqual({ type: 'usage', inputTokens: 21, outputTokens: 8, totalTokens: 29 });
+    expect(lines.some((line) => line.includes('nested-gemini'))).toBe(true);
+    expect(lines.some((line) => line.includes('result-gemini'))).toBe(true);
+  });
+
+  it('preserves message lifecycle usage and untyped text deltas', () => {
+    const lines: string[] = [];
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler((line) => lines.push(line), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({ type: 'message_start', message: { usage: { input_tokens: 13 } } }));
+    handler(JSON.stringify({ type: 'message_delta', usage: { output_tokens: 5 } }));
+    handler(JSON.stringify({ type: 'content_block_delta', delta: { text: '[{"id":"untyped-delta"}]' } }));
+
+    expect(events.map((event) => event.type)).toEqual(['usage', 'usage', 'text']);
+    expect(lines.some((line) => line.includes('untyped-delta'))).toBe(true);
+  });
+
+  it('extracts safe paths from JSON-string tool arguments', () => {
+    const lines: string[] = [];
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler((line) => lines.push(line), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'function_call',
+      name: 'read_file',
+      arguments: JSON.stringify({ path: '/workspace/src/string-args.ts', secret: 'do not emit' }),
+    }));
+
+    expect(events).toEqual([{ type: 'tool', name: 'read_file', path: '/workspace/src/string-args.ts' }]);
+    expect(lines.some((line) => line.includes('string-args.ts'))).toBe(true);
+    expect(JSON.stringify(events)).not.toContain('do not emit');
   });
 
   it('reports unknown event types through redacted verbose diagnostics', () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -286,6 +286,44 @@ describe('createStreamProgressHandler', () => {
     expect(JSON.stringify(events)).not.toContain('do not emit');
   });
 
+  it('redacts error result details and reports an error instead of completion', () => {
+    const lines: string[] = [];
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler((line) => lines.push(line), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'sensitive provider error details',
+    }));
+
+    expect(events).toEqual([{ type: 'error' }]);
+    expect(lines.some((line) => line.includes('Provider stream error'))).toBe(true);
+    expect(lines.some((line) => line.includes('LLM done'))).toBe(false);
+    expect(JSON.stringify(events)).not.toContain('sensitive provider error details');
+  });
+
+  it('normalizes Codex event content and Claude total cost', () => {
+    const lines: string[] = [];
+    const events: NormalizedProviderStreamEvent[] = [];
+    const handler = createStreamProgressHandler((line) => lines.push(line), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'event',
+      content: [{ type: 'output_text', text: '[{"id":"codex-event"}]' }],
+    }));
+    handler(JSON.stringify({ type: 'result', total_cost_usd: 0.079 }));
+
+    expect(events.map((event) => event.type)).toEqual(['text', 'result']);
+    expect(events[1]).toEqual({ type: 'result', costUsd: 0.079 });
+    expect(lines.some((line) => line.includes('codex-event'))).toBe(true);
+    expect(lines.some((line) => line.includes('$0.0790'))).toBe(true);
+  });
+
   it('reports unknown event types through redacted verbose diagnostics', () => {
     const lines: string[] = [];
     const handler = createStreamProgressHandler((t) => lines.push(t), { verbose: true });

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -122,6 +122,103 @@ describe('createStreamProgressHandler', () => {
     expect(resultLines[0]).toContain('$0.0523');
   });
 
+  it('normalizes a captured Claude assistant frame without exposing reasoning text', () => {
+    const lines: string[] = [];
+    const events: Array<{ type: string }> = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'private chain of thought' },
+          { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/workspace/src/plan.ts' } },
+          { type: 'text', text: '[{"id":"implement-stream-events"}]' },
+        ],
+        usage: { input_tokens: 120, output_tokens: 30 },
+      },
+    }));
+
+    expect(events.map((event) => event.type)).toEqual(['usage', 'reasoning', 'tool', 'text']);
+    expect(lines.some((line) => line.includes('Reasoning...'))).toBe(true);
+    expect(lines.some((line) => line.includes('Reading') && line.includes('plan.ts'))).toBe(true);
+    expect(lines.some((line) => line.includes('Planned chunk:') && line.includes('implement-stream-events'))).toBe(true);
+    expect(lines.join('')).not.toContain('private chain of thought');
+  });
+
+  it('normalizes captured Codex item and turn frames', () => {
+    const lines: string[] = [];
+    const events: Array<{ type: string }> = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({ type: 'item.started', item: { type: 'reasoning', text: 'private reasoning' } }));
+    handler(JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'command_execution', command: 'npm test', status: 'completed' },
+    }));
+    handler(JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '[{"id":"codex-plan"}]' },
+    }));
+    handler(JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 80, output_tokens: 20 },
+    }));
+
+    expect(events.map((event) => event.type)).toEqual(['reasoning', 'tool', 'text', 'usage', 'result']);
+    expect(lines.some((line) => line.includes('Reasoning...'))).toBe(true);
+    expect(lines.some((line) => line.includes('Running'))).toBe(true);
+    expect(lines.some((line) => line.includes('codex-plan'))).toBe(true);
+    expect(lines.join('')).not.toContain('private reasoning');
+    expect(lines.join('')).not.toContain('npm test');
+  });
+
+  it('normalizes captured Gemini message, tool, and result frames', () => {
+    const lines: string[] = [];
+    const events: Array<{ type: string }> = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t), {
+      onEvent: (event) => events.push(event),
+    });
+
+    handler(JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: '[{"id":"gemini-plan"}]',
+      delta: true,
+    }));
+    handler(JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'read_file',
+      tool_id: 'read-1',
+      parameters: { file_path: '/workspace/src/gemini.ts' },
+    }));
+    handler(JSON.stringify({
+      type: 'result',
+      status: 'success',
+      stats: { input_tokens: 45, output_tokens: 15, duration_ms: 2500 },
+    }));
+
+    expect(events.map((event) => event.type)).toEqual(['text', 'tool', 'usage', 'result']);
+    expect(lines.some((line) => line.includes('gemini-plan'))).toBe(true);
+    expect(lines.some((line) => line.includes('Using read_file:') && line.includes('gemini.ts'))).toBe(true);
+    expect(lines.some((line) => line.includes('LLM done') && line.includes('2.5s'))).toBe(true);
+  });
+
+  it('reports unknown event types through redacted verbose diagnostics', () => {
+    const lines: string[] = [];
+    const handler = createStreamProgressHandler((t) => lines.push(t), { verbose: true });
+
+    handler(JSON.stringify({ type: 'provider.secret_frame', content: 'sensitive payload' }));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Unknown provider stream event: provider.secret_frame');
+    expect(lines[0]).not.toContain('sensitive payload');
+  });
+
   it('skips hookSpecificOutput objects', () => {
     const lines: string[] = [];
     const handler = createStreamProgressHandler((t) => lines.push(t));


### PR DESCRIPTION
## Summary
- normalize real Claude, Codex, and Gemini CLI stream frames into a typed provider-neutral contract
- render safe incremental reasoning, tool, text/chunk, retry, error, usage, and result activity while redacting raw reasoning and payloads
- expose redacted unknown-frame diagnostics in verbose mode and retain existing partial-stream support

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/adapters/stream-progress.test.ts` (25 passed)
- `npm run test --workspace @franken/orchestrator` (4040 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npx eslint packages/franken-orchestrator/src/adapters/stream-progress.ts packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts`
- `npm run build`

Closes #3309