### PR TITLE
docs(architecture): reconcile workspace package counts

### DIFF
--- a/docs/adr/031-architecture-consolidation-provider-agnostic.md
+++ b/docs/adr/031-architecture-consolidation-provider-agnostic.md
@@ -5,7 +5,7 @@
 - **Deciders:** pfk
 - **Supersedes:** Portions of ADR-011 (monorepo structure)
 
-> **Implementation outcome note:** This ADR records the consolidation decision, but the repository's current post-facto state differs from the original package table: the workspace currently has 10 packages, and `packages/franken-mcp-suite` remains as the shipped `fbeast` CLI/MCP suite package. Treat the package-count/removal table below as historical intent unless a later amendment supersedes it.
+> **Implementation outcome note:** This ADR records the consolidation decision, but the repository's current post-facto state differs from the original package table: the workspace currently has 10 packages, and `packages/franken-mcp-suite` remains as the shipped `fbeast` CLI/MCP suite package. The [README's current workspace package inventory](../../README.md#current-workspace-packages) is authoritative; treat the 13 → 8 count and removal table below as the historical consolidation outcome unless a later amendment supersedes it.
 
 ## Context
 
@@ -251,7 +251,7 @@ The platform should be easily extendable, either through forking or a secure plu
 
 ### Positive
 
-- **13 → 8 packages**: Less surface area, faster builds, simpler onboarding
+- **Historical consolidation (13 → 8 packages at implementation):** Reduced the original package surface for faster builds and simpler onboarding. The workspace later grew to the [current 10-package inventory](../../README.md#current-workspace-packages).
 - **Provider agnostic**: Claude, Codex, and Gemini all work — CLI or API
 - **Crash resilient**: Brain serialization survives provider outages mid-task
 - **Focused scope**: Every remaining package addresses an area where existing frameworks take a different approach or leave gaps — not unique ideas, but a unique combination and depth of implementation

--- a/tests/docs-issue-3370.test.ts
+++ b/tests/docs-issue-3370.test.ts
@@ -1,0 +1,28 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readText = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+const currentWorkspacePackageCount = () =>
+  readdirSync(resolve(ROOT, 'packages'), { withFileTypes: true }).filter(
+    (entry) =>
+      entry.isDirectory() && existsSync(resolve(ROOT, 'packages', entry.name, 'package.json')),
+  ).length;
+
+describe('issue #3370 workspace package counts', () => {
+  it('distinguishes the historical ADR consolidation count from the current inventory', () => {
+    const readme = readText('README.md');
+    const adr = readText('docs/adr/031-architecture-consolidation-provider-agnostic.md');
+
+    expect(currentWorkspacePackageCount()).toBe(10);
+    expect(readme).toContain('currently organized as 10 npm workspace packages');
+    expect(readme).toContain('Treat the current ten-package inventory above as authoritative');
+
+    expect(adr).toContain('Historical consolidation (13 → 8 packages at implementation)');
+    expect(adr).toContain('[current 10-package inventory](../../README.md#current-workspace-packages)');
+    expect(adr).not.toContain('- **13 → 8 packages**:');
+  });
+});


### PR DESCRIPTION
## Summary
- mark ADR-031's 13 → 8 package reduction as the historical consolidation outcome
- link ADR-031 to the README's authoritative current 10-package inventory
- add a focused regression test that derives the workspace count and guards the historical/current wording

## Verification
- `npm run test:root -- --run tests/docs-issue-3370.test.ts tests/docs-issue-1094.test.ts` (5 tests passed)
- `npm run lint` (10 workspace lint tasks passed; pre-existing warnings only)
- `git diff --check`

Closes #3370