### PR TITLE
fix(orchestrator): update Codex workspace sandbox args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,28 @@ jobs:
       - name: Phantom dependency check (every runtime import is declared)
         run: node scripts/check-phantom-deps.mjs
 
+  codex-cli-compatibility:
+    name: Codex CLI compatibility (${{ matrix.codex-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # 0.143.0 is the oldest Codex release Frankenbeast supports.
+        codex-version: ['0.143.0', 'latest']
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Codex CLI
+        run: npm install --global "@openai/codex@${{ matrix.codex-version }}"
+
+      - name: Validate workspace-write invocation arguments
+        run: node scripts/check-codex-cli-compat.mjs
+
   publish-smoke:
     name: publish smoke (pack + offline install + run)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deps:vulnerability-sla": "node scripts/check-package-manager.mjs --quiet && node scripts/dependency-vulnerability-sla.mjs",
     "check:package-manager": "node scripts/check-package-manager.mjs",
     "check:dependabot-supply-chain": "node scripts/check-dependabot-supply-chain.mjs",
+    "check:codex-cli-compat": "node scripts/check-codex-cli-compat.mjs",
     "dr:worker-push-rollback:dry-run": "node scripts/worker-push-rollback-plan.mjs --dry-run",
     "dr:runtime-config-rollback:dry-run": "node scripts/runtime-config-rollback-plan.mjs --dry-run",
     "create:project": "bash scripts/create-project.sh",

--- a/packages/franken-orchestrator/src/errors/command-failure.ts
+++ b/packages/franken-orchestrator/src/errors/command-failure.ts
@@ -1,4 +1,5 @@
 import { wallClockNow } from '@franken/types';
+import { redactSensitiveText } from '../logging/redaction.js';
 export type CommandFailureKind = 'rate_limit' | 'timeout' | 'spawn_error' | 'command_failed';
 
 export const MAX_RATE_LIMIT_SLEEP_MS = 120_000;
@@ -123,15 +124,17 @@ export function classifyCommandFailure(options: ClassifyCommandFailureOptions): 
     rateLimited,
     ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     ...(retryAfterClamped ? { retryAfterClamped: true } : {}),
-    stdout,
-    stderr,
+    stdout: redactSensitiveText(stdout),
+    stderr: redactSensitiveText(stderr),
     summary: buildSummary({
       kind,
       tool: options.tool,
       command: options.command,
       provider: options.provider,
       exitCode: options.exitCode,
+      stdout,
       stderr,
+      normalizedOutput: options.normalizedOutput,
     }),
     ...(options.details ? { details: options.details } : {}),
   };
@@ -225,10 +228,12 @@ function buildSummary(input: {
   command: string;
   provider?: string | undefined;
   exitCode?: number | undefined;
+  stdout: string;
   stderr: string;
+  normalizedOutput?: string | undefined;
 }): string {
   const subject = input.provider ?? input.tool;
-  const suffix = buildStderrSuffix(input.stderr);
+  const suffix = buildDiagnosticSuffix(input.normalizedOutput, input.stderr, input.stdout);
   if (input.kind === 'rate_limit') {
     return `${subject} rate limited while running ${input.command}${suffix}`;
   }
@@ -238,9 +243,24 @@ function buildSummary(input: {
   return `${input.tool} command failed: ${input.command}${input.exitCode !== undefined ? ` (exit ${input.exitCode})` : ''}${suffix}`;
 }
 
-function buildStderrSuffix(stderr: string): string {
-  const excerpt = stderr.trim().split('\n').filter(Boolean)[0];
-  return excerpt ? `: ${excerpt}` : '';
+function buildDiagnosticSuffix(normalizedOutput: string | undefined, stderr: string, stdout: string): string {
+  const normalizedExcerpt = diagnosticExcerpt(normalizedOutput ?? '');
+  const stderrExcerpt = diagnosticExcerpt(stderr);
+  const stdoutExcerpt = diagnosticExcerpt(stdout);
+  const parts: string[] = [];
+
+  if (normalizedExcerpt) parts.push(normalizedExcerpt);
+  if (stderrExcerpt && stderrExcerpt !== normalizedExcerpt) {
+    parts.push(normalizedExcerpt ? `stderr: ${stderrExcerpt}` : stderrExcerpt);
+  }
+  if (parts.length === 0 && stdoutExcerpt) parts.push(stdoutExcerpt);
+
+  return parts.length > 0 ? `: ${parts.join(' | ')}` : '';
+}
+
+function diagnosticExcerpt(text: string): string {
+  const firstLine = text.trim().split('\n').find((line) => line.trim().length > 0)?.trim() ?? '';
+  return redactSensitiveText(firstLine).slice(0, 1_000);
 }
 
 function readExecText(value: unknown): string {

--- a/packages/franken-orchestrator/src/providers/codex-args.ts
+++ b/packages/franken-orchestrator/src/providers/codex-args.ts
@@ -1,0 +1,65 @@
+const DEFAULT_SANDBOX_ARGS = ['--sandbox', 'workspace-write'] as const;
+
+export interface ResolvedCodexArgs {
+  sandboxArgs: string[];
+  extraArgs: string[];
+}
+
+/**
+ * Resolve a single deterministic Codex sandbox selection while preserving
+ * supported user arguments. Explicit user/config sandbox settings replace the
+ * default; ambiguous combinations fail before a Codex process is spawned.
+ */
+export function resolveCodexSandboxArgs(
+  extraArgs: readonly string[] | undefined,
+  hasConfiguredSandbox = false,
+): ResolvedCodexArgs {
+  const extras = [...(extraArgs ?? [])];
+  let sandboxSelections = hasConfiguredSandbox ? 1 : 0;
+
+  for (let index = 0; index < extras.length; index++) {
+    const arg = extras[index]!;
+    if (arg === '--full-auto' || arg.startsWith('--full-auto=')) {
+      throw new Error(
+        'Codex --full-auto is deprecated for Frankenbeast launches; use --sandbox workspace-write or one explicit sandbox selection.',
+      );
+    }
+
+    if (arg === '--sandbox' || arg === '-s') {
+      const value = extras[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error(`Codex ${arg} requires a sandbox mode.`);
+      }
+      sandboxSelections++;
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith('--sandbox=') || arg.startsWith('-s=')) {
+      if (arg.endsWith('=')) {
+        throw new Error('Codex sandbox selection requires a sandbox mode.');
+      }
+      sandboxSelections++;
+      continue;
+    }
+
+    if (arg === '--dangerously-bypass-approvals-and-sandbox') {
+      sandboxSelections++;
+      continue;
+    }
+
+    if ((arg === '-c' || arg === '--config') && /^sandbox_mode\s*=/.test(extras[index + 1] ?? '')) {
+      sandboxSelections++;
+      index++;
+    }
+  }
+
+  if (sandboxSelections > 1) {
+    throw new Error('Configure exactly one Codex sandbox selection; conflicting sandbox arguments are not supported.');
+  }
+
+  return {
+    sandboxArgs: sandboxSelections === 0 ? [...DEFAULT_SANDBOX_ARGS] : [],
+    extraArgs: extras,
+  };
+}

--- a/packages/franken-orchestrator/src/providers/codex-args.ts
+++ b/packages/franken-orchestrator/src/providers/codex-args.ts
@@ -48,12 +48,15 @@ export function resolveCodexSandboxArgs(
       continue;
     }
 
-    if (/^(?:--config|-c)=sandbox_mode\s*=/.test(arg)) {
+    if (/^(?:--config|-c)=(?:sandbox_mode|default_permissions)\s*=/.test(arg)) {
       sandboxSelections++;
       continue;
     }
 
-    if ((arg === '-c' || arg === '--config') && /^sandbox_mode\s*=/.test(extras[index + 1] ?? '')) {
+    if (
+      (arg === '-c' || arg === '--config')
+      && /^(?:sandbox_mode|default_permissions)\s*=/.test(extras[index + 1] ?? '')
+    ) {
       sandboxSelections++;
       index++;
     }

--- a/packages/franken-orchestrator/src/providers/codex-args.ts
+++ b/packages/franken-orchestrator/src/providers/codex-args.ts
@@ -43,7 +43,12 @@ export function resolveCodexSandboxArgs(
       continue;
     }
 
-    if (arg === '--dangerously-bypass-approvals-and-sandbox') {
+    if (arg === '--dangerously-bypass-approvals-and-sandbox' || arg === '--yolo') {
+      sandboxSelections++;
+      continue;
+    }
+
+    if (/^(?:--config|-c)=sandbox_mode\s*=/.test(arg)) {
       sandboxSelections++;
       continue;
     }

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -110,7 +110,8 @@ export class CodexCliAdapter implements ILlmProvider {
   }
 
   buildArgs(request: LlmRequest): string[] {
-    const hasConfiguredSandbox = Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode');
+    const hasConfiguredSandbox = this.options.profile !== undefined
+      || Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode');
     const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(
       this.options.extraArgs,
       hasConfiguredSandbox,

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -14,6 +14,7 @@ import { deterministicUuid } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 import { sanitizeRunConfigIntegrityEnv } from '../cli/run-config-integrity.js';
+import { resolveCodexSandboxArgs } from './codex-args.js';
 
 function terminateRunningProcess(proc: ChildProcess): void {
   if (proc.exitCode === null && proc.signalCode === null) {
@@ -109,7 +110,17 @@ export class CodexCliAdapter implements ILlmProvider {
   }
 
   buildArgs(request: LlmRequest): string[] {
-    const args = ['exec', '--json', '--ephemeral'];
+    const hasConfiguredSandbox = Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode');
+    const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(
+      this.options.extraArgs,
+      hasConfiguredSandbox,
+    );
+    const args = [
+      'exec',
+      ...sandboxArgs,
+      '--json',
+      '--ephemeral',
+    ];
     if (request.systemPrompt) {
       args.push('-c', `instructions=${request.systemPrompt}`);
     }
@@ -126,9 +137,7 @@ export class CodexCliAdapter implements ILlmProvider {
         args.push('-c', `${key}=${value}`);
       }
     }
-    if (this.options.extraArgs?.length) {
-      args.push(...this.options.extraArgs);
-    }
+    args.push(...extraArgs);
     return args;
   }
 

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -110,8 +110,8 @@ export class CodexCliAdapter implements ILlmProvider {
   }
 
   buildArgs(request: LlmRequest): string[] {
-    const hasConfiguredSandbox = this.options.profile !== undefined
-      || Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode');
+    const hasConfiguredSandbox = Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode')
+      || Object.hasOwn(this.options.configOverrides ?? {}, 'default_permissions');
     const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(
       this.options.extraArgs,
       hasConfiguredSandbox,

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -110,6 +110,10 @@ export class CodexCliAdapter implements ILlmProvider {
   }
 
   buildArgs(request: LlmRequest): string[] {
+    // A profile is not itself a sandbox selection: profiles commonly contain
+    // only model/reasoning settings. Callers that need profile-specific
+    // permissions must pass the explicit config override so workspace-write is
+    // omitted deterministically instead of silently falling back to read-only.
     const hasConfiguredSandbox = Object.hasOwn(this.options.configOverrides ?? {}, 'sandbox_mode')
       || Object.hasOwn(this.options.configOverrides ?? {}, 'default_permissions');
     const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -34,16 +34,20 @@ export class CodexProvider implements ICliProvider {
       .filter((line) => line.length > 0);
 
     const extracted: string[] = [];
+    const errors: string[] = [];
     for (const line of lines) {
       try {
         const parsed = JSON.parse(line) as unknown;
         tryExtractTextFromNode(parsed, extracted);
+        if (typeof parsed === 'object' && parsed !== null && 'error' in parsed) {
+          tryExtractTextFromNode((parsed as { error: unknown }).error, errors);
+        }
       } catch {
         extracted.push(line);
       }
     }
 
-    return extracted.join('\n').trim();
+    return (extracted.length > 0 ? extracted : errors).join('\n').trim();
   }
 
   estimateTokens(text: string): number {

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -8,6 +8,7 @@
 import type { ICliProvider, ProviderOpts } from './cli-provider.js';
 import { tryExtractTextFromNode, BASE_RATE_LIMIT_PATTERNS } from './stream-json-utils.js';
 import { sanitizeRunConfigIntegrityEnv } from '../../cli/run-config-integrity.js';
+import { resolveCodexSandboxArgs } from '../../providers/codex-args.js';
 
 const RATE_LIMIT_PATTERNS = BASE_RATE_LIMIT_PATTERNS;
 
@@ -17,13 +18,12 @@ export class CodexProvider implements ICliProvider {
   readonly chatModel = 'codex-mini';
 
   buildArgs(opts: ProviderOpts): string[] {
-    const args: string[] = ['exec', '--full-auto', '--json', '--color', 'never'];
+    const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(opts.extraArgs);
+    const args: string[] = ['exec', ...sandboxArgs, '--json', '--color', 'never'];
     if (opts.model) {
       args.push('--model', opts.model);
     }
-    if (opts.extraArgs) {
-      args.push(...opts.extraArgs);
-    }
+    args.push(...extraArgs);
     return args;
   }
 

--- a/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
+++ b/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
@@ -264,7 +264,6 @@ export function tryExtractTextFromNode(node: unknown, out: string[]): void {
     'result',
     'response',
     'message',
-    'error',
     'content_block',
     'item',
     'items',

--- a/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
+++ b/packages/franken-orchestrator/src/skills/providers/stream-json-utils.ts
@@ -264,6 +264,7 @@ export function tryExtractTextFromNode(node: unknown, out: string[]): void {
     'result',
     'response',
     'message',
+    'error',
     'content_block',
     'item',
     'items',

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -424,7 +424,9 @@ describe('CliLlmAdapter', () => {
 
         const args = calls[0]!.args;
         expect(args).toContain('exec');
-        expect(args).toContain('--full-auto');
+        expect(args).toContain('--sandbox');
+        expect(args).toContain('workspace-write');
+        expect(args).not.toContain('--full-auto');
         expect(args).toContain('--json');
         expect(args).toContain('--color');
         // prompt piped via stdin, not in args
@@ -497,6 +499,19 @@ describe('CliLlmAdapter', () => {
             rateLimited: false,
           }));
         }
+      });
+
+      it('reports normalized Codex JSONL failures alongside redacted stderr warnings', async () => {
+        const { spawnFn } = createMockSpawn({
+          stdout: JSON.stringify({ type: 'error', error: { message: 'workspace is not trusted' } }),
+          stderr: 'warning: deprecated option; API_KEY=super-secret-value',
+          exitCode: 1,
+        });
+        const adapter = new CliLlmAdapter(codexProvider, baseOpts, spawnFn);
+
+        await expect(adapter.execute({ prompt: 'test', maxTurns: 1 })).rejects.toThrow(
+          /workspace is not trusted.*warning: deprecated option; API_KEY=<redacted>/,
+        );
       });
 
       it('kills child process on timeout and rejects', async () => {

--- a/packages/franken-orchestrator/tests/unit/errors/command-failure.test.ts
+++ b/packages/franken-orchestrator/tests/unit/errors/command-failure.test.ts
@@ -65,6 +65,22 @@ describe('classifyCommandFailure', () => {
     expect(failure.summary).toContain('git checkout main');
   });
 
+  it('summarizes normalized stdout before redacted stderr diagnostics', () => {
+    const failure = classifyCommandFailure({
+      tool: 'llm',
+      provider: 'codex',
+      command: 'codex',
+      exitCode: 1,
+      stdout: '{"type":"error"}',
+      normalizedOutput: 'workspace is not trusted',
+      stderr: 'warning: deprecated option; API_KEY=super-secret-value',
+    });
+
+    expect(failure.summary).toContain('workspace is not trusted');
+    expect(failure.summary).toContain('warning: deprecated option; API_KEY=<redacted>');
+    expect(failure.summary).not.toContain('super-secret-value');
+  });
+
   it('clamps finite provider retry hints and rejects non-finite values', () => {
     const base = {
       tool: 'llm',

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -136,13 +136,13 @@ describe('CodexCliAdapter', () => {
         .toThrow(/one Codex sandbox selection/i);
     });
 
-    it('preserves profile sandbox configuration instead of overriding it', () => {
-      const profiled = new CodexCliAdapter({ profile: 'read-only-profile' });
+    it('keeps workspace-write for profiles without an explicit sandbox override', () => {
+      const profiled = new CodexCliAdapter({ profile: 'model-only-profile' });
       const args = profiled.buildArgs({ systemPrompt: '', messages: [] });
       expect(args).toContain('-p');
-      expect(args).toContain('read-only-profile');
-      expect(args).not.toContain('--sandbox');
-      expect(args).not.toContain('workspace-write');
+      expect(args).toContain('model-only-profile');
+      expect(args).toContain('--sandbox');
+      expect(args).toContain('workspace-write');
     });
 
     it('adds -c for system prompt', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -95,11 +95,45 @@ describe('CodexCliAdapter', () => {
   });
 
   describe('buildArgs()', () => {
-    it('includes exec --json --ephemeral', () => {
+    it('includes the supported workspace-write sandbox', () => {
       const args = adapter.buildArgs({ systemPrompt: '', messages: [] });
       expect(args[0]).toBe('exec');
+      expect(args).toContain('--sandbox');
+      expect(args).toContain('workspace-write');
       expect(args).toContain('--json');
       expect(args).toContain('--ephemeral');
+      expect(args).not.toContain('--full-auto');
+    });
+
+    it('uses one explicit sandbox selection and rejects conflicts', () => {
+      const readOnly = new CodexCliAdapter({ extraArgs: ['--sandbox', 'read-only'] });
+      const args = readOnly.buildArgs({ systemPrompt: '', messages: [] });
+      expect(args.filter((arg) => arg === '--sandbox')).toHaveLength(1);
+      expect(args).toContain('read-only');
+      expect(args).not.toContain('workspace-write');
+
+      const conflicting = new CodexCliAdapter({
+        extraArgs: ['--sandbox', 'read-only', '--sandbox=workspace-write'],
+      });
+      expect(() => conflicting.buildArgs({ systemPrompt: '', messages: [] }))
+        .toThrow(/one Codex sandbox selection/i);
+    });
+
+    it('treats sandbox_mode config as the single sandbox selection', () => {
+      const configured = new CodexCliAdapter({
+        configOverrides: { sandbox_mode: 'read-only' },
+      });
+      const args = configured.buildArgs({ systemPrompt: '', messages: [] });
+      expect(args).toContain('sandbox_mode=read-only');
+      expect(args).not.toContain('--sandbox');
+      expect(args).not.toContain('workspace-write');
+
+      const conflicting = new CodexCliAdapter({
+        configOverrides: { sandbox_mode: 'read-only' },
+        extraArgs: ['--sandbox', 'workspace-write'],
+      });
+      expect(() => conflicting.buildArgs({ systemPrompt: '', messages: [] }))
+        .toThrow(/one Codex sandbox selection/i);
     });
 
     it('adds -c for system prompt', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -96,7 +96,7 @@ describe('CodexCliAdapter', () => {
 
   describe('buildArgs()', () => {
     it('includes the supported workspace-write sandbox', () => {
-      const args = adapter.buildArgs({ systemPrompt: '', messages: [] });
+      const args = new CodexCliAdapter().buildArgs({ systemPrompt: '', messages: [] });
       expect(args[0]).toBe('exec');
       expect(args).toContain('--sandbox');
       expect(args).toContain('workspace-write');
@@ -134,6 +134,15 @@ describe('CodexCliAdapter', () => {
       });
       expect(() => conflicting.buildArgs({ systemPrompt: '', messages: [] }))
         .toThrow(/one Codex sandbox selection/i);
+    });
+
+    it('preserves profile sandbox configuration instead of overriding it', () => {
+      const profiled = new CodexCliAdapter({ profile: 'read-only-profile' });
+      const args = profiled.buildArgs({ systemPrompt: '', messages: [] });
+      expect(args).toContain('-p');
+      expect(args).toContain('read-only-profile');
+      expect(args).not.toContain('--sandbox');
+      expect(args).not.toContain('workspace-write');
     });
 
     it('adds -c for system prompt', () => {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-config.test.ts
@@ -56,6 +56,8 @@ describe('createLlmProvider', () => {
     expect(codex).toBeInstanceOf(CodexCliAdapter);
     expect((codex as CodexCliAdapter).buildArgs(request)).toEqual([
       'exec',
+      '--sandbox',
+      'workspace-write',
       '--json',
       '--ephemeral',
       '-c',
@@ -86,6 +88,8 @@ describe('createLlmProvider', () => {
     expect(codex).toBeInstanceOf(CodexCliAdapter);
     expect((codex as CodexCliAdapter).buildArgs(request)).toEqual([
       'exec',
+      '--sandbox',
+      'workspace-write',
       '--json',
       '--ephemeral',
       '-c',

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -234,7 +234,7 @@ describe('MartinLoop', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       '/usr/bin/codex',
-      ['exec', '--full-auto', '--json', '--color', 'never', expect.stringContaining('Implement feature X')],
+      ['exec', '--sandbox', 'workspace-write', '--json', '--color', 'never', expect.stringContaining('Implement feature X')],
       expect.objectContaining({
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: '/tmp/test-project',

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -51,6 +51,8 @@ describe('CodexProvider', () => {
   it.each([
     ['--config=sandbox_mode="read-only"'],
     ['-c=sandbox_mode="read-only"'],
+    ['--config=default_permissions=":read-only"'],
+    ['-c=default_permissions=":read-only"'],
     ['--yolo'],
   ])('recognizes single-token sandbox selection %s', (...extraArgs) => {
     const args = provider.buildArgs({ extraArgs });
@@ -182,6 +184,20 @@ describe('CodexProvider', () => {
   it('normalizeOutput extracts Codex JSONL error messages', () => {
     const raw = JSON.stringify({ type: 'error', error: { message: 'workspace is not trusted' } });
     expect(provider.normalizeOutput(raw)).toBe('workspace is not trusted');
+  });
+
+  it('normalizeOutput ignores recovered tool errors when final output exists', () => {
+    const raw = [
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'tool_call', error: { message: 'temporary MCP failure' } },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'final answer' },
+      }),
+    ].join('\n');
+    expect(provider.normalizeOutput(raw)).toBe('final answer');
   });
 
   it('normalizeOutput extracts assistant text from codex item.completed events', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -48,6 +48,16 @@ describe('CodexProvider', () => {
     expect(args).not.toContain('workspace-write');
   });
 
+  it.each([
+    ['--config=sandbox_mode="read-only"'],
+    ['-c=sandbox_mode="read-only"'],
+    ['--yolo'],
+  ])('recognizes single-token sandbox selection %s', (...extraArgs) => {
+    const args = provider.buildArgs({ extraArgs });
+    expect(args).toEqual(['exec', '--json', '--color', 'never', ...extraArgs]);
+    expect(args).not.toContain('workspace-write');
+  });
+
   it('rejects deprecated or contradictory sandbox arguments', () => {
     expect(() => provider.buildArgs({ extraArgs: ['--full-auto'] })).toThrow(/deprecated/i);
     expect(() => provider.buildArgs({

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -23,11 +23,10 @@ describe('CodexProvider', () => {
 
   // -- buildArgs -----------------------------------------------------------
 
-  it('buildArgs includes exec --full-auto --json', () => {
+  it('buildArgs uses the supported workspace-write sandbox', () => {
     const args = provider.buildArgs({});
-    expect(args[0]).toBe('exec');
-    expect(args).toContain('--full-auto');
-    expect(args).toContain('--json');
+    expect(args).toEqual(['exec', '--sandbox', 'workspace-write', '--json', '--color', 'never']);
+    expect(args).not.toContain('--full-auto');
   });
 
   it('buildArgs includes --color never', () => {
@@ -38,9 +37,22 @@ describe('CodexProvider', () => {
   });
 
   it('buildArgs appends extraArgs', () => {
-    const args = provider.buildArgs({ extraArgs: ['--model', 'o3'] });
-    expect(args).toContain('--model');
-    expect(args).toContain('o3');
+    const args = provider.buildArgs({ extraArgs: ['--foo', 'bar'] });
+    expect(args.slice(-2)).toEqual(['--foo', 'bar']);
+  });
+
+  it('lets one explicit sandbox argument replace the default', () => {
+    const args = provider.buildArgs({ extraArgs: ['--sandbox', 'read-only'] });
+    expect(args.filter((arg) => arg === '--sandbox')).toHaveLength(1);
+    expect(args).toContain('read-only');
+    expect(args).not.toContain('workspace-write');
+  });
+
+  it('rejects deprecated or contradictory sandbox arguments', () => {
+    expect(() => provider.buildArgs({ extraArgs: ['--full-auto'] })).toThrow(/deprecated/i);
+    expect(() => provider.buildArgs({
+      extraArgs: ['--sandbox', 'read-only', '-s', 'workspace-write'],
+    })).toThrow(/one Codex sandbox selection/i);
   });
 
   it('buildArgs includes the selected model', () => {
@@ -155,6 +167,11 @@ describe('CodexProvider', () => {
     const result = provider.normalizeOutput(raw);
     expect(result).toContain('from json');
     expect(result).toContain('plain line');
+  });
+
+  it('normalizeOutput extracts Codex JSONL error messages', () => {
+    const raw = JSON.stringify({ type: 'error', error: { message: 'workspace is not trusted' } });
+    expect(provider.normalizeOutput(raw)).toBe('workspace is not trusted');
   });
 
   it('normalizeOutput extracts assistant text from codex item.completed events', () => {

--- a/scripts/check-codex-cli-compat.mjs
+++ b/scripts/check-codex-cli-compat.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const codexBinary = process.env.CODEX_BINARY?.trim() || 'codex';
+const requiredArgs = ['exec', '--sandbox', 'workspace-write', '--json', '--color', 'never', '--help'];
+const result = spawnSync(codexBinary, requiredArgs, {
+  encoding: 'utf8',
+  stdio: 'pipe',
+});
+
+if (result.error) {
+  console.error(`Codex CLI compatibility check could not start ${codexBinary}: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  const diagnostic = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+  console.error(`Codex CLI rejected Frankenbeast's workspace-write arguments (exit ${result.status}).`);
+  if (diagnostic) console.error(diagnostic);
+  process.exit(result.status ?? 1);
+}
+
+const help = `${result.stdout}\n${result.stderr}`;
+if (!help.includes('workspace-write')) {
+  console.error('Codex CLI help did not advertise the required workspace-write sandbox mode.');
+  process.exit(1);
+}
+
+const version = spawnSync(codexBinary, ['--version'], { encoding: 'utf8', stdio: 'pipe' });
+const versionText = `${version.stdout}\n${version.stderr}`.trim() || 'unknown version';
+console.log(`Codex CLI compatibility check passed: ${versionText}`);

--- a/tasks/issue-3369-codex-cli-compat-progress.md
+++ b/tasks/issue-3369-codex-cli-compat-progress.md
@@ -1,0 +1,8 @@
+# Issue 3369 — Codex CLI compatibility progress
+
+- [x] Inspect issue, current Codex launch paths, failure classification, tests, and repository lessons.
+- [x] Add failing regression tests for supported workspace-write arguments, deterministic sandbox override handling, and JSONL failure summaries.
+- [x] Replace deprecated launch flags in legacy and consolidated Codex providers.
+- [x] Add minimum/latest Codex CLI compatibility smoke coverage.
+- [x] Run targeted tests, package typecheck/lint/build, compatibility smoke, real Codex execution, and self-review.
+- [ ] Commit, push, open a PR closing #3369, complete Codex review loop, and verify CI.


### PR DESCRIPTION
Closes #3369

## Summary
- replace deprecated Codex `--full-auto` launches with `--sandbox workspace-write` in both provider paths
- preserve explicit extra/config sandbox choices while rejecting contradictory selections
- include normalized Codex JSONL failures alongside redacted stderr diagnostics
- test real Codex CLI argument compatibility against 0.143.0 and latest in CI

## Verification
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run lint:security`
- orchestrator unit suite: 277 files / 4036 tests passed
- targeted regression suite: 6 files / 156 tests passed
- compatibility smoke: Codex CLI 0.143.0 and 0.144.6
- real Codex 0.143.0 workspace-write execution returned `CODEX_WORKSPACE_WRITE_OK`