### PR TITLE
feat(orchestrator): show stage-aware planning progress

### DIFF
--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -1,11 +1,15 @@
 import { ANSI } from '../logging/beast-logger.js';
 import { wallClockNow } from '@franken/types';
+import type { PlanningProgressEvent } from '../planning/planning-progress.js';
+import { PLANNING_STAGE_LABELS } from '../planning/planning-progress.js';
 
 const FRAMES = ['|', '/', '-', '\\'];
 const SPINNER_INTERVAL_MS = 100;
 
 export interface StreamProgressHandle {
   onLine: (line: string) => void;
+  update: (event: PlanningProgressEvent) => void;
+  currentStage: () => PlanningProgressEvent | undefined;
   stop: () => void;
 }
 
@@ -35,38 +39,51 @@ export interface StreamProgressOptions {
   /** Receives derived metadata only; raw provider output is never forwarded. */
   onProgressEvent?: (event: StreamProgressEvent) => void;
   heartbeatIntervalMs?: number;
+  /** Supply stage context for provider result and retry messages. */
+  operationLabel?: () => string;
 }
 
-/**
- * Creates a stream progress handler with an integrated spinner.
- * The spinner shows elapsed time from the start; progress lines
- * (thinking, tool use, chunk IDs) appear above the spinner line.
- * Call `stop()` after the LLM call resolves to clear the spinner.
- */
+function formatDuration(ms: number): string {
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${Math.round(seconds % 60)}s`;
+}
+
+/** Combines sanitized persistent progress with stage-aware terminal status. */
 export function createStreamProgressWithSpinner(
   options: StreamProgressOptions = {},
 ): StreamProgressHandle {
-  const write = options.write ?? ((t: string) => process.stderr.write(t));
-  const label = options.label ?? 'LLM working...';
-
-  let frameIdx = 0;
-  const startMs = wallClockNow();
-  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? 30_000;
+  const write = options.write ?? ((text: string) => process.stderr.write(text));
+  const fallbackLabel = options.label ?? 'Planning';
+  const totalStartedAt = wallClockNow();
+  let stageStartedAt = totalStartedAt;
+  let frameIndex = 0;
+  let stopped = false;
+  let activeEvent: PlanningProgressEvent | undefined;
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? 15_000;
   let lastHeartbeatMs = 0;
 
   const renderSpinner = (): void => {
-    const frame = FRAMES[frameIdx % FRAMES.length]!;
-    const secs = ((wallClockNow() - startMs) / 1000).toFixed(1);
-    write(`\r\x1b[K${frame} ${label} (${secs}s)`);
-    frameIdx++;
-    const elapsedMs = wallClockNow() - startMs;
+    if (stopped) return;
+    const now = wallClockNow();
+    const frame = FRAMES[frameIndex % FRAMES.length]!;
+    const label = activeEvent?.message ?? fallbackLabel;
+    const position = activeEvent ? ` [${activeEvent.position}/${activeEvent.total}]` : '';
+    write(`\r\x1b[K${frame} ${label}${position} ${ANSI.dim}(stage ${formatDuration(now - stageStartedAt)} · total ${formatDuration(now - totalStartedAt)})${ANSI.reset}`);
+    frameIndex++;
+    const elapsedMs = now - totalStartedAt;
     if (heartbeatIntervalMs > 0 && elapsedMs - lastHeartbeatMs >= heartbeatIntervalMs) {
       lastHeartbeatMs = elapsedMs;
       options.onProgressEvent?.({ type: 'heartbeat', elapsedMs });
+      if (activeEvent?.status === 'started') {
+        write(`\r\x1b[K${ANSI.dim}Still ${activeEvent.message.toLowerCase()} — ${formatDuration(now - stageStartedAt)} in stage, ${formatDuration(elapsedMs)} total${ANSI.reset}\n`);
+      }
     }
   };
 
   const interval = setInterval(renderSpinner, SPINNER_INTERVAL_MS);
+  interval.unref?.();
   renderSpinner();
 
   const writeProgress = (text: string): void => {
@@ -74,11 +91,30 @@ export function createStreamProgressWithSpinner(
     write(text);
   };
 
-  const handler = createStreamProgressHandler(writeProgress, options);
+  const operationLabel = (): string => activeEvent
+    ? PLANNING_STAGE_LABELS[activeEvent.stage]
+    : (options.operationLabel?.() ?? '');
+  const handler = createStreamProgressHandler(writeProgress, { ...options, operationLabel });
 
   return {
     onLine: handler,
+    update: (event): void => {
+      if (stopped) return;
+      const now = wallClockNow();
+      if (event.status === 'started') {
+        activeEvent = event;
+        stageStartedAt = now;
+        renderSpinner();
+        return;
+      }
+      const next = event.nextStage ? ` Next: ${event.nextStage}.` : '';
+      writeProgress(`  ${ANSI.dim}${event.status === 'skipped' ? '↷' : '✓'} ${event.message} (stage ${formatDuration(now - stageStartedAt)} · total ${formatDuration(now - totalStartedAt)}).${next}${ANSI.reset}\n`);
+      activeEvent = event;
+    },
+    currentStage: () => activeEvent,
     stop: () => {
+      if (stopped) return;
+      stopped = true;
       clearInterval(interval);
       write('\r\x1b[K');
     },
@@ -279,6 +315,21 @@ export function createStreamProgressHandler(
     if ('hookSpecificOutput' in obj) return;
 
     const rawType = stringValue(obj['type']);
+    const rawStatus = stringValue(obj['status']);
+    if (rawType === 'franken_progress') {
+      let message: string | undefined;
+      if (rawStatus === 'fallback') {
+        message = `Provider ${String(obj['provider'] ?? 'unknown')} unavailable; falling back to ${String(obj['nextProvider'] ?? 'next provider')}`;
+      } else if (rawStatus === 'rate_limit_wait') {
+        message = `Providers rate-limited; retrying in ${formatDuration(Number(obj['retryAfterMs'] ?? 0))}`;
+      } else if (rawStatus === 'timeout') {
+        message = 'Provider timed out; checking fallback options';
+      } else if (rawStatus === 'retry') {
+        message = `Retrying provider ${String(obj['provider'] ?? '')}`.trim();
+      }
+      if (message) write(`  ${ANSI.dim}↻ ${message}${ANSI.reset}\n`);
+      return;
+    }
     const isPartialToolStart = rawType === 'content_block_start';
     if (rawType === 'content_block_start') {
       const blockType = stringValue(asRecord(obj['content_block'])?.['type']);
@@ -328,7 +379,9 @@ export function createStreamProgressHandler(
         if (event.durationMs !== undefined) parts.push(`${(event.durationMs / 1000).toFixed(1)}s`);
         if (event.costUsd !== undefined) parts.push(`$${event.costUsd.toFixed(4)}`);
         if (event.turns !== undefined && event.turns > 1) parts.push(`${event.turns} turns`);
-        write(`  ${ANSI.dim}LLM done${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
+        const operation = options.operationLabel?.();
+        const completionLabel = operation ? `${operation} provider call complete` : 'LLM done';
+        write(`  ${ANSI.dim}${completionLabel}${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
         options.onProgressEvent?.({
           type: 'complete',
           ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
@@ -336,7 +389,8 @@ export function createStreamProgressHandler(
           ...(event.turns !== undefined ? { turns: event.turns } : {}),
         });
       } else if (event.type === 'retry') {
-        write(`  ${ANSI.dim}Provider retrying...${ANSI.reset}\n`);
+        const operation = options.operationLabel?.();
+        write(`  ${ANSI.dim}${operation ? `${operation} provider retrying...` : 'Provider retrying...'}${ANSI.reset}\n`);
       } else if (event.type === 'error') {
         write(`  ${ANSI.dim}Provider stream error${ANSI.reset}\n`);
       } else if (event.type === 'unknown' && options.verbose) {

--- a/packages/franken-orchestrator/src/adapters/stream-progress.ts
+++ b/packages/franken-orchestrator/src/adapters/stream-progress.ts
@@ -379,9 +379,8 @@ export function createStreamProgressHandler(
         if (event.durationMs !== undefined) parts.push(`${(event.durationMs / 1000).toFixed(1)}s`);
         if (event.costUsd !== undefined) parts.push(`$${event.costUsd.toFixed(4)}`);
         if (event.turns !== undefined && event.turns > 1) parts.push(`${event.turns} turns`);
-        const operation = options.operationLabel?.();
-        const completionLabel = operation ? `${operation} provider call complete` : 'LLM done';
-        write(`  ${ANSI.dim}${completionLabel}${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
+        const operation = options.operationLabel?.() || 'LLM';
+        write(`  ${ANSI.dim}${operation} provider call complete${parts.length > 0 ? ` (${parts.join(', ')})` : ''}${ANSI.reset}\n`);
         options.onProgressEvent?.({
           type: 'complete',
           ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
@@ -389,8 +388,8 @@ export function createStreamProgressHandler(
           ...(event.turns !== undefined ? { turns: event.turns } : {}),
         });
       } else if (event.type === 'retry') {
-        const operation = options.operationLabel?.();
-        write(`  ${ANSI.dim}${operation ? `${operation} provider retrying...` : 'Provider retrying...'}${ANSI.reset}\n`);
+        const operation = options.operationLabel?.() || 'LLM';
+        write(`  ${ANSI.dim}${operation} provider retrying...${ANSI.reset}\n`);
       } else if (event.type === 'error') {
         write(`  ${ANSI.dim}Provider stream error${ANSI.reset}\n`);
       } else if (event.type === 'unknown' && options.verbose) {

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -372,6 +372,21 @@ export class Session {
     };
     const persistLifecycleEvent = (event: CliLlmLifecycleEvent): void => {
       planLogSink.logger?.debug('LLM provider lifecycle', event, 'planner');
+      if (event.type === 'fallback') {
+        progress.onLine(JSON.stringify({
+          type: 'franken_progress', status: 'fallback', provider: event.from, nextProvider: event.to,
+        }));
+      } else if (event.type === 'wait') {
+        progress.onLine(JSON.stringify({
+          type: 'franken_progress', status: 'rate_limit_wait', retryAfterMs: event.durationMs,
+        }));
+      } else if (event.type === 'timeout') {
+        progress.onLine(JSON.stringify({ type: 'franken_progress', status: 'timeout' }));
+      } else if (event.type === 'attempt' && event.attempt > 1) {
+        progress.onLine(JSON.stringify({
+          type: 'franken_progress', status: 'retry', provider: event.provider,
+        }));
+      }
     };
     const createPlanProgress = () => createStreamProgressWithSpinner({
       label: 'Planning...',
@@ -510,17 +525,14 @@ export class Session {
     const contextGatherer = new PlanContextGatherer(paths.root);
     const llmGraphBuilder = new LlmGraphBuilder(cachingLlm, contextGatherer, {
       ...(this.config.planningTimeoutMs !== undefined ? { timeoutMs: this.config.planningTimeoutMs } : {}),
+      onProgress: (event) => progress.update(event),
     });
     const chunkWriter = new ChunkFileWriter(paths.plansDir);
 
     logger.info('Decomposing design into chunks...', 'planner');
 
     // Build the plan graph — lastChunks preserves the structured LLM output
-    try {
-      await runPlanStage('decompose', () => llmGraphBuilder.build({ goal: designContent }));
-    } finally {
-      progress.stop();
-    }
+    await runPlanStage('decompose', () => llmGraphBuilder.build({ goal: designContent }));
 
     const chunks = llmGraphBuilder.lastChunks;
     const issues = llmGraphBuilder.lastValidationIssues;
@@ -540,8 +552,19 @@ export class Session {
     }
 
     // Write chunk files using ChunkFileWriter
+    progress.update?.({
+      stage: 'writing-chunks', status: 'started', position: 6, total: 6,
+      message: 'Writing chunk files',
+    });
     let chunkPaths = chunkWriter.write(chunks, issues);
+    progress.update?.({
+      stage: 'writing-chunks', status: 'completed', position: 6, total: 6,
+      message: `Chunk writing complete — ${chunkPaths.length} file${chunkPaths.length === 1 ? '' : 's'}`,
+      chunks: chunkPaths.length,
+      nextStage: 'Reviewing plan',
+    });
     logger.info(`Wrote chunk files to ${paths.plansDir}`, 'planner');
+    progress.stop();
 
     // Review loop
     await reviewLoop({
@@ -554,14 +577,24 @@ export class Session {
           await runPlanStage('revise', () => llmGraphBuilder.build({
             goal: `${designContent}\n\nRevision feedback: ${feedback}`,
           }));
+          progress.update?.({
+            stage: 'writing-chunks', status: 'started', position: 6, total: 6,
+            message: 'Writing revised chunk files',
+          });
+          chunkPaths = chunkWriter.write(
+            llmGraphBuilder.lastChunks,
+            llmGraphBuilder.lastValidationIssues,
+          );
+          progress.update?.({
+            stage: 'writing-chunks', status: 'completed', position: 6, total: 6,
+            message: `Revised chunk writing complete — ${chunkPaths.length} file${chunkPaths.length === 1 ? '' : 's'}`,
+            chunks: chunkPaths.length,
+            nextStage: 'Reviewing plan',
+          });
+          return chunkPaths;
         } finally {
           progress.stop();
         }
-        chunkPaths = chunkWriter.write(
-          llmGraphBuilder.lastChunks,
-          llmGraphBuilder.lastValidationIssues,
-        );
-        return chunkPaths;
       },
     });
     logger.info('Plan cycle completed', {

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -7,6 +7,11 @@ import { ChunkValidator, type ValidationIssue } from './chunk-validator.js';
 import { ChunkRemediator } from './chunk-remediator.js';
 import type { PlanContextGatherer, PlanContext } from './plan-context-gatherer.js';
 import { CHUNK_GUARDRAILS } from './chunk-guardrails.js';
+import {
+  PLANNING_STAGE_TOTAL,
+  type PlanningProgressEvent,
+  type PlanningProgressListener,
+} from './planning-progress.js';
 
 const DEFAULT_PLAN_TIMEOUT_MS = 120_000;
 const QUALITY_RAMP_UP_MAX_CHARS = 2_000;
@@ -38,6 +43,7 @@ export interface LlmGraphBuilderOptions {
   /** Total deadline shared by context gathering, all LLM passes, retries, and fallbacks. */
   timeoutMs?: number;
   signal?: AbortSignal;
+  onProgress?: PlanningProgressListener;
 }
 
 class PlanBudgetExceededError extends Error {
@@ -134,18 +140,37 @@ export class LlmGraphBuilder implements GraphBuilder {
 
     try {
       this.throwIfAborted(controller.signal);
+      this.progress({
+        stage: 'gathering-context', status: 'started', position: 1,
+        message: 'Gathering codebase context',
+      });
       const context = this.contextGatherer
         ? await this.awaitWithAbort(this.contextGatherer.gather(intent.goal), controller.signal)
         : emptyContext;
-      checkPlanningDeadline();
+      if (this.contextGatherer) checkPlanningDeadline();
+      this.progress({
+        stage: 'gathering-context', status: this.contextGatherer ? 'completed' : 'skipped', position: 1,
+        message: this.contextGatherer ? 'Codebase context gathered' : 'Codebase context skipped — no gatherer configured',
+        nextStage: 'Decomposing design',
+      });
 
       const decomposer = new ChunkDecomposer(meteredLlm, { maxChunks: this.maxChunks });
+      this.progress({
+        stage: 'decomposing', status: 'started', position: 2,
+        message: 'Decomposing design into chunks',
+      });
       let chunks = await this.runStage(
         'decompose',
         controller.signal,
         () => decomposer.decompose(intent.goal, context, { signal: controller.signal }),
         checkPlanningDeadline,
       );
+      this.progress({
+        stage: 'decomposing', status: 'completed', position: 2,
+        message: `Decomposition complete — ${chunks.length} chunk${chunks.length === 1 ? '' : 's'}`,
+        chunks: chunks.length,
+        nextStage: 'Validating chunks',
+      });
       let validationIssues: ValidationIssue[] = [];
 
       const shouldValidate = !this.options.skipValidation
@@ -159,6 +184,10 @@ export class LlmGraphBuilder implements GraphBuilder {
         const validator = new ChunkValidator(meteredLlm);
 
         try {
+          this.progress({
+            stage: 'validating', status: 'started', position: 3,
+            message: 'Validating chunks',
+          });
           const result = await this.runStage(
             'validate',
             controller.signal,
@@ -168,16 +197,40 @@ export class LlmGraphBuilder implements GraphBuilder {
 
           if (result.revisedChunks) chunks = result.revisedChunks;
           validationIssues = result.issues;
+          const errors = result.issues.filter((issue) => issue.severity === 'error').length;
+          const warnings = result.issues.filter((issue) => issue.severity === 'warning').length;
+          this.progress({
+            stage: 'validating', status: 'completed', position: 3,
+            message: result.valid
+              ? `Validation passed — ${warnings} warning${warnings === 1 ? '' : 's'}`
+              : `Validation complete — ${errors} error${errors === 1 ? '' : 's'}, ${warnings} warning${warnings === 1 ? '' : 's'}`,
+            errors, warnings,
+            nextStage: result.valid ? 'Writing chunks' : 'Remediating chunks',
+          });
 
           if (!result.valid) {
             const remediator = new ChunkRemediator(meteredLlm);
+            this.progress({
+              stage: 'remediating', status: 'started', position: 4,
+              message: 'Remediating validation errors',
+            });
             chunks = await this.runStage(
               'remediate',
               controller.signal,
               () => remediator.remediate(chunks, result.issues, qualityContext, { signal: controller.signal }),
               checkPlanningDeadline,
             );
+            this.progress({
+              stage: 'remediating', status: 'completed', position: 4,
+              message: `Remediation complete — ${chunks.length} chunk${chunks.length === 1 ? '' : 's'} updated`,
+              chunks: chunks.length,
+              nextStage: 'Re-validating chunks',
+            });
 
+            this.progress({
+              stage: 'revalidating', status: 'started', position: 5,
+              message: 'Re-validating remediated chunks',
+            });
             const revalidation = await this.runStage(
               'revalidate',
               controller.signal,
@@ -186,6 +239,25 @@ export class LlmGraphBuilder implements GraphBuilder {
             );
             if (revalidation.revisedChunks) chunks = revalidation.revisedChunks;
             validationIssues = revalidation.issues;
+            const remainingErrors = revalidation.issues.filter((issue) => issue.severity === 'error').length;
+            const remainingWarnings = revalidation.issues.filter((issue) => issue.severity === 'warning').length;
+            this.progress({
+              stage: 'revalidating', status: 'completed', position: 5,
+              message: `Re-validation complete — ${remainingErrors} error${remainingErrors === 1 ? '' : 's'}, ${remainingWarnings} warning${remainingWarnings === 1 ? '' : 's'}`,
+              errors: remainingErrors,
+              warnings: remainingWarnings,
+              nextStage: 'Writing chunks',
+            });
+          } else {
+            this.progress({
+              stage: 'remediating', status: 'skipped', position: 4,
+              message: 'Remediation skipped — validation passed',
+            });
+            this.progress({
+              stage: 'revalidating', status: 'skipped', position: 5,
+              message: 'Re-validation skipped — no remediation required',
+              nextStage: 'Writing chunks',
+            });
           }
         } catch (error) {
           if (
@@ -202,6 +274,25 @@ export class LlmGraphBuilder implements GraphBuilder {
             this.buildDraftWarning(controller.signal.reason, timeoutMs),
           ];
         }
+      } else {
+        const reason = this.options.skipValidation
+          ? 'validation disabled'
+          : !this.contextGatherer
+            ? 'no codebase context available'
+            : 'adaptive validation not required';
+        this.progress({
+          stage: 'validating', status: 'skipped', position: 3,
+          message: `Validation skipped — ${reason}`,
+        });
+        this.progress({
+          stage: 'remediating', status: 'skipped', position: 4,
+          message: 'Remediation skipped — validation did not run',
+        });
+        this.progress({
+          stage: 'revalidating', status: 'skipped', position: 5,
+          message: 'Re-validation skipped — validation did not run',
+          nextStage: 'Writing chunks',
+        });
       }
 
       this.lastChunks = chunks;
@@ -324,6 +415,10 @@ export class LlmGraphBuilder implements GraphBuilder {
       description: `${description}; saved the completed decomposition as a draft`,
       suggestion: `Review the draft manually or retry with a plan timeout above ${timeoutMs}ms`,
     };
+  }
+
+  private progress(event: Omit<PlanningProgressEvent, 'total'>): void {
+    this.options.onProgress?.({ ...event, total: PLANNING_STAGE_TOTAL });
   }
 
   /** Sanitize chunk ID: only alphanumeric, underscores, hyphens. */

--- a/packages/franken-orchestrator/src/planning/planning-progress.ts
+++ b/packages/franken-orchestrator/src/planning/planning-progress.ts
@@ -1,0 +1,34 @@
+export type PlanningStage =
+  | 'gathering-context'
+  | 'decomposing'
+  | 'validating'
+  | 'remediating'
+  | 'revalidating'
+  | 'writing-chunks';
+
+export type PlanningStageStatus = 'started' | 'completed' | 'skipped';
+
+export interface PlanningProgressEvent {
+  readonly stage: PlanningStage;
+  readonly status: PlanningStageStatus;
+  readonly position: number;
+  readonly total: number;
+  readonly message: string;
+  readonly nextStage?: string;
+  readonly chunks?: number;
+  readonly errors?: number;
+  readonly warnings?: number;
+}
+
+export type PlanningProgressListener = (event: PlanningProgressEvent) => void;
+
+export const PLANNING_STAGE_TOTAL = 6;
+
+export const PLANNING_STAGE_LABELS: Readonly<Record<PlanningStage, string>> = {
+  'gathering-context': 'Context gathering',
+  decomposing: 'Decomposition',
+  validating: 'Validation',
+  remediating: 'Remediation',
+  revalidating: 'Re-validation',
+  'writing-chunks': 'Chunk writing',
+};

--- a/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/stream-progress.test.ts
@@ -108,7 +108,10 @@ describe('createStreamProgressHandler', () => {
 
   it('shows completion stats on result event', () => {
     const lines: string[] = [];
-    const handler = createStreamProgressHandler((t) => lines.push(t));
+    const handler = createStreamProgressHandler(
+      (t) => lines.push(t),
+      { operationLabel: () => 'Validation' },
+    );
 
     handler(JSON.stringify({
       type: 'result',
@@ -117,7 +120,7 @@ describe('createStreamProgressHandler', () => {
       duration_ms: 15200,
     }));
 
-    const resultLines = lines.filter(l => l.includes('LLM done'));
+    const resultLines = lines.filter(l => l.includes('Validation provider call complete'));
     expect(resultLines).toHaveLength(1);
     expect(resultLines[0]).toContain('15.2s');
     expect(resultLines[0]).toContain('$0.0523');
@@ -206,7 +209,8 @@ describe('createStreamProgressHandler', () => {
     expect(events.map((event) => event.type)).toEqual(['text', 'tool', 'usage', 'result']);
     expect(lines.some((line) => line.includes('gemini-plan'))).toBe(true);
     expect(lines.some((line) => line.includes('Using read_file:') && line.includes('gemini.ts'))).toBe(true);
-    expect(lines.some((line) => line.includes('LLM done') && line.includes('2.5s'))).toBe(true);
+    expect(lines.some((line) => line.includes('LLM provider call complete') && line.includes('2.5s'))).toBe(true);
+    expect(lines.join('')).not.toContain('LLM done');
   });
 
   it('redacts tool payloads from normalized events', () => {
@@ -458,7 +462,7 @@ describe('createStreamProgressWithSpinner', () => {
       duration_ms: 5000,
     }));
 
-    const doneLines = output.filter(t => t.includes('LLM done'));
+    const doneLines = output.filter(t => t.includes('LLM provider call complete'));
     expect(doneLines).toHaveLength(1);
     expect(doneLines[0]).toContain('5.0s');
 

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -16,6 +16,8 @@ let llmGraphBuilderCtorArg: unknown = undefined;
 let llmGraphBuilderCtorOptions: unknown = undefined;
 let lastCreateCliDepsOptions: import('../../../src/cli/dep-factory.js').CliDepOptions | undefined;
 let streamProgressOptions: { onProgressEvent?: (event: { type: string; [key: string]: unknown }) => void } | undefined;
+const mockProgressUpdate = vi.fn();
+const mockCurrentStage = vi.fn();
 const mockFinalize = vi.fn(async () => {});
 
 // ── Mock heavy deps ──
@@ -155,7 +157,7 @@ vi.mock('../../../src/planning/chunk-file-writer.js', () => {
 vi.mock('../../../src/adapters/stream-progress.js', () => ({
   createStreamProgressWithSpinner: vi.fn((options: typeof streamProgressOptions) => {
     streamProgressOptions = options;
-    return { onLine: vi.fn(), stop: vi.fn() };
+    return { onLine: vi.fn(), update: mockProgressUpdate, currentStage: mockCurrentStage, stop: vi.fn() };
   }),
   createStreamProgressHandler: vi.fn(() => vi.fn()),
 }));
@@ -310,7 +312,7 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     const config = makeConfig({ maxDurationMs: 300_000, planningTimeoutMs: 75_000 });
     await new Session(config).start();
 
-    expect(llmGraphBuilderCtorOptions).toEqual({ timeoutMs: 75_000 });
+    expect(llmGraphBuilderCtorOptions).toEqual(expect.objectContaining({ timeoutMs: 75_000 }));
   });
 
   it('runPlan() persists sanitized live progress and discloses the build log path', async () => {

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -877,6 +877,87 @@ describe('LlmGraphBuilder', () => {
       expect(builder.lastValidationIssues[0]!.severity).toBe('warning');
     });
 
+    it('reports the complete ordered stage sequence for a remediated plan', async () => {
+      const validationResponse = JSON.stringify({
+        valid: false,
+        issues: [{
+          severity: 'error',
+          chunkId: '01_setup',
+          category: 'chunk_too_thin',
+          description: 'Missing context field',
+          suggestion: 'Add context',
+        }],
+        revisedChunks: null,
+      });
+      const revalidationResponse = JSON.stringify({ valid: true, issues: [], revisedChunks: null });
+      const llm = {
+        complete: vi.fn()
+          .mockResolvedValueOnce(validChunksJson(twoChunks))
+          .mockResolvedValueOnce(validationResponse)
+          .mockResolvedValueOnce(validChunksJson(twoChunks))
+          .mockResolvedValueOnce(revalidationResponse),
+      };
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const events: Array<{
+        stage: string; status: string; position: number; total: number;
+        chunks?: number; errors?: number;
+      }> = [];
+
+      const builder = new LlmGraphBuilder(llm, gatherer as any, {
+        validationMode: 'always',
+        onProgress: (event) => events.push(event),
+      });
+      await builder.build(intent);
+
+      expect(events.map((event) =>
+        `${event.position}/${event.total}:${event.stage}:${event.status}`,
+      )).toEqual([
+        '1/6:gathering-context:started',
+        '1/6:gathering-context:completed',
+        '2/6:decomposing:started',
+        '2/6:decomposing:completed',
+        '3/6:validating:started',
+        '3/6:validating:completed',
+        '4/6:remediating:started',
+        '4/6:remediating:completed',
+        '5/6:revalidating:started',
+        '5/6:revalidating:completed',
+      ]);
+      expect(events.find((event) => event.stage === 'decomposing' && event.status === 'completed'))
+        .toMatchObject({ chunks: 2 });
+      expect(events.find((event) => event.stage === 'validating' && event.status === 'completed'))
+        .toMatchObject({ errors: 1 });
+    });
+
+    it('reports conditional remediation and re-validation as skipped', async () => {
+      const validationResponse = JSON.stringify({ valid: true, issues: [], revisedChunks: null });
+      const llm = {
+        complete: vi.fn()
+          .mockResolvedValueOnce(validChunksJson(twoChunks))
+          .mockResolvedValueOnce(validationResponse),
+      };
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const events: Array<{ stage: string; status: string }> = [];
+
+      const builder = new LlmGraphBuilder(llm, gatherer as any, {
+        onProgress: (event) => events.push(event),
+      });
+      await builder.build(intent);
+
+      expect(events.slice(-2)).toEqual([
+        expect.objectContaining({ stage: 'remediating', status: 'skipped' }),
+        expect.objectContaining({ stage: 'revalidating', status: 'skipped' }),
+      ]);
+    });
+
     it('skips remediation when validation passes', async () => {
       const validationResponse = JSON.stringify({
         valid: true,

--- a/tasks/issue-3307-progress.md
+++ b/tasks/issue-3307-progress.md
@@ -1,0 +1,10 @@
+# Issue #3307 progress — stage-aware planning UX
+
+- [x] Emit structured planning lifecycle events from graph construction.
+- [x] Surface bounded heartbeat, stage/total timing, skipped stages, retries, fallback, completion, failure, and cancellation in the CLI.
+- [x] Stop progress rendering during interactive review and resume it for revisions.
+- [x] Preserve recoverable drafts and report the active stage on Ctrl-C.
+- [x] Cover event ordering, fallback/retry behavior, spinner timing, and session cancellation with unit tests.
+- [x] Rebase onto `origin/main` and pass targeted tests, orchestrator tests, root build, typecheck, and lint.
+- [ ] Open PR and complete CI/Codex review gate.
+- [ ] Merge and verify issue closure.

--- a/tasks/issue-3307-progress.md
+++ b/tasks/issue-3307-progress.md
@@ -6,5 +6,6 @@
 - [x] Preserve recoverable drafts and report the active stage on Ctrl-C.
 - [x] Cover event ordering, fallback/retry behavior, spinner timing, and session cancellation with unit tests.
 - [x] Rebase onto `origin/main` and pass targeted tests, orchestrator tests, root build, typecheck, and lint.
-- [ ] Open PR and complete CI/Codex review gate.
+- [x] Open PR #3371.
+- [ ] Complete CI/Codex review gate.
 - [ ] Merge and verify issue closure.


### PR DESCRIPTION
## Summary
- add a typed planning-progress lifecycle across decomposition, validation, remediation, re-validation, and chunk writing
- render stage-aware CLI status with per-stage/total timing, bounded heartbeats, skip/next-stage context, and retry/fallback/timeout events
- report Ctrl-C cancellation with the active stage and recoverable-draft status while stopping progress during interactive review

## Test plan
- [x] `npm run test --workspace @franken/orchestrator -- tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/adapters/stream-progress.test.ts tests/unit/cli/session-plan.test.ts tests/unit/llm-graph-builder.test.ts` (124 tests)
- [x] `npm run test --workspace @franken/orchestrator` (4,037 tests)
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint` (warnings only; no errors)

Closes #3307
