### PR TITLE
fix(chat): bound message content length

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -17,7 +17,7 @@ import type {
   MessageResult,
   TurnOutcome,
 } from '@franken/types';
-import { isoNow } from '@franken/types';
+import { isoNow, MAX_CHAT_MESSAGE_CONTENT_LENGTH } from '@franken/types';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -30,7 +30,7 @@ const CreateSessionBody = z.object({
 }).strict();
 
 const SubmitMessageBody = z.object({
-  content: z.string().min(1),
+  content: z.string().min(1).max(MAX_CHAT_MESSAGE_CONTENT_LENGTH),
   executionMode: z.enum(['process', 'container']).optional(),
 }).strict();
 

--- a/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-routes.test.ts
@@ -21,6 +21,7 @@ import { ContainerBeastExecutor } from '../../../src/beasts/execution/container-
 import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-policy.js';
 import type { BeastProcessSpec } from '../../../src/beasts/types.js';
 import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
+import { MAX_CHAT_MESSAGE_CONTENT_LENGTH } from '@franken/types';
 
 import { testCredential } from '../../support/test-credentials.js';
 
@@ -263,6 +264,50 @@ describe('Chat HTTP Routes', () => {
     const sessionBody = await sessionRes.json();
     expect(sessionBody.data.transcript).toHaveLength(2);
     expect(sessionBody.data.state).toBe('active');
+  });
+
+  it('accepts chat message content at the 16,000-character limit', async () => {
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+    const content = 'x'.repeat(MAX_CHAT_MESSAGE_CONTENT_LENGTH);
+
+    const res = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(llmComplete).toHaveBeenCalledOnce();
+    expect(llmComplete.mock.calls[0]?.[0]).toContain(content);
+  });
+
+  it('rejects chat message content above the 16,000-character limit before runtime execution', async () => {
+    const createRes = await app.request('/v1/chat/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'proj' }),
+    });
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/v1/chat/sessions/${created.id}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'x'.repeat(MAX_CHAT_MESSAGE_CONTENT_LENGTH + 1) }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+      },
+    });
+    expect(llmComplete).not.toHaveBeenCalled();
   });
 
   it('POST /v1/chat/sessions/:id/messages rejects sends while approval is pending', async () => {

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../src/http/ws-chat-auth.js';
 import { createChatApp } from '../../../src/http/chat-app.js';
 import { InMemoryRateLimiter } from '../../../src/beasts/http/beast-rate-limit.js';
+import { MAX_CHAT_MESSAGE_CONTENT_LENGTH } from '@franken/types';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/ws-chat');
@@ -442,6 +443,48 @@ describe('ws chat server', () => {
     expect(events.map((event) => event.type)).toContain('assistant.typing.start');
     expect(events.map((event) => event.type)).toContain('assistant.message.delta');
     expect(events.map((event) => event.type)).toContain('assistant.message.complete');
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('enforces the shared chat content limit on websocket message sends', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const runtime = { run: vi.fn().mockResolvedValue(createRuntimeResult(session)) };
+    const controller = new ChatSocketController({
+      runtime: runtime as never,
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    const contentAtLimit = 'x'.repeat(MAX_CHAT_MESSAGE_CONTENT_LENGTH);
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-at-limit',
+      content: contentAtLimit,
+    }));
+    await controller.receive(peer, JSON.stringify({
+      type: 'message.send',
+      clientMessageId: 'client-over-limit',
+      content: `${contentAtLimit}x`,
+    }));
+
+    expect(runtime.run).toHaveBeenCalledOnce();
+    expect(runtime.run).toHaveBeenCalledWith(contentAtLimit, expect.any(Object));
+    expect(sent.map((raw) => JSON.parse(raw))).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'INVALID_EVENT',
+    }));
 
     rmSync(TMP, { recursive: true, force: true });
   });

--- a/packages/franken-types/src/comms.ts
+++ b/packages/franken-types/src/comms.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
 
+// Keep below the default 16 KiB HTTP body cap so the JSON envelope has
+// headroom while REST and WebSocket enforce one shared content limit.
+export const MAX_CHAT_MESSAGE_CONTENT_LENGTH = 16_000;
+
 export const ClientSocketEventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('message.send'),
     clientMessageId: z.string().min(1),
-    content: z.string().min(1).max(16_384),
+    content: z.string().min(1).max(MAX_CHAT_MESSAGE_CONTENT_LENGTH),
     executionMode: z.enum(['process', 'container']).optional(),
   }).strict(),
   z.object({


### PR DESCRIPTION
## Summary
- define one shared 16,000-character chat content limit
- enforce the limit on REST message submissions and WebSocket message sends
- cover accepted boundary values and rejected over-limit inputs before runtime execution

## Verification
- `npx vitest run tests/integration/chat/chat-routes.test.ts tests/integration/chat/ws-chat-server.test.ts -t 'chat message content|shared chat content limit'` (3 passed)
- `npm test` in `packages/franken-types` (117 passed)
- `npx turbo run build --filter=@franken/orchestrator...`
- `npx turbo run typecheck --filter=@franken/orchestrator...`
- `npx turbo run lint --filter=@franken/types --filter=@franken/orchestrator` (passes with pre-existing warnings)

Closes #2778
