### PR TITLE
docs(readme): update external agent integration index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ frankenbeast/
 - [Run the Dashboard Chat](docs/guides/run-dashboard-chat.md) — start the WebSocket chat server and dashboard locally
 - [Run the Network Operator](docs/guides/run-network-operator.md) — start Frankenbeast request-serving services through `frankenbeast network`
 - [Add an LLM Provider](docs/guides/add-llm-provider.md) — add CLI execution providers through `ICliProvider` or API-backed clients through the provider registry
-- [Wrap an External Agent](docs/guides/wrap-external-agent.md) — firewall-as-proxy or full orchestration
+- [Wrap an External Agent](docs/guides/wrap-external-agent.md) — MCP tool governance, orchestrator runtime, or BeastLoop dependency integration
 - [Contract Matrix](docs/CONTRACT_MATRIX.md) — all port interfaces documented
 - [ADRs](docs/adr/) — architectural decisions and rationale
 - [Design Plans](docs/plans/) — design docs and implementation plans

--- a/tests/docs-issue-3363.test.ts
+++ b/tests/docs-issue-3363.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readme = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+
+describe('issue #3363 external-agent docs index', () => {
+  it('advertises only the currently supported integration modes', () => {
+    const docsIndex = readme.slice(readme.indexOf('## Documentation'));
+    const externalAgentEntry = docsIndex
+      .split('\n')
+      .find((line) => line.includes('[Wrap an External Agent]'));
+
+    expect(externalAgentEntry).toBe(
+      '- [Wrap an External Agent](docs/guides/wrap-external-agent.md) — MCP tool governance, orchestrator runtime, or BeastLoop dependency integration',
+    );
+    expect(externalAgentEntry).not.toContain('firewall-as-proxy');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the stale firewall-as-proxy description in the README documentation index
- list the supported MCP, orchestrator, and BeastLoop integration modes
- add a focused docs regression test for the index entry

## Test plan
- `npm run test:root -- tests/docs-issue-3363.test.ts tests/docs-issue-2631.test.ts tests/docs-issue-961.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint`

Closes #3363