### PR TITLE
fix(security): keep SSE tickets out of request URLs

### DIFF
--- a/docs/adr/030-sse-connection-tickets-auth.md
+++ b/docs/adr/030-sse-connection-tickets-auth.md
@@ -17,7 +17,7 @@ Use a **connection ticket** pattern — an industry-standard approach for authen
 **Canonical endpoints:**
 
 - Ticket issuance: `POST /v1/beasts/events/ticket`
-- Dashboard stream: `GET /v1/beasts/events/stream?ticket=<uuid>`
+- Dashboard stream: `GET /v1/beasts/events/stream`
 
 These paths are shared by the daemon routes in `packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts` and the dashboard client in `packages/franken-web/src/lib/beast-api.ts`. Older per-agent `/api/beasts/:id/events` examples are not the dashboard stream contract.
 
@@ -25,9 +25,9 @@ These paths are shared by the daemon routes in `packages/franken-orchestrator/sr
 
 1. Dashboard calls `POST /v1/beasts/events/ticket` with `Authorization: Bearer <operator-token>`
 2. Daemon validates the bearer token, generates a single-use UUID ticket, and stores its token digest in the shared Beast SQLite database with a 30-second TTL
-3. Response: `{ ticket: "<uuid>" }`
-4. Dashboard opens `EventSource` to the canonical `/v1/beasts/events/stream?ticket=<uuid>` endpoint
-5. Daemon validates the ticket: must exist, not expired, not already used
+3. Response sets the ticket in an `HttpOnly`, `SameSite=Strict` cookie scoped only to `/v1/beasts/events/stream`; HTTPS requests also set `Secure`
+4. Dashboard opens `EventSource` to the canonical `/v1/beasts/events/stream` endpoint without putting the ticket in the URL
+5. Daemon reads and validates the scoped cookie: the ticket must exist, not be expired, and not be already used
 6. Ticket is atomically marked consumed on first use; the short-lived consumed marker prevents native EventSource retries from looping
 7. SSE stream is established and authenticated for the lifetime of the connection
 
@@ -47,6 +47,7 @@ When `EventSource` reconnects after a network interruption, it opens a new HTTP 
 
 ### Positive
 - Operator token never appears in URLs, logs, or browser history
+- Connection tickets never appear in proxy/server request URLs or access logs
 - Tickets are single-use and short-lived — no replay risk
 - Restart-safe and shared across daemon processes that use the same Beast database
 - Works with existing bearer token auth model
@@ -66,6 +67,6 @@ When `EventSource` reconnects after a network interruption, it opens a new HTTP 
 | Option | Pros | Cons | Rejected Because |
 |--------|------|------|-----------------|
 | Token in query parameter | Simple, no extra round-trip | Token in URLs/logs/history; security risk | OWASP explicitly recommends against this |
-| Cookie-based auth | Auto-sent by browser | Requires session store; CORS cookie complexity; CSRF risk | Adds infrastructure complexity for a dev tool |
+| Long-lived operator-token cookie auth | Auto-sent by browser | Broad credential lifetime and CSRF exposure | A scoped, single-use connection-ticket cookie limits both lifetime and path exposure |
 | Custom protocol over WebSocket | Full header support | More complex than SSE; bidirectional not needed | SSE is simpler for unidirectional push |
 | mTLS / client certificates | Strong auth | Complex setup; not practical for a dev dashboard | Over-engineered for the use case |

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -1,9 +1,21 @@
 import { timingSafeEqual } from 'node:crypto';
 import { Hono } from 'hono';
+import { getCookie, setCookie } from 'hono/cookie';
 import { streamSSE } from 'hono/streaming';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from '../operator-auth.js';
+
+const SSE_TICKET_COOKIE = 'frankenbeast_sse_ticket';
+const SSE_STREAM_PATH = '/v1/beasts/events/stream';
+
+function isHttpsRequest(
+  requestUrl: string,
+  forwardedProto: string | undefined,
+): boolean {
+  const proto = forwardedProto?.split(',')[0]?.trim().toLowerCase();
+  return proto ? proto === 'https' : new URL(requestUrl).protocol === 'https:';
+}
 
 function safeTokenCompare(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
@@ -56,11 +68,17 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
     }
 
     const ticket = ticketStore.issue(operatorToken);
-    return c.json({ ticket });
+    setCookie(c, SSE_TICKET_COOKIE, ticket, {
+      httpOnly: true,
+      path: SSE_STREAM_PATH,
+      sameSite: 'Strict',
+      secure: isHttpsRequest(c.req.url, c.req.header('x-forwarded-proto')),
+    });
+    return c.json({ issued: true });
   });
 
-  app.get('/v1/beasts/events/stream', (c) => {
-    const ticket = c.req.query('ticket');
+  app.get(SSE_STREAM_PATH, (c) => {
+    const ticket = getCookie(c, SSE_TICKET_COOKIE);
     if (!ticket) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -734,8 +734,11 @@ describe('beast daemon', () => {
       headers: { authorization: `Bearer ${operatorToken}` },
     });
     expect(ticketResponse.status).toBe(200);
-    const ticketBody = await ticketResponse.json() as { ticket: string };
-    const streamResponse = await fetch(`${daemon.url}/v1/beasts/events/stream?ticket=${ticketBody.ticket}`);
+    const ticketCookie = ticketResponse.headers.get('set-cookie')?.split(';', 1)[0];
+    expect(ticketCookie).toBeTruthy();
+    const streamResponse = await fetch(`${daemon.url}/v1/beasts/events/stream`, {
+      headers: { cookie: ticketCookie! },
+    });
     expect(streamResponse.status).toBe(200);
 
     await expect(Promise.race([

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -28,8 +28,9 @@ async function issueTicket(app: Hono): Promise<string> {
     method: 'POST',
     headers: { Authorization: `Bearer ${OPERATOR_TOKEN}` },
   });
-  const body = await res.json() as { ticket: string };
-  return body.ticket;
+  const cookie = res.headers.get('set-cookie');
+  expect(cookie).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
+  return cookie!.split(';', 1)[0]!;
 }
 
 /**
@@ -58,6 +59,7 @@ async function readSseEventsUntil(
   until: (events: ParsedSseEvent[]) => boolean,
   options: {
     headers?: HeadersInit;
+    cookie?: string;
     onConnected?: () => void;
     timeoutMs?: number;
     continueAfterMatchMs?: number;
@@ -77,9 +79,11 @@ async function readSseEventsUntil(
 
   timeoutSignal.addEventListener('abort', abortOnTimeout, { once: true });
 
+  const headers = new Headers(options.headers);
+  if (options.cookie) headers.set('cookie', options.cookie);
   const req = new Request(url, {
     signal: controller.signal,
-    headers: options.headers,
+    headers,
   });
   const res = await app.request(req);
   if (!res.body) {
@@ -142,7 +146,7 @@ describe('Beast SSE routes', () => {
     ticketStore = undefined;
   });
 
-  it('POST /v1/beasts/events/ticket returns a ticket', async () => {
+  it('POST /v1/beasts/events/ticket sets a scoped ticket cookie', async () => {
     const ctx = createSseApp();
     ticketStore = ctx.ticketStore;
 
@@ -152,9 +156,9 @@ describe('Beast SSE routes', () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
     const body = await res.json();
-    expect(body.ticket).toBeDefined();
-    expect(typeof body.ticket).toBe('string');
+    expect(body).toEqual({ issued: true });
   });
 
   it('POST /v1/beasts/events/ticket accepts same-origin operator cookies', async () => {
@@ -171,7 +175,7 @@ describe('Beast SSE routes', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.ticket).toBeDefined();
+    expect(body).toEqual({ issued: true });
   });
 
   it('POST /v1/beasts/events/ticket accepts proxied HTTPS same-origin operator cookies', async () => {
@@ -190,8 +194,9 @@ describe('Beast SSE routes', () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toContain('; Secure');
     const body = await res.json();
-    expect(body.ticket).toBeDefined();
+    expect(body).toEqual({ issued: true });
   });
 
   it('POST /v1/beasts/events/ticket rejects cross-origin operator cookies', async () => {
@@ -225,7 +230,9 @@ describe('Beast SSE routes', () => {
     const ctx = createSseApp();
     ticketStore = ctx.ticketStore;
 
-    const res = await ctx.app.request('/v1/beasts/events/stream?ticket=bogus');
+    const res = await ctx.app.request('/v1/beasts/events/stream', {
+      headers: { cookie: 'frankenbeast_sse_ticket=bogus' },
+    });
 
     expect(res.status).toBe(401);
   });
@@ -238,12 +245,13 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      'http://localhost/v1/beasts/events/stream',
       (candidateEvents) => (
         candidateEvents.some((e) => e.event === 'agent.status')
         && candidateEvents.some((e) => e.event === 'run.status')
       ),
       {
+        cookie: ticket,
         onConnected: () => {
           ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
           ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
@@ -272,8 +280,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      'http://localhost/v1/beasts/events/stream',
       (candidateEvents) => candidateEvents.some((e) => e.event === 'snapshot'),
+      { cookie: ticket },
     );
     const snapshot = events.find((e) => e.event === 'snapshot');
 
@@ -296,12 +305,12 @@ describe('Beast SSE routes', () => {
     // Reconnect with Last-Event-ID=1 — should replay events 2 and 3
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      'http://localhost/v1/beasts/events/stream',
       (candidateEvents) => (
         candidateEvents.some((e) => e.id === '2')
         && candidateEvents.some((e) => e.id === '3')
       ),
-      { headers: { 'Last-Event-ID': '1' }, continueAfterMatchMs: 25 },
+      { cookie: ticket, headers: { 'Last-Event-ID': '1' }, continueAfterMatchMs: 25 },
     );
 
     // Should NOT contain event id=1 (already seen)
@@ -322,9 +331,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      `http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`,
+      'http://localhost/v1/beasts/events/stream?lastEventId=1',
       (candidateEvents) => candidateEvents.some((e) => e.id === '2'),
-      { continueAfterMatchMs: 25 },
+      { cookie: ticket, continueAfterMatchMs: 25 },
     );
 
     expect(events.find((e) => e.id === '1')).toBeUndefined();
@@ -349,9 +358,11 @@ describe('Beast SSE routes', () => {
     ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
 
     const ticket = await issueTicket(ctx.app);
-    const query = options.query ? `&${options.query}` : '';
-    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}${query}`, {
-      headers: options.headers,
+    const query = options.query ? '?' + options.query : '';
+    const headers = new Headers(options.headers);
+    headers.set('cookie', ticket);
+    const req = new Request('http://localhost/v1/beasts/events/stream' + query, {
+      headers,
     });
     const res = await ctx.app.request(req);
 
@@ -370,8 +381,8 @@ describe('Beast SSE routes', () => {
     ticketStore = ctx.ticketStore;
 
     const ticket = await issueTicket(ctx.app);
-    const req = new Request(`http://localhost/v1/beasts/events/stream?ticket=${ticket}&lastEventId=1`, {
-      headers: { 'Last-Event-ID': '1abc' },
+    const req = new Request('http://localhost/v1/beasts/events/stream?lastEventId=1', {
+      headers: { 'Last-Event-ID': '1abc', cookie: ticket },
     });
     const res = await ctx.app.request(req);
 
@@ -389,9 +400,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      'http://localhost/v1/beasts/events/stream',
       () => false,
-      { headers: { 'Last-Event-ID': '0' }, timeoutMs: 50, allowTimeout: true },
+      { cookie: ticket, headers: { 'Last-Event-ID': '0' }, timeoutMs: 50, allowTimeout: true },
     );
     expect(events.find((e) => e.event === 'snapshot')).toBeUndefined();
   });
@@ -404,9 +415,10 @@ describe('Beast SSE routes', () => {
 
     const events = (await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?ticket=' + ticket,
+      'http://localhost/v1/beasts/events/stream',
       (candidateEvents) => candidateEvents.filter((e) => e.event === 'run.log').length === 5,
       {
+        cookie: ticket,
         continueAfterMatchMs: 25,
         onConnected: () => {
           for (let i = 0; i < 5; i++) {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -397,10 +397,14 @@ describe('chat server bootstrap', () => {
 
     });
     expect(ticketResponse.status).toBe(200);
-    const ticketBody = await ticketResponse.json() as { ticket: string };
-    const streamResponse = await fetch(`${server.url}/v1/beasts/events/stream?ticket=${ticketBody.ticket}`, {
+    const ticketCookie = ticketResponse.headers.get('set-cookie')?.split(';', 1)[0];
+    expect(ticketCookie).toBeTruthy();
+    const streamResponse = await fetch(`${server.url}/v1/beasts/events/stream`, {
 
-      headers: { authorization: `Bearer ${TEST_SHARED_TOKEN}` },
+      headers: {
+        authorization: `Bearer ${TEST_SHARED_TOKEN}`,
+        cookie: ticketCookie!,
+      },
 
     });
     expect(streamResponse.status).toBe(200);

--- a/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
@@ -28,21 +28,47 @@ describe('beast SSE routes', () => {
       method: 'POST',
       headers: { authorization: 'Bearer operator-token' },
     });
-    const { ticket } = await ticketRes.json() as { ticket: string };
+    const cookie = ticketRes.headers.get('set-cookie');
+    expect(cookie).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Strict');
+    expect(cookie).toContain('Path=/v1/beasts/events/stream');
+    expect(await ticketRes.json()).toEqual({ issued: true });
 
-    const first = await app.request(`/v1/beasts/events/stream?ticket=${ticket}`);
+    const first = await app.request('/v1/beasts/events/stream', {
+      headers: { cookie: cookie!.split(';', 1)[0]! },
+    });
     expect(first.status).toBe(200);
     await first.body?.cancel();
 
-    const second = await app.request(`/v1/beasts/events/stream?ticket=${ticket}`);
+    const second = await app.request('/v1/beasts/events/stream', {
+      headers: { cookie: cookie!.split(';', 1)[0]! },
+    });
     expect(second.status).toBe(204);
     expect(await second.text()).toBe('');
+  });
+
+  it('does not accept stream tickets from query strings', async () => {
+    const app = createRoutes();
+    const ticketRes = await app.request('/v1/beasts/events/ticket', {
+      method: 'POST',
+      headers: { authorization: 'Bearer operator-token' },
+    });
+    const cookie = ticketRes.headers.get('set-cookie');
+    expect(cookie).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
+    const ticket = cookie!.split(';', 1)[0]!.split('=', 2)[1]!;
+
+    const response = await app.request(`/v1/beasts/events/stream?ticket=${ticket}`);
+
+    expect(response.status).toBe(401);
   });
 
   it('returns unauthorized for invalid stream tickets', async () => {
     const app = createRoutes();
 
-    const res = await app.request('/v1/beasts/events/stream?ticket=bogus');
+    const res = await app.request('/v1/beasts/events/stream', {
+      headers: { cookie: 'frankenbeast_sse_ticket=bogus' },
+    });
 
     expect(res.status).toBe(401);
     const body = await res.json() as { error: { message: string } };

--- a/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
@@ -66,19 +66,22 @@ describe('chat app beast daemon proxy', () => {
     expect((init.headers as Headers).get('authorization')).toBe(`Bearer ${TEST_DAEMON_TOKEN}`);
   });
 
-  it('lets ticket-authenticated SSE streams reach the daemon proxy without bearer auth', async () => {
+  it('forwards cookie-authenticated SSE streams without putting tickets in the URL', async () => {
     const fetchMock = vi.fn(async () => new Response('event: snapshot\ndata: {}\n\n', {
       headers: { 'content-type': 'text/event-stream' },
     }));
     vi.stubGlobal('fetch', fetchMock);
     const app = createProxyApp();
 
-    const response = await app.request('/v1/beasts/events/stream?ticket=ticket-1');
+    const response = await app.request('/v1/beasts/events/stream', {
+      headers: { cookie: 'frankenbeast_sse_ticket=ticket-1' },
+    });
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
-    expect(url.toString()).toBe('http://127.0.0.1:4050/v1/beasts/events/stream?ticket=ticket-1');
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+    expect(url.toString()).toBe('http://127.0.0.1:4050/v1/beasts/events/stream');
+    expect((init.headers as Headers).get('cookie')).toBe('frankenbeast_sse_ticket=ticket-1');
   });
 
   it('injects the effective gateway token for daemon SSE ticket requests', async () => {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -248,14 +248,15 @@ export class BeastApiClient {
     };
 
     const connect = async () => {
-      const body = await this.requestRaw<{ ticket: string }>('/v1/beasts/events/ticket', { method: 'POST' });
+      await this.requestRaw<{ issued: boolean }>('/v1/beasts/events/ticket', {
+        method: 'POST',
+        credentials: 'include',
+      });
       if (closed) return;
       eventSource?.close();
-      const query = new URLSearchParams({ ticket: body.ticket });
-      if (lastEventId) query.set('lastEventId', lastEventId);
-      const nextSource = new EventSource(
-        `${this.baseUrl}/v1/beasts/events/stream?${query.toString()}`,
-      );
+      const streamUrl = new URL(`${this.baseUrl}/v1/beasts/events/stream`);
+      if (lastEventId) streamUrl.searchParams.set('lastEventId', lastEventId);
+      const nextSource = new EventSource(streamUrl.toString(), { withCredentials: true });
       eventSource = nextSource;
 
       nextSource.addEventListener('open', () => {

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -366,8 +366,10 @@ describe('BeastApiClient', () => {
       );
       const init = mockFetch.mock.calls[0]![1] as RequestInit;
       expect(new Headers(init.headers).has('authorization')).toBe(false);
+      expect(init.credentials).toBe('include');
       expect(MockEventSource).toHaveBeenCalledWith(
-        'http://localhost:3000/v1/beasts/events/stream?ticket=sse-ticket',
+        'http://localhost:3000/v1/beasts/events/stream',
+        { withCredentials: true },
       );
 
       listeners['run.log']?.({ data: JSON.stringify({ runId: 'run-1', stream: 'stdout', line: 'one' }) });
@@ -467,7 +469,8 @@ describe('BeastApiClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2',
+        'http://localhost:3000/v1/beasts/events/stream',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -574,7 +577,8 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(expect.any(SyntaxError));
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',
+        'http://localhost:3000/v1/beasts/events/stream?lastEventId=42',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -638,7 +642,8 @@ describe('BeastApiClient', () => {
 
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=42',
+        'http://localhost:3000/v1/beasts/events/stream?lastEventId=42',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -689,7 +694,8 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('reconnecting') }));
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=45',
+        'http://localhost:3000/v1/beasts/events/stream?lastEventId=45',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -743,7 +749,8 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(handlerError);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2&lastEventId=44',
+        'http://localhost:3000/v1/beasts/events/stream?lastEventId=44',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -792,7 +799,8 @@ describe('BeastApiClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-3',
+        'http://localhost:3000/v1/beasts/events/stream',
+        { withCredentials: true },
       );
 
       unsubscribe();
@@ -834,7 +842,8 @@ describe('BeastApiClient', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(MockEventSource).toHaveBeenCalledWith(
-        'http://localhost:3000/v1/beasts/events/stream?ticket=ticket-2',
+        'http://localhost:3000/v1/beasts/events/stream',
+        { withCredentials: true },
       );
 
       unsubscribe();

--- a/tests/docs-issue-3226.test.ts
+++ b/tests/docs-issue-3226.test.ts
@@ -24,12 +24,12 @@ describe('issue #3226 dashboard SSE endpoint contract', () => {
 
     const daemonPath = requireMatch(
       daemonRoutes,
-      /app\.get\('([^']*\/events\/stream)'/u,
+      /const SSE_STREAM_PATH = '(\/[^']*\/events\/stream)'/u,
       'daemon SSE route should be declared',
     );
     const dashboardPath = requireMatch(
       dashboardClient,
-      /`\$\{this\.baseUrl\}(\/[^?]*\/events\/stream)\?\$\{query\.toString\(\)\}`/u,
+      /new URL\([^)]*?(\/v1\/beasts\/events\/stream)/u,
       'dashboard EventSource path should be declared',
     );
 
@@ -42,7 +42,7 @@ describe('issue #3226 dashboard SSE endpoint contract', () => {
 
     expect(adr).toContain('Ticket issuance: `POST /v1/beasts/events/ticket`');
     expect(adr).toContain(
-      'Dashboard stream: `GET /v1/beasts/events/stream?ticket=<uuid>`',
+      'Dashboard stream: `GET /v1/beasts/events/stream`',
     );
     expect(adr).not.toContain('`useBeastEventStream`');
   });


### PR DESCRIPTION
## Summary
- issue one-time Beast SSE tickets in an HttpOnly, stream-scoped SameSite cookie instead of returning the credential to JavaScript
- open EventSource connections without the ticket query parameter while preserving Last-Event-ID reconnects
- retain ticket TTL, single-use consumption, proxy forwarding, and HTTPS Secure-cookie behavior

## Test plan
- `npm run build`
- `npm run typecheck`
- `npm run lint --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/web`
- `npm run lint:security`
- `npm run test --workspace @franken/orchestrator` (4,102 tests)
- `npm run test --workspace @franken/web` (664 tests)
- `npm run test:root` (620 passed, 1 skipped)

Closes #3360