### PR TITLE
docs(readme): use plan for design document example

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,8 @@ The CLI is available as `frankenbeast`, `franken`, or `frkn` — all are identic
 # Start from scratch — interview, design, plan, execute
 frankenbeast
 
-# Start from an existing design document
-frankenbeast --design-doc docs/my-feature-design.md
+# Plan from an existing design document
+frankenbeast plan --design-doc docs/my-feature-design.md
 
 # Start from existing chunk files
 frankenbeast --plan-dir ./my-chunks/

--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ The CLI is available as `frankenbeast`, `franken`, or `frkn` — all are identic
 # Start from scratch — interview, design, plan, execute
 frankenbeast
 
-# Plan from an existing design document
+# Start from an existing design document — plan, then execute
 frankenbeast plan --design-doc docs/my-feature-design.md
+frankenbeast run
 
 # Start from existing chunk files
 frankenbeast --plan-dir ./my-chunks/

--- a/tests/docs-issue-3378.test.ts
+++ b/tests/docs-issue-3378.test.ts
@@ -4,12 +4,15 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const README = readFileSync(resolve(ROOT, "README.md"), "utf8");
+const INTERACTIVE_SESSION = README.match(
+  /### Interactive Session \(idea to PR\)([\s\S]*?)### Subcommands/,
+)?.[1];
 
 describe("issue #3378 design-doc CLI example", () => {
-  it("routes design documents through the plan subcommand", () => {
-    expect(README).toContain(
-      "frankenbeast plan --design-doc docs/my-feature-design.md",
+  it("uses the explicit plan-then-run flow for an existing design document", () => {
+    expect(INTERACTIVE_SESSION).toContain(
+      "frankenbeast plan --design-doc docs/my-feature-design.md\nfrankenbeast run",
     );
-    expect(README).not.toMatch(/^frankenbeast\s+--design-doc\b/m);
+    expect(INTERACTIVE_SESSION).not.toMatch(/^frankenbeast\s+--design-doc\b/m);
   });
 });

--- a/tests/docs-issue-3378.test.ts
+++ b/tests/docs-issue-3378.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const README = readFileSync(resolve(ROOT, "README.md"), "utf8");
+
+describe("issue #3378 design-doc CLI example", () => {
+  it("routes design documents through the plan subcommand", () => {
+    expect(README).toContain(
+      "frankenbeast plan --design-doc docs/my-feature-design.md",
+    );
+    expect(README).not.toMatch(/^frankenbeast\s+--design-doc\b/m);
+  });
+});


### PR DESCRIPTION
## Summary
- route the README design-document example through the supported `plan` subcommand
- add a regression test that rejects bare `--design-doc` README commands

## Test plan
- `npm run test:root -- tests/docs-issue-3378.test.ts`
- `npm run test:root`
- `npm run typecheck`
- `npm run build`
- `npm run lint`

Closes #3378