### PR TITLE
fix(planning): persist live plan cycle progress

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -45,6 +45,15 @@ type LlmReplayRecorder = (record: {
 
 type ReplayRunId = string | (() => string | undefined);
 
+export type CliLlmLifecycleEvent =
+  | { type: 'attempt'; provider: string; attempt: number }
+  | { type: 'complete'; provider: string; attempt: number }
+  | { type: 'rate-limit'; provider: string }
+  | { type: 'failure'; provider: string }
+  | { type: 'fallback'; from: string; to: string }
+  | { type: 'wait'; durationMs: number }
+  | { type: 'timeout'; provider: string; durationMs: number };
+
 type SpawnFn = (
   command: string,
   args: readonly string[],
@@ -61,6 +70,8 @@ export interface CliLlmAdapterOpts {
   chatMode?: boolean;
   /** Called with each complete line of stdout as it arrives (for streaming progress). */
   onStreamLine?: (line: string) => void;
+  /** Called with bounded provider lifecycle metadata; never includes prompt or output. */
+  onLifecycleEvent?: (event: CliLlmLifecycleEvent) => void;
   /** Capture replayable LLM request/response content. */
   replayRecorder?: LlmReplayRecorder | undefined;
   /** Stable run/session id for replay records. Defaults to per-request id. */
@@ -86,6 +97,7 @@ export class CliLlmAdapter implements IAdapter {
     model?: string;
     chatMode: boolean;
     onStreamLine?: (line: string) => void;
+    onLifecycleEvent?: (event: CliLlmLifecycleEvent) => void;
     replayRecorder?: LlmReplayRecorder | undefined;
     replayRunId?: ReplayRunId | undefined;
     providers?: readonly string[] | undefined;
@@ -113,6 +125,7 @@ export class CliLlmAdapter implements IAdapter {
       ...(opts.commandOverride !== undefined ? { commandOverride: opts.commandOverride } : {}),
       ...(opts.model !== undefined ? { model: opts.model } : {}),
       ...(opts.onStreamLine !== undefined ? { onStreamLine: opts.onStreamLine } : {}),
+      ...(opts.onLifecycleEvent !== undefined ? { onLifecycleEvent: opts.onLifecycleEvent } : {}),
       ...(opts.replayRecorder !== undefined ? { replayRecorder: opts.replayRecorder } : {}),
       ...(opts.replayRunId !== undefined ? { replayRunId: opts.replayRunId } : {}),
       ...(opts.providers !== undefined ? { providers: opts.providers } : {}),
@@ -166,10 +179,13 @@ export class CliLlmAdapter implements IAdapter {
     const initialProvider = this.provider.name;
     let activeProvider = initialProvider;
     let rateLimitRetryCycles = 0;
+    let attempt = 0;
 
     while (true) {
+      attempt++;
       const provider = this.resolveProvider(activeProvider);
       const activeModel = this.resolveModel(activeProvider, model);
+      this.opts.onLifecycleEvent?.({ type: 'attempt', provider: activeProvider, attempt });
       if (requestId) {
         const replayRunId = this.resolveReplayRunId(requestId);
         this.opts.replayRecorder?.({
@@ -221,10 +237,23 @@ export class CliLlmAdapter implements IAdapter {
           },
         });
 
+        if (failure.rateLimited) {
+          this.opts.onLifecycleEvent?.({ type: 'rate-limit', provider: activeProvider });
+        } else if (error instanceof Error && /timeout/i.test(error.message)) {
+          this.opts.onLifecycleEvent?.({
+            type: 'timeout',
+            provider: activeProvider,
+            durationMs: this.opts.timeoutMs,
+          });
+        } else {
+          this.opts.onLifecycleEvent?.({ type: 'failure', provider: activeProvider });
+        }
+
         if (failure.kind === 'spawn_error') {
           exhaustedProviders.set(activeProvider, failure);
           const nextProvider = providers.find((name) => !exhaustedProviders.has(name));
           if (nextProvider) {
+            this.opts.onLifecycleEvent?.({ type: 'fallback', from: activeProvider, to: nextProvider });
             activeProvider = nextProvider;
             continue;
           }
@@ -235,6 +264,7 @@ export class CliLlmAdapter implements IAdapter {
               });
             }
             const sleepMs = this.resolveSleepMs(exhaustedProviders);
+            this.opts.onLifecycleEvent?.({ type: 'wait', durationMs: sleepMs });
             await sleepFn(sleepMs);
             rateLimitRetryCycles++;
             exhaustedProviders.clear();
@@ -248,6 +278,7 @@ export class CliLlmAdapter implements IAdapter {
       }
 
       if (result.exitCode === 0) {
+        this.opts.onLifecycleEvent?.({ type: 'complete', provider: activeProvider, attempt });
       if (chatMode && sessionId) {
         const nativeSessionId = this.extractNativeSessionId(result.stdout);
         if (nativeSessionId) {
@@ -303,13 +334,16 @@ export class CliLlmAdapter implements IAdapter {
       });
 
       if (!failure.rateLimited) {
+        this.opts.onLifecycleEvent?.({ type: 'failure', provider: activeProvider });
         throw new Error(failure.summary, { cause: failure });
       }
 
+      this.opts.onLifecycleEvent?.({ type: 'rate-limit', provider: activeProvider });
       exhaustedProviders.set(activeProvider, failure);
 
       const nextProvider = providers.find((name) => !exhaustedProviders.has(name));
       if (nextProvider) {
+        this.opts.onLifecycleEvent?.({ type: 'fallback', from: activeProvider, to: nextProvider });
         activeProvider = nextProvider;
         continue;
       }
@@ -320,6 +354,7 @@ export class CliLlmAdapter implements IAdapter {
           cause: lastRateLimitedFailure(exhaustedProviders),
         });
       }
+      this.opts.onLifecycleEvent?.({ type: 'wait', durationMs: sleepMs });
       await sleepFn(sleepMs);
       rateLimitRetryCycles++;
       exhaustedProviders.clear();

--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -19,11 +19,22 @@ export type NormalizedProviderStreamEvent =
   | { type: 'error' }
   | { type: 'unknown'; sourceType: string };
 
+export type StreamProgressEvent =
+  | { type: 'heartbeat'; elapsedMs: number }
+  | { type: 'reasoning' }
+  | { type: 'chunk-detected'; count: number }
+  | { type: 'complete'; durationMs?: number; costUsd?: number; turns?: number };
+
 export interface StreamProgressOptions {
   /** Emit redacted diagnostics for unrecognized provider frames. */
   verbose?: boolean;
-  /** Receive provider-neutral, redacted events for terminal or persistent sinks. */
+  /** Receive provider-neutral normalized events for terminal-only consumers. */
   onEvent?: (event: NormalizedProviderStreamEvent) => void;
+  write?: (text: string) => void;
+  label?: string;
+  /** Receives derived metadata only; raw provider output is never forwarded. */
+  onProgressEvent?: (event: StreamProgressEvent) => void;
+  heartbeatIntervalMs?: number;
 }
 
 /**
@@ -33,19 +44,26 @@ export interface StreamProgressOptions {
  * Call `stop()` after the LLM call resolves to clear the spinner.
  */
 export function createStreamProgressWithSpinner(
-  options: StreamProgressOptions & { write?: (text: string) => void; label?: string } = {},
+  options: StreamProgressOptions = {},
 ): StreamProgressHandle {
   const write = options.write ?? ((t: string) => process.stderr.write(t));
   const label = options.label ?? 'LLM working...';
 
   let frameIdx = 0;
   const startMs = wallClockNow();
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? 30_000;
+  let lastHeartbeatMs = 0;
 
   const renderSpinner = (): void => {
     const frame = FRAMES[frameIdx % FRAMES.length]!;
     const secs = ((wallClockNow() - startMs) / 1000).toFixed(1);
     write(`\r\x1b[K${frame} ${label} (${secs}s)`);
     frameIdx++;
+    const elapsedMs = wallClockNow() - startMs;
+    if (heartbeatIntervalMs > 0 && elapsedMs - lastHeartbeatMs >= heartbeatIntervalMs) {
+      lastHeartbeatMs = elapsedMs;
+      options.onProgressEvent?.({ type: 'heartbeat', elapsedMs });
+    }
   };
 
   const interval = setInterval(renderSpinner, SPINNER_INTERVAL_MS);
@@ -294,6 +312,7 @@ export function createStreamProgressHandler(
         if (!showedThinking) {
           showedThinking = true;
           write(`  ${ANSI.dim}Reasoning...${ANSI.reset}\n`);
+          options.onProgressEvent?.({ type: 'reasoning' });
         }
       } else if (event.type === 'tool') {
         if (event.name) {
@@ -303,13 +322,19 @@ export function createStreamProgressHandler(
         }
       } else if (event.type === 'text') {
         textAccumulator += event.content;
-        detectChunkIds(textAccumulator, seenChunkIds, write);
+        detectChunkIds(textAccumulator, seenChunkIds, write, options.onProgressEvent);
       } else if (event.type === 'result') {
         const parts: string[] = [];
         if (event.durationMs !== undefined) parts.push(`${(event.durationMs / 1000).toFixed(1)}s`);
         if (event.costUsd !== undefined) parts.push(`$${event.costUsd.toFixed(4)}`);
         if (event.turns !== undefined && event.turns > 1) parts.push(`${event.turns} turns`);
         write(`  ${ANSI.dim}LLM done${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
+        options.onProgressEvent?.({
+          type: 'complete',
+          ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
+          ...(event.costUsd !== undefined ? { costUsd: event.costUsd } : {}),
+          ...(event.turns !== undefined ? { turns: event.turns } : {}),
+        });
       } else if (event.type === 'retry') {
         write(`  ${ANSI.dim}Provider retrying...${ANSI.reset}\n`);
       } else if (event.type === 'error') {
@@ -409,6 +434,7 @@ function detectChunkIds(
   text: string,
   seen: Set<string>,
   write: (text: string) => void,
+  onEvent?: (event: StreamProgressEvent) => void,
 ): void {
   const pattern = /"id"\s*:\s*"([^"]+)"/g;
   let match: RegExpExecArray | null;
@@ -417,6 +443,7 @@ function detectChunkIds(
     if (!seen.has(id)) {
       seen.add(id);
       write(`  ${ANSI.dim}Planned chunk:${ANSI.reset} ${id}\n`);
+      onEvent?.({ type: 'chunk-detected', count: seen.size });
     }
   }
 }

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -5,7 +5,7 @@ import { BeastLogger } from '../logging/beast-logger.js';
 import { MartinLoop } from '../skills/martin-loop.js';
 import { GitBranchIsolator } from '../skills/git-branch-isolator.js';
 import { CliSkillExecutor, type ObserverDeps } from '../skills/cli-skill-executor.js';
-import { CliLlmAdapter } from '../adapters/cli-llm-adapter.js';
+import { CliLlmAdapter, type CliLlmLifecycleEvent } from '../adapters/cli-llm-adapter.js';
 import { createDefaultRegistry } from '../skills/providers/cli-provider.js';
 import { CliObserverBridge } from '../adapters/cli-observer-bridge.js';
 import { FileCheckpointStore } from '../checkpoint/file-checkpoint-store.js';
@@ -60,6 +60,8 @@ export interface CliDepOptions {
   dryRun?: boolean | undefined;
   /** Stream line callback for real-time progress during LLM calls. */
   onStreamLine?: ((line: string) => void) | undefined;
+  /** Sanitized LLM provider lifecycle callback for persistent diagnostics. */
+  onLlmLifecycleEvent?: ((event: CliLlmLifecycleEvent) => void) | undefined;
   /**
    * Override working directory for the LLM adapter.
    * Use os.tmpdir() for planning calls to prevent project-scoped plugins
@@ -109,6 +111,7 @@ export interface CliDeps {
   observerBridge: CliObserverBridge;
   logger: BeastLogger;
   finalize: () => Promise<void>;
+  artifacts: SessionArtifacts;
   issueDeps?: IssueCliDeps | undefined;
   skillManager?: import('../skills/skill-manager.js').SkillManager | undefined;
   providerRegistry?: import('../providers/provider-registry.js').ProviderRegistry | undefined;
@@ -204,7 +207,7 @@ interface EffectiveCliConfig {
   };
 }
 
-interface SessionArtifacts {
+export interface SessionArtifacts {
   planName: string;
   checkpointFile: string;
   logFile: string;
@@ -594,6 +597,7 @@ function createCachedCliLlmClient(
     ...((model ?? override?.model ?? options.adapterModel) != null ? { model: (model ?? override?.model ?? options.adapterModel)! } : {}),
     ...(options.chatMode ? { chatMode: true } : {}),
     ...(options.onStreamLine ? { onStreamLine: options.onStreamLine } : {}),
+    ...(options.onLlmLifecycleEvent ? { onLifecycleEvent: options.onLlmLifecycleEvent } : {}),
     replayRunId: () => observer.observerBridge.getActiveSessionId() ?? observer.runSessionId,
     replayRecorder: (record) => observer.observerBridge.recordReplay(record),
     ...(resolveCliRegistryNames(options, options.providers) ? { providers: resolveCliRegistryNames(options, options.providers) } : {}),
@@ -1144,6 +1148,7 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
       observerBridge: observer.observerBridge,
       logger: observer.logger,
       finalize,
+      artifacts,
       issueDeps,
       ...(consolidated.skillManager ? { skillManager: consolidated.skillManager } : {}),
       ...(consolidated.providerRegistry ? { providerRegistry: consolidated.providerRegistry } : {}),

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -366,17 +366,18 @@ export class Session {
     depOptions.adapterWorkingDir = tmpdir();
     const planLogSink: { logger?: BeastLogger } = {};
     const persistProgressEvent = (event: StreamProgressEvent): void => {
-      planLogSink.logger?.info('Plan progress', event, 'planner');
+      planLogSink.logger?.debug('Plan progress', event, 'planner');
     };
     const persistLifecycleEvent = (event: CliLlmLifecycleEvent): void => {
-      planLogSink.logger?.info('LLM provider lifecycle', event, 'planner');
+      planLogSink.logger?.debug('LLM provider lifecycle', event, 'planner');
     };
-    const progress = createStreamProgressWithSpinner({
+    const createPlanProgress = () => createStreamProgressWithSpinner({
       label: 'Planning...',
       verbose: this.config.verbose,
       onProgressEvent: persistProgressEvent,
     });
-    depOptions.onStreamLine = progress.onLine;
+    let progress = createPlanProgress();
+    depOptions.onStreamLine = (line) => progress.onLine(line);
     depOptions.onLlmLifecycleEvent = persistLifecycleEvent;
     const { cliLlmAdapter, logger, finalize, artifacts } = await createCliDeps(depOptions);
     planLogSink.logger = logger;
@@ -389,8 +390,6 @@ export class Session {
     let cancellationSignal: NodeJS.Signals | undefined;
     const planLogFile = artifacts?.logFile ?? paths.logFile;
     const projectLogPath = relative(paths.root, planLogFile) || planLogFile;
-    io.display(`Build log: ${projectLogPath}\nFollow live: tail -f ${shellQuote(planLogFile)}`);
-    logger.info('Plan cycle started', { logFile: planLogFile }, 'planner');
 
     const runPlanStage = async <T>(stage: string, operation: () => Promise<T>): Promise<T> => {
       const stageStartedAt = Date.now();
@@ -458,6 +457,9 @@ export class Session {
     process.on('SIGTERM', onSigterm);
 
     try {
+      io.display(`Build log: ${projectLogPath}\nFollow live: tail -f ${shellQuote(planLogFile)}`);
+      logger.info('Plan cycle started', { logFile: planLogFile }, 'planner');
+
       // Load design doc
     let designContent: string;
     if (designDocPath) {
@@ -534,9 +536,14 @@ export class Session {
       artifactLabel: 'Chunk files',
       io,
       onRevise: async (feedback) => {
-        await runPlanStage('revise', () => llmGraphBuilder.build({
-          goal: `${designContent}\n\nRevision feedback: ${feedback}`,
-        }));
+        progress = createPlanProgress();
+        try {
+          await runPlanStage('revise', () => llmGraphBuilder.build({
+            goal: `${designContent}\n\nRevision feedback: ${feedback}`,
+          }));
+        } finally {
+          progress.stop();
+        }
         chunkPaths = chunkWriter.write(
           llmGraphBuilder.lastChunks,
           llmGraphBuilder.lastValidationIssues,

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -49,6 +49,10 @@ function appendPromptContext(value: string, promptText: string | undefined): str
   return `${value}\n\nAdditional prompt context:\n${promptText.trim()}`;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function loadPromptConfigFromEnv(): RunConfig['promptConfig'] | undefined {
   const runConfigDocument = loadRunConfigDocumentFromEnv();
   const promptConfig = typeof runConfigDocument === 'object' && runConfigDocument !== null
@@ -360,12 +364,12 @@ export class Session {
     // from loading in the spawned CLI. Plugins poison the session by injecting skill
     // instructions that make the CLI explore the codebase instead of returning JSON.
     depOptions.adapterWorkingDir = tmpdir();
-    let planLogger: BeastLogger | undefined;
+    const planLogSink: { logger?: BeastLogger } = {};
     const persistProgressEvent = (event: StreamProgressEvent): void => {
-      planLogger?.info('Plan progress', event, 'planner');
+      planLogSink.logger?.info('Plan progress', event, 'planner');
     };
     const persistLifecycleEvent = (event: CliLlmLifecycleEvent): void => {
-      planLogger?.info('LLM provider lifecycle', event, 'planner');
+      planLogSink.logger?.info('LLM provider lifecycle', event, 'planner');
     };
     const progress = createStreamProgressWithSpinner({
       label: 'Planning...',
@@ -375,30 +379,83 @@ export class Session {
     depOptions.onStreamLine = progress.onLine;
     depOptions.onLlmLifecycleEvent = persistLifecycleEvent;
     const { cliLlmAdapter, logger, finalize, artifacts } = await createCliDeps(depOptions);
-    planLogger = logger;
+    planLogSink.logger = logger;
     const planStartedAt = Date.now();
     const elapsed = (): number => Date.now() - planStartedAt;
+    let finalizePromise: Promise<void> | undefined;
+    const finalizePlan = (): Promise<void> => finalizePromise ??= finalize();
+    let activeStage: string | undefined;
+    let activeStageStartedAt: number | undefined;
+    let cancellationSignal: NodeJS.Signals | undefined;
     const planLogFile = artifacts?.logFile ?? paths.logFile;
     const projectLogPath = relative(paths.root, planLogFile) || planLogFile;
-    io.display(`Build log: ${projectLogPath}\nFollow live: tail -f ${JSON.stringify(planLogFile)}`);
+    io.display(`Build log: ${projectLogPath}\nFollow live: tail -f ${shellQuote(planLogFile)}`);
     logger.info('Plan cycle started', { logFile: planLogFile }, 'planner');
 
     const runPlanStage = async <T>(stage: string, operation: () => Promise<T>): Promise<T> => {
+      const stageStartedAt = Date.now();
+      activeStage = stage;
+      activeStageStartedAt = stageStartedAt;
       logger.info('Plan stage started', { stage, totalElapsedMs: elapsed() }, 'planner');
       try {
         const result = await operation();
-        logger.info('Plan stage completed', { stage, totalElapsedMs: elapsed() }, 'planner');
+        if (cancellationSignal) {
+          const error = new Error(`Plan cancelled by ${cancellationSignal}`);
+          error.name = 'AbortError';
+          throw error;
+        }
+        logger.info('Plan stage completed', {
+          stage,
+          stageElapsedMs: Date.now() - stageStartedAt,
+          totalElapsedMs: elapsed(),
+        }, 'planner');
         return result;
       } catch (error) {
         const cancelled = error instanceof Error
           && (error.name === 'AbortError' || /cancel(?:led|ed)/i.test(error.message));
-        logger.warn(cancelled ? 'Plan stage cancelled' : 'Plan stage failed', {
-          stage,
-          totalElapsedMs: elapsed(),
-        }, 'planner');
+        if (!cancellationSignal) {
+          logger.warn(cancelled ? 'Plan stage cancelled' : 'Plan stage failed', {
+            stage,
+            stageElapsedMs: Date.now() - stageStartedAt,
+            totalElapsedMs: elapsed(),
+          }, 'planner');
+        }
         throw error;
+      } finally {
+        if (activeStage === stage) {
+          activeStage = undefined;
+          activeStageStartedAt = undefined;
+        }
       }
     };
+
+    const removeSignalHandlers = (): void => {
+      process.removeListener('SIGINT', onSigint);
+      process.removeListener('SIGTERM', onSigterm);
+    };
+    const handleSignal = (signal: NodeJS.Signals): void => {
+      if (cancellationSignal) return;
+      cancellationSignal = signal;
+      const cancellation = {
+        ...(activeStage ? { stage: activeStage } : {}),
+        ...(activeStageStartedAt !== undefined ? { stageElapsedMs: Date.now() - activeStageStartedAt } : {}),
+        signal,
+        totalElapsedMs: elapsed(),
+      };
+      if (activeStage) logger.warn('Plan stage cancelled', cancellation, 'planner');
+      logger.warn('Plan cycle cancelled', cancellation, 'planner');
+      progress.stop();
+      removeSignalHandlers();
+      const exitCode = signal === 'SIGINT' ? 130 : 143;
+      void finalizePlan().then(
+        () => process.exit(exitCode),
+        () => process.exit(exitCode),
+      );
+    };
+    const onSigint = (): void => handleSignal('SIGINT');
+    const onSigterm = (): void => handleSignal('SIGTERM');
+    process.on('SIGINT', onSigint);
+    process.on('SIGTERM', onSigterm);
 
     try {
       // Load design doc
@@ -489,18 +546,22 @@ export class Session {
     });
     logger.info('Plan cycle completed', {
       chunks: llmGraphBuilder.lastChunks.length,
+      validationWarnings: llmGraphBuilder.lastValidationIssues.length,
       totalElapsedMs: elapsed(),
     }, 'planner');
     } catch (error) {
       const cancelled = error instanceof Error
         && (error.name === 'AbortError' || /cancel(?:led|ed)/i.test(error.message));
-      logger.warn(cancelled ? 'Plan cycle cancelled' : 'Plan cycle failed', {
-        totalElapsedMs: elapsed(),
-      }, 'planner');
+      if (!cancellationSignal) {
+        logger.warn(cancelled ? 'Plan cycle cancelled' : 'Plan cycle failed', {
+          totalElapsedMs: elapsed(),
+        }, 'planner');
+      }
       throw error;
     } finally {
+      removeSignalHandlers();
       progress.stop();
-      await finalize();
+      await finalizePlan();
     }
   }
 

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { relative } from 'node:path';
 import { resolveContainedExistingPath } from '@franken/types/path-containment';
 import { tmpdir } from 'node:os';
 import { ZodError } from 'zod';
@@ -11,8 +12,9 @@ import { ChunkFileWriter } from '../planning/chunk-file-writer.js';
 import { InterviewLoop } from '../planning/interview-loop.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
 import { ProgressLlmClient } from '../adapters/progress-llm-client.js';
-import { ANSI, budgetBar, statusBadge, logHeader } from '../logging/beast-logger.js';
-import { createStreamProgressWithSpinner } from '../adapters/stream-progress.js';
+import { ANSI, budgetBar, statusBadge, logHeader, type BeastLogger } from '../logging/beast-logger.js';
+import { createStreamProgressWithSpinner, type StreamProgressEvent } from '../adapters/stream-progress.js';
+import type { CliLlmLifecycleEvent } from '../adapters/cli-llm-adapter.js';
 import type { InterviewIO } from '../planning/interview-loop.js';
 import type { BeastResult } from '../types.js';
 import type { ProjectPaths } from './project-root.js';
@@ -358,12 +360,45 @@ export class Session {
     // from loading in the spawned CLI. Plugins poison the session by injecting skill
     // instructions that make the CLI explore the codebase instead of returning JSON.
     depOptions.adapterWorkingDir = tmpdir();
+    let planLogger: BeastLogger | undefined;
+    const persistProgressEvent = (event: StreamProgressEvent): void => {
+      planLogger?.info('Plan progress', event, 'planner');
+    };
+    const persistLifecycleEvent = (event: CliLlmLifecycleEvent): void => {
+      planLogger?.info('LLM provider lifecycle', event, 'planner');
+    };
     const progress = createStreamProgressWithSpinner({
       label: 'Planning...',
       verbose: this.config.verbose,
+      onProgressEvent: persistProgressEvent,
     });
     depOptions.onStreamLine = progress.onLine;
-    const { cliLlmAdapter, logger, finalize } = await createCliDeps(depOptions);
+    depOptions.onLlmLifecycleEvent = persistLifecycleEvent;
+    const { cliLlmAdapter, logger, finalize, artifacts } = await createCliDeps(depOptions);
+    planLogger = logger;
+    const planStartedAt = Date.now();
+    const elapsed = (): number => Date.now() - planStartedAt;
+    const planLogFile = artifacts?.logFile ?? paths.logFile;
+    const projectLogPath = relative(paths.root, planLogFile) || planLogFile;
+    io.display(`Build log: ${projectLogPath}\nFollow live: tail -f ${JSON.stringify(planLogFile)}`);
+    logger.info('Plan cycle started', { logFile: planLogFile }, 'planner');
+
+    const runPlanStage = async <T>(stage: string, operation: () => Promise<T>): Promise<T> => {
+      logger.info('Plan stage started', { stage, totalElapsedMs: elapsed() }, 'planner');
+      try {
+        const result = await operation();
+        logger.info('Plan stage completed', { stage, totalElapsedMs: elapsed() }, 'planner');
+        return result;
+      } catch (error) {
+        const cancelled = error instanceof Error
+          && (error.name === 'AbortError' || /cancel(?:led|ed)/i.test(error.message));
+        logger.warn(cancelled ? 'Plan stage cancelled' : 'Plan stage failed', {
+          stage,
+          totalElapsedMs: elapsed(),
+        }, 'planner');
+        throw error;
+      }
+    };
 
     try {
       // Load design doc
@@ -419,7 +454,7 @@ export class Session {
 
     // Build the plan graph — lastChunks preserves the structured LLM output
     try {
-      await llmGraphBuilder.build({ goal: designContent });
+      await runPlanStage('decompose', () => llmGraphBuilder.build({ goal: designContent }));
     } finally {
       progress.stop();
     }
@@ -442,9 +477,9 @@ export class Session {
       artifactLabel: 'Chunk files',
       io,
       onRevise: async (feedback) => {
-        await llmGraphBuilder.build({
+        await runPlanStage('revise', () => llmGraphBuilder.build({
           goal: `${designContent}\n\nRevision feedback: ${feedback}`,
-        });
+        }));
         chunkPaths = chunkWriter.write(
           llmGraphBuilder.lastChunks,
           llmGraphBuilder.lastValidationIssues,
@@ -452,6 +487,17 @@ export class Session {
         return chunkPaths;
       },
     });
+    logger.info('Plan cycle completed', {
+      chunks: llmGraphBuilder.lastChunks.length,
+      totalElapsedMs: elapsed(),
+    }, 'planner');
+    } catch (error) {
+      const cancelled = error instanceof Error
+        && (error.name === 'AbortError' || /cancel(?:led|ed)/i.test(error.message));
+      logger.warn(cancelled ? 'Plan cycle cancelled' : 'Plan cycle failed', {
+        totalElapsedMs: elapsed(),
+      }, 'planner');
+      throw error;
     } finally {
       progress.stop();
       await finalize();

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -706,6 +706,7 @@ describe('CliLlmAdapter', () => {
       });
 
       it('switches to the next provider when the selected provider is rate limited', async () => {
+        const lifecycleEvents: unknown[] = [];
         const { spawnFn, calls } = createQueuedSpawn([
           { stderr: 'rate limit exceeded', exitCode: 1 },
           { stdout: 'codex success', exitCode: 0 },
@@ -715,6 +716,7 @@ describe('CliLlmAdapter', () => {
           {
             ...baseOpts,
             providers: ['codex', 'claude'],
+            onLifecycleEvent: (event: unknown) => lifecycleEvents.push(event),
           } as never,
           spawnFn,
         );
@@ -725,6 +727,13 @@ describe('CliLlmAdapter', () => {
         expect(calls).toHaveLength(2);
         expect(calls[0]!.cmd).toBe('claude');
         expect(calls[1]!.cmd).toBe('codex');
+        expect(lifecycleEvents).toEqual([
+          { type: 'attempt', provider: 'claude', attempt: 1 },
+          { type: 'rate-limit', provider: 'claude' },
+          { type: 'fallback', from: 'claude', to: 'codex' },
+          { type: 'attempt', provider: 'codex', attempt: 2 },
+          { type: 'complete', provider: 'codex', attempt: 2 },
+        ]);
       });
 
       it('switches to the next provider when the selected provider is rate limited via stdout only', async () => {
@@ -792,6 +801,7 @@ describe('CliLlmAdapter', () => {
 
       it('sleeps after all configured providers are exhausted, then retries from the selected provider', async () => {
         const sleepFn = vi.fn(async () => {});
+        const lifecycleEvents: unknown[] = [];
         const { spawnFn, calls } = createQueuedSpawn([
           { stderr: 'retry-after: 5', exitCode: 1 },
           { stderr: 'resets in 3s', exitCode: 1 },
@@ -803,6 +813,7 @@ describe('CliLlmAdapter', () => {
             ...baseOpts,
             providers: ['claude', 'codex'],
             _sleepFn: sleepFn,
+            onLifecycleEvent: (event: unknown) => lifecycleEvents.push(event),
           } as never,
           spawnFn,
         );
@@ -815,6 +826,9 @@ describe('CliLlmAdapter', () => {
         expect(calls[0]!.cmd).toBe('claude');
         expect(calls[1]!.cmd).toBe('codex');
         expect(calls[2]!.cmd).toBe('claude');
+        expect(lifecycleEvents).toContainEqual({ type: 'wait', durationMs: 3_000 });
+        expect(lifecycleEvents).toContainEqual({ type: 'attempt', provider: 'claude', attempt: 3 });
+        expect(lifecycleEvents).toContainEqual({ type: 'complete', provider: 'claude', attempt: 3 });
       });
 
       it('retries a rate-limited provider when later fallback provider CLI is missing', async () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -477,4 +477,33 @@ describe('createStreamProgressWithSpinner', () => {
 
     handle.stop();
   });
+
+  it('emits bounded sanitized lifecycle events without persisting streamed content', () => {
+    const events: Array<{ type: string; [key: string]: unknown }> = [];
+    const handle = createStreamProgressWithSpinner({
+      write: vi.fn(),
+      heartbeatIntervalMs: 30_000,
+      onProgressEvent: (event) => events.push(event),
+    });
+
+    handle.onLine(JSON.stringify({
+      type: 'content_block_delta',
+      delta: { type: 'text_delta', text: 'TOP_SECRET_PROMPT_CONTENT' },
+    }));
+    vi.advanceTimersByTime(30_000);
+    handle.onLine(JSON.stringify({
+      type: 'result',
+      duration_ms: 31_200,
+      cost_usd: 0.04,
+      num_turns: 2,
+    }));
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'heartbeat', elapsedMs: 30_000 }),
+      expect.objectContaining({ type: 'complete', durationMs: 31_200, turns: 2 }),
+    ]));
+    expect(JSON.stringify(events)).not.toContain('TOP_SECRET_PROMPT_CONTENT');
+
+    handle.stop();
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/session-interview-ux.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-interview-ux.test.ts
@@ -256,9 +256,12 @@ describe('Session interview UX', () => {
       expect.stringContaining(`Current document:\n${currentDesignDoc}`),
     );
     expect(readFileSync(paths.designDocFile, 'utf-8')).toBe(revisedDesignDoc);
-    expect(io.display).toHaveBeenCalledTimes(2);
+    expect(io.display).toHaveBeenCalledTimes(3);
     expect((io.display as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toContain(
       'rollback handling',
+    );
+    expect((io.display as ReturnType<typeof vi.fn>).mock.calls[2]?.[0]).toContain(
+      'Build log:',
     );
     expect(planBuilds).toEqual([{ goal: revisedDesignDoc }]);
   });

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -14,7 +14,7 @@ let progressCtorOptions: unknown = undefined;
 let progressInstance: unknown = undefined;
 let llmGraphBuilderCtorArg: unknown = undefined;
 let lastCreateCliDepsOptions: import('../../../src/cli/dep-factory.js').CliDepOptions | undefined;
-let streamProgressOptions: { onEvent?: (event: { type: string; [key: string]: unknown }) => void } | undefined;
+let streamProgressOptions: { onProgressEvent?: (event: { type: string; [key: string]: unknown }) => void } | undefined;
 const mockFinalize = vi.fn(async () => {});
 
 // ── Mock heavy deps ──
@@ -306,7 +306,7 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     const expectedLogFile = resolve(config.paths.buildDir, 'session-build.log');
 
     await new Session(config).start();
-    streamProgressOptions?.onEvent?.({ type: 'chunk-detected', count: 2 });
+    streamProgressOptions?.onProgressEvent?.({ type: 'chunk-detected', count: 2 });
     lastCreateCliDepsOptions?.onLlmLifecycleEvent?.({
       type: 'fallback',
       from: 'claude',
@@ -330,8 +330,61 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     );
     expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining('Build log:'));
     expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining(expectedLogFile));
-    expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining('tail -f'));
+    expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining(`tail -f '${expectedLogFile}'`));
+    expect(mockDeps.logger.info).toHaveBeenCalledWith(
+      'Plan stage completed',
+      expect.objectContaining({ stage: 'decompose', stageElapsedMs: expect.any(Number), totalElapsedMs: expect.any(Number) }),
+      'planner',
+    );
   });
+
+  it.each(['SIGINT', 'SIGTERM'] as const)(
+    'runPlan() flushes one active-stage cancellation record on %s and removes signal handlers',
+    async (signal) => {
+      const signalHandlers = new Map<NodeJS.Signals, () => void>();
+      const onSpy = vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
+        if (event === 'SIGINT' || event === 'SIGTERM') {
+          signalHandlers.set(event, listener);
+        }
+        return process;
+      }) as typeof process.on);
+      const removeSpy = vi.spyOn(process, 'removeListener').mockImplementation((() => process) as typeof process.removeListener);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+      let resolveBuild!: () => void;
+      mockLlmGraphBuild.mockImplementationOnce(() => new Promise((resolveBuildPromise) => {
+        resolveBuild = () => resolveBuildPromise({ tasks: [] });
+      }));
+      const { Session } = await import('../../../src/cli/session.js');
+
+      const startPromise = new Session(makeConfig()).start();
+      await vi.waitFor(() => expect(signalHandlers.size).toBe(2));
+      signalHandlers.get(signal)!();
+      await vi.waitFor(() => expect(mockFinalize).toHaveBeenCalledTimes(1));
+      resolveBuild();
+
+      await expect(startPromise).rejects.toThrow(`Plan cancelled by ${signal}`);
+      expect(mockDeps.logger.warn).toHaveBeenCalledWith(
+        'Plan stage cancelled',
+        expect.objectContaining({ stage: 'decompose', signal }),
+        'planner',
+      );
+      expect(mockDeps.logger.warn).toHaveBeenCalledWith(
+        'Plan cycle cancelled',
+        expect.objectContaining({ signal }),
+        'planner',
+      );
+      expect(mockDeps.logger.warn.mock.calls.filter(([message]) => message === 'Plan stage cancelled')).toHaveLength(1);
+      expect(mockDeps.logger.warn.mock.calls.filter(([message]) => message === 'Plan cycle cancelled')).toHaveLength(1);
+      expect(mockFinalize).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(signal === 'SIGINT' ? 130 : 143);
+      expect(removeSpy).toHaveBeenCalledWith('SIGINT', signalHandlers.get('SIGINT'));
+      expect(removeSpy).toHaveBeenCalledWith('SIGTERM', signalHandlers.get('SIGTERM'));
+
+      onSpy.mockRestore();
+      removeSpy.mockRestore();
+      exitSpy.mockRestore();
+    },
+  );
 
   it('runPlan() finalizes CLI dependencies so replay records are persisted', async () => {
     const { Session } = await import('../../../src/cli/session.js');

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -313,14 +313,19 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
       to: 'codex',
     });
 
-    expect(mockDeps.logger.info).toHaveBeenCalledWith(
+    expect(mockDeps.logger.debug).toHaveBeenCalledWith(
       'Plan progress',
       { type: 'chunk-detected', count: 2 },
       'planner',
     );
-    expect(mockDeps.logger.info).toHaveBeenCalledWith(
+    expect(mockDeps.logger.debug).toHaveBeenCalledWith(
       'LLM provider lifecycle',
       { type: 'fallback', from: 'claude', to: 'codex' },
+      'planner',
+    );
+    expect(mockDeps.logger.info).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^(Plan progress|LLM provider lifecycle)$/),
+      expect.anything(),
       'planner',
     );
     expect(mockDeps.logger.info).not.toHaveBeenCalledWith(
@@ -336,6 +341,37 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
       expect.objectContaining({ stage: 'decompose', stageElapsedMs: expect.any(Number), totalElapsedMs: expect.any(Number) }),
       'planner',
     );
+  });
+
+  it('runPlan() restarts stream progress while applying review revisions', async () => {
+    const { reviewLoop } = await import('../../../src/cli/review-loop.js');
+    vi.mocked(reviewLoop).mockImplementationOnce(async ({ onRevise }) => {
+      await onRevise('Split the plan into smaller chunks');
+    });
+    const { createStreamProgressWithSpinner } = await import('../../../src/adapters/stream-progress.js');
+    const { Session } = await import('../../../src/cli/session.js');
+
+    await new Session(makeConfig()).start();
+
+    expect(createStreamProgressWithSpinner).toHaveBeenCalledTimes(2);
+    expect(mockLlmGraphBuild).toHaveBeenCalledTimes(2);
+    for (const result of vi.mocked(createStreamProgressWithSpinner).mock.results) {
+      expect(result.value.stop).toHaveBeenCalled();
+    }
+  });
+
+  it('runPlan() finalizes when build-log disclosure fails', async () => {
+    const io = mockIO();
+    vi.mocked(io.display).mockImplementationOnce(() => {
+      throw new Error('output closed');
+    });
+    const { createStreamProgressWithSpinner } = await import('../../../src/adapters/stream-progress.js');
+    const { Session } = await import('../../../src/cli/session.js');
+
+    await expect(new Session(makeConfig({ io })).start()).rejects.toThrow('output closed');
+
+    expect(mockFinalize).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createStreamProgressWithSpinner).mock.results.at(-1)?.value.stop).toHaveBeenCalled();
   });
 
   it.each(['SIGINT', 'SIGTERM'] as const)(

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -14,6 +14,7 @@ let progressCtorOptions: unknown = undefined;
 let progressInstance: unknown = undefined;
 let llmGraphBuilderCtorArg: unknown = undefined;
 let lastCreateCliDepsOptions: import('../../../src/cli/dep-factory.js').CliDepOptions | undefined;
+let streamProgressOptions: { onEvent?: (event: { type: string; [key: string]: unknown }) => void } | undefined;
 const mockFinalize = vi.fn(async () => {});
 
 // ── Mock heavy deps ──
@@ -63,6 +64,11 @@ vi.mock('../../../src/cli/dep-factory.js', () => ({
       logger: mockDeps.logger,
       finalize: mockFinalize,
       cliLlmAdapter: mockCliLlmAdapter,
+      artifacts: {
+        planName: 'session',
+        checkpointFile: resolve(options.paths.buildDir, 'session.checkpoint'),
+        logFile: resolve(options.paths.buildDir, 'session-build.log'),
+      },
     };
   }),
 }));
@@ -143,10 +149,10 @@ vi.mock('../../../src/planning/chunk-file-writer.js', () => {
 
 // Mock stream-progress to prevent real timers/stderr writes
 vi.mock('../../../src/adapters/stream-progress.js', () => ({
-  createStreamProgressWithSpinner: vi.fn(() => ({
-    onLine: vi.fn(),
-    stop: vi.fn(),
-  })),
+  createStreamProgressWithSpinner: vi.fn((options: typeof streamProgressOptions) => {
+    streamProgressOptions = options;
+    return { onLine: vi.fn(), stop: vi.fn() };
+  }),
   createStreamProgressHandler: vi.fn(() => vi.fn()),
 }));
 
@@ -251,6 +257,7 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     progressInstance = undefined;
     llmGraphBuilderCtorArg = undefined;
     lastCreateCliDepsOptions = undefined;
+    streamProgressOptions = undefined;
     console.info = vi.fn();
   });
 
@@ -291,6 +298,39 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     await new Session(config).start();
 
     expect(mockLlmGraphBuild).toHaveBeenCalled();
+  });
+
+  it('runPlan() persists sanitized live progress and discloses the build log path', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    const config = makeConfig();
+    const expectedLogFile = resolve(config.paths.buildDir, 'session-build.log');
+
+    await new Session(config).start();
+    streamProgressOptions?.onEvent?.({ type: 'chunk-detected', count: 2 });
+    lastCreateCliDepsOptions?.onLlmLifecycleEvent?.({
+      type: 'fallback',
+      from: 'claude',
+      to: 'codex',
+    });
+
+    expect(mockDeps.logger.info).toHaveBeenCalledWith(
+      'Plan progress',
+      { type: 'chunk-detected', count: 2 },
+      'planner',
+    );
+    expect(mockDeps.logger.info).toHaveBeenCalledWith(
+      'LLM provider lifecycle',
+      { type: 'fallback', from: 'claude', to: 'codex' },
+      'planner',
+    );
+    expect(mockDeps.logger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ prompt: expect.anything() }),
+      expect.anything(),
+    );
+    expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining('Build log:'));
+    expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining(expectedLogFile));
+    expect(config.io.display).toHaveBeenCalledWith(expect.stringContaining('tail -f'));
   });
 
   it('runPlan() finalizes CLI dependencies so replay records are persisted', async () => {

--- a/tasks/issue-3308-progress.md
+++ b/tasks/issue-3308-progress.md
@@ -1,0 +1,10 @@
+# Issue 3308 Progress
+
+- [x] Inspect issue, plan-cycle execution, build-log creation, and existing tests.
+- [x] Add regression coverage for bounded progress metadata and log disclosure.
+- [x] Emit sanitized stream and provider lifecycle events without persisting raw model output.
+- [x] Persist plan stages, elapsed timing, heartbeats, provider attempts/fallbacks/waits, and terminal outcomes.
+- [x] Print the active build-log path and a copyable `tail -f` command before decomposition starts.
+- [x] Verify targeted tests, full orchestrator tests, typecheck, and build.
+- [ ] Open the linked pull request and complete CI/Codex review.
+- [ ] Merge, verify issue closure, and record reusable lessons.


### PR DESCRIPTION
## Summary
- persist sanitized live plan stages, heartbeats, chunk counts, and terminal outcomes in the session build log
- record provider attempts, fallback/rate-limit waits, timeouts, failures, and completion without logging raw model output
- disclose the active log path and a copyable `tail -f` command before decomposition starts

## Test plan
- `npx vitest run tests/unit/cli/session.test.ts tests/unit/cli/session-interview-ux.test.ts tests/unit/cli/session-plan.test.ts tests/unit/adapters/stream-progress.test.ts tests/unit/adapters/cli-llm-adapter.test.ts`
- `npm test --workspace franken-orchestrator` (2334 passed, 1 skipped)
- `npm run typecheck --workspace franken-orchestrator`
- `npm run build --workspace franken-orchestrator`

Closes #3308
