### PR TITLE
fix(web): use live skills in agent wizard

### DIFF
--- a/packages/franken-web/src/components/beasts/steps/step-skills.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-skills.tsx
@@ -1,23 +1,18 @@
 import { useState } from 'react';
 import { useBeastStore } from '../../../stores/beast-store';
-
-const STATIC_SKILLS = [
-  { id: 'code-review', name: 'Code Review', description: 'Automated code review', category: 'quality' },
-  { id: 'test-gen', name: 'Test Generation', description: 'Generate tests from code', category: 'testing' },
-  { id: 'doc-gen', name: 'Documentation', description: 'Generate documentation', category: 'docs' },
-  { id: 'refactor', name: 'Refactoring', description: 'Code refactoring suggestions', category: 'quality' },
-  { id: 'security-scan', name: 'Security Scan', description: 'Security vulnerability detection', category: 'security' },
-  { id: 'dep-check', name: 'Dependency Check', description: 'Check for outdated dependencies', category: 'ops' },
-];
+import { useDashboardStore } from '../../../stores/dashboard-store';
 
 export function StepSkills() {
   const { stepValues, setStepValues } = useBeastStore();
+  const skills = useDashboardStore((state) => state.skills);
+  const loading = useDashboardStore((state) => state.loading);
+  const error = useDashboardStore((state) => state.error);
   const values = (stepValues[4] ?? {}) as { selectedSkills?: string[] };
   const selected = values.selectedSkills ?? [];
   const [search, setSearch] = useState('');
 
-  const filtered = STATIC_SKILLS.filter((s) =>
-    !search || s.name.toLowerCase().includes(search.toLowerCase()) || s.description.toLowerCase().includes(search.toLowerCase())
+  const filtered = skills.filter((skill) =>
+    !search || skill.name.toLowerCase().includes(search.toLowerCase()),
   );
 
   function addSkill(id: string) {
@@ -27,7 +22,7 @@ export function StepSkills() {
   }
 
   function removeSkill(id: string) {
-    setStepValues(4, { ...values, selectedSkills: selected.filter((s) => s !== id) });
+    setStepValues(4, { ...values, selectedSkills: selected.filter((skillId) => skillId !== id) });
   }
 
   function toggleSkill(id: string, isSelected: boolean) {
@@ -39,18 +34,48 @@ export function StepSkills() {
     addSkill(id);
   }
 
+  if (loading) {
+    return (
+      <div className="p-8">
+        <p role="status" aria-live="polite" className="text-sm text-beast-muted">
+          Loading installed skills…
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8">
+        <p role="alert" className="px-4 py-3 rounded-lg bg-red-900/30 border border-red-700 text-red-300 text-sm">
+          Unable to load installed skills. {error}
+        </p>
+      </div>
+    );
+  }
+
+  if (skills.length === 0) {
+    return (
+      <div className="p-8">
+        <p role="status" className="text-sm text-beast-muted">
+          No installed skills are available.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="p-8 space-y-6">
-      {/* Selected chips */}
       {selected.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-beast-muted mb-2 uppercase tracking-wide">Selected</h3>
           <div className="flex flex-wrap gap-2">
             {selected.map((id) => {
-              const skill = STATIC_SKILLS.find((s) => s.id === id);
+              const skill = skills.find((candidate) => candidate.name === id);
+              const label = skill?.name ?? id;
               return (
                 <span key={id} className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-beast-accent-soft text-beast-accent text-xs font-medium border border-beast-accent/30">
-                  {skill?.name ?? id}
+                  {label}
                   <button
                     type="button"
                     onClick={() => removeSkill(id)}
@@ -61,7 +86,7 @@ export function StepSkills() {
                       }
                     }}
                     className="hover:text-beast-danger p-0.5"
-                    aria-label={`Remove ${skill?.name ?? id}`}
+                    aria-label={`Remove ${label}`}
                   >
                     <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -74,46 +99,60 @@ export function StepSkills() {
         </div>
       )}
 
-      {/* Search */}
-      <input
-        type="text"
-        placeholder="Search skills..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full bg-beast-control border border-beast-border rounded-lg px-3 py-2.5
-          text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none
-          focus:ring-2 focus:ring-beast-accent"
-      />
+      <label className="block">
+        <span className="sr-only">Search installed skills</span>
+        <input
+          type="text"
+          placeholder="Search skills..."
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="w-full bg-beast-control border border-beast-border rounded-lg px-3 py-2.5
+            text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none
+            focus:ring-2 focus:ring-beast-accent"
+        />
+      </label>
 
-      {/* Skill cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-        {filtered.map((skill) => {
-          const isSelected = selected.includes(skill.id);
-          return (
-            <button
-              key={skill.id}
-              type="button"
-              aria-pressed={isSelected}
-              onClick={() => toggleSkill(skill.id, isSelected)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault();
-                  toggleSkill(skill.id, isSelected);
-                }
-              }}
-              className={`p-4 rounded-xl border-2 text-left transition-all min-h-[5rem]
-                ${isSelected
-                  ? 'border-beast-accent bg-beast-accent-soft ring-1 ring-beast-accent/30'
-                  : 'border-beast-border bg-beast-panel hover:bg-beast-elevated hover:border-beast-subtle'
-                }`}
-            >
-              <h3 className="text-sm font-medium text-beast-text">{skill.name}</h3>
-              <p className="text-xs text-beast-subtle mt-1 leading-relaxed">{skill.description}</p>
-              <span className="text-[10px] text-beast-muted mt-2 inline-block px-1.5 py-0.5 rounded bg-beast-control">{skill.category}</span>
-            </button>
-          );
-        })}
-      </div>
+      {filtered.length === 0 ? (
+        <p role="status" className="text-sm text-beast-muted">No installed skills match your search.</p>
+      ) : (
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((skill) => {
+            const isSelected = selected.includes(skill.name);
+            return (
+              <button
+                key={skill.name}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => toggleSkill(skill.name, isSelected)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    toggleSkill(skill.name, isSelected);
+                  }
+                }}
+                className={`p-4 rounded-xl border-2 text-left transition-all min-h-[5rem]
+                  ${isSelected
+                    ? 'border-beast-accent bg-beast-accent-soft ring-1 ring-beast-accent/30'
+                    : 'border-beast-border bg-beast-panel hover:bg-beast-elevated hover:border-beast-subtle'
+                  }`}
+              >
+                <h3 className="text-sm font-medium text-beast-text">{skill.name}</h3>
+                <p className="text-xs text-beast-subtle mt-1 leading-relaxed">Installed runtime skill</p>
+                <div className="flex flex-wrap gap-1.5 mt-2" aria-label={`${skill.name} capabilities`}>
+                  {skill.hasContext && (
+                    <span className="text-[10px] text-beast-muted inline-block px-1.5 py-0.5 rounded bg-beast-control">Context</span>
+                  )}
+                  {skill.mcpServerCount > 0 && (
+                    <span className="text-[10px] text-beast-muted inline-block px-1.5 py-0.5 rounded bg-beast-control">
+                      {skill.mcpServerCount} MCP {skill.mcpServerCount === 1 ? 'server' : 'servers'}
+                    </span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/franken-web/src/components/beasts/steps/step-skills.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-skills.tsx
@@ -11,7 +11,8 @@ export function StepSkills() {
   const selected = values.selectedSkills ?? [];
   const [search, setSearch] = useState('');
 
-  const filtered = skills.filter((skill) =>
+  const enabledSkills = skills.filter((skill) => skill.enabled);
+  const filtered = enabledSkills.filter((skill) =>
     !search || skill.name.toLowerCase().includes(search.toLowerCase()),
   );
 
@@ -54,11 +55,11 @@ export function StepSkills() {
     );
   }
 
-  if (skills.length === 0) {
+  if (enabledSkills.length === 0) {
     return (
       <div className="p-8">
         <p role="status" className="text-sm text-beast-muted">
-          No installed skills are available.
+          No enabled installed skills are available.
         </p>
       </div>
     );

--- a/packages/franken-web/src/pages/beasts-page.test.tsx
+++ b/packages/franken-web/src/pages/beasts-page.test.tsx
@@ -9,7 +9,9 @@ import { useDashboardStore } from '../stores/dashboard-store';
 import type { DashboardApiClient, DashboardSnapshot } from '../lib/dashboard-api';
 
 const snapshot: DashboardSnapshot = {
-  skills: [],
+  skills: [
+    { name: 'live-runtime-skill', enabled: true, hasContext: true, mcpServerCount: 1 },
+  ],
   security: {
     profile: 'standard',
     injectionDetection: true,
@@ -64,7 +66,7 @@ describe('BeastsPage', () => {
     useDashboardStore.getState().reset();
   });
 
-  it('loads the dashboard provider snapshot before showing wizard model selectors', async () => {
+  it('loads the dashboard snapshot before showing wizard runtime choices', async () => {
     const dashboardClient = {
       fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
     } as unknown as DashboardApiClient;
@@ -76,6 +78,7 @@ describe('BeastsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Toggle form mode' }));
 
     expect(await screen.findByText('openai')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /live-runtime-skill/i })).toBeTruthy();
     fireEvent.change(screen.getAllByLabelText('Provider')[0]!, { target: { value: 'openai' } });
     expect(screen.getByText('gpt-4.1')).toBeTruthy();
   });

--- a/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
@@ -1,29 +1,57 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
-afterEach(cleanup);
 import { StepSkills } from '../../../../src/components/beasts/steps/step-skills';
 import { useBeastStore } from '../../../../src/stores/beast-store';
+import { useDashboardStore } from '../../../../src/stores/dashboard-store';
+
+const snapshotSecurity = {
+  profile: 'standard',
+  injectionDetection: true,
+  piiMasking: true,
+  outputValidation: true,
+};
+
+function seedSkills() {
+  useDashboardStore.getState().setSnapshot({
+    skills: [
+      { name: 'code-review', enabled: true, hasContext: true, mcpServerCount: 1 },
+      { name: 'runtime-only', enabled: false, hasContext: false, mcpServerCount: 0 },
+    ],
+    security: snapshotSecurity,
+    providers: [],
+  });
+}
 
 describe('StepSkills', () => {
   beforeEach(() => {
     useBeastStore.getState().resetWizard();
+    useDashboardStore.getState().reset();
+    seedSkills();
   });
 
-  it('renders available skill cards and search input', () => {
+  afterEach(() => {
+    cleanup();
+    useBeastStore.getState().resetWizard();
+    useDashboardStore.getState().reset();
+  });
+
+  it('renders the live runtime skill inventory instead of static placeholders', () => {
     render(<StepSkills />);
     expect(screen.getByPlaceholderText(/search skills/i)).toBeTruthy();
-    expect(screen.getByRole('button', { name: /code review/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /test generation/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /code-review/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /runtime-only/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /test generation/i })).toBeNull();
   });
 
   it('adds and removes a skill via pointer interaction', () => {
     render(<StepSkills />);
-    const codeReview = screen.getByRole('button', { name: /code review/i });
+    const codeReview = screen.getByRole('button', { name: /code-review/i });
 
     fireEvent.click(codeReview);
     expect(codeReview.getAttribute('aria-pressed')).toBe('true');
-    const selectedChipRemove = screen.getByLabelText('Remove Code Review');
+    expect(useBeastStore.getState().stepValues[4]?.selectedSkills).toEqual(['code-review']);
+    const selectedChipRemove = screen.getByLabelText('Remove code-review');
     expect(selectedChipRemove).toBeTruthy();
 
     fireEvent.click(selectedChipRemove);
@@ -32,14 +60,14 @@ describe('StepSkills', () => {
 
   it('supports keyboard activation and accessible removal flow for selected skills', () => {
     render(<StepSkills />);
-    const codeReview = screen.getByRole('button', { name: /code review/i });
+    const codeReview = screen.getByRole('button', { name: /code-review/i });
 
     expect(codeReview.getAttribute('aria-pressed')).toBe('false');
     codeReview.focus();
     fireEvent.keyDown(codeReview, { key: 'Enter', code: 'Enter' });
     expect(codeReview.getAttribute('aria-pressed')).toBe('true');
 
-    const selectedChipRemove = screen.getByLabelText('Remove Code Review');
+    const selectedChipRemove = screen.getByLabelText('Remove code-review');
     expect(selectedChipRemove).toBeTruthy();
     selectedChipRemove.focus();
     fireEvent.keyDown(selectedChipRemove, { key: 'Enter', code: 'Enter' });
@@ -54,12 +82,40 @@ describe('StepSkills', () => {
 
   it('keeps aria-pressed in sync when a skill is toggled', () => {
     render(<StepSkills />);
-    const skill = screen.getByRole('button', { name: /code review/i });
+    const skill = screen.getByRole('button', { name: /code-review/i });
 
     expect(skill.getAttribute('aria-pressed')).toBe('false');
     fireEvent.click(skill);
     expect(skill.getAttribute('aria-pressed')).toBe('true');
     fireEvent.click(skill);
     expect(skill.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('announces loading, failure, and successful empty inventory states', () => {
+    useDashboardStore.getState().reset();
+    const { rerender } = render(<StepSkills />);
+    expect(screen.getByRole('status').textContent).toMatch(/loading installed skills/i);
+
+    useDashboardStore.getState().setError('Inventory request failed.');
+    rerender(<StepSkills />);
+    expect(screen.getByRole('alert').textContent).toMatch(/inventory request failed/i);
+
+    useDashboardStore.getState().setSnapshot({
+      skills: [],
+      security: snapshotSecurity,
+      providers: [],
+    });
+    rerender(<StepSkills />);
+    expect(screen.getByRole('status').textContent).toMatch(/no installed skills are available/i);
+  });
+
+  it('filters the runtime inventory without changing persisted skill IDs', () => {
+    render(<StepSkills />);
+    fireEvent.change(screen.getByLabelText(/search installed skills/i), { target: { value: 'runtime' } });
+
+    expect(screen.getByRole('button', { name: /runtime-only/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /code-review/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /runtime-only/i }));
+    expect(useBeastStore.getState().stepValues[4]?.selectedSkills).toEqual(['runtime-only']);
   });
 });

--- a/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-skills.test.tsx
@@ -16,7 +16,8 @@ function seedSkills() {
   useDashboardStore.getState().setSnapshot({
     skills: [
       { name: 'code-review', enabled: true, hasContext: true, mcpServerCount: 1 },
-      { name: 'runtime-only', enabled: false, hasContext: false, mcpServerCount: 0 },
+      { name: 'runtime-only', enabled: true, hasContext: false, mcpServerCount: 0 },
+      { name: 'disabled-runtime', enabled: false, hasContext: false, mcpServerCount: 0 },
     ],
     security: snapshotSecurity,
     providers: [],
@@ -41,6 +42,7 @@ describe('StepSkills', () => {
     expect(screen.getByPlaceholderText(/search skills/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /code-review/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /runtime-only/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /disabled-runtime/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /test generation/i })).toBeNull();
   });
 
@@ -101,12 +103,14 @@ describe('StepSkills', () => {
     expect(screen.getByRole('alert').textContent).toMatch(/inventory request failed/i);
 
     useDashboardStore.getState().setSnapshot({
-      skills: [],
+      skills: [
+        { name: 'disabled-runtime', enabled: false, hasContext: false, mcpServerCount: 0 },
+      ],
       security: snapshotSecurity,
       providers: [],
     });
     rerender(<StepSkills />);
-    expect(screen.getByRole('status').textContent).toMatch(/no installed skills are available/i);
+    expect(screen.getByRole('status').textContent).toMatch(/no enabled installed skills are available/i);
   });
 
   it('filters the runtime inventory without changing persisted skill IDs', () => {

--- a/tasks/issue-3129-progress.md
+++ b/tasks/issue-3129-progress.md
@@ -1,8 +1,0 @@
-# Issue 3129 progress
-
-- [x] Read issue, repository instructions, shared lessons, and current implementation/tests.
-- [x] Add focused failing coverage for the live runtime skill inventory and status states.
-- [x] Replace the static catalog with dashboard inventory data and runtime skill IDs.
-- [x] Run focused tests, package tests, lint, typecheck, and build.
-- [ ] Self-review, commit, push, open the one-issue PR, and complete Codex/CI gates.
-- [ ] Merge, verify issue closure, and record any durable lesson.

--- a/tasks/issue-3129-progress.md
+++ b/tasks/issue-3129-progress.md
@@ -1,0 +1,8 @@
+# Issue 3129 progress
+
+- [x] Read issue, repository instructions, shared lessons, and current implementation/tests.
+- [x] Add focused failing coverage for the live runtime skill inventory and status states.
+- [x] Replace the static catalog with dashboard inventory data and runtime skill IDs.
+- [x] Run focused tests, package tests, lint, typecheck, and build.
+- [ ] Self-review, commit, push, open the one-issue PR, and complete Codex/CI gates.
+- [ ] Merge, verify issue closure, and record any durable lesson.


### PR DESCRIPTION
## Summary
- replace the Beast wizard static skill placeholders with the dashboard runtime inventory
- persist exact runtime skill names and expose accessible loading, error, empty, and search-empty states
- cover the snapshot-to-wizard integration plus pointer and keyboard selection behavior

## Verification
- `npm test` in `packages/franken-web` (666 tests passed)
- `npm run lint` in `packages/franken-web` (0 errors; 17 pre-existing warnings)
- `npm run typecheck` in `packages/franken-web`
- `npm run build` at repository root (10 packages)
- `npm run build` in `packages/franken-web`

Closes #3129