### PR TITLE
fix(orchestrator): remove stale banner dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,6 @@ FRANKEN_MIN_CRITIQUE_SCORE=0.7
 # FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL=0
 
 # ── Advanced local diagnostics ──
-# FRANKENBEAST_PLAIN_BANNER=0
 # Internal marker set by `frankenbeast network` for managed child services.
 # Leave unset for normal standalone debugging. When set to literal "1", managed
 # children suppress the CLI startup banner and `chat-server` requires an operator

--- a/README.md
+++ b/README.md
@@ -544,8 +544,6 @@ If `stateDir` is set to a path inside a sibling Hermes profile such as `.hermes/
 
 ### Operator environment variables
 
-Set `FRANKENBEAST_PLAIN_BANNER=1` to force the CLI startup banner to use the plain ASCII fallback instead of the image-rendered graphic banner. This is useful for CI logs, terminals with limited image rendering support, and log processors that should receive a text-only banner layout. The fallback banner may still include ANSI color codes; leave the variable unset, or set it to any value other than `1`, to keep the normal graphic banner path.
-
 `FRANKENBEAST_NETWORK_MANAGED=1` is an internal child-process marker owned by `frankenbeast network`. The supervisor sets it for managed services such as `chat-server`; operators normally should not export it for standalone local debugging. Managed children suppress the normal CLI startup banner, and managed `chat-server` fails closed without an operator token even on loopback. If a standalone `chat-server` run unexpectedly asks for an operator token on `127.0.0.1` or `localhost`, unset `FRANKENBEAST_NETWORK_MANAGED`; if you intentionally exercise managed semantics, provide `FRANKENBEAST_BEAST_OPERATOR_TOKEN` or the configured secret-store token reference.
 
 ### Project Layout

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "eslint-config-prettier": "^10.1.8",
         "js-yaml": "^5.2.1",
         "jsdom": "^29.1.1",
-        "sharp": "^0.35.3",
         "tsx": "^4.23.1",
         "turbo": "^2.10.5",
         "typescript": "^5.9.3",
@@ -649,96 +648,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5441,56 +5350,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.1.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.8.5"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6805,9 +6664,6 @@
       },
       "engines": {
         "node": ">=22.13.0 <23 || >=24.0.0 <26"
-      },
-      "optionalDependencies": {
-        "sharp": "^0.35.3"
       }
     },
     "packages/franken-planner": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "eslint-config-prettier": "^10.1.8",
     "jsdom": "^29.1.1",
     "js-yaml": "^5.2.1",
-    "sharp": "^0.35.3",
     "tsx": "^4.23.1",
     "turbo": "^2.10.5",
     "typescript": "^5.9.3",

--- a/packages/franken-orchestrator/package.json
+++ b/packages/franken-orchestrator/package.json
@@ -64,8 +64,5 @@
     "@types/ws": "^8.18.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.9"
-  },
-  "optionalDependencies": {
-    "sharp": "^0.35.3"
   }
 }

--- a/tests/issue-3361-banner-dependency.test.ts
+++ b/tests/issue-3361-banner-dependency.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const readText = (relativePath: string) =>
+  readFileSync(resolve(ROOT, relativePath), "utf8");
+const readJson = <T>(relativePath: string): T =>
+  JSON.parse(readText(relativePath)) as T;
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+type PackageLock = {
+  packages: Record<string, PackageManifest>;
+};
+
+const directDependency = (manifest: PackageManifest, name: string) =>
+  manifest.dependencies?.[name] ??
+  manifest.devDependencies?.[name] ??
+  manifest.optionalDependencies?.[name];
+
+describe("issue #3361 static banner cleanup", () => {
+  it("does not declare sharp after removing the image-rendered banner", () => {
+    const rootPackage = readJson<PackageManifest>("package.json");
+    const orchestratorPackage = readJson<PackageManifest>(
+      "packages/franken-orchestrator/package.json",
+    );
+    const packageLock = readJson<PackageLock>("package-lock.json");
+
+    expect(directDependency(rootPackage, "sharp")).toBeUndefined();
+    expect(directDependency(orchestratorPackage, "sharp")).toBeUndefined();
+    expect(
+      directDependency(packageLock.packages[""] ?? {}, "sharp"),
+    ).toBeUndefined();
+    expect(
+      directDependency(
+        packageLock.packages["packages/franken-orchestrator"] ?? {},
+        "sharp",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not document the removed plain-banner flag", () => {
+    expect(readText("README.md")).not.toContain("FRANKENBEAST_PLAIN_BANNER");
+    expect(readText(".env.example")).not.toContain("FRANKENBEAST_PLAIN_BANNER");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the obsolete root and orchestrator `sharp` declarations plus their lockfile artifacts
- remove stale `FRANKENBEAST_PLAIN_BANNER` documentation from the README and environment example
- add a focused regression test covering package metadata, lockfile declarations, and documentation

## Validation
- `npm exec -- vitest run tests/issue-3361-banner-dependency.test.ts` (2 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `npx turbo run build --filter=@franken/orchestrator...` (7/7 tasks passed)
- `npm pack --dry-run --workspace @franken/orchestrator --json`
- `npm test --workspace @franken/orchestrator` (4,100/4,101 passed; one timing-sensitive planner deadline assertion failed, then passed in isolation)
- `npm exec -- vitest run tests/unit/llm-graph-builder.test.ts -t 'checks the deadline after synchronous stage parsing completes'` (passed)

Closes #3361
