### PR TITLE
fix(orchestrator): isolate cached Claude sessions

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -181,7 +181,7 @@ export class CliLlmAdapter implements IAdapter {
         });
       }
       const activeCommand = this.resolveCommand(activeProvider);
-      const providerSessionContinue = sessionContinue && activeProvider === initialProvider;
+      const providerSessionContinue = sessionContinue && (chatMode || activeProvider === initialProvider);
       let result: { stdout: string; stderr: string; exitCode: number };
       try {
         result = await this.spawnSingle({
@@ -192,7 +192,7 @@ export class CliLlmAdapter implements IAdapter {
             chatMode,
             sessionContinue: providerSessionContinue,
             persistSession: Boolean(cacheSession?.persist),
-            ...(sessionId && activeProvider === initialProvider
+            ...(sessionId && (chatMode || activeProvider === initialProvider)
               ? { sessionId: chatMode ? this.resolveProviderSessionId(activeProvider, sessionId, providerSessionContinue) : sessionId }
               : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -96,7 +96,7 @@ export class CliLlmAdapter implements IAdapter {
   private readonly _spawn: SpawnFn;
   private readonly registry: ProviderRegistry;
   private readonly responseProviders = new Map<string, string>();
-  private readonly responseSessions = new Map<string, { provider: string; model?: string | undefined; sessionKey: string }>();
+  private readonly responseSessions = new Map<string, { provider: string; model?: string | undefined; sessionId: string }>();
   private readonly chatNativeSessions = new Map<string, string>();
   private chatCallCount = 0;
 
@@ -141,7 +141,7 @@ export class CliLlmAdapter implements IAdapter {
     const cacheCapabilities = resolveProviderCacheCapabilities(this.provider);
     const sessionContinue = this.opts.chatMode
       ? req.sessionContinue ?? this.chatCallCount > 0
-      : Boolean(cacheSession?.key && cacheCapabilities.nativeWorkSessions);
+      : Boolean(cacheSession?.key && req.session_id && cacheCapabilities.nativeWorkSessions);
     const transformed: CliTransformed = {
       prompt: last?.content ?? '',
       maxTurns: 1,
@@ -181,6 +181,7 @@ export class CliLlmAdapter implements IAdapter {
         });
       }
       const activeCommand = this.resolveCommand(activeProvider);
+      const providerSessionContinue = sessionContinue && activeProvider === initialProvider;
       let result: { stdout: string; stderr: string; exitCode: number };
       try {
         result = await this.spawnSingle({
@@ -189,8 +190,11 @@ export class CliLlmAdapter implements IAdapter {
             maxTurns,
             model: activeModel,
             chatMode,
-            sessionContinue,
-            ...(sessionId ? { sessionId: this.resolveProviderSessionId(activeProvider, sessionId, sessionContinue) } : {}),
+            sessionContinue: providerSessionContinue,
+            persistSession: Boolean(cacheSession?.persist),
+            ...(sessionId && activeProvider === initialProvider
+              ? { sessionId: chatMode ? this.resolveProviderSessionId(activeProvider, sessionId, providerSessionContinue) : sessionId }
+              : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),
           }),
           env: provider.filterEnv(this.captureEnv()),
@@ -262,11 +266,14 @@ export class CliLlmAdapter implements IAdapter {
           });
           this.responseProviders.set(requestId, activeProvider);
           if (cacheSession?.persist && resolveProviderCacheCapabilities(provider).persistentAcrossProcesses) {
-            this.responseSessions.set(requestId, {
-              provider: activeProvider,
-              ...(this.resolveModel(activeProvider, model) ? { model: this.resolveModel(activeProvider, model) } : {}),
-              sessionKey: cacheSession.key,
-            });
+            const nativeSessionId = this.extractNativeSessionId(result.stdout);
+            if (nativeSessionId) {
+              this.responseSessions.set(requestId, {
+                provider: activeProvider,
+                ...(this.resolveModel(activeProvider, model) ? { model: this.resolveModel(activeProvider, model) } : {}),
+                sessionId: nativeSessionId,
+              });
+            }
           }
         }
         return result.stdout;
@@ -332,7 +339,7 @@ export class CliLlmAdapter implements IAdapter {
     return feature === 'text-completion';
   }
 
-  consumeSessionMetadata(requestId: string): { provider: string; model?: string | undefined; sessionKey: string } | undefined {
+  consumeSessionMetadata(requestId: string): { provider: string; model?: string | undefined; sessionId: string } | undefined {
     const session = this.responseSessions.get(requestId);
     if (!session) {
       return undefined;

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -339,6 +339,10 @@ export class CliLlmAdapter implements IAdapter {
     return feature === 'text-completion';
   }
 
+  getProviderName(): string {
+    return this.provider.name;
+  }
+
   consumeSessionMetadata(requestId: string): { provider: string; model?: string | undefined; sessionId: string } | undefined {
     const session = this.responseSessions.get(requestId);
     if (!session) {

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -18,6 +18,7 @@ interface CliAdapterLike {
   execute(providerRequest: unknown): Promise<unknown>;
   transformResponse(providerResponse: unknown, requestId: string): { content: string | null };
   consumeSessionMetadata?(requestId: string): CliSessionMetadata | undefined;
+  getProviderName?(): string;
 }
 
 export interface LlmCacheHint {
@@ -75,6 +76,7 @@ export class CachedCliLlmClient implements ILlmClient {
           model: this.options.model,
           resume: async (sessionId: string | undefined, nextPrompt: string) => {
             let response: { content: string; sessionId?: string | undefined };
+            let clearSession = false;
             try {
               response = await this.invoke(nextPrompt, workId, sessionId);
             } catch (error) {
@@ -82,11 +84,13 @@ export class CachedCliLlmClient implements ILlmClient {
                 throw error;
               }
               this.metrics.recordNativeSessionFallback();
+              clearSession = true;
               response = await this.invoke(nextPrompt, workId);
             }
             return {
               content: response.content,
               ...(response.sessionId ? { sessionId: response.sessionId } : {}),
+              ...(clearSession && !response.sessionId ? { clearSession: true } : {}),
             };
           },
         }
@@ -138,8 +142,11 @@ export class CachedCliLlmClient implements ILlmClient {
       const response = this.options.cliAdapter.transformResponse(providerResponse, requestId);
       const content = response.content ?? '';
       const sessionMetadata = this.options.cliAdapter.consumeSessionMetadata?.(requestId);
-      const matchingSessionId = sessionMetadata?.provider === this.options.provider
-        && sessionMetadata.model === this.options.model
+      const configuredProvider = this.options.cliAdapter.getProviderName?.() ?? this.options.provider;
+      const matchingSessionId = sessionMetadata?.provider === configuredProvider
+        && (sessionMetadata.model === undefined
+          || this.options.model === undefined
+          || sessionMetadata.model === this.options.model)
         ? sessionMetadata.sessionId
         : undefined;
 
@@ -198,6 +205,25 @@ function isExpectedStaleSessionError(error: unknown): boolean {
     }
     if (typeof current === 'string') {
       messages.push(current);
+      break;
+    }
+    if (typeof current === 'object') {
+      const record = current as Record<string, unknown>;
+      for (const key of ['message', 'stdout', 'stderr', 'normalizedOutput']) {
+        try {
+          if (typeof record[key] === 'string') {
+            messages.push(record[key]);
+          }
+        } catch {
+          // Ignore hostile getters while classifying an error payload.
+        }
+      }
+      try {
+        current = record['cause'];
+        continue;
+      } catch {
+        break;
+      }
     }
     break;
   }

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -4,10 +4,13 @@ import { CachedLlmClient } from './cached-llm-client.js';
 import { LlmCacheStore } from './llm-cache-store.js';
 import { LlmCachePolicy } from './llm-cache-policy.js';
 import { ProviderSessionStore } from './provider-session-store.js';
+import { CacheMetrics } from './cache-metrics.js';
 import { now as deterministicNow, seededRandom } from '@franken/types';
 
 interface CliSessionMetadata {
-  sessionKey: string;
+  provider: string;
+  model?: string | undefined;
+  sessionId: string;
 }
 
 interface CliAdapterLike {
@@ -37,14 +40,17 @@ export interface CachedCliLlmClientOptions {
   workPrefix?: string | undefined;
   schemaVersion?: number | undefined;
   observer?: ILlmObserver | undefined;
+  metrics?: CacheMetrics | undefined;
 }
 
 export class CachedCliLlmClient implements ILlmClient {
   private readonly cached: CachedLlmClient;
   private readonly schemaVersion: number;
+  private readonly metrics: CacheMetrics;
 
   constructor(private readonly options: CachedCliLlmClientOptions) {
     this.schemaVersion = options.schemaVersion ?? 1;
+    this.metrics = options.metrics ?? new CacheMetrics();
     this.cached = new CachedLlmClient({
       llm: {
         complete: async (prompt: string) => {
@@ -55,6 +61,7 @@ export class CachedCliLlmClient implements ILlmClient {
       cacheStore: new LlmCacheStore(options.cacheRootDir, { schemaVersion: this.schemaVersion }),
       policy: new LlmCachePolicy(),
       providerSessions: new ProviderSessionStore(options.cacheRootDir, { schemaVersion: this.schemaVersion }),
+      metrics: this.metrics,
     });
   }
 
@@ -66,11 +73,20 @@ export class CachedCliLlmClient implements ILlmClient {
       ? {
           provider: this.options.provider,
           model: this.options.model,
-          resume: async (_sessionId: string | undefined, nextPrompt: string) => {
-            const response = await this.invoke(nextPrompt, workId);
+          resume: async (sessionId: string | undefined, nextPrompt: string) => {
+            let response: { content: string; sessionId?: string | undefined };
+            try {
+              response = await this.invoke(nextPrompt, workId, sessionId);
+            } catch (error) {
+              if (!sessionId || !isExpectedStaleSessionError(error)) {
+                throw error;
+              }
+              this.metrics.recordNativeSessionFallback();
+              response = await this.invoke(nextPrompt, workId);
+            }
             return {
               content: response.content,
-              sessionId: response.sessionId ?? workId,
+              ...(response.sessionId ? { sessionId: response.sessionId } : {}),
             };
           },
         }
@@ -89,13 +105,18 @@ export class CachedCliLlmClient implements ILlmClient {
     });
   }
 
-  private async invoke(prompt: string, cacheSessionKey?: string): Promise<{ content: string; sessionId?: string | undefined }> {
+  private async invoke(
+    prompt: string,
+    cacheSessionKey?: string,
+    providerSessionId?: string,
+  ): Promise<{ content: string; sessionId?: string | undefined }> {
     const requestId = `llm-${deterministicNow()}-${seededRandom.random().toString(16).slice(2)}`;
     const request = {
       id: requestId,
       provider: 'adapter',
       model: this.options.model,
       messages: [{ role: 'user', content: prompt }],
+      ...(providerSessionId ? { session_id: providerSessionId } : {}),
       ...(cacheSessionKey
         ? {
             cacheSession: {
@@ -117,6 +138,10 @@ export class CachedCliLlmClient implements ILlmClient {
       const response = this.options.cliAdapter.transformResponse(providerResponse, requestId);
       const content = response.content ?? '';
       const sessionMetadata = this.options.cliAdapter.consumeSessionMetadata?.(requestId);
+      const matchingSessionId = sessionMetadata?.provider === this.options.provider
+        && sessionMetadata.model === this.options.model
+        ? sessionMetadata.sessionId
+        : undefined;
 
       if (this.options.observer && span) {
         this.options.observer.recordTokenUsage(
@@ -132,7 +157,7 @@ export class CachedCliLlmClient implements ILlmClient {
 
       return {
         content,
-        ...(sessionMetadata?.sessionKey ? { sessionId: sessionMetadata.sessionKey } : {}),
+        ...(matchingSessionId ? { sessionId: matchingSessionId } : {}),
       };
     } finally {
       if (this.options.observer && span) {
@@ -158,4 +183,24 @@ function joinNonEmpty(parts: Array<string | undefined>): string | undefined {
     return undefined;
   }
   return normalized.join('\n');
+}
+
+function isExpectedStaleSessionError(error: unknown): boolean {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) {
+      messages.push(current.message);
+      current = current.cause;
+      continue;
+    }
+    if (typeof current === 'string') {
+      messages.push(current);
+    }
+    break;
+  }
+  const text = messages.join('\n');
+  return /(?:session|conversation).*(?:expired|invalid|not found|no longer exists|stale)|(?:expired|invalid|stale).*(?:session|conversation)/i.test(text);
 }

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -89,6 +89,7 @@ export class CachedCliLlmClient implements ILlmClient {
               }
               this.metrics.recordNativeSessionFallback();
               clearSession = true;
+              await this.cached.invalidateProviderSession(this.options.projectId, workId);
               response = await this.invoke(nextPrompt, workId);
             }
             return {

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -64,7 +64,7 @@ export class CachedCliLlmClient implements ILlmClient {
       cacheStore: new LlmCacheStore(options.cacheRootDir, { schemaVersion: this.schemaVersion }),
       policy: new LlmCachePolicy(),
       providerSessions: new ProviderSessionStore(options.cacheRootDir, {
-        schemaVersion: PROVIDER_SESSION_SCHEMA_VERSION,
+        schemaVersion: Math.max(PROVIDER_SESSION_SCHEMA_VERSION, this.schemaVersion),
       }),
       metrics: this.metrics,
     });

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -7,6 +7,8 @@ import { ProviderSessionStore } from './provider-session-store.js';
 import { CacheMetrics } from './cache-metrics.js';
 import { now as deterministicNow, seededRandom } from '@franken/types';
 
+const PROVIDER_SESSION_SCHEMA_VERSION = 2;
+
 interface CliSessionMetadata {
   provider: string;
   model?: string | undefined;
@@ -61,7 +63,9 @@ export class CachedCliLlmClient implements ILlmClient {
       },
       cacheStore: new LlmCacheStore(options.cacheRootDir, { schemaVersion: this.schemaVersion }),
       policy: new LlmCachePolicy(),
-      providerSessions: new ProviderSessionStore(options.cacheRootDir, { schemaVersion: this.schemaVersion }),
+      providerSessions: new ProviderSessionStore(options.cacheRootDir, {
+        schemaVersion: PROVIDER_SESSION_SCHEMA_VERSION,
+      }),
       metrics: this.metrics,
     });
   }
@@ -228,5 +232,5 @@ function isExpectedStaleSessionError(error: unknown): boolean {
     break;
   }
   const text = messages.join('\n');
-  return /(?:session|conversation).*(?:expired|invalid|not found|no longer exists|stale)|(?:expired|invalid|stale).*(?:session|conversation)/i.test(text);
+  return /(?:session|conversation).*(?:expired|invalid|not found|no longer exists|stale)|(?:expired|invalid|stale).*(?:session|conversation)|no\s+(?:session|conversation)\s+found/i.test(text);
 }

--- a/packages/franken-orchestrator/src/cache/cached-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-llm-client.ts
@@ -152,4 +152,8 @@ export class CachedLlmClient {
       });
     }
   }
+
+  async invalidateProviderSession(projectId: string, workId: string): Promise<void> {
+    await this.deps.providerSessions.remove(projectId, workId);
+  }
 }

--- a/packages/franken-orchestrator/src/cache/cached-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-llm-client.ts
@@ -7,6 +7,7 @@ import { isoNow } from '@franken/types';
 export interface NativeSessionResult {
   content: string;
   sessionId?: string | undefined;
+  clearSession?: boolean | undefined;
 }
 
 export interface NativeSessionController {
@@ -74,7 +75,10 @@ export class CachedLlmClient {
       const resumed = await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
       if (resumed) {
         this.metrics.recordNativeSessionHit();
-        const sessionId = resumed.sessionId ?? existingSession?.sessionId;
+        if (resumed.clearSession) {
+          await this.deps.providerSessions.remove(request.scope.projectId, workId);
+        }
+        const sessionId = resumed.sessionId ?? (resumed.clearSession ? undefined : existingSession?.sessionId);
         if (sessionId) {
           const now = isoNow();
           await this.deps.providerSessions.save({

--- a/packages/franken-orchestrator/src/cache/cached-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-llm-client.ts
@@ -71,29 +71,25 @@ export class CachedLlmClient {
         promptFingerprint: computed.sessionFingerprint,
       });
 
-      try {
-        const resumed = await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
-        if (resumed) {
-          this.metrics.recordNativeSessionHit();
-          const sessionId = resumed.sessionId ?? existingSession?.sessionId;
-          if (sessionId) {
-            const now = isoNow();
-            await this.deps.providerSessions.save({
-              projectId: request.scope.projectId,
-              workId,
-              provider: request.nativeSession.provider,
-              model: request.nativeSession.model,
-              sessionId,
-              promptFingerprint: computed.sessionFingerprint,
-              createdAt: existingSession?.createdAt ?? now,
-              updatedAt: now,
-            });
-          }
-          await this.persistCacheArtifacts(request, computed, resumed.content);
-          return resumed.content;
+      const resumed = await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
+      if (resumed) {
+        this.metrics.recordNativeSessionHit();
+        const sessionId = resumed.sessionId ?? existingSession?.sessionId;
+        if (sessionId) {
+          const now = isoNow();
+          await this.deps.providerSessions.save({
+            projectId: request.scope.projectId,
+            workId,
+            provider: request.nativeSession.provider,
+            model: request.nativeSession.model,
+            sessionId,
+            promptFingerprint: computed.sessionFingerprint,
+            createdAt: existingSession?.createdAt ?? now,
+            updatedAt: now,
+          });
         }
-      } catch {
-        // Fall through to backing llm call.
+        await this.persistCacheArtifacts(request, computed, resumed.content);
+        return resumed.content;
       }
 
       this.metrics.recordNativeSessionFallback();

--- a/packages/franken-orchestrator/src/cache/provider-session-store.ts
+++ b/packages/franken-orchestrator/src/cache/provider-session-store.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
 import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from '../init/init-json-file.js';
 import type {
   CacheStoreOptions,
@@ -46,6 +47,10 @@ export class ProviderSessionStore {
     }
 
     return stored;
+  }
+
+  async remove(projectId: string, workId: string): Promise<void> {
+    await rm(this.sessionPath(projectId, workId), { force: true });
   }
 
   private sessionPath(projectId: string, workId: string): string {

--- a/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
@@ -34,7 +34,7 @@ export class ClaudeProvider implements ICliProvider {
       } else {
         args.push('--continue');
       }
-    } else if (!opts.chatMode || !opts.sessionId) {
+    } else if (!opts.persistSession && (!opts.chatMode || !opts.sessionId)) {
       args.push('--no-session-persistence');
     }
 

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -26,6 +26,8 @@ export interface ProviderOpts {
   readonly sessionContinue?: boolean | undefined;
   /** Provider-native session id to resume, when known. */
   readonly sessionId?: string | undefined;
+  /** Keep a newly started provider session so its native id can be captured. */
+  readonly persistSession?: boolean | undefined;
 }
 
 export interface ProviderCacheCapabilities {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter-cache.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter-cache.test.ts
@@ -12,8 +12,11 @@ function createMockSpawn(result: {
   exitCode?: number;
 }): {
   spawnFn: (cmd: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+  calls: Array<{ cmd: string; args: readonly string[]; options: SpawnOptions }>;
 } {
-  const spawnFn = (_cmd: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+  const calls: Array<{ cmd: string; args: readonly string[]; options: SpawnOptions }> = [];
+  const spawnFn = (cmd: string, args: readonly string[], options: SpawnOptions): ChildProcess => {
+    calls.push({ cmd, args, options });
     const proc = new EventEmitter() as ChildProcess;
     const stdinStream = new PassThrough();
     const stdoutStream = new PassThrough();
@@ -36,12 +39,16 @@ function createMockSpawn(result: {
     return proc;
   };
 
-  return { spawnFn };
+  return { spawnFn, calls };
 }
 
 describe('CliLlmAdapter cache session support', () => {
-  it('enables sessionContinue from a cache-session hint for providers with native work sessions', () => {
-    const adapter = new CliLlmAdapter(new ClaudeProvider(), { workingDir: '/tmp/test' });
+  it('starts a persisted cache session without ambient continuation when no provider session id exists', async () => {
+    const { spawnFn, calls } = createMockSpawn({
+      stdout: '{"type":"result","session_id":"provider-session-123","result":"ok"}\n',
+      exitCode: 0,
+    });
+    const adapter = new CliLlmAdapter(new ClaudeProvider(), { workingDir: '/tmp/test' }, spawnFn);
 
     const transformed = adapter.transformRequest({
       id: 'req-native',
@@ -53,11 +60,33 @@ describe('CliLlmAdapter cache session support', () => {
     });
 
     expect(transformed).toMatchObject({
-      sessionContinue: true,
+      sessionContinue: false,
       cacheSession: {
         key: 'issue:99',
         persist: true,
       },
+    });
+    await adapter.execute(transformed);
+    expect(calls[0]?.args).not.toContain('--continue');
+    expect(calls[0]?.args).not.toContain('--no-session-persistence');
+  });
+
+  it('continues a cache session only with an explicit provider session id', () => {
+    const adapter = new CliLlmAdapter(new ClaudeProvider(), { workingDir: '/tmp/test' });
+
+    const transformed = adapter.transformRequest({
+      id: 'req-native',
+      messages: [{ role: 'user', content: 'continue work' }],
+      session_id: 'provider-session-123',
+      cacheSession: {
+        key: 'issue:99',
+        persist: true,
+      },
+    });
+
+    expect(transformed).toMatchObject({
+      sessionContinue: true,
+      sessionId: 'provider-session-123',
     });
   });
 
@@ -82,8 +111,11 @@ describe('CliLlmAdapter cache session support', () => {
     });
   });
 
-  it('persists cache session metadata for successful native-capable executions', async () => {
-    const { spawnFn } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+  it('persists the provider-issued session id for successful native-capable executions', async () => {
+    const { spawnFn } = createMockSpawn({
+      stdout: '{"type":"result","session_id":"provider-session-123","result":"ok"}\n',
+      exitCode: 0,
+    });
     const adapter = new CliLlmAdapter(new ClaudeProvider(), { workingDir: '/tmp/test' }, spawnFn);
 
     const transformed = adapter.transformRequest({
@@ -99,7 +131,7 @@ describe('CliLlmAdapter cache session support', () => {
 
     expect(adapter.consumeSessionMetadata('req-native')).toMatchObject({
       provider: 'claude',
-      sessionKey: 'issue:99',
+      sessionId: 'provider-session-123',
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -891,6 +891,7 @@ describe('CliLlmAdapter', () => {
           provider: 'adapter',
           model: 'adapter',
           messages: [{ role: 'user', content: 'hello' }],
+          session_id: 'chat-app-1',
         });
 
         expect(request.model).toBe('codex-mini');
@@ -900,6 +901,7 @@ describe('CliLlmAdapter', () => {
         expect(calls[0]!.cmd).toBe('codex');
         expect(calls[1]!.cmd).toBe('claude');
         expect(calls[1]!.args).not.toContain('codex-mini');
+        expect(calls[1]!.args).not.toContain('--no-session-persistence');
       });
 
       it('normalizes successful fallback output with the provider that produced it', async () => {

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CachedCliLlmClient } from '../../../src/cache/cached-cli-llm-client.js';
+import { CacheMetrics } from '../../../src/cache/cache-metrics.js';
 
 interface FakeCliAdapter {
   transformRequest: ReturnType<typeof vi.fn>;
@@ -17,7 +18,11 @@ function createAdapter(): FakeCliAdapter {
     execute: vi.fn(async (request: { messages: Array<{ content: string }>; cacheSession?: { key: string } }) =>
       `response:${request.messages[0]?.content ?? ''}`),
     transformResponse: vi.fn((raw: string) => ({ content: raw })),
-    consumeSessionMetadata: vi.fn((requestId: string) => ({ sessionKey: `native:${requestId}` })),
+    consumeSessionMetadata: vi.fn((requestId: string) => ({
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: `native:${requestId}`,
+    })),
   };
 }
 
@@ -114,5 +119,38 @@ describe('CachedCliLlmClient', () => {
         persist: true,
       },
     });
+    expect(adapter.transformRequest.mock.calls[0]?.[0]).not.toHaveProperty('session_id');
+    const firstRequestId = (adapter.transformRequest.mock.calls[0]?.[0] as { id?: string }).id;
+    expect(adapter.transformRequest.mock.calls[1]?.[0]).toMatchObject({
+      session_id: `native:${firstRequestId}`,
+    });
+  });
+
+  it('retries once with a fresh isolated session when the stored provider session is stale', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
+    const adapter = createAdapter();
+    const metrics = new CacheMetrics();
+    const client = new CachedCliLlmClient({
+      cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
+      cliAdapter: adapter,
+      projectId: 'frankenbeast',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      operation: 'plan-build',
+      workId: 'plan:alpha',
+      metrics,
+    });
+
+    await client.complete('first prompt');
+    adapter.execute
+      .mockRejectedValueOnce(new Error('Conversation session not found'))
+      .mockResolvedValueOnce('response:fresh');
+
+    await expect(client.complete('second prompt')).resolves.toBe('response:fresh');
+
+    expect(adapter.transformRequest.mock.calls[1]?.[0]).toHaveProperty('session_id');
+    expect(adapter.transformRequest.mock.calls[2]?.[0]).not.toHaveProperty('session_id');
+    expect(adapter.execute).toHaveBeenCalledTimes(3);
+    expect(metrics.snapshot()).toMatchObject({ nativeSessionFallbacks: 1 });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -208,6 +208,19 @@ describe('CachedCliLlmClient', () => {
     await client.complete('first prompt');
 
     expect(adapter.transformRequest.mock.calls[0]?.[0]).not.toHaveProperty('session_id');
+
+    const bumpedClient = new CachedCliLlmClient({
+      cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
+      cliAdapter: adapter as never,
+      projectId: 'frankenbeast',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      operation: 'plan-build',
+      workId: 'plan:legacy',
+      schemaVersion: 3,
+    });
+    await bumpedClient.complete('second prompt');
+    expect(adapter.transformRequest.mock.calls[1]?.[0]).not.toHaveProperty('session_id');
   });
 
   it('keeps provider-issued sessions for aliases when the CLI model is implicit', async () => {

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CachedCliLlmClient } from '../../../src/cache/cached-cli-llm-client.js';
@@ -10,6 +10,7 @@ interface FakeCliAdapter {
   execute: ReturnType<typeof vi.fn>;
   transformResponse: ReturnType<typeof vi.fn>;
   consumeSessionMetadata: ReturnType<typeof vi.fn>;
+  getProviderName: ReturnType<typeof vi.fn>;
 }
 
 function createAdapter(): FakeCliAdapter {
@@ -23,6 +24,7 @@ function createAdapter(): FakeCliAdapter {
       model: 'claude-sonnet-4-6',
       sessionId: `native:${requestId}`,
     })),
+    getProviderName: vi.fn(() => 'claude'),
   };
 }
 
@@ -129,10 +131,13 @@ describe('CachedCliLlmClient', () => {
   it('retries once with a fresh isolated session when the stored provider session is stale', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
     const adapter = createAdapter();
+    adapter.consumeSessionMetadata
+      .mockReturnValueOnce({ provider: 'claude', model: 'claude-sonnet-4-6', sessionId: 'stored-session' })
+      .mockReturnValue(undefined);
     const metrics = new CacheMetrics();
     const client = new CachedCliLlmClient({
       cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
-      cliAdapter: adapter,
+      cliAdapter: adapter as never,
       projectId: 'frankenbeast',
       provider: 'claude',
       model: 'claude-sonnet-4-6',
@@ -143,7 +148,9 @@ describe('CachedCliLlmClient', () => {
 
     await client.complete('first prompt');
     adapter.execute
-      .mockRejectedValueOnce(new Error('Conversation session not found'))
+      .mockRejectedValueOnce(new Error('Claude CLI failed', {
+        cause: { stdout: 'Conversation session not found', stderr: '' },
+      }))
       .mockResolvedValueOnce('response:fresh');
 
     await expect(client.complete('second prompt')).resolves.toBe('response:fresh');
@@ -152,5 +159,42 @@ describe('CachedCliLlmClient', () => {
     expect(adapter.transformRequest.mock.calls[2]?.[0]).not.toHaveProperty('session_id');
     expect(adapter.execute).toHaveBeenCalledTimes(3);
     expect(metrics.snapshot()).toMatchObject({ nativeSessionFallbacks: 1 });
+    await expect(access(join(
+      workDir,
+      '.fbeast',
+      '.cache',
+      'llm',
+      'work',
+      'frankenbeast',
+      'plan%3Aalpha',
+      'provider-session.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('keeps provider-issued sessions for aliases when the CLI model is implicit', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
+    const adapter = createAdapter();
+    adapter.consumeSessionMetadata.mockImplementation((requestId: string) => ({
+      provider: 'claude',
+      model: undefined,
+      sessionId: `native:${requestId}`,
+    }));
+    const client = new CachedCliLlmClient({
+      cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
+      cliAdapter: adapter as never,
+      projectId: 'frankenbeast',
+      provider: 'prod-claude',
+      model: 'prod-claude',
+      operation: 'plan-build',
+      workId: 'plan:alias',
+    });
+
+    await client.complete('first prompt');
+    await client.complete('second prompt');
+
+    const firstRequestId = (adapter.transformRequest.mock.calls[0]?.[0] as { id?: string }).id;
+    expect(adapter.transformRequest.mock.calls[1]?.[0]).toMatchObject({
+      session_id: `native:${firstRequestId}`,
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -171,6 +171,44 @@ describe('CachedCliLlmClient', () => {
     ))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('clears a stale stored session even when the fresh isolated retry fails', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
+    const adapter = createAdapter();
+    adapter.consumeSessionMetadata.mockReturnValueOnce({
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: 'stored-session',
+    });
+    const client = new CachedCliLlmClient({
+      cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
+      cliAdapter: adapter as never,
+      projectId: 'frankenbeast',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      operation: 'plan-build',
+      workId: 'plan:alpha',
+    });
+
+    await client.complete('first prompt');
+    adapter.execute
+      .mockRejectedValueOnce(new Error('Claude CLI failed', {
+        cause: { stdout: 'No conversation found with session ID: stored-session', stderr: '' },
+      }))
+      .mockRejectedValueOnce(new Error('Claude CLI rate limited'));
+
+    await expect(client.complete('second prompt')).rejects.toThrow('Claude CLI rate limited');
+    await expect(access(join(
+      workDir,
+      '.fbeast',
+      '.cache',
+      'llm',
+      'work',
+      'frankenbeast',
+      'plan%3Aalpha',
+      'provider-session.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('ignores legacy provider-session records that contain application work keys', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
     const sessionDir = join(

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { access, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CachedCliLlmClient } from '../../../src/cache/cached-cli-llm-client.js';
@@ -149,7 +149,7 @@ describe('CachedCliLlmClient', () => {
     await client.complete('first prompt');
     adapter.execute
       .mockRejectedValueOnce(new Error('Claude CLI failed', {
-        cause: { stdout: 'Conversation session not found', stderr: '' },
+        cause: { stdout: 'No conversation found with session ID: stored-session', stderr: '' },
       }))
       .mockResolvedValueOnce('response:fresh');
 
@@ -169,6 +169,45 @@ describe('CachedCliLlmClient', () => {
       'plan%3Aalpha',
       'provider-session.json',
     ))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('ignores legacy provider-session records that contain application work keys', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-cached-cli-'));
+    const sessionDir = join(
+      workDir,
+      '.fbeast',
+      '.cache',
+      'llm',
+      'work',
+      'frankenbeast',
+      'plan%3Alegacy',
+    );
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'provider-session.json'), JSON.stringify({
+      schemaVersion: 1,
+      projectId: 'frankenbeast',
+      workId: 'plan:legacy',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: 'plan:legacy',
+      promptFingerprint: 'legacy-fingerprint',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }));
+    const adapter = createAdapter();
+    const client = new CachedCliLlmClient({
+      cacheRootDir: join(workDir, '.fbeast', '.cache', 'llm'),
+      cliAdapter: adapter as never,
+      projectId: 'frankenbeast',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      operation: 'plan-build',
+      workId: 'plan:legacy',
+    });
+
+    await client.complete('first prompt');
+
+    expect(adapter.transformRequest.mock.calls[0]?.[0]).not.toHaveProperty('session_id');
   });
 
   it('keeps provider-issued sessions for aliases when the CLI model is implicit', async () => {

--- a/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
@@ -247,4 +247,31 @@ describe('CachedLlmClient', () => {
       innerCalls: 1,
     });
   });
+
+  it('preserves native session failures instead of silently doubling the provider call', async () => {
+    const { llm, client, metrics } = await createHarness();
+    const failure = new Error('provider process exited unexpectedly');
+    const resume = vi.fn().mockRejectedValue(failure);
+
+    await expect(client.complete({
+      scope: {
+        projectId: 'frankenbeast',
+        workId: 'plan:session',
+      },
+      operation: 'plan-build',
+      volatileSuffix: 'build plan',
+      nativeSession: {
+        provider: 'claude',
+        model: 'claude-sonnet-4-6',
+        resume,
+      },
+    })).rejects.toBe(failure);
+
+    expect(llm.callCount).toBe(0);
+    expect(metrics.snapshot()).toMatchObject({
+      nativeSessionAttempts: 1,
+      nativeSessionFallbacks: 0,
+      innerCalls: 0,
+    });
+  });
 });

--- a/tasks/issue-3310-ambient-claude-session-progress.md
+++ b/tasks/issue-3310-ambient-claude-session-progress.md
@@ -1,0 +1,12 @@
+# Issue #3310 — Ambient Claude Session Continuation Progress
+
+- [x] Read issue, shared lessons, and affected cache/provider code.
+- [x] Add regression coverage proving the first cache-managed call starts an isolated persisted session without ambient continuation.
+- [x] Add regression coverage proving subsequent calls resume only the captured provider session ID.
+- [x] Prevent silent duplicate provider calls after native-session errors.
+- [x] Retry exactly once with a fresh isolated session for classified stale/invalid provider-session failures.
+- [x] Run focused orchestrator tests.
+- [x] Run orchestrator typecheck, lint, and build.
+- [ ] Commit and open a single issue-scoped PR with `Closes #3310`.
+- [ ] Obtain green CI and current-head Codex clean with zero unresolved Codex threads.
+- [ ] Squash-merge, verify issue closure, and record any reusable lesson.

--- a/tasks/issue-3310-ambient-claude-session-progress.md
+++ b/tasks/issue-3310-ambient-claude-session-progress.md
@@ -7,6 +7,6 @@
 - [x] Retry exactly once with a fresh isolated session for classified stale/invalid provider-session failures.
 - [x] Run focused orchestrator tests.
 - [x] Run orchestrator typecheck, lint, and build.
-- [ ] Commit and open a single issue-scoped PR with `Closes #3310`.
+- [x] Commit and open a single issue-scoped PR with `Closes #3310`.
 - [ ] Obtain green CI and current-head Codex clean with zero unresolved Codex threads.
 - [ ] Squash-merge, verify issue closure, and record any reusable lesson.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Provider-native cache session isolation
+- Never translate an application cache/work key into a provider continuation flag. Start the first native-capable cache call without `--continue`, capture the provider-issued session id, and resume only that exact id when provider and model still match.
+- Treat only classified stale/invalid-session failures as retryable: emit fallback telemetry and retry once in a fresh persisted session; propagate all other provider errors so failures cannot silently double expensive calls.
+
 ## 2026-07-19 — Deterministic abort handling regression
 - Prefer deterministic abort fixtures over timing sleeps: for HTTP disconnect behavior, verify both in-band and immediate-abort paths by asserting that `AbortSignal` is already aborted when `request.destroyed`/`request.aborted` is true before app handler execution.
 - Use a pre-aborted request object (or equivalent event-driven signal path) in unit tests when asserting handler abort behavior, and keep timeouts only as a bounded safety net, not as fixture synchronization.


### PR DESCRIPTION
## Summary
- start cache-managed Claude work in a fresh persisted session instead of using ambient `--continue`
- capture and resume only the exact provider-issued session ID for the matching provider/model
- retry stale/invalid stored sessions once in a fresh isolated session while surfacing unexpected provider failures
- add regression coverage for fresh-session flags, exact-session reuse, stale-session recovery, and duplicate-call prevention

## Verification
- `npm test --workspace @franken/orchestrator -- --run` (4,032 tests passed)
- `npm run build` (10 packages built)
- `npm run typecheck` (17 tasks passed)
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- focused cache/session tests (22 tests passed)

Closes #3310
