### PR TITLE
docs(readme): remove stale release announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,9 @@ The bootstrap command delegates to [`scripts/bootstrap.sh`](scripts/bootstrap.sh
 ./scripts/bootstrap.sh --dry-run
 ```
 
-## Latest release announcement
+## Releases
 
-[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0) is the latest Frankenbeast release line. It packages the recent one-click onboarding cleanup, security hardening across MCP, observer, orchestrator, governor, and web surfaces, plus deterministic mode improvements for repeatable validation, recovery, and release gates.
-
-Highlights:
-
-- **One-click onboarding:** refreshed init, MCP setup, dashboard, provider, and quickstart guidance so operators can choose the right setup path without mixing local-checkout and published-package commands.
-- **Security hardening:** tightened path containment, webhook/token handling, approval signing, chat/dashboard auth, config validation, and persisted-state hydration safeguards.
-- **Deterministic mode:** expanded root/package verification, release checks, replay validation, and schema guards so CI and operators catch drift before runtime.
-
-Community announcement target: share this release summary in the Frankenbeast Discord once the v0.45.0 GitHub release is published.
+See [GitHub Releases](https://github.com/djm204/frankenbeast/releases) for the latest published release and [CHANGELOG.md](CHANGELOG.md) for the complete release history.
 
 ## Modes
 

--- a/tests/unit/readme-release-communication.test.ts
+++ b/tests/unit/readme-release-communication.test.ts
@@ -6,16 +6,14 @@ const ROOT = resolve(import.meta.dirname, '../..');
 const README = readFileSync(resolve(ROOT, 'README.md'), 'utf-8');
 
 describe('README release communication', () => {
-  it('shows the latest release badge and release notes link', () => {
+  it('links to version-independent release information', () => {
     expect(README).toContain('[![Latest root release](https://img.shields.io/github/v/release/djm204/frankenbeast?filter=v*&label=release)](https://github.com/djm204/frankenbeast/releases?q=v*&expanded=true)');
-    expect(README).toContain('[Release v0.45.0](https://github.com/djm204/frankenbeast/releases/tag/v0.45.0)');
-    expect(README).toContain('is the latest Frankenbeast release line.');
+    expect(README).toContain('[GitHub Releases](https://github.com/djm204/frankenbeast/releases)');
+    expect(README).toContain('[CHANGELOG.md](CHANGELOG.md)');
   });
 
-  it('announces the release highlights to repository visitors', () => {
-    expect(README).toContain('## Latest release announcement');
-    expect(README).toContain('one-click onboarding');
-    expect(README).toContain('security hardening');
-    expect(README).toContain('deterministic mode');
+  it('does not pin a release version or future announcement instructions', () => {
+    expect(README).not.toMatch(/\[Release v\d+\.\d+\.\d+\][^\n]*is the latest Frankenbeast release line\./);
+    expect(README).not.toContain('Community announcement target:');
   });
 });


### PR DESCRIPTION
## Summary
- replace the manually versioned README release announcement with evergreen links to GitHub Releases and the changelog
- update the guard test to reject pinned "latest release" claims and future announcement instructions

## Test plan
- `npm run test:root -- tests/unit/readme-release-communication.test.ts`
- `npm run test:root` (91 files passed, 620 tests passed, 1 skipped)

Closes #3362