### PR TITLE
fix(types): alias MCP suite and live bench sources

### DIFF
--- a/scripts/vitest-source-aliases.ts
+++ b/scripts/vitest-source-aliases.ts
@@ -13,6 +13,8 @@ const FRANKEN_SOURCE_ENTRYPOINTS = {
   '@franken/types/utils': 'packages/franken-types/src/utils/index.ts',
   '@franken/types': 'packages/franken-types/src/index.ts',
   '@franken/orchestrator': 'packages/franken-orchestrator/src/index.ts',
+  '@franken/mcp-suite': 'packages/franken-mcp-suite/src/index.ts',
+  '@franken/live-bench': 'packages/live-bench/src/index.ts',
 } as const;
 
 export type FrankenSourceAlias = keyof typeof FRANKEN_SOURCE_ENTRYPOINTS;

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -38,6 +38,8 @@ const EXPECTED_ALIASES: Record<string, string> = {
   "@franken/types/utils": "./packages/franken-types/src/utils/index.ts",
   "@franken/types": "./packages/franken-types/src/index.ts",
   "@franken/orchestrator": "./packages/franken-orchestrator/src/index.ts",
+  "@franken/mcp-suite": "./packages/franken-mcp-suite/src/index.ts",
+  "@franken/live-bench": "./packages/live-bench/src/index.ts",
 };
 
 const ALIASED_WORKSPACE_PACKAGES = new Set(
@@ -53,10 +55,6 @@ const ALIASED_WORKSPACE_PACKAGES = new Set(
 );
 
 const PATH_ALIAS_ALLOWLIST: Record<string, string> = {
-  "@franken/live-bench":
-    "CLI-only benchmark workspace; consumers should use the package build/bin instead of a root source alias.",
-  "@franken/mcp-suite":
-    "CLI/server package with package-level Vitest aliases; no root @franken source alias is exported intentionally.",
   "@franken/web":
     "Vite application workspace, not an importable library entrypoint.",
 };

--- a/tests/vitest-package-source-aliases.test.ts
+++ b/tests/vitest-package-source-aliases.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { deterministicUuid } from '@franken/types/utils';
+import { FbeastConfig } from '@franken/mcp-suite';
+import { BenchmarkTaskSchema } from '@franken/live-bench';
 import { createFrankenSourceAliases } from '../scripts/vitest-source-aliases.js';
 
 const ROOT = join(import.meta.dirname, '..');
@@ -17,6 +19,8 @@ const EXPECTED_ALIASES = {
   '@franken/types/utils': resolve(ROOT, 'packages/franken-types/src/utils/index.ts'),
   '@franken/types': resolve(ROOT, 'packages/franken-types/src/index.ts'),
   '@franken/orchestrator': resolve(ROOT, 'packages/franken-orchestrator/src/index.ts'),
+  '@franken/mcp-suite': resolve(ROOT, 'packages/franken-mcp-suite/src/index.ts'),
+  '@franken/live-bench': resolve(ROOT, 'packages/live-bench/src/index.ts'),
 };
 
 const PACKAGE_CONFIGS = [
@@ -37,6 +41,11 @@ const PACKAGE_CONFIGS = [
 describe('package Vitest source aliases', () => {
   it('lets root Vitest resolve the @franken/types/utils subpath from source', () => {
     expect(deterministicUuid('root-vitest-alias', 0)).toMatch(/^[0-9a-f-]+$/u);
+  });
+
+  it('lets root Vitest resolve MCP suite and live bench from source', () => {
+    expect(FbeastConfig).toBeDefined();
+    expect(BenchmarkTaskSchema).toBeDefined();
   });
 
   it('maps every first-party package scope to its TypeScript source entrypoint', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,12 @@
       ],
       "@franken/orchestrator": [
         "./packages/franken-orchestrator/src/index.ts"
+      ],
+      "@franken/mcp-suite": [
+        "./packages/franken-mcp-suite/src/index.ts"
+      ],
+      "@franken/live-bench": [
+        "./packages/live-bench/src/index.ts"
       ]
     }
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -114,6 +114,8 @@ export default defineConfig({
       '@franken/types/utils': resolve(__dirname, 'packages/franken-types/src/utils/index.ts'),
       '@franken/types': resolve(__dirname, 'packages/franken-types/src/index.ts'),
       '@franken/orchestrator': resolve(__dirname, 'packages/franken-orchestrator/src/index.ts'),
+      '@franken/mcp-suite': resolve(__dirname, 'packages/franken-mcp-suite/src/index.ts'),
+      '@franken/live-bench': resolve(__dirname, 'packages/live-bench/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- add root TypeScript source aliases for `@franken/mcp-suite` and `@franken/live-bench`
- update the workspace alias drift test so both programmatic workspaces remain covered

## Test plan
- `npm run test:root -- tests/tsconfig-paths.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/live-bench`

Closes #2885