### PR TITLE
perf(orchestrator): bound multi-pass planning latency

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import { now as deterministicNow, seededRandom } from '@franken/types';
 
 type UnifiedRequest = {
@@ -15,6 +15,8 @@ type UnifiedRequest = {
   max_tokens?: number;
   session_id?: string;
   sessionContinue?: boolean;
+  signal?: AbortSignal;
+  timeoutMs?: number;
 };
 
 type UnifiedResponse = {
@@ -60,7 +62,10 @@ export class AdapterLlmClient implements ILlmClient {
     this.defaultModel = defaultModel;
   }
 
-  async complete(prompt: string, options?: { sessionContinue?: boolean; sessionId?: string }): Promise<string> {
+  async complete(
+    prompt: string,
+    options?: LlmCompletionOptions & { sessionContinue?: boolean; sessionId?: string },
+  ): Promise<string> {
     const requestId = `llm-${deterministicNow()}-${seededRandom.random().toString(16).slice(2)}`;
     const model = this.defaultModel;
     
@@ -71,6 +76,8 @@ export class AdapterLlmClient implements ILlmClient {
       messages: [{ role: 'user', content: prompt }],
       ...(options?.sessionId ? { session_id: options.sessionId } : {}),
       ...(options?.sessionContinue !== undefined ? { sessionContinue: options.sessionContinue } : {}),
+      ...(options?.signal ? { signal: options.signal } : {}),
+      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
     };
 
     let span: any;

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -27,6 +27,8 @@ type CliTransformed = {
   sessionId?: string | undefined;
   cacheSession?: CliCacheSessionHint | undefined;
   requestId?: string | undefined;
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
 };
 
 type ProviderOverride = {
@@ -134,6 +136,8 @@ export class CliLlmAdapter implements IAdapter {
       cacheSession?: CliCacheSessionHint;
       sessionContinue?: boolean;
       session_id?: string;
+      signal?: AbortSignal;
+      timeoutMs?: number;
     };
     const userMessages = req.messages.filter((m) => m.role === 'user');
     const last = userMessages[userMessages.length - 1];
@@ -150,6 +154,8 @@ export class CliLlmAdapter implements IAdapter {
       sessionContinue,
       ...(req.session_id ? { sessionId: req.session_id } : {}),
       ...(req.id ? { requestId: req.id } : {}),
+      ...(req.signal ? { signal: req.signal } : {}),
+      ...(req.timeoutMs !== undefined ? { timeoutMs: req.timeoutMs } : {}),
     };
     if (cacheSession) {
       transformed.cacheSession = cacheSession;
@@ -158,7 +164,18 @@ export class CliLlmAdapter implements IAdapter {
   }
 
   async execute(providerRequest: unknown): Promise<string> {
-    const { prompt, maxTurns, model, chatMode, sessionContinue, sessionId, requestId, cacheSession } = providerRequest as CliTransformed;
+    const {
+      prompt,
+      maxTurns,
+      model,
+      chatMode,
+      sessionContinue,
+      sessionId,
+      requestId,
+      cacheSession,
+      signal: callerSignal,
+      timeoutMs: requestedTimeoutMs,
+    } = providerRequest as CliTransformed;
     if (chatMode) this.chatCallCount++;
     const providers = normalizeProviderChain(this.provider.name, this.opts.providers);
     const exhaustedProviders = new Map<string, CommandFailure>();
@@ -166,8 +183,32 @@ export class CliLlmAdapter implements IAdapter {
     const initialProvider = this.provider.name;
     let activeProvider = initialProvider;
     let rateLimitRetryCycles = 0;
+    const timeoutMs = requestedTimeoutMs ?? this.opts.timeoutMs;
+    const deadlineAt = Date.now() + timeoutMs;
+    const logicalController = new AbortController();
+    const abortFromCaller = (): void => {
+      logicalController.abort(
+        callerSignal?.reason instanceof Error
+          ? callerSignal.reason
+          : new Error('LLM request cancelled'),
+      );
+    };
+    if (callerSignal?.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+    }
+    const logicalTimeout = setTimeout(() => {
+      logicalController.abort(
+        Object.assign(new Error(`CLI timeout after ${timeoutMs}ms`), { code: 'ETIMEDOUT' }),
+      );
+    }, timeoutMs);
+    logicalTimeout.unref?.();
+    const signal = logicalController.signal;
 
-    while (true) {
+    try {
+      while (true) {
+      throwIfAborted(signal);
       const provider = this.resolveProvider(activeProvider);
       const activeModel = this.resolveModel(activeProvider, model);
       if (requestId) {
@@ -195,11 +236,14 @@ export class CliLlmAdapter implements IAdapter {
           }),
           env: provider.filterEnv(this.captureEnv()),
           prompt,
+          signal,
+          timeoutMs: Math.max(1, deadlineAt - Date.now()),
         });
       } catch (error) {
         if (requestId) {
           this.responseSessions.delete(requestId);
         }
+        throwIfAborted(signal);
 
         const failure = commandFailureFromExecError({
           tool: 'llm',
@@ -231,7 +275,7 @@ export class CliLlmAdapter implements IAdapter {
               });
             }
             const sleepMs = this.resolveSleepMs(exhaustedProviders);
-            await sleepFn(sleepMs);
+            await sleepWithAbort(sleepMs, sleepFn, signal);
             rateLimitRetryCycles++;
             exhaustedProviders.clear();
             activeProvider = initialProvider;
@@ -313,10 +357,14 @@ export class CliLlmAdapter implements IAdapter {
           cause: lastRateLimitedFailure(exhaustedProviders),
         });
       }
-      await sleepFn(sleepMs);
+      await sleepWithAbort(sleepMs, sleepFn, signal);
       rateLimitRetryCycles++;
       exhaustedProviders.clear();
       activeProvider = initialProvider;
+      }
+    } finally {
+      clearTimeout(logicalTimeout);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
     }
   }
 
@@ -439,6 +487,8 @@ export class CliLlmAdapter implements IAdapter {
     args: string[];
     env: Record<string, string>;
     prompt: string;
+    signal?: AbortSignal | undefined;
+    timeoutMs?: number | undefined;
   }): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
       const child = this._spawn(input.cmd, input.args, {
@@ -453,22 +503,72 @@ export class CliLlmAdapter implements IAdapter {
       let stdout = '';
       let stderr = '';
       let settled = false;
-      let timedOut = false;
+      let terminated = false;
       let hardKillTimer: ReturnType<typeof setTimeout> | undefined;
       let lineBuffer = '';
 
+      const settle = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        fn();
+      };
+
+      const scheduleHardKill = (): void => {
+        hardKillTimer = setTimeout(() => {
+          try {
+            child.kill('SIGKILL');
+          } catch (error) {
+            console.warn('[CliLlmAdapter] Failed to hard-kill timed-out CLI process', {
+              signal: 'SIGKILL',
+              pid: child.pid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }, 5_000);
+        // Do not keep short-lived invocations alive for the hard-kill fallback.
+        hardKillTimer.unref();
+      };
+
+      const terminate = (label: 'timed-out' | 'aborted'): void => {
+        terminated = true;
+        try {
+          child.kill('SIGTERM');
+        } catch (error) {
+          console.warn(`[CliLlmAdapter] Failed to terminate ${label} CLI process`, {
+            signal: 'SIGTERM',
+            pid: child.pid,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        scheduleHardKill();
+      };
+
+      const effectiveTimeoutMs = input.timeoutMs ?? this.opts.timeoutMs;
+      const timer = setTimeout(() => {
+        input.signal?.removeEventListener('abort', abortRequest);
+        terminate('timed-out');
+        const error = Object.assign(new Error(`CLI timeout after ${effectiveTimeoutMs}ms`), { code: 'ETIMEDOUT' });
+        settle(() => reject(error));
+      }, effectiveTimeoutMs);
+
       const clearTimers = (): void => {
         clearTimeout(timer);
+        input.signal?.removeEventListener('abort', abortRequest);
         if (hardKillTimer) {
           clearTimeout(hardKillTimer);
           hardKillTimer = undefined;
         }
       };
 
-      const settle = (fn: () => void): void => {
+      const abortRequest = (): void => {
         if (settled) return;
-        settled = true;
-        fn();
+        clearTimeout(timer);
+        input.signal?.removeEventListener('abort', abortRequest);
+        const reason = input.signal?.reason;
+        const timedOut = reason instanceof Error
+          && (reason as NodeJS.ErrnoException).code === 'ETIMEDOUT';
+        terminate(timedOut ? 'timed-out' : 'aborted');
+        settle(() => reject(reason instanceof Error ? reason : new Error('LLM request aborted')));
       };
 
       child.stdout!.on('data', (chunk: Buffer) => {
@@ -491,49 +591,24 @@ export class CliLlmAdapter implements IAdapter {
         stderr += chunk.toString();
       });
 
-      const timer = setTimeout(() => {
-        timedOut = true;
-        try {
-          child.kill('SIGTERM');
-        } catch (error) {
-          console.warn('[CliLlmAdapter] Failed to terminate timed-out CLI process', {
-            signal: 'SIGTERM',
-            pid: child.pid,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-        hardKillTimer = setTimeout(() => {
-          try {
-            child.kill('SIGKILL');
-          } catch (error) {
-            console.warn('[CliLlmAdapter] Failed to hard-kill timed-out CLI process', {
-              signal: 'SIGKILL',
-              pid: child.pid,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }, 5_000);
-        // Don't keep the event loop alive waiting on the hard-kill fallback;
-        // short-lived invocations should exit promptly after a timeout reject.
-        hardKillTimer.unref();
-        const error = Object.assign(new Error(`CLI timeout after ${this.opts.timeoutMs}ms`), { code: 'ETIMEDOUT' });
-        settle(() => reject(error));
-      }, this.opts.timeoutMs);
+      if (input.signal?.aborted) {
+        abortRequest();
+      } else {
+        input.signal?.addEventListener('abort', abortRequest, { once: true });
+      }
 
       child.on('close', (code) => {
         clearTimers();
         if (this.opts.onStreamLine && lineBuffer.trim().length > 0) {
           this.opts.onStreamLine(lineBuffer);
         }
-        if (timedOut) return;
+        if (terminated) return;
         settle(() => resolve({ stdout, stderr, exitCode: code ?? 1 }));
       });
 
       child.on('error', (err) => {
-        if (timedOut) {
-          // An 'error' here can mean the process couldn't be killed; keep the
-          // scheduled hard-kill (SIGKILL) so a process that ignored SIGTERM is
-          // still terminated. Only cancel the original deadline timer.
+        if (terminated) {
+          // Preserve the scheduled SIGKILL fallback if termination failed.
           clearTimeout(timer);
           return;
         }
@@ -600,4 +675,51 @@ function buildNoCliProvidersAvailableSummary(exhaustedProviders: Map<string, Com
 
 function defaultSleep(durationMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error('LLM request aborted');
+}
+
+function sleepWithAbort(
+  durationMs: number,
+  sleepFn: (durationMs: number) => Promise<void>,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (!signal) return sleepFn(durationMs);
+  throwIfAborted(signal);
+
+  if (sleepFn === defaultSleep) {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal.removeEventListener('abort', abort);
+        resolve();
+      }, durationMs);
+      const abort = (): void => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', abort);
+        reject(signal.reason instanceof Error ? signal.reason : new Error('LLM request aborted'));
+      };
+      signal.addEventListener('abort', abort, { once: true });
+    });
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const abort = (): void => {
+      signal.removeEventListener('abort', abort);
+      reject(signal.reason instanceof Error ? signal.reason : new Error('LLM request aborted'));
+    };
+    signal.addEventListener('abort', abort, { once: true });
+    sleepFn(durationMs).then(
+      () => {
+        signal.removeEventListener('abort', abort);
+        resolve();
+      },
+      (error) => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      },
+    );
+  });
 }

--- a/packages/franken-orchestrator/src/adapters/progress-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/progress-llm-client.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import { Spinner } from '../cli/spinner.js';
 
 export interface ProgressLlmClientOptions {
@@ -20,7 +20,7 @@ export class ProgressLlmClient implements ILlmClient {
     this.write = options.write ?? ((text: string) => process.stderr.write(text));
   }
 
-  async complete(prompt: string): Promise<string> {
+  async complete(prompt: string, options?: LlmCompletionOptions): Promise<string> {
     const spinner = new Spinner({
       silent: this.silent,
       write: (text: string) => {
@@ -35,7 +35,9 @@ export class ProgressLlmClient implements ILlmClient {
     spinner.start(this.label);
 
     try {
-      const result = await this.inner.complete(prompt);
+      const result = options
+        ? await this.inner.complete(prompt, options)
+        : await this.inner.complete(prompt);
       const elapsedSeconds = (spinner.elapsed() / 1000).toFixed(1);
       const tokenCount = estimateTokens(result);
 

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import type { ILlmObserver } from '../adapters/adapter-llm-client.js';
 import { CachedLlmClient } from './cached-llm-client.js';
 import { LlmCacheStore } from './llm-cache-store.js';
@@ -17,7 +17,7 @@ interface CliAdapterLike {
   consumeSessionMetadata?(requestId: string): CliSessionMetadata | undefined;
 }
 
-export interface LlmCacheHint {
+export interface LlmCacheHint extends LlmCompletionOptions {
   operation?: string | undefined;
   workId?: string | undefined;
   stablePrefix?: string | undefined;
@@ -47,8 +47,8 @@ export class CachedCliLlmClient implements ILlmClient {
     this.schemaVersion = options.schemaVersion ?? 1;
     this.cached = new CachedLlmClient({
       llm: {
-        complete: async (prompt: string) => {
-          const response = await this.invoke(prompt);
+        complete: async (prompt: string, completionOptions?: LlmCompletionOptions) => {
+          const response = await this.invoke(prompt, undefined, completionOptions);
           return response.content;
         },
       },
@@ -66,8 +66,8 @@ export class CachedCliLlmClient implements ILlmClient {
       ? {
           provider: this.options.provider,
           model: this.options.model,
-          resume: async (_sessionId: string | undefined, nextPrompt: string) => {
-            const response = await this.invoke(nextPrompt, workId);
+          resume: async (_sessionId: string | undefined, nextPrompt: string, completionOptions?: LlmCompletionOptions) => {
+            const response = await this.invoke(nextPrompt, workId, completionOptions);
             return {
               content: response.content,
               sessionId: response.sessionId ?? workId,
@@ -86,16 +86,26 @@ export class CachedCliLlmClient implements ILlmClient {
       ...(workPrefix ? { workPrefix } : {}),
       volatileSuffix: prompt,
       ...(nativeSession ? { nativeSession } : {}),
+      completionOptions: {
+        ...(hint?.signal ? { signal: hint.signal } : {}),
+        ...(hint?.timeoutMs !== undefined ? { timeoutMs: hint.timeoutMs } : {}),
+      },
     });
   }
 
-  private async invoke(prompt: string, cacheSessionKey?: string): Promise<{ content: string; sessionId?: string | undefined }> {
+  private async invoke(
+    prompt: string,
+    cacheSessionKey?: string,
+    completionOptions?: LlmCompletionOptions,
+  ): Promise<{ content: string; sessionId?: string | undefined }> {
     const requestId = `llm-${deterministicNow()}-${seededRandom.random().toString(16).slice(2)}`;
     const request = {
       id: requestId,
       provider: 'adapter',
       model: this.options.model,
       messages: [{ role: 'user', content: prompt }],
+      ...(completionOptions?.signal ? { signal: completionOptions.signal } : {}),
+      ...(completionOptions?.timeoutMs !== undefined ? { timeoutMs: completionOptions.timeoutMs } : {}),
       ...(cacheSessionKey
         ? {
             cacheSession: {

--- a/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-cli-llm-client.ts
@@ -85,6 +85,7 @@ export class CachedCliLlmClient implements ILlmClient {
           ) => {
             let response: { content: string; sessionId?: string | undefined };
             let clearSession = false;
+            const resumeStartedAt = Date.now();
             try {
               response = await this.invoke(nextPrompt, workId, completionOptions, sessionId);
             } catch (error) {
@@ -94,7 +95,11 @@ export class CachedCliLlmClient implements ILlmClient {
               this.metrics.recordNativeSessionFallback();
               clearSession = true;
               await this.cached.invalidateProviderSession(this.options.projectId, workId);
-              response = await this.invoke(nextPrompt, workId, completionOptions);
+              response = await this.invoke(
+                nextPrompt,
+                workId,
+                remainingCompletionOptions(completionOptions, resumeStartedAt),
+              );
             }
             return {
               content: response.content,
@@ -206,6 +211,20 @@ function joinNonEmpty(parts: Array<string | undefined>): string | undefined {
     return undefined;
   }
   return normalized.join('\n');
+}
+
+function remainingCompletionOptions(
+  options: LlmCompletionOptions | undefined,
+  startedAt: number,
+): LlmCompletionOptions | undefined {
+  if (options?.timeoutMs === undefined) return options;
+  const remainingMs = options.timeoutMs - (Date.now() - startedAt);
+  if (remainingMs <= 0) {
+    throw Object.assign(new Error('LLM completion deadline exceeded before stale-session retry'), {
+      code: 'ETIMEDOUT',
+    });
+  }
+  return { ...options, timeoutMs: remainingMs };
 }
 
 function isExpectedStaleSessionError(error: unknown): boolean {

--- a/packages/franken-orchestrator/src/cache/cached-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-llm-client.ts
@@ -68,7 +68,9 @@ export class CachedLlmClient {
     }
     this.metrics.recordManagedResponseMiss();
 
+    let completionOptions = request.completionOptions;
     if (request.nativeSession && workId) {
+      const nativeStartedAt = Date.now();
       this.metrics.recordNativeSessionAttempt();
       const existingSession = await this.deps.providerSessions.load({
         projectId: request.scope.projectId,
@@ -78,11 +80,11 @@ export class CachedLlmClient {
         promptFingerprint: computed.sessionFingerprint,
       });
 
-      const resumed = request.completionOptions
+      const resumed = completionOptions
         ? await request.nativeSession.resume(
             existingSession?.sessionId,
             computed.fullPrompt,
-            request.completionOptions,
+            completionOptions,
           )
         : await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
       if (resumed) {
@@ -109,11 +111,12 @@ export class CachedLlmClient {
       }
 
       this.metrics.recordNativeSessionFallback();
+      completionOptions = remainingCompletionOptions(completionOptions, nativeStartedAt);
     }
 
     this.metrics.recordInnerCall();
-    const response = request.completionOptions
-      ? await this.deps.llm.complete(computed.fullPrompt, request.completionOptions)
+    const response = completionOptions
+      ? await this.deps.llm.complete(computed.fullPrompt, completionOptions)
       : await this.deps.llm.complete(computed.fullPrompt);
     await this.persistCacheArtifacts(request, computed, response);
     return response;
@@ -170,4 +173,18 @@ export class CachedLlmClient {
   async invalidateProviderSession(projectId: string, workId: string): Promise<void> {
     await this.deps.providerSessions.remove(projectId, workId);
   }
+}
+
+function remainingCompletionOptions(
+  options: LlmCompletionOptions | undefined,
+  startedAt: number,
+): LlmCompletionOptions | undefined {
+  if (options?.timeoutMs === undefined) return options;
+  const remainingMs = options.timeoutMs - (Date.now() - startedAt);
+  if (remainingMs <= 0) {
+    throw Object.assign(new Error('LLM completion deadline exceeded before native fallback'), {
+      code: 'ETIMEDOUT',
+    });
+  }
+  return { ...options, timeoutMs: remainingMs };
 }

--- a/packages/franken-orchestrator/src/cache/cached-llm-client.ts
+++ b/packages/franken-orchestrator/src/cache/cached-llm-client.ts
@@ -3,6 +3,7 @@ import { LlmCacheStore } from './llm-cache-store.js';
 import { LlmCachePolicy, type CacheablePromptRequest } from './llm-cache-policy.js';
 import { ProviderSessionStore } from './provider-session-store.js';
 import { isoNow } from '@franken/types';
+import type { LlmCompletionOptions } from '@franken/types';
 
 export interface NativeSessionResult {
   content: string;
@@ -12,15 +13,20 @@ export interface NativeSessionResult {
 export interface NativeSessionController {
   provider: string;
   model: string;
-  resume(sessionId: string | undefined, prompt: string): Promise<NativeSessionResult | undefined>;
+  resume(
+    sessionId: string | undefined,
+    prompt: string,
+    options?: LlmCompletionOptions,
+  ): Promise<NativeSessionResult | undefined>;
 }
 
 export interface CachedPromptRequest extends CacheablePromptRequest {
   nativeSession?: NativeSessionController | undefined;
+  completionOptions?: LlmCompletionOptions | undefined;
 }
 
 export interface CachedLlmClientDeps {
-  llm: { complete(prompt: string): Promise<string> };
+  llm: { complete(prompt: string, options?: LlmCompletionOptions): Promise<string> };
   cacheStore: LlmCacheStore;
   policy: LlmCachePolicy;
   providerSessions: ProviderSessionStore;
@@ -72,7 +78,13 @@ export class CachedLlmClient {
       });
 
       try {
-        const resumed = await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
+        const resumed = request.completionOptions
+          ? await request.nativeSession.resume(
+              existingSession?.sessionId,
+              computed.fullPrompt,
+              request.completionOptions,
+            )
+          : await request.nativeSession.resume(existingSession?.sessionId, computed.fullPrompt);
         if (resumed) {
           this.metrics.recordNativeSessionHit();
           const sessionId = resumed.sessionId ?? existingSession?.sessionId;
@@ -92,7 +104,8 @@ export class CachedLlmClient {
           await this.persistCacheArtifacts(request, computed, resumed.content);
           return resumed.content;
         }
-      } catch {
+      } catch (error) {
+        if (request.completionOptions?.signal?.aborted || isTimeoutError(error)) throw error;
         // Fall through to backing llm call.
       }
 
@@ -100,7 +113,9 @@ export class CachedLlmClient {
     }
 
     this.metrics.recordInnerCall();
-    const response = await this.deps.llm.complete(computed.fullPrompt);
+    const response = request.completionOptions
+      ? await this.deps.llm.complete(computed.fullPrompt, request.completionOptions)
+      : await this.deps.llm.complete(computed.fullPrompt);
     await this.persistCacheArtifacts(request, computed, response);
     return response;
   }
@@ -152,4 +167,9 @@ export class CachedLlmClient {
       });
     }
   }
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (error as NodeJS.ErrnoException).code === 'ETIMEDOUT' || error.name === 'TimeoutError';
 }

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1646,6 +1646,7 @@ export async function main(): Promise<void> {
     dryRun: args.dryRun,
     maxCritiqueIterations: config.maxCritiqueIterations,
     maxDurationMs: config.maxDurationMs,
+    planningTimeoutMs: config.planningTimeoutMs,
     enableTracing: config.enableTracing,
     enableHeartbeat: config.enableHeartbeat,
     enableReflection: config.enableReflection,

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -95,6 +95,8 @@ export interface SessionConfig {
   maxCritiqueIterations?: number | undefined;
   /** Maximum execution time in milliseconds */
   maxDurationMs?: number | undefined;
+  /** Maximum end-to-end planning time in milliseconds */
+  planningTimeoutMs?: number | undefined;
   /** Whether to emit observability spans */
   enableTracing?: boolean | undefined;
   /** Whether to run a heartbeat pulse after execution */
@@ -409,7 +411,9 @@ export class Session {
       workPrefix: `plan:${planName}`,
     });
     const contextGatherer = new PlanContextGatherer(paths.root);
-    const llmGraphBuilder = new LlmGraphBuilder(cachingLlm, contextGatherer);
+    const llmGraphBuilder = new LlmGraphBuilder(cachingLlm, contextGatherer, {
+      ...(this.config.planningTimeoutMs !== undefined ? { timeoutMs: this.config.planningTimeoutMs } : {}),
+    });
     const chunkWriter = new ChunkFileWriter(paths.plansDir);
 
     logger.info('Decomposing design into chunks...', 'planner');
@@ -424,6 +428,15 @@ export class Session {
     const chunks = llmGraphBuilder.lastChunks;
     const issues = llmGraphBuilder.lastValidationIssues;
     logger.info(`Planned ${chunks.length} chunk(s)`, 'planner');
+    const planningMetrics = llmGraphBuilder.lastRunMetrics;
+    if (planningMetrics) {
+      logger.info('Planning pipeline metrics', {
+        passCount: planningMetrics.passCount,
+        promptBytes: planningMetrics.promptBytes,
+        elapsedMs: planningMetrics.elapsedMs,
+        stages: planningMetrics.stages,
+      });
+    }
 
     if (issues.length > 0) {
       logger.warn(`${issues.length} validation warning(s) attached to chunks`, 'planner');

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -184,6 +184,9 @@ const BaseOrchestratorConfigSchema = z.object({
   /** Maximum execution time in milliseconds. */
   maxDurationMs: z.number().int().min(1000).default(300_000),
 
+  /** Maximum end-to-end planning time in milliseconds. */
+  planningTimeoutMs: z.number().int().min(1000).default(120_000),
+
   /** Whether to run a heartbeat pulse after execution. Defaults off so production deployments must opt in. */
   enableHeartbeat: z.boolean().default(false),
 

--- a/packages/franken-orchestrator/src/planning/chunk-decomposer.ts
+++ b/packages/franken-orchestrator/src/planning/chunk-decomposer.ts
@@ -150,6 +150,17 @@ Each chunk object has the following fields:
     if (missing.length > 0) {
       throw new Error(`Chunk missing required fields: ${missing.join(', ')}`);
     }
+    const stringFields = ['id', 'objective', 'successCriteria', 'verificationCommand'];
+    const invalidStrings = stringFields.filter((field) => typeof c[field] !== 'string');
+    if (invalidStrings.length > 0) {
+      throw new Error(`Chunk fields must be strings: ${invalidStrings.join(', ')}`);
+    }
+    if (!Array.isArray(c.files) || !c.files.every((file) => typeof file === 'string')) {
+      throw new Error('Chunk field files must be an array of strings');
+    }
+    if (!Array.isArray(c.dependencies) || !c.dependencies.every((dependency) => typeof dependency === 'string')) {
+      throw new Error('Chunk field dependencies must be an array of strings');
+    }
   }
 
   private validate(chunks: ChunkDefinition[]): void {

--- a/packages/franken-orchestrator/src/planning/chunk-decomposer.ts
+++ b/packages/franken-orchestrator/src/planning/chunk-decomposer.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import type { ChunkDefinition } from '../cli/file-writer.js';
 import type { PlanContext } from './plan-context-gatherer.js';
 import { cleanLlmJson } from '../skills/providers/stream-json-utils.js';
@@ -16,9 +16,13 @@ export class ChunkDecomposer {
     private readonly options: { maxChunks: number },
   ) {}
 
-  async decompose(designDoc: string, context: PlanContext): Promise<ChunkDefinition[]> {
+  async decompose(
+    designDoc: string,
+    context: PlanContext,
+    completionOptions?: LlmCompletionOptions,
+  ): Promise<ChunkDefinition[]> {
     const prompt = this.buildDecompositionPrompt(designDoc, context);
-    const raw = await this.llm.complete(prompt);
+    const raw = await this.llm.complete(prompt, completionOptions);
     const chunks = this.parseResponse(raw);
     this.validate(chunks);
 

--- a/packages/franken-orchestrator/src/planning/chunk-file-writer.ts
+++ b/packages/franken-orchestrator/src/planning/chunk-file-writer.ts
@@ -196,7 +196,7 @@ export class ChunkFileWriter {
 
     // Warnings (only if there are validation issues for this chunk)
     if (validationIssues) {
-      const chunkIssues = validationIssues.filter((i) => i.chunkId === chunk.id);
+      const chunkIssues = validationIssues.filter((i) => i.chunkId === null || i.chunkId === chunk.id);
       if (chunkIssues.length > 0) {
         const issueLines = chunkIssues.map(
           (i) =>

--- a/packages/franken-orchestrator/src/planning/chunk-remediator.ts
+++ b/packages/franken-orchestrator/src/planning/chunk-remediator.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import type { ChunkDefinition } from '../cli/file-writer.js';
 import type { PlanContext } from './plan-context-gatherer.js';
 import type { ValidationIssue } from './chunk-validator.js';
@@ -19,9 +19,10 @@ export class ChunkRemediator {
     chunks: ChunkDefinition[],
     issues: ValidationIssue[],
     context: PlanContext,
+    completionOptions?: LlmCompletionOptions,
   ): Promise<ChunkDefinition[]> {
     const prompt = this.buildRemediationPrompt(chunks, issues, context);
-    const raw = await this.llm.complete(prompt);
+    const raw = await this.llm.complete(prompt, completionOptions);
     return this.parseResponse(raw, chunks);
   }
 

--- a/packages/franken-orchestrator/src/planning/chunk-validator.ts
+++ b/packages/franken-orchestrator/src/planning/chunk-validator.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import type { ChunkDefinition } from '../cli/file-writer.js';
 import type { PlanContext } from './plan-context-gatherer.js';
 import { cleanLlmJson } from '../skills/providers/stream-json-utils.js';
@@ -13,7 +13,8 @@ export interface ValidationIssue {
     | 'missing_interface'
     | 'design_gap'
     | 'chunk_too_large'
-    | 'chunk_too_thin';
+    | 'chunk_too_thin'
+    | 'planning_budget_exceeded';
   description: string;
   suggestion: string;
 }
@@ -39,9 +40,10 @@ export class ChunkValidator {
     chunks: ChunkDefinition[],
     designDoc: string,
     context: PlanContext,
+    completionOptions?: LlmCompletionOptions,
   ): Promise<ValidationResult> {
     const prompt = this.buildValidationPrompt(chunks, designDoc, context);
-    const raw = await this.llm.complete(prompt);
+    const raw = await this.llm.complete(prompt, completionOptions);
     return this.parseResponse(raw);
   }
 

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -9,6 +9,9 @@ import type { PlanContextGatherer, PlanContext } from './plan-context-gatherer.j
 import { CHUNK_GUARDRAILS } from './chunk-guardrails.js';
 
 const DEFAULT_PLAN_TIMEOUT_MS = 120_000;
+const QUALITY_RAMP_UP_MAX_CHARS = 2_000;
+const QUALITY_SIGNATURE_MAX_CHARS = 500;
+const QUALITY_PATTERN_MAX_CHARS = 500;
 
 type PlanStageName = 'decompose' | 'validate' | 'remediate' | 'revalidate';
 type PlanStageStatus = 'completed' | 'timed_out' | 'failed';
@@ -137,7 +140,6 @@ export class LlmGraphBuilder implements GraphBuilder {
       let chunks = await this.runStage('decompose', controller.signal, () =>
         decomposer.decompose(intent.goal, context, { signal: controller.signal }),
       );
-      const decompositionDraft = chunks;
       let validationIssues: ValidationIssue[] = [];
 
       const shouldValidate = !this.options.skipValidation
@@ -145,9 +147,9 @@ export class LlmGraphBuilder implements GraphBuilder {
         && (this.options.validationMode === 'always' || !this.isSimplePlan(chunks));
 
       if (shouldValidate) {
-        // Decomposition already contains the relevant context. Avoid resending the
-        // unchanged RAMP_UP/signature payload during every quality pass.
-        const qualityContext = emptyContext;
+        // Standalone providers still need codebase facts, but quality passes should
+        // not resend the full unchanged context gathered for decomposition.
+        const qualityContext = this.compactContext(context);
         const validator = new ChunkValidator(meteredLlm);
 
         try {
@@ -175,7 +177,6 @@ export class LlmGraphBuilder implements GraphBuilder {
           if (!controller.signal.aborted && isTimeoutError(error)) expirePlanningBudget();
           if (!controller.signal.aborted) throw error;
           if (!planningBudgetExceeded) throw error;
-          chunks = decompositionDraft;
           validationIssues = [this.buildDraftWarning(controller.signal.reason, timeoutMs)];
         }
       }
@@ -230,6 +231,25 @@ export class LlmGraphBuilder implements GraphBuilder {
       seenChunkIds.add(chunk.id);
     }
     return true;
+  }
+
+  private compactContext(context: PlanContext): PlanContext {
+    return {
+      rampUp: truncateContext(context.rampUp, QUALITY_RAMP_UP_MAX_CHARS),
+      relevantSignatures: context.relevantSignatures.slice(0, 8).map((entry) => ({
+        path: entry.path,
+        signatures: truncateContext(entry.signatures, QUALITY_SIGNATURE_MAX_CHARS),
+      })),
+      packageDeps: Object.fromEntries(
+        Object.entries(context.packageDeps)
+          .slice(0, 12)
+          .map(([name, dependencies]) => [name, dependencies.slice(0, 20)]),
+      ),
+      existingPatterns: context.existingPatterns.slice(0, 8).map((pattern) => ({
+        description: truncateContext(pattern.description, 200),
+        example: truncateContext(pattern.example, QUALITY_PATTERN_MAX_CHARS),
+      })),
+    };
   }
 
   private normalizeTimeout(timeoutMs: number | undefined): number {
@@ -373,6 +393,19 @@ export class LlmGraphBuilder implements GraphBuilder {
 }
 
 function isTimeoutError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return (error as NodeJS.ErrnoException).code === 'ETIMEDOUT' || error.name === 'TimeoutError';
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if ((current as NodeJS.ErrnoException).code === 'ETIMEDOUT' || current.name === 'TimeoutError') {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}
+
+function truncateContext(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n[context truncated]`;
 }

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -158,6 +158,7 @@ export class LlmGraphBuilder implements GraphBuilder {
           );
 
           if (result.revisedChunks) chunks = result.revisedChunks;
+          validationIssues = result.issues;
 
           if (!result.valid) {
             const remediator = new ChunkRemediator(meteredLlm);
@@ -170,14 +171,15 @@ export class LlmGraphBuilder implements GraphBuilder {
             );
             if (revalidation.revisedChunks) chunks = revalidation.revisedChunks;
             validationIssues = revalidation.issues;
-          } else {
-            validationIssues = result.issues;
           }
         } catch (error) {
           if (!controller.signal.aborted && isTimeoutError(error)) expirePlanningBudget();
           if (!controller.signal.aborted) throw error;
           if (!planningBudgetExceeded) throw error;
-          validationIssues = [this.buildDraftWarning(controller.signal.reason, timeoutMs)];
+          validationIssues = [
+            ...validationIssues,
+            this.buildDraftWarning(controller.signal.reason, timeoutMs),
+          ];
         }
       }
 
@@ -395,12 +397,24 @@ export class LlmGraphBuilder implements GraphBuilder {
 function isTimeoutError(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current = error;
-  while (current instanceof Error && !seen.has(current)) {
+  while (current && (typeof current === 'object' || typeof current === 'function') && !seen.has(current)) {
     seen.add(current);
-    if ((current as NodeJS.ErrnoException).code === 'ETIMEDOUT' || current.name === 'TimeoutError') {
+    const candidate = current as {
+      code?: unknown;
+      name?: unknown;
+      kind?: unknown;
+      timedOut?: unknown;
+      cause?: unknown;
+    };
+    if (
+      candidate.code === 'ETIMEDOUT'
+      || candidate.name === 'TimeoutError'
+      || candidate.kind === 'timeout'
+      || candidate.timedOut === true
+    ) {
       return true;
     }
-    current = current.cause;
+    current = candidate.cause;
   }
   return false;
 }

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -82,10 +82,12 @@ export class LlmGraphBuilder implements GraphBuilder {
     const timeoutMs = this.normalizeTimeout(this.options.timeoutMs);
     const controller = new AbortController();
     let planningBudgetExceeded = false;
-    const timeout = setTimeout(() => {
+    const expirePlanningBudget = (): void => {
+      if (controller.signal.aborted) return;
       planningBudgetExceeded = true;
       controller.abort(new PlanBudgetExceededError(timeoutMs));
-    }, timeoutMs);
+    };
+    const timeout = setTimeout(expirePlanningBudget, timeoutMs);
 
     const abortFromCaller = (): void => {
       controller.abort(this.options.signal?.reason ?? new Error('Planning cancelled'));
@@ -128,6 +130,7 @@ export class LlmGraphBuilder implements GraphBuilder {
       const context = this.contextGatherer
         ? await this.awaitWithAbort(this.contextGatherer.gather(intent.goal), controller.signal)
         : emptyContext;
+      if (Date.now() - startedAt >= timeoutMs) expirePlanningBudget();
       this.throwIfAborted(controller.signal);
 
       const decomposer = new ChunkDecomposer(meteredLlm, { maxChunks: this.maxChunks });
@@ -169,6 +172,7 @@ export class LlmGraphBuilder implements GraphBuilder {
             validationIssues = result.issues;
           }
         } catch (error) {
+          if (!controller.signal.aborted && isTimeoutError(error)) expirePlanningBudget();
           if (!controller.signal.aborted) throw error;
           if (!planningBudgetExceeded) throw error;
           chunks = decompositionDraft;
@@ -201,7 +205,7 @@ export class LlmGraphBuilder implements GraphBuilder {
       this.throwIfAborted(signal);
       return await this.awaitWithAbort(run(), signal);
     } catch (error) {
-      stage.status = signal.aborted ? 'timed_out' : 'failed';
+      stage.status = signal.aborted || isTimeoutError(error) ? 'timed_out' : 'failed';
       throw error;
     } finally {
       stage.elapsedMs = Date.now() - startedAt;
@@ -366,4 +370,9 @@ export class LlmGraphBuilder implements GraphBuilder {
 
     return parts.join('\n');
   }
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (error as NodeJS.ErrnoException).code === 'ETIMEDOUT' || error.name === 'TimeoutError';
 }

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -1,4 +1,4 @@
-import type { ILlmClient } from '@franken/types';
+import type { ILlmClient, LlmCompletionOptions } from '@franken/types';
 import type { PlanGraph, PlanTask, PlanIntent } from '../deps.js';
 import type { GraphBuilder } from './chunk-file-graph-builder.js';
 import type { ChunkDefinition } from '../cli/file-writer.js';
@@ -8,32 +8,98 @@ import { ChunkRemediator } from './chunk-remediator.js';
 import type { PlanContextGatherer, PlanContext } from './plan-context-gatherer.js';
 import { CHUNK_GUARDRAILS } from './chunk-guardrails.js';
 
+const DEFAULT_PLAN_TIMEOUT_MS = 120_000;
+
+type PlanStageName = 'decompose' | 'validate' | 'remediate' | 'revalidate';
+type PlanStageStatus = 'completed' | 'timed_out' | 'failed';
+
+export interface PlanStageMetrics {
+  name: PlanStageName;
+  promptBytes: number;
+  elapsedMs: number;
+  status: PlanStageStatus;
+}
+
+export interface PlanRunMetrics {
+  passCount: number;
+  promptBytes: number;
+  elapsedMs: number;
+  stages: PlanStageMetrics[];
+}
+
+export interface LlmGraphBuilderOptions {
+  maxChunks?: number;
+  skipValidation?: boolean;
+  /** Adaptive skips quality passes for structurally simple one/two-chunk plans. */
+  validationMode?: 'adaptive' | 'always';
+  /** Total deadline shared by context gathering, all LLM passes, retries, and fallbacks. */
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+class PlanBudgetExceededError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Planning deadline exceeded after ${timeoutMs}ms`);
+    this.name = 'PlanBudgetExceededError';
+  }
+}
+
 /**
  * GraphBuilder implementation that uses ILlmClient.complete() to decompose
  * a design document into a PlanGraph with ordered impl+harden task pairs.
  *
- * Uses a multi-pass pipeline:
- *   Pass 1: Decompose (ChunkDecomposer)
- *   Pass 2: Validate (ChunkValidator) — optional
- *   Pass 3: Remediate (ChunkRemediator) — conditional on validation errors
- *   Pass 4: Re-validate (ChunkValidator) — conditional on remediation
+ * Uses an adaptive, bounded pipeline:
+ *   Pass 1: Decompose (always)
+ *   Pass 2: Validate (complex plans only by default)
+ *   Pass 3: Remediate (conditional on validation errors)
+ *   Pass 4: Re-validate (conditional on remediation)
  */
 export class LlmGraphBuilder implements GraphBuilder {
   private readonly maxChunks: number;
+  private activeStage: PlanStageMetrics | undefined;
   /** The parsed chunk definitions from the last build() call. */
   public lastChunks: ChunkDefinition[] = [];
   /** Validation issues from the last build() call (warnings after remediation). */
   public lastValidationIssues: ValidationIssue[] = [];
+  /** Per-stage performance evidence from the last build() call. */
+  public lastRunMetrics: PlanRunMetrics = {
+    passCount: 0,
+    promptBytes: 0,
+    elapsedMs: 0,
+    stages: [],
+  };
 
   constructor(
     private readonly llm: ILlmClient,
     private readonly contextGatherer?: PlanContextGatherer,
-    private readonly options?: { maxChunks?: number; skipValidation?: boolean },
+    private readonly options: LlmGraphBuilderOptions = {},
   ) {
-    this.maxChunks = options?.maxChunks ?? 12;
+    this.maxChunks = options.maxChunks ?? 12;
   }
 
   async build(intent: PlanIntent): Promise<PlanGraph> {
+    const startedAt = Date.now();
+    const timeoutMs = this.normalizeTimeout(this.options.timeoutMs);
+    const controller = new AbortController();
+    let planningBudgetExceeded = false;
+    const timeout = setTimeout(() => {
+      planningBudgetExceeded = true;
+      controller.abort(new PlanBudgetExceededError(timeoutMs));
+    }, timeoutMs);
+
+    const abortFromCaller = (): void => {
+      controller.abort(this.options.signal?.reason ?? new Error('Planning cancelled'));
+    };
+    if (this.options.signal?.aborted) {
+      abortFromCaller();
+    } else {
+      this.options.signal?.addEventListener('abort', abortFromCaller, { once: true });
+    }
+
+    this.lastChunks = [];
+    this.lastValidationIssues = [];
+    this.lastRunMetrics = { passCount: 0, promptBytes: 0, elapsedMs: 0, stages: [] };
+
     const emptyContext: PlanContext = {
       rampUp: '',
       relevantSignatures: [],
@@ -41,46 +107,173 @@ export class LlmGraphBuilder implements GraphBuilder {
       existingPatterns: [],
     };
 
-    // Gather codebase context (or use empty if no gatherer provided)
-    const context = this.contextGatherer
-      ? await this.contextGatherer.gather(intent.goal)
-      : emptyContext;
+    const meteredLlm: ILlmClient = {
+      complete: async (prompt: string, completionOptions?: LlmCompletionOptions) => {
+        const promptBytes = Buffer.byteLength(prompt, 'utf8');
+        this.lastRunMetrics.promptBytes += promptBytes;
+        if (this.activeStage) this.activeStage.promptBytes += promptBytes;
+        const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
+        const response = await this.llm.complete(prompt, {
+          ...completionOptions,
+          signal: controller.signal,
+          timeoutMs: Math.min(completionOptions?.timeoutMs ?? remainingMs, remainingMs),
+        });
+        this.throwIfAborted(controller.signal);
+        return response;
+      },
+    };
 
-    // Pass 1: Decompose
-    const decomposer = new ChunkDecomposer(this.llm, { maxChunks: this.maxChunks });
-    let chunks = await decomposer.decompose(intent.goal, context);
+    try {
+      this.throwIfAborted(controller.signal);
+      const context = this.contextGatherer
+        ? await this.awaitWithAbort(this.contextGatherer.gather(intent.goal), controller.signal)
+        : emptyContext;
+      this.throwIfAborted(controller.signal);
 
-    let validationIssues: ValidationIssue[] = [];
+      const decomposer = new ChunkDecomposer(meteredLlm, { maxChunks: this.maxChunks });
+      let chunks = await this.runStage('decompose', controller.signal, () =>
+        decomposer.decompose(intent.goal, context, { signal: controller.signal }),
+      );
+      const decompositionDraft = chunks;
+      let validationIssues: ValidationIssue[] = [];
 
-    // Pass 2-4: Validate → Remediate → Re-validate (unless skipped)
-    if (!this.options?.skipValidation && this.contextGatherer) {
-      const validator = new ChunkValidator(this.llm);
-      const result = await validator.validate(chunks, intent.goal, context);
+      const shouldValidate = !this.options.skipValidation
+        && Boolean(this.contextGatherer)
+        && (this.options.validationMode === 'always' || !this.isSimplePlan(chunks));
 
-      if (result.revisedChunks) {
-        chunks = result.revisedChunks;
-      }
+      if (shouldValidate) {
+        // Decomposition already contains the relevant context. Avoid resending the
+        // unchanged RAMP_UP/signature payload during every quality pass.
+        const qualityContext = emptyContext;
+        const validator = new ChunkValidator(meteredLlm);
 
-      if (!result.valid) {
-        // Pass 3: Remediate (max 1 attempt)
-        const remediator = new ChunkRemediator(this.llm);
-        chunks = await remediator.remediate(chunks, result.issues, context);
+        try {
+          const result = await this.runStage('validate', controller.signal, () =>
+            validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+          );
 
-        // Pass 4: Re-validate
-        const revalidation = await validator.validate(chunks, intent.goal, context);
-        if (revalidation.revisedChunks) {
-          chunks = revalidation.revisedChunks;
+          if (result.revisedChunks) chunks = result.revisedChunks;
+
+          if (!result.valid) {
+            const remediator = new ChunkRemediator(meteredLlm);
+            chunks = await this.runStage('remediate', controller.signal, () =>
+              remediator.remediate(chunks, result.issues, qualityContext, { signal: controller.signal }),
+            );
+
+            const revalidation = await this.runStage('revalidate', controller.signal, () =>
+              validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+            );
+            if (revalidation.revisedChunks) chunks = revalidation.revisedChunks;
+            validationIssues = revalidation.issues;
+          } else {
+            validationIssues = result.issues;
+          }
+        } catch (error) {
+          if (!controller.signal.aborted) throw error;
+          if (!planningBudgetExceeded) throw error;
+          chunks = decompositionDraft;
+          validationIssues = [this.buildDraftWarning(controller.signal.reason, timeoutMs)];
         }
-        // Remaining issues become warnings
-        validationIssues = revalidation.issues;
-      } else {
-        validationIssues = result.issues; // warnings only
       }
+
+      this.lastChunks = chunks;
+      this.lastValidationIssues = validationIssues;
+      return this.buildGraph(chunks);
+    } finally {
+      clearTimeout(timeout);
+      this.options.signal?.removeEventListener('abort', abortFromCaller);
+      this.lastRunMetrics.elapsedMs = Date.now() - startedAt;
+      this.activeStage = undefined;
+    }
+  }
+
+  private async runStage<T>(
+    name: PlanStageName,
+    signal: AbortSignal,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = Date.now();
+    const stage: PlanStageMetrics = { name, promptBytes: 0, elapsedMs: 0, status: 'completed' };
+    this.lastRunMetrics.passCount += 1;
+    this.lastRunMetrics.stages.push(stage);
+    this.activeStage = stage;
+    try {
+      this.throwIfAborted(signal);
+      return await this.awaitWithAbort(run(), signal);
+    } catch (error) {
+      stage.status = signal.aborted ? 'timed_out' : 'failed';
+      throw error;
+    } finally {
+      stage.elapsedMs = Date.now() - startedAt;
+      this.activeStage = undefined;
+    }
+  }
+
+  private isSimplePlan(chunks: ChunkDefinition[]): boolean {
+    if (chunks.length === 0 || chunks.length > 2) return false;
+
+    const seenChunkIds = new Set<string>();
+    const claimedFiles = new Set<string>();
+    for (const chunk of chunks) {
+      if (seenChunkIds.has(chunk.id) || chunk.files.length === 0 || chunk.files.length > 4) return false;
+      if (chunk.dependencies.length > 1 || chunk.dependencies.some((dependency) => !seenChunkIds.has(dependency))) {
+        return false;
+      }
+      for (const file of chunk.files) {
+        if (claimedFiles.has(file)) return false;
+        claimedFiles.add(file);
+      }
+      seenChunkIds.add(chunk.id);
+    }
+    return true;
+  }
+
+  private normalizeTimeout(timeoutMs: number | undefined): number {
+    if (timeoutMs === undefined) return DEFAULT_PLAN_TIMEOUT_MS;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error('Planning timeoutMs must be a positive finite number');
+    }
+    return Math.floor(timeoutMs);
+  }
+
+  private throwIfAborted(signal: AbortSignal): void {
+    if (!signal.aborted) return;
+    throw signal.reason instanceof Error ? signal.reason : new Error('Planning cancelled');
+  }
+
+  private awaitWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    if (signal.aborted) {
+      return Promise.reject(signal.reason instanceof Error ? signal.reason : new Error('Planning cancelled'));
     }
 
-    this.lastChunks = chunks;
-    this.lastValidationIssues = validationIssues;
-    return this.buildGraph(chunks);
+    return new Promise<T>((resolve, reject) => {
+      const abort = (): void => {
+        signal.removeEventListener('abort', abort);
+        reject(signal.reason instanceof Error ? signal.reason : new Error('Planning cancelled'));
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      promise.then(
+        (value) => {
+          signal.removeEventListener('abort', abort);
+          resolve(value);
+        },
+        (error) => {
+          signal.removeEventListener('abort', abort);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private buildDraftWarning(reason: unknown, timeoutMs: number): ValidationIssue {
+    const description = reason instanceof Error ? reason.message : 'Planning quality pass was cancelled';
+    return {
+      severity: 'warning',
+      chunkId: null,
+      category: 'planning_budget_exceeded',
+      description: `${description}; saved the completed decomposition as a draft`,
+      suggestion: `Review the draft manually or retry with a plan timeout above ${timeoutMs}ms`,
+    };
   }
 
   /** Sanitize chunk ID: only alphanumeric, underscores, hyphens. */

--- a/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
+++ b/packages/franken-orchestrator/src/planning/llm-graph-builder.ts
@@ -90,6 +90,10 @@ export class LlmGraphBuilder implements GraphBuilder {
       planningBudgetExceeded = true;
       controller.abort(new PlanBudgetExceededError(timeoutMs));
     };
+    const checkPlanningDeadline = (): void => {
+      if (Date.now() - startedAt >= timeoutMs) expirePlanningBudget();
+      this.throwIfAborted(controller.signal);
+    };
     const timeout = setTimeout(expirePlanningBudget, timeoutMs);
 
     const abortFromCaller = (): void => {
@@ -133,12 +137,14 @@ export class LlmGraphBuilder implements GraphBuilder {
       const context = this.contextGatherer
         ? await this.awaitWithAbort(this.contextGatherer.gather(intent.goal), controller.signal)
         : emptyContext;
-      if (Date.now() - startedAt >= timeoutMs) expirePlanningBudget();
-      this.throwIfAborted(controller.signal);
+      checkPlanningDeadline();
 
       const decomposer = new ChunkDecomposer(meteredLlm, { maxChunks: this.maxChunks });
-      let chunks = await this.runStage('decompose', controller.signal, () =>
-        decomposer.decompose(intent.goal, context, { signal: controller.signal }),
+      let chunks = await this.runStage(
+        'decompose',
+        controller.signal,
+        () => decomposer.decompose(intent.goal, context, { signal: controller.signal }),
+        checkPlanningDeadline,
       );
       let validationIssues: ValidationIssue[] = [];
 
@@ -153,8 +159,11 @@ export class LlmGraphBuilder implements GraphBuilder {
         const validator = new ChunkValidator(meteredLlm);
 
         try {
-          const result = await this.runStage('validate', controller.signal, () =>
-            validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+          const result = await this.runStage(
+            'validate',
+            controller.signal,
+            () => validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+            checkPlanningDeadline,
           );
 
           if (result.revisedChunks) chunks = result.revisedChunks;
@@ -162,18 +171,30 @@ export class LlmGraphBuilder implements GraphBuilder {
 
           if (!result.valid) {
             const remediator = new ChunkRemediator(meteredLlm);
-            chunks = await this.runStage('remediate', controller.signal, () =>
-              remediator.remediate(chunks, result.issues, qualityContext, { signal: controller.signal }),
+            chunks = await this.runStage(
+              'remediate',
+              controller.signal,
+              () => remediator.remediate(chunks, result.issues, qualityContext, { signal: controller.signal }),
+              checkPlanningDeadline,
             );
 
-            const revalidation = await this.runStage('revalidate', controller.signal, () =>
-              validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+            const revalidation = await this.runStage(
+              'revalidate',
+              controller.signal,
+              () => validator.validate(chunks, intent.goal, qualityContext, { signal: controller.signal }),
+              checkPlanningDeadline,
             );
             if (revalidation.revisedChunks) chunks = revalidation.revisedChunks;
             validationIssues = revalidation.issues;
           }
         } catch (error) {
-          if (!controller.signal.aborted && isTimeoutError(error)) expirePlanningBudget();
+          if (
+            !controller.signal.aborted
+            && isTimeoutError(error)
+            && Date.now() - startedAt >= timeoutMs
+          ) {
+            expirePlanningBudget();
+          }
           if (!controller.signal.aborted) throw error;
           if (!planningBudgetExceeded) throw error;
           validationIssues = [
@@ -198,6 +219,7 @@ export class LlmGraphBuilder implements GraphBuilder {
     name: PlanStageName,
     signal: AbortSignal,
     run: () => Promise<T>,
+    checkDeadline?: () => void,
   ): Promise<T> {
     const startedAt = Date.now();
     const stage: PlanStageMetrics = { name, promptBytes: 0, elapsedMs: 0, status: 'completed' };
@@ -206,7 +228,9 @@ export class LlmGraphBuilder implements GraphBuilder {
     this.activeStage = stage;
     try {
       this.throwIfAborted(signal);
-      return await this.awaitWithAbort(run(), signal);
+      const value = await this.awaitWithAbort(run(), signal);
+      checkDeadline?.();
+      return value;
     } catch (error) {
       stage.status = signal.aborted || isTimeoutError(error) ? 'timed_out' : 'failed';
       throw error;

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -27,6 +27,19 @@ describe('AdapterLlmClient', () => {
     await expect(client.complete('prompt')).resolves.toBe('hello');
   });
 
+  it('forwards cancellation and deadline options to the adapter request', async () => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+    const controller = new AbortController();
+
+    await client.complete('prompt', { signal: controller.signal, timeoutMs: 42 });
+
+    expect(adapter.transformRequest).toHaveBeenCalledWith(expect.objectContaining({
+      signal: controller.signal,
+      timeoutMs: 42,
+    }));
+  });
+
   it('wraps adapter execute() failures in AdapterLlmError with the cause attached', async () => {
     const boom = new Error('socket hang up');
     const client = new AdapterLlmClient(

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -513,6 +513,63 @@ describe('CliLlmAdapter', () => {
           .rejects.toThrow(/timeout/i);
       });
 
+      it('allows a per-request timeout to extend beyond the adapter default', async () => {
+        vi.useFakeTimers();
+        try {
+          const { spawnFn } = createMockSpawn({ neverExit: true });
+          const adapter = new CliLlmAdapter(
+            claudeProvider,
+            { ...baseOpts, timeoutMs: 50 },
+            spawnFn,
+          );
+
+          const result = adapter.execute({ prompt: 'test', maxTurns: 1, timeoutMs: 100 });
+          let state: 'pending' | 'resolved' | 'rejected' = 'pending';
+          void result.then(
+            () => { state = 'resolved'; },
+            () => { state = 'rejected'; },
+          );
+
+          await vi.advanceTimersByTimeAsync(50);
+          expect(state).toBe('pending');
+          await vi.advanceTimersByTimeAsync(50);
+          await expect(result).rejects.toThrow('CLI timeout after 100ms');
+          expect(state).toBe('rejected');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('kills the active child process when the request aborts', async () => {
+        const kill = vi.fn(() => true);
+        const spawnFn = (): ChildProcess => {
+          const proc = new EventEmitter() as ChildProcess;
+          Object.defineProperty(proc, 'stdin', { value: new PassThrough(), writable: false });
+          Object.defineProperty(proc, 'stdout', { value: new PassThrough(), writable: false });
+          Object.defineProperty(proc, 'stderr', { value: new PassThrough(), writable: false });
+          Object.defineProperty(proc, 'pid', { value: 24680, writable: false });
+          Object.defineProperty(proc, 'kill', { value: kill, writable: false });
+          return proc;
+        };
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          { ...baseOpts, timeoutMs: 60_000 },
+          spawnFn,
+        );
+        const controller = new AbortController();
+
+        const result = adapter.execute({
+          prompt: 'test',
+          maxTurns: 1,
+          signal: controller.signal,
+          timeoutMs: 30_000,
+        });
+        controller.abort(new Error('plan deadline exceeded'));
+
+        await expect(result).rejects.toThrow('plan deadline exceeded');
+        expect(kill).toHaveBeenCalledWith('SIGTERM');
+      });
+
       it('warns and still rejects when the timeout SIGTERM fails', async () => {
         vi.useFakeTimers();
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -815,6 +872,62 @@ describe('CliLlmAdapter', () => {
         expect(calls[0]!.cmd).toBe('claude');
         expect(calls[1]!.cmd).toBe('codex');
         expect(calls[2]!.cmd).toBe('claude');
+      });
+
+      it('aborts an in-flight provider retry wait without starting another process', async () => {
+        const sleepFn = vi.fn(() => new Promise<void>(() => {}));
+        const { spawnFn, calls } = createQueuedSpawn([
+          { stderr: 'retry-after: 5', exitCode: 1 },
+          { stderr: 'resets in 3s', exitCode: 1 },
+          { stdout: 'must not run after cancellation', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['claude', 'codex'],
+            _sleepFn: sleepFn,
+          } as never,
+          spawnFn,
+        );
+        const controller = new AbortController();
+
+        const result = adapter.execute({
+          prompt: 'test',
+          maxTurns: 1,
+          signal: controller.signal,
+        });
+        await vi.waitFor(() => expect(sleepFn).toHaveBeenCalledWith(3_000));
+        controller.abort(new Error('plan deadline exceeded'));
+
+        await expect(result).rejects.toThrow('plan deadline exceeded');
+        expect(calls).toHaveLength(2);
+      });
+
+      it('enforces the logical completion timeout while waiting to retry providers', async () => {
+        const sleepFn = vi.fn(() => new Promise<void>(() => {}));
+        const { spawnFn, calls } = createQueuedSpawn([
+          { stderr: 'retry-after: 5', exitCode: 1 },
+          { stderr: 'resets in 3s', exitCode: 1 },
+          { stdout: 'must not run after timeout', exitCode: 0 },
+        ]);
+        const adapter = new CliLlmAdapter(
+          claudeProvider,
+          {
+            ...baseOpts,
+            providers: ['claude', 'codex'],
+            _sleepFn: sleepFn,
+          } as never,
+          spawnFn,
+        );
+
+        await expect(adapter.execute({
+          prompt: 'test',
+          maxTurns: 1,
+          timeoutMs: 25,
+        })).rejects.toThrow('CLI timeout after 25ms');
+        expect(sleepFn).toHaveBeenCalled();
+        expect(calls).toHaveLength(2);
       });
 
       it('retries a rate-limited provider when later fallback provider CLI is missing', async () => {

--- a/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-cli-llm-client.test.ts
@@ -148,15 +148,22 @@ describe('CachedCliLlmClient', () => {
 
     await client.complete('first prompt');
     adapter.execute
-      .mockRejectedValueOnce(new Error('Claude CLI failed', {
-        cause: { stdout: 'No conversation found with session ID: stored-session', stderr: '' },
-      }))
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        throw new Error('Claude CLI failed', {
+          cause: { stdout: 'No conversation found with session ID: stored-session', stderr: '' },
+        });
+      })
       .mockResolvedValueOnce('response:fresh');
 
-    await expect(client.complete('second prompt')).resolves.toBe('response:fresh');
+    await expect(client.complete('second prompt', { timeoutMs: 200 })).resolves.toBe('response:fresh');
 
     expect(adapter.transformRequest.mock.calls[1]?.[0]).toHaveProperty('session_id');
     expect(adapter.transformRequest.mock.calls[2]?.[0]).not.toHaveProperty('session_id');
+    expect(adapter.transformRequest.mock.calls[2]?.[0]).toEqual(expect.objectContaining({
+      timeoutMs: expect.any(Number),
+    }));
+    expect((adapter.transformRequest.mock.calls[2]?.[0] as { timeoutMs: number }).timeoutMs).toBeLessThan(200);
     expect(adapter.execute).toHaveBeenCalledTimes(3);
     expect(metrics.snapshot()).toMatchObject({ nativeSessionFallbacks: 1 });
     await expect(access(join(

--- a/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
@@ -173,8 +173,12 @@ describe('CachedLlmClient', () => {
   it('treats corrupt provider-session JSON as a miss before native-session fallback', async () => {
     const { llm, client, rootDir, metrics } = await createHarness();
     const resume = vi.fn<
-      (sessionId: string | undefined, prompt: string) => Promise<{ content: string; sessionId: string } | undefined>
-    >().mockResolvedValueOnce(undefined);
+      (sessionId: string | undefined, prompt: string, options?: { timeoutMs?: number }) => Promise<{ content: string; sessionId: string } | undefined>
+    >().mockImplementationOnce(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return undefined;
+    });
+    const completeSpy = vi.spyOn(llm, 'complete');
     const request = {
       scope: {
         projectId: 'frankenbeast',
@@ -184,6 +188,7 @@ describe('CachedLlmClient', () => {
       stablePrefix: 'skill injection',
       workPrefix: 'issue 99 summary',
       volatileSuffix: 'new comment text',
+      completionOptions: { timeoutMs: 200 },
       nativeSession: {
         provider: 'claude',
         model: 'claude-sonnet-4-6',
@@ -200,7 +205,10 @@ describe('CachedLlmClient', () => {
 
     await expect(client.complete(request)).resolves.toBe('LLM RESULT');
 
-    expect(resume).toHaveBeenCalledWith(undefined, expect.any(String));
+    expect(resume).toHaveBeenCalledWith(undefined, expect.any(String), { timeoutMs: 200 });
+    const fallbackCall = completeSpy.mock.calls[0] as unknown as [string, { timeoutMs: number }];
+    expect(fallbackCall[1].timeoutMs).toBeLessThan(200);
+    expect(fallbackCall[1].timeoutMs).toBeGreaterThan(0);
     expect(llm.callCount).toBe(1);
     expect(metrics.snapshot()).toMatchObject({
       nativeSessionAttempts: 1,

--- a/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/cached-llm-client.test.ts
@@ -247,4 +247,34 @@ describe('CachedLlmClient', () => {
       innerCalls: 1,
     });
   });
+
+  it('propagates native-session timeouts without starting a backing LLM call', async () => {
+    const { llm, client, metrics } = await createHarness();
+    const timeout = Object.assign(new Error('CLI timeout after 25ms'), { code: 'ETIMEDOUT' });
+    const resume = vi.fn().mockRejectedValue(timeout);
+
+    await expect(client.complete({
+      scope: {
+        projectId: 'frankenbeast',
+        workId: 'issue:99',
+      },
+      operation: 'issue-triage',
+      stablePrefix: 'skill injection',
+      workPrefix: 'issue 99 summary',
+      volatileSuffix: 'new comment text',
+      nativeSession: {
+        provider: 'claude',
+        model: 'claude-sonnet-4-6',
+        resume,
+      },
+      completionOptions: { timeoutMs: 25 },
+    })).rejects.toBe(timeout);
+
+    expect(llm.callCount).toBe(0);
+    expect(metrics.snapshot()).toMatchObject({
+      nativeSessionAttempts: 1,
+      nativeSessionFallbacks: 0,
+      innerCalls: 0,
+    });
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/chunk-decomposer.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chunk-decomposer.test.ts
@@ -205,6 +205,22 @@ describe('ChunkDecomposer', () => {
       ).rejects.toThrow(/parse|JSON/i);
     });
 
+    it('rejects non-array chunk fields before dependency traversal', async () => {
+      const malformed = [{
+        id: 'chunk-a',
+        objective: 'A',
+        files: ['a.ts'],
+        successCriteria: 'A passes',
+        verificationCommand: 'npx vitest run',
+        dependencies: '',
+      }];
+      const decomposer = new ChunkDecomposer(mockLlm(JSON.stringify(malformed)), { maxChunks: 12 });
+
+      await expect(decomposer.decompose(designDoc, emptyContext)).rejects.toThrow(
+        'Chunk field dependencies must be an array of strings',
+      );
+    });
+
     it('validates dependency references exist', async () => {
       const badDeps = [
         {

--- a/packages/franken-orchestrator/tests/unit/chunk-file-writer.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chunk-file-writer.test.ts
@@ -188,6 +188,33 @@ describe('ChunkFileWriter', () => {
     expect(content).not.toContain('Unrelated issue');
   });
 
+  it('renders plan-level draft warnings in every saved chunk', () => {
+    const chunks: ChunkDefinition[] = [
+      {
+        id: 'define-types', objective: 'Define types', files: ['src/types.ts'],
+        successCriteria: 'Types compile', verificationCommand: 'npx tsc --noEmit', dependencies: [],
+      },
+      {
+        id: 'wire-runtime', objective: 'Wire runtime', files: ['src/runtime.ts'],
+        successCriteria: 'Runtime works', verificationCommand: 'npm test', dependencies: ['define-types'],
+      },
+    ];
+    const issues: ValidationIssue[] = [{
+      severity: 'warning',
+      chunkId: null,
+      category: 'planning_budget_exceeded',
+      description: 'Quality pass timed out; saved draft',
+      suggestion: 'Review manually',
+    }];
+
+    const writer = new ChunkFileWriter(fixtureDir);
+    const paths = writer.write(chunks, issues);
+
+    for (const path of paths) {
+      expect(readFileSync(path, 'utf-8')).toContain('planning_budget_exceeded');
+    }
+  });
+
   it('clears existing writer-owned chunk files after preparing replacements', () => {
     const writer = new ChunkFileWriter(fixtureDir);
 

--- a/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-plan.test.ts
@@ -13,6 +13,7 @@ let progressCtorInner: unknown = undefined;
 let progressCtorOptions: unknown = undefined;
 let progressInstance: unknown = undefined;
 let llmGraphBuilderCtorArg: unknown = undefined;
+let llmGraphBuilderCtorOptions: unknown = undefined;
 let lastCreateCliDepsOptions: import('../../../src/cli/dep-factory.js').CliDepOptions | undefined;
 const mockFinalize = vi.fn(async () => {});
 
@@ -116,8 +117,11 @@ vi.mock('../../../src/planning/llm-graph-builder.js', () => {
   const MockLlmGraphBuilder = vi.fn(function (
     this: { build: typeof mockLlmGraphBuild; lastChunks: unknown[]; lastValidationIssues: unknown[] },
     llm: unknown,
+    _contextGatherer: unknown,
+    options: unknown,
   ) {
     llmGraphBuilderCtorArg = llm;
+    llmGraphBuilderCtorOptions = options;
     this.lastChunks = [{ id: 'chunk-a', objective: 'Build A', files: ['src/a.ts'], successCriteria: 'Tests pass', verificationCommand: 'npx vitest run', dependencies: [] }];
     this.lastValidationIssues = [];
     this.build = mockLlmGraphBuild;
@@ -250,6 +254,7 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     progressCtorOptions = undefined;
     progressInstance = undefined;
     llmGraphBuilderCtorArg = undefined;
+    llmGraphBuilderCtorOptions = undefined;
     lastCreateCliDepsOptions = undefined;
     console.info = vi.fn();
   });
@@ -291,6 +296,14 @@ describe('Session plan phase — CliLlmAdapter wiring', () => {
     await new Session(config).start();
 
     expect(mockLlmGraphBuild).toHaveBeenCalled();
+  });
+
+  it('runPlan() uses the dedicated planning deadline instead of the execution deadline', async () => {
+    const { Session } = await import('../../../src/cli/session.js');
+    const config = makeConfig({ maxDurationMs: 300_000, planningTimeoutMs: 75_000 });
+    await new Session(config).start();
+
+    expect(llmGraphBuilderCtorOptions).toEqual({ timeoutMs: 75_000 });
   });
 
   it('runPlan() finalizes CLI dependencies so replay records are persisted', async () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config.test.ts
@@ -11,6 +11,7 @@ describe('OrchestratorConfig', () => {
       expect(config.maxCritiqueIterations).toBe(3);
       expect(config.maxTotalTokens).toBe(100_000);
       expect(config.maxDurationMs).toBe(300_000);
+      expect(config.planningTimeoutMs).toBe(120_000);
       expect(config.enableHeartbeat).toBe(false);
       expect(config.enableTracing).toBe(false);
       expect(config.minCritiqueScore).toBe(0.7);

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -431,9 +431,10 @@ describe('LlmGraphBuilder', () => {
           .mockResolvedValueOnce(validChunksJson(threeChunks))
           .mockResolvedValueOnce(validationResponse),
       };
+      const largeContext = `Important planner architecture facts.\n${'unchanged detail '.repeat(300)}`;
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
-          rampUp: 'Large unchanged codebase context',
+          rampUp: largeContext,
           relevantSignatures: [],
           packageDeps: {},
           existingPatterns: [],
@@ -445,8 +446,10 @@ describe('LlmGraphBuilder', () => {
 
       expect(llm.complete).toHaveBeenCalledTimes(2);
       expect(builder.lastRunMetrics.passCount).toBe(2);
-      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toContain('Large unchanged codebase context');
-      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0]).not.toContain('Large unchanged codebase context');
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toContain(largeContext);
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0]).toContain('Important planner architecture facts');
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0]).toContain('[context truncated]');
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0]).not.toContain(largeContext);
     });
 
     it('records pass count, prompt bytes, stage timing, and elapsed time', async () => {
@@ -534,6 +537,62 @@ describe('LlmGraphBuilder', () => {
         expect.objectContaining({ name: 'validate', status: 'timed_out' }),
       );
       expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
+    });
+
+    it('recognizes a provider timeout wrapped in an error cause', async () => {
+      const providerTimeout = Object.assign(new Error('provider deadline'), { code: 'ETIMEDOUT' });
+      const wrappedTimeout = new Error('adapter failed', { cause: providerTimeout });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockRejectedValueOnce(wrappedTimeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always', timeoutMs: 20,
+      });
+
+      await expect(builder.build(intent)).resolves.toEqual(expect.objectContaining({ tasks: expect.any(Array) }));
+      expect(builder.lastChunks).toEqual(threeChunks);
+      expect(builder.lastValidationIssues[0]?.category).toBe('planning_budget_exceeded');
+      expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
+    });
+
+    it('keeps completed remediation when revalidation times out', async () => {
+      const validationResponse = JSON.stringify({
+        valid: false,
+        issues: [{
+          severity: 'error', chunkId: '01_setup', category: 'design_gap',
+          description: 'needs repair', suggestion: 'repair it',
+        }],
+        revisedChunks: null,
+      });
+      const remediatedChunks = threeChunks.map((chunk, index) =>
+        index === 0 ? { ...chunk, objective: 'Remediated objective' } : chunk);
+      const timeout = Object.assign(new Error('revalidation timed out'), { code: 'ETIMEDOUT' });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockResolvedValueOnce(validationResponse)
+        .mockResolvedValueOnce(validChunksJson(remediatedChunks))
+        .mockRejectedValueOnce(timeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always', timeoutMs: 100,
+      });
+
+      await builder.build(intent);
+
+      expect(builder.lastChunks).toEqual(remediatedChunks);
+      expect(builder.lastValidationIssues[0]?.category).toBe('planning_budget_exceeded');
+      expect(builder.lastRunMetrics.stages.at(-1)).toEqual(
+        expect.objectContaining({ name: 'revalidate', status: 'timed_out' }),
+      );
     });
 
     it('re-checks the wall-clock budget after synchronous context gathering', async () => {

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -502,6 +502,62 @@ describe('LlmGraphBuilder', () => {
       expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
     });
 
+    it('preserves the decomposition draft when the LLM client rejects on its own timeout', async () => {
+      const timeout = Object.assign(new Error('CLI timeout after 20ms'), { code: 'ETIMEDOUT' });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockRejectedValueOnce(timeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always',
+        timeoutMs: 20,
+      });
+
+      const graph = await builder.build(intent);
+
+      expect(graph.tasks).toHaveLength(6);
+      expect(builder.lastChunks).toEqual(threeChunks);
+      expect(builder.lastValidationIssues).toEqual([
+        expect.objectContaining({
+          severity: 'warning',
+          category: 'planning_budget_exceeded',
+        }),
+      ]);
+      expect(builder.lastRunMetrics.stages.at(-1)).toEqual(
+        expect.objectContaining({ name: 'validate', status: 'timed_out' }),
+      );
+      expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
+    });
+
+    it('re-checks the wall-clock budget after synchronous context gathering', async () => {
+      const llm = mockLlm(validChunksJson(twoChunks));
+      const gatherer = {
+        gather: vi.fn(() => {
+          const blockedUntil = Date.now() + 10;
+          while (Date.now() < blockedUntil) {
+            // Simulate synchronous context-file reads blocking the event loop.
+          }
+          return Promise.resolve({
+            rampUp: '',
+            relevantSignatures: [],
+            packageDeps: {},
+            existingPatterns: [],
+          });
+        }),
+      };
+      const builder = new LlmGraphBuilder(llm, gatherer as any, { timeoutMs: 1 });
+
+      await expect(builder.build(intent)).rejects.toThrow('Planning deadline exceeded after 1ms');
+      expect(llm.complete).not.toHaveBeenCalled();
+    });
+
     it('propagates caller cancellation during a quality pass instead of saving a draft', async () => {
       const complete = vi.fn().mockImplementation((_: string, options?: { signal?: AbortSignal }) => {
         if (complete.mock.calls.length === 1) {

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -505,11 +505,17 @@ describe('LlmGraphBuilder', () => {
       expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
     });
 
-    it('preserves the decomposition draft when the LLM client rejects on its own timeout', async () => {
+    it('preserves the decomposition draft when the LLM timeout arrives after the planner deadline', async () => {
       const timeout = Object.assign(new Error('CLI timeout after 20ms'), { code: 'ETIMEDOUT' });
       const complete = vi.fn()
         .mockResolvedValueOnce(validChunksJson(threeChunks))
-        .mockRejectedValueOnce(timeout);
+        .mockImplementationOnce(() => {
+          const blockedUntil = Date.now() + 25;
+          while (Date.now() < blockedUntil) {
+            // Simulate a CLI timeout delivered after the configured planner deadline.
+          }
+          return Promise.reject(timeout);
+        });
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
           rampUp: '',
@@ -544,7 +550,13 @@ describe('LlmGraphBuilder', () => {
       const wrappedTimeout = new Error('adapter failed', { cause: providerTimeout });
       const complete = vi.fn()
         .mockResolvedValueOnce(validChunksJson(threeChunks))
-        .mockRejectedValueOnce(wrappedTimeout);
+        .mockImplementationOnce(() => {
+          const blockedUntil = Date.now() + 25;
+          while (Date.now() < blockedUntil) {
+            // Simulate a provider timeout reported after the planner deadline.
+          }
+          return Promise.reject(wrappedTimeout);
+        });
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
           rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
@@ -566,7 +578,13 @@ describe('LlmGraphBuilder', () => {
       });
       const complete = vi.fn()
         .mockResolvedValueOnce(validChunksJson(threeChunks))
-        .mockRejectedValueOnce(wrappedTimeout);
+        .mockImplementationOnce(() => {
+          const blockedUntil = Date.now() + 25;
+          while (Date.now() < blockedUntil) {
+            // Keep the event loop occupied until the planner deadline is exceeded.
+          }
+          return Promise.reject(wrappedTimeout);
+        });
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
           rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
@@ -582,6 +600,39 @@ describe('LlmGraphBuilder', () => {
       expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
     });
 
+    it('propagates a provider timeout that occurs before the planning deadline', async () => {
+      const providerTimeout = Object.assign(new Error('provider timeout'), { code: 'ETIMEDOUT' });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockRejectedValueOnce(providerTimeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always', timeoutMs: 1_000,
+      });
+
+      await expect(builder.build(intent)).rejects.toThrow('provider timeout');
+      expect(builder.lastValidationIssues).toEqual([]);
+    });
+
+    it('checks the deadline after synchronous stage parsing completes', async () => {
+      const largeChunk = {
+        ...twoChunks[0]!,
+        objective: `Implement setup ${'x'.repeat(2_000_000)}`,
+        dependencies: [],
+      };
+      const llm = mockLlm(validChunksJson([largeChunk]));
+      const builder = new LlmGraphBuilder(llm, undefined, { timeoutMs: 1 });
+
+      await expect(builder.build(intent)).rejects.toThrow('Planning deadline exceeded after 1ms');
+      expect(builder.lastRunMetrics.stages[0]).toEqual(
+        expect.objectContaining({ name: 'decompose', status: 'timed_out' }),
+      );
+    });
+
     it('keeps completed validation findings when remediation times out', async () => {
       const validationIssue = {
         severity: 'error', chunkId: '01_setup', category: 'design_gap',
@@ -594,14 +645,20 @@ describe('LlmGraphBuilder', () => {
       const complete = vi.fn()
         .mockResolvedValueOnce(validChunksJson(threeChunks))
         .mockResolvedValueOnce(validationResponse)
-        .mockRejectedValueOnce(timeout);
+        .mockImplementationOnce(() => {
+          const blockedUntil = Date.now() + 25;
+          while (Date.now() < blockedUntil) {
+            // Simulate remediation finishing with a timeout after the planner deadline.
+          }
+          return Promise.reject(timeout);
+        });
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
           rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
         }),
       };
       const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
-        validationMode: 'always', timeoutMs: 100,
+        validationMode: 'always', timeoutMs: 20,
       });
 
       await builder.build(intent);
@@ -631,14 +688,20 @@ describe('LlmGraphBuilder', () => {
         .mockResolvedValueOnce(validChunksJson(threeChunks))
         .mockResolvedValueOnce(validationResponse)
         .mockResolvedValueOnce(validChunksJson(remediatedChunks))
-        .mockRejectedValueOnce(timeout);
+        .mockImplementationOnce(() => {
+          const blockedUntil = Date.now() + 25;
+          while (Date.now() < blockedUntil) {
+            // Simulate revalidation finishing with a timeout after the planner deadline.
+          }
+          return Promise.reject(timeout);
+        });
       const gatherer = {
         gather: vi.fn().mockResolvedValue({
           rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
         }),
       };
       const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
-        validationMode: 'always', timeoutMs: 100,
+        validationMode: 'always', timeoutMs: 20,
       });
 
       await builder.build(intent);

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -560,6 +560,61 @@ describe('LlmGraphBuilder', () => {
       expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
     });
 
+    it('recognizes a CLI timeout represented by a plain-object cause', async () => {
+      const wrappedTimeout = new Error('CLI command failed', {
+        cause: { kind: 'timeout', timedOut: true, summary: 'command timed out' },
+      });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockRejectedValueOnce(wrappedTimeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always', timeoutMs: 20,
+      });
+
+      await builder.build(intent);
+
+      expect(builder.lastValidationIssues[0]?.category).toBe('planning_budget_exceeded');
+      expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
+    });
+
+    it('keeps completed validation findings when remediation times out', async () => {
+      const validationIssue = {
+        severity: 'error', chunkId: '01_setup', category: 'design_gap',
+        description: 'needs repair', suggestion: 'repair it',
+      } as const;
+      const validationResponse = JSON.stringify({
+        valid: false, issues: [validationIssue], revisedChunks: null,
+      });
+      const timeout = Object.assign(new Error('remediation timed out'), { code: 'ETIMEDOUT' });
+      const complete = vi.fn()
+        .mockResolvedValueOnce(validChunksJson(threeChunks))
+        .mockResolvedValueOnce(validationResponse)
+        .mockRejectedValueOnce(timeout);
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '', relevantSignatures: [], packageDeps: {}, existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always', timeoutMs: 100,
+      });
+
+      await builder.build(intent);
+
+      expect(builder.lastValidationIssues).toEqual([
+        validationIssue,
+        expect.objectContaining({ category: 'planning_budget_exceeded' }),
+      ]);
+      expect(builder.lastRunMetrics.stages.at(-1)).toEqual(
+        expect.objectContaining({ name: 'remediate', status: 'timed_out' }),
+      );
+    });
+
     it('keeps completed remediation when revalidation times out', async () => {
       const validationResponse = JSON.stringify({
         valid: false,
@@ -589,7 +644,10 @@ describe('LlmGraphBuilder', () => {
       await builder.build(intent);
 
       expect(builder.lastChunks).toEqual(remediatedChunks);
-      expect(builder.lastValidationIssues[0]?.category).toBe('planning_budget_exceeded');
+      expect(builder.lastValidationIssues).toEqual([
+        expect.objectContaining({ category: 'design_gap' }),
+        expect.objectContaining({ category: 'planning_budget_exceeded' }),
+      ]);
       expect(builder.lastRunMetrics.stages.at(-1)).toEqual(
         expect.objectContaining({ name: 'revalidate', status: 'timed_out' }),
       );

--- a/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
+++ b/packages/franken-orchestrator/tests/unit/llm-graph-builder.test.ts
@@ -36,6 +36,18 @@ const twoChunks = [
   },
 ];
 
+const threeChunks = [
+  ...twoChunks,
+  {
+    id: '03_integration',
+    objective: 'Integrate and document the widget system',
+    files: ['src/integration.ts', 'README.md'],
+    successCriteria: 'Integration tests pass',
+    verificationCommand: 'npx vitest run tests/integration',
+    dependencies: ['02_feature'],
+  },
+];
+
 const intent = { goal: 'Build a new widget system with React components' };
 
 describe('LlmGraphBuilder', () => {
@@ -367,6 +379,162 @@ describe('LlmGraphBuilder', () => {
   });
 
   describe('multi-pass pipeline', () => {
+    it('uses a one-pass fast path for a simple decomposition', async () => {
+      const llm = mockLlm(validChunksJson(twoChunks));
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: 'Large unchanged codebase context',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+
+      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      await builder.build(intent);
+
+      expect(llm.complete).toHaveBeenCalledOnce();
+      expect(builder.lastRunMetrics.passCount).toBe(1);
+    });
+
+    it('uses validation when a short decomposition has low-confidence file overlap', async () => {
+      const overlapping = [
+        twoChunks[0]!,
+        { ...twoChunks[1]!, files: ['src/index.ts'] },
+      ];
+      const validationResponse = JSON.stringify({ valid: true, issues: [], revisedChunks: null });
+      const llm = {
+        complete: vi.fn()
+          .mockResolvedValueOnce(validChunksJson(overlapping))
+          .mockResolvedValueOnce(validationResponse),
+      };
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+
+      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      await builder.build(intent);
+
+      expect(llm.complete).toHaveBeenCalledTimes(2);
+      expect(builder.lastRunMetrics.passCount).toBe(2);
+    });
+
+    it('uses two passes for a complex decomposition that validates cleanly', async () => {
+      const validationResponse = JSON.stringify({ valid: true, issues: [], revisedChunks: null });
+      const llm = {
+        complete: vi.fn()
+          .mockResolvedValueOnce(validChunksJson(threeChunks))
+          .mockResolvedValueOnce(validationResponse),
+      };
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: 'Large unchanged codebase context',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+
+      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      await builder.build(intent);
+
+      expect(llm.complete).toHaveBeenCalledTimes(2);
+      expect(builder.lastRunMetrics.passCount).toBe(2);
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toContain('Large unchanged codebase context');
+      expect((llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0]).not.toContain('Large unchanged codebase context');
+    });
+
+    it('records pass count, prompt bytes, stage timing, and elapsed time', async () => {
+      const llm = mockLlm(validChunksJson(twoChunks));
+      const builder = new LlmGraphBuilder(llm);
+
+      await builder.build(intent);
+
+      expect(builder.lastRunMetrics.passCount).toBe(1);
+      expect(builder.lastRunMetrics.promptBytes).toBeGreaterThan(0);
+      expect(builder.lastRunMetrics.elapsedMs).toBeGreaterThanOrEqual(0);
+      expect(builder.lastRunMetrics.stages).toEqual([
+        expect.objectContaining({ name: 'decompose', status: 'completed' }),
+      ]);
+    });
+
+    it('preserves decomposition as a warning-marked draft when the quality budget expires', async () => {
+      const complete = vi.fn().mockImplementation((_: string, options?: { signal?: AbortSignal }) => {
+        if (complete.mock.calls.length === 1) {
+          return Promise.resolve(validChunksJson(threeChunks));
+        }
+        return new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+      });
+      const llm = { complete };
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+      const builder = new LlmGraphBuilder(llm, gatherer as any, {
+        validationMode: 'always',
+        timeoutMs: 20,
+      });
+
+      const graph = await builder.build(intent);
+
+      expect(graph.tasks).toHaveLength(6);
+      expect(builder.lastChunks).toEqual(threeChunks);
+      expect(builder.lastValidationIssues).toEqual([
+        expect.objectContaining({
+          severity: 'warning',
+          category: 'planning_budget_exceeded',
+        }),
+      ]);
+      expect(builder.lastRunMetrics.stages.at(-1)).toEqual(
+        expect.objectContaining({ name: 'validate', status: 'timed_out' }),
+      );
+      expect(complete.mock.calls[1]![1].signal.aborted).toBe(true);
+    });
+
+    it('propagates caller cancellation during a quality pass instead of saving a draft', async () => {
+      const complete = vi.fn().mockImplementation((_: string, options?: { signal?: AbortSignal }) => {
+        if (complete.mock.calls.length === 1) {
+          return Promise.resolve(validChunksJson(threeChunks));
+        }
+        return new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+      });
+      const gatherer = {
+        gather: vi.fn().mockResolvedValue({
+          rampUp: '',
+          relevantSignatures: [],
+          packageDeps: {},
+          existingPatterns: [],
+        }),
+      };
+      const controller = new AbortController();
+      const builder = new LlmGraphBuilder({ complete }, gatherer as any, {
+        validationMode: 'always',
+        timeoutMs: 60_000,
+        signal: controller.signal,
+      });
+
+      const result = builder.build(intent);
+      await vi.waitFor(() => expect(complete).toHaveBeenCalledTimes(2));
+      controller.abort(new Error('operator cancelled planning'));
+
+      await expect(result).rejects.toThrow('operator cancelled planning');
+      expect(builder.lastChunks).toEqual([]);
+      expect(builder.lastValidationIssues).toEqual([]);
+    });
+
     it('uses contextGatherer when provided', async () => {
       const llm = mockLlm(validChunksJson(twoChunks));
       const gatherer = {
@@ -464,7 +632,7 @@ describe('LlmGraphBuilder', () => {
         }),
       };
 
-      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      const builder = new LlmGraphBuilder(llm, gatherer as any, { validationMode: 'always' });
       const graph = await builder.build(intent);
 
       expect(llm.complete).toHaveBeenCalledTimes(4);
@@ -496,7 +664,7 @@ describe('LlmGraphBuilder', () => {
         }),
       };
 
-      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      const builder = new LlmGraphBuilder(llm, gatherer as any, { validationMode: 'always' });
       await builder.build(intent);
 
       // Only 2 LLM calls: decompose + validate
@@ -536,7 +704,7 @@ describe('LlmGraphBuilder', () => {
         }),
       };
 
-      const builder = new LlmGraphBuilder(llm, gatherer as any);
+      const builder = new LlmGraphBuilder(llm, gatherer as any, { validationMode: 'always' });
       const graph = await builder.build(intent);
 
       // Should use the revised chunks (1 chunk = 2 tasks)

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -44,7 +44,7 @@ export type { Verdict } from './verdict.js';
 export type { RationaleBlock, VerificationResult } from './rationale.js';
 
 // LLM client interfaces
-export type { ILlmClient, IResultLlmClient } from './llm.js';
+export type { ILlmClient, IResultLlmClient, LlmCompletionOptions } from './llm.js';
 
 // Token
 export type { TokenSpend } from './token.js';

--- a/packages/franken-types/src/llm.ts
+++ b/packages/franken-types/src/llm.ts
@@ -4,8 +4,15 @@ import type { Result } from './result.js';
  * Provider-agnostic LLM client interface (brain variant).
  * Returns plain string — caller handles parsing.
  */
+export interface LlmCompletionOptions {
+  /** Cancels the logical completion, including any provider process or retry wait. */
+  signal?: AbortSignal | undefined;
+  /** Maximum time for this logical completion, including provider fallback/retries. */
+  timeoutMs?: number | undefined;
+}
+
 export interface ILlmClient {
-  complete(prompt: string): Promise<string>;
+  complete(prompt: string, options?: LlmCompletionOptions): Promise<string>;
 }
 
 /**

--- a/tasks/issue-3306-performance-bound-planning-progress.md
+++ b/tasks/issue-3306-performance-bound-planning-progress.md
@@ -1,0 +1,14 @@
+# Issue #3306 progress
+
+- [x] Refresh live issue and verify no existing PR/closing reference.
+- [x] Read shared issue-resolution lessons and repository lessons.
+- [x] Create isolated branch/worktree from `origin/main`.
+- [x] Trace planner, cache, adapter, CLI session, timeout, and subprocess behavior.
+- [x] Add failing tests for adaptive 1/2/4-pass planning, prompt-context reduction, metrics, draft recovery, and subprocess cancellation.
+- [x] Implement a 120-second configurable planning deadline with cancellation propagation through cache/adapter layers.
+- [x] Preserve the completed decomposition as a warning-marked draft when a later quality pass exceeds the budget.
+- [x] Emit pass count, prompt bytes, total elapsed time, and per-stage timing/status metrics.
+- [x] Verify 112 focused timeout/cancellation/cache/planning tests, package build/typecheck/lint, and the full orchestrator suite (4,038/4,039 passed; the unrelated provider-snapshot failure passed on isolated rerun).
+- [x] Complete an independent Codex pre-commit review, address four timeout/cancellation findings, and obtain a clean final review.
+- [ ] Open one PR with `Closes #3306`.
+- [ ] Drive GitHub Codex review and CI to clean, merge, verify issue closure, and record a reusable lesson.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -391,3 +391,4 @@
 
 ## Lessons
 - 2026-07-19 — Docs regression tests should assert exact pinned values from manifest and treat setup commands as gate-narrow/full setup distinctions.
+- 2026-07-19 — Bounded multi-pass LLM flows need one shared deadline propagated through cache/client/adapter layers, explicit subprocess and retry-wait cancellation, and a caller-side abort race for implementations that ignore signals. Preserve the last useful pre-quality artifact on timeout, use deterministic structural confidence for fast paths, avoid resending unchanged repository context, and test 1/2/4-pass paths plus child-process termination.


### PR DESCRIPTION
## Summary
- add a configurable plan-level deadline that propagates through cache, adapter, retry waits, and provider processes
- add an adaptive deterministic fast path, compact repeated prompt context, draft recovery, and planning metrics
- preserve external cancellation semantics and prevent timeout-triggered duplicate native-session fallback calls

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/adapters/cli-llm-adapter.test.ts tests/unit/cache/cached-llm-client.test.ts tests/unit/llm-graph-builder.test.ts` (112 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- targeted ESLint (0 errors; existing warnings only)
- full orchestrator suite: 4,038/4,039 passed; unrelated provider snapshot test passed on isolated rerun
- independent Codex pre-commit review: clean after addressing four timeout/cancellation findings

Closes #3306