### PR TITLE
fix(web): explain locked wizard steps

### DIFF
--- a/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 interface WizardStepIndicatorProps {
   steps: string[];
   currentStep: number;
@@ -7,49 +9,61 @@ interface WizardStepIndicatorProps {
 }
 
 export function WizardStepIndicator({ steps, currentStep, highestCompleted, stepStatuses = {}, onStepClick }: WizardStepIndicatorProps) {
-  return (
-    <div className="flex items-center gap-1 px-6 py-3 border-b border-beast-border overflow-x-auto shrink-0" role="navigation" aria-label="Wizard steps">
-      {steps.map((label, i) => {
-        const status = stepStatuses[i];
-        const hasError = status === 'error';
-        const isCompleted = i <= highestCompleted && !hasError;
-        const isCurrent = i === currentStep;
-        const isClickable = isCompleted || isCurrent || hasError;
-        const ariaLabel = hasError
-          ? `${label}, validation errors`
-          : isCurrent
-            ? `${label}, current step`
-            : isCompleted
-              ? `${label}, completed`
-              : `${label}, upcoming step`;
+  const lockedReasonId = useId();
+  const firstIncompleteStep = steps[highestCompleted + 1];
+  const hasLockedSteps = highestCompleted < steps.length - 1 && firstIncompleteStep !== undefined;
 
-        return (
-          <button
-            key={label}
-            type="button"
-            onClick={() => isClickable && onStepClick(i)}
-            disabled={!isClickable}
-            aria-current={isCurrent ? 'step' : undefined}
-            aria-label={ariaLabel}
-            className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-colors
-              ${isCurrent && !hasError ? 'text-beast-accent-strong bg-beast-accent-soft' : ''}
-              ${hasError ? 'text-beast-danger bg-red-900/20 border border-red-700/60' : ''}
-              ${isCompleted && !isCurrent ? 'text-beast-accent hover:bg-beast-elevated cursor-pointer' : ''}
-              ${!isClickable ? 'text-beast-subtle cursor-not-allowed opacity-40' : ''}
-            `}
-          >
-            <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-bold shrink-0
-              ${isCurrent && !hasError ? 'bg-beast-accent text-beast-bg' : ''}
-              ${hasError ? 'bg-red-900/50 text-red-200' : ''}
-              ${isCompleted && !isCurrent ? 'bg-beast-accent/30 text-beast-accent' : ''}
-              ${!isClickable ? 'bg-beast-border text-beast-subtle' : ''}
-            `}>
-              {hasError ? '!' : isCompleted && !isCurrent ? '✓' : i + 1}
-            </span>
-            <span className="hidden sm:inline">{label}</span>
-          </button>
-        );
-      })}
+  return (
+    <div className="border-b border-beast-border shrink-0" role="navigation" aria-label="Wizard steps">
+      <div className="flex items-center gap-1 px-6 py-3 overflow-x-auto">
+        {steps.map((label, i) => {
+          const status = stepStatuses[i];
+          const hasError = status === 'error';
+          const isCompleted = i <= highestCompleted && !hasError;
+          const isCurrent = i === currentStep;
+          const isClickable = isCompleted || isCurrent || hasError;
+          const ariaLabel = hasError
+            ? `${label}, validation errors`
+            : isCurrent
+              ? `${label}, current step`
+              : isCompleted
+                ? `${label}, completed`
+                : `${label}, locked`;
+
+          return (
+            <button
+              key={label}
+              type="button"
+              onClick={() => isClickable && onStepClick(i)}
+              disabled={!isClickable}
+              aria-current={isCurrent ? 'step' : undefined}
+              aria-label={ariaLabel}
+              aria-describedby={!isClickable ? lockedReasonId : undefined}
+              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition-colors
+                ${isCurrent && !hasError ? 'text-beast-accent-strong bg-beast-accent-soft' : ''}
+                ${hasError ? 'text-beast-danger bg-red-900/20 border border-red-700/60' : ''}
+                ${isCompleted && !isCurrent ? 'text-beast-accent hover:bg-beast-elevated cursor-pointer' : ''}
+                ${!isClickable ? 'text-beast-subtle cursor-not-allowed opacity-40' : ''}
+              `}
+            >
+              <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-bold shrink-0
+                ${isCurrent && !hasError ? 'bg-beast-accent text-beast-bg' : ''}
+                ${hasError ? 'bg-red-900/50 text-red-200' : ''}
+                ${isCompleted && !isCurrent ? 'bg-beast-accent/30 text-beast-accent' : ''}
+                ${!isClickable ? 'bg-beast-border text-beast-subtle' : ''}
+              `}>
+                {hasError ? '!' : isCompleted && !isCurrent ? '✓' : i + 1}
+              </span>
+              <span className="hidden sm:inline">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+      {hasLockedSteps && (
+        <p id={lockedReasonId} className="-mt-1 px-6 pb-3 text-xs text-beast-muted">
+          Complete {firstIncompleteStep} to unlock later steps.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-step-indicator.tsx
@@ -11,7 +11,9 @@ interface WizardStepIndicatorProps {
 export function WizardStepIndicator({ steps, currentStep, highestCompleted, stepStatuses = {}, onStepClick }: WizardStepIndicatorProps) {
   const lockedReasonId = useId();
   const firstIncompleteStep = steps[highestCompleted + 1];
-  const hasLockedSteps = highestCompleted < steps.length - 1 && firstIncompleteStep !== undefined;
+  const hasLockedSteps = steps.some(
+    (_, i) => i > highestCompleted && i !== currentStep && stepStatuses[i] !== 'error',
+  );
 
   return (
     <div className="border-b border-beast-border shrink-0" role="navigation" aria-label="Wizard steps">

--- a/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
@@ -42,6 +42,19 @@ describe('WizardStepIndicator', () => {
     expect(lockedStep.hasAttribute('disabled')).toBe(true);
   });
 
+  it('hides the locked-step explanation when the current final step is the only incomplete step', () => {
+    render(
+      <WizardStepIndicator
+        steps={STEPS}
+        currentStep={STEPS.length - 1}
+        highestCompleted={STEPS.length - 2}
+        onStepClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/unlock later steps/i)).toBeNull();
+  });
+
   it('completed steps are clickable', () => {
     const onClick = vi.fn();
     render(<WizardStepIndicator steps={STEPS} currentStep={3} highestCompleted={2} onStepClick={onClick} />);

--- a/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
+++ b/packages/franken-web/tests/components/beasts/wizard-step-indicator.test.tsx
@@ -24,7 +24,7 @@ describe('WizardStepIndicator', () => {
     expect(current.getAttribute('aria-current')).toBe('step');
   });
 
-  it('announces completed and upcoming states in accessible labels', () => {
+  it('explains the prerequisite for locked steps to sighted and screen reader users', () => {
     render(
       <WizardStepIndicator
         steps={STEPS}
@@ -35,7 +35,11 @@ describe('WizardStepIndicator', () => {
     );
 
     expect(screen.getByRole('button', { name: /Identity, completed/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Modules, upcoming step/i })).toBeTruthy();
+    const lockedStep = screen.getByRole('button', { name: /Modules, locked/i });
+    const reason = screen.getByText('Complete LLM Targets to unlock later steps.');
+
+    expect(lockedStep.getAttribute('aria-describedby')).toBe(reason.id);
+    expect(lockedStep.hasAttribute('disabled')).toBe(true);
   });
 
   it('completed steps are clickable', () => {


### PR DESCRIPTION
## Summary
- show which wizard step must be completed before later steps unlock
- connect every locked button to the visible prerequisite with `aria-describedby`
- preserve navigation for current, completed, and validation-error steps

## Test Plan
- `npm test -- --run tests/components/beasts/wizard-step-indicator.test.tsx`
- `npm test` (663 tests)
- `npm run lint` (0 errors; 17 pre-existing warnings)
- `npm run typecheck`
- `npm run build`

Closes #3154