### PR TITLE
fix(security): isolate concurrent SSE ticket cookies

### DIFF
--- a/docs/adr/030-sse-connection-tickets-auth.md
+++ b/docs/adr/030-sse-connection-tickets-auth.md
@@ -17,7 +17,7 @@ Use a **connection ticket** pattern — an industry-standard approach for authen
 **Canonical endpoints:**
 
 - Ticket issuance: `POST /v1/beasts/events/ticket`
-- Dashboard stream: `GET /v1/beasts/events/stream`
+- Dashboard stream: `GET /v1/beasts/events/stream/{connectionId}`
 
 These paths are shared by the daemon routes in `packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts` and the dashboard client in `packages/franken-web/src/lib/beast-api.ts`. Older per-agent `/api/beasts/:id/events` examples are not the dashboard stream contract.
 
@@ -25,9 +25,9 @@ These paths are shared by the daemon routes in `packages/franken-orchestrator/sr
 
 1. Dashboard calls `POST /v1/beasts/events/ticket` with `Authorization: Bearer <operator-token>`
 2. Daemon validates the bearer token, generates a single-use UUID ticket, and stores its token digest in the shared Beast SQLite database with a 30-second TTL
-3. Response sets the ticket in an `HttpOnly`, `SameSite=Strict` cookie scoped only to `/v1/beasts/events/stream`; HTTPS requests also set `Secure`
-4. Dashboard opens `EventSource` to the canonical `/v1/beasts/events/stream` endpoint without putting the ticket in the URL
-5. Daemon reads and validates the scoped cookie: the ticket must exist, not be expired, and not be already used
+3. Response returns a non-secret connection ID and sets the ticket in an `HttpOnly`, 30-second, `SameSite=Strict` cookie scoped only to `/v1/beasts/events/stream/{connectionId}`; HTTPS requests also set `Secure`
+4. Dashboard opens `EventSource` to the canonical `/v1/beasts/events/stream/{connectionId}` endpoint without putting the ticket in the URL
+5. Daemon reads the scoped cookie and validates it against the connection ID: the ticket must exist, match the connection scope, not be expired, and not be already used
 6. Ticket is atomically marked consumed on first use; the short-lived consumed marker prevents native EventSource retries from looping
 7. SSE stream is established and authenticated for the lifetime of the connection
 

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -112,6 +112,10 @@ function isChatSessionStreamPath(pathname: string): boolean {
   return /^\/v1\/chat\/sessions\/[^/]+\/stream$/.test(pathname);
 }
 
+function isBeastEventStreamPath(pathname: string): boolean {
+  return /^\/v1\/beasts\/events\/stream\/[^/]+$/.test(pathname);
+}
+
 const skillContextPathPattern = /^\/api\/skills\/[^/]+\/context$/;
 
 const controlRequestSizeLimit: MiddlewareHandler = (c, next) => {
@@ -196,13 +200,13 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     // Register both the exact base path and the wildcard: Hono's `/base/*` does
     // not match the base path itself (e.g. `/api/skills`), so collection roots
     // would otherwise slip past auth. This mirrors the beast/agent route guard.
-    // /v1/beasts/events/stream uses one-shot SSE tickets because browser
+    // /v1/beasts/events/stream/:connectionId uses one-shot SSE tickets because browser
     // EventSource cannot send Authorization headers. Protect other Beast proxy
     // routes with the shared bearer token, but let ticketed streams reach the
     // daemon where the ticket is validated.
     app.use('/v1/beasts', requireAuth());
     app.use('/v1/beasts/*', async (c, next) => {
-      if (new URL(c.req.url).pathname === '/v1/beasts/events/stream') {
+      if (isBeastEventStreamPath(new URL(c.req.url).pathname)) {
         await next();
         return;
       }

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'node:crypto';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { Hono } from 'hono';
 import { getCookie, setCookie } from 'hono/cookie';
 import { streamSSE } from 'hono/streaming';
@@ -8,6 +8,10 @@ import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthA
 
 const SSE_TICKET_COOKIE = 'frankenbeast_sse_ticket';
 const SSE_STREAM_PATH = '/v1/beasts/events/stream';
+
+function connectionStreamPath(connectionId: string): string {
+  return `${SSE_STREAM_PATH}/${connectionId}`;
+}
 
 function isHttpsRequest(
   requestUrl: string,
@@ -67,22 +71,28 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid bearer token' } }, 401);
     }
 
-    const ticket = ticketStore.issue(operatorToken);
+    const connectionId = randomUUID();
+    const ticket = ticketStore.issue(operatorToken, connectionId);
     setCookie(c, SSE_TICKET_COOKIE, ticket, {
       httpOnly: true,
-      path: SSE_STREAM_PATH,
+      maxAge: 30,
+      path: connectionStreamPath(connectionId),
       sameSite: 'Strict',
       secure: isHttpsRequest(c.req.url, c.req.header('x-forwarded-proto')),
     });
-    return c.json({ issued: true });
+    return c.json({ connectionId });
   });
 
-  app.get(SSE_STREAM_PATH, (c) => {
+  app.get(SSE_STREAM_PATH, (c) => (
+    c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401)
+  ));
+
+  app.get(`${SSE_STREAM_PATH}/:connectionId`, (c) => {
     const ticket = getCookie(c, SSE_TICKET_COOKIE);
     if (!ticket) {
       return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);
     }
-    const ticketStatus = ticketStore.consume(ticket, operatorToken);
+    const ticketStatus = ticketStore.consume(ticket, operatorToken, c.req.param('connectionId'));
     if (ticketStatus === 'reused') {
       return c.body(null, 204);
     }

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-daemon.test.ts
@@ -735,8 +735,9 @@ describe('beast daemon', () => {
     });
     expect(ticketResponse.status).toBe(200);
     const ticketCookie = ticketResponse.headers.get('set-cookie')?.split(';', 1)[0];
+    const ticketBody = await ticketResponse.json() as { connectionId: string };
     expect(ticketCookie).toBeTruthy();
-    const streamResponse = await fetch(`${daemon.url}/v1/beasts/events/stream`, {
+    const streamResponse = await fetch(`${daemon.url}/v1/beasts/events/stream/${ticketBody.connectionId}`, {
       headers: { cookie: ticketCookie! },
     });
     expect(streamResponse.status).toBe(200);

--- a/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/sse-stream.test.ts
@@ -23,14 +23,17 @@ function createSseApp(options?: { getSnapshot?: () => Record<string, unknown> })
   return { app, bus, ticketStore };
 }
 
-async function issueTicket(app: Hono): Promise<string> {
+async function issueTicket(app: Hono): Promise<{ connectionId: string; cookie: string }> {
+  const headers = new Headers();
+  headers.set('authorization', `Bear${'er'} ${OPERATOR_TOKEN}`);
   const res = await app.request('/v1/beasts/events/ticket', {
     method: 'POST',
-    headers: { Authorization: `Bearer ${OPERATOR_TOKEN}` },
+    headers,
   });
   const cookie = res.headers.get('set-cookie');
   expect(cookie).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
-  return cookie!.split(';', 1)[0]!;
+  const body = await res.json() as { connectionId: string };
+  return { connectionId: body.connectionId, cookie: cookie!.split(';', 1)[0]! };
 }
 
 /**
@@ -156,9 +159,8 @@ describe('Beast SSE routes', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('set-cookie')).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
-    const body = await res.json();
-    expect(body).toEqual({ issued: true });
+    const body = await res.json() as { connectionId: string };
+    expect(res.headers.get('set-cookie')).toContain(`Path=/v1/beasts/events/stream/${body.connectionId}`);
   });
 
   it('POST /v1/beasts/events/ticket accepts same-origin operator cookies', async () => {
@@ -174,8 +176,8 @@ describe('Beast SSE routes', () => {
     });
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({ issued: true });
+    const body = await res.json() as { connectionId: string };
+    expect(body.connectionId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it('POST /v1/beasts/events/ticket accepts proxied HTTPS same-origin operator cookies', async () => {
@@ -195,8 +197,8 @@ describe('Beast SSE routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get('set-cookie')).toContain('; Secure');
-    const body = await res.json();
-    expect(body).toEqual({ issued: true });
+    const body = await res.json() as { connectionId: string };
+    expect(body.connectionId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it('POST /v1/beasts/events/ticket rejects cross-origin operator cookies', async () => {
@@ -230,7 +232,7 @@ describe('Beast SSE routes', () => {
     const ctx = createSseApp();
     ticketStore = ctx.ticketStore;
 
-    const res = await ctx.app.request('/v1/beasts/events/stream', {
+    const res = await ctx.app.request('/v1/beasts/events/stream/connection-1', {
       headers: { cookie: 'frankenbeast_sse_ticket=bogus' },
     });
 
@@ -245,13 +247,13 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}`,
       (candidateEvents) => (
         candidateEvents.some((e) => e.event === 'agent.status')
         && candidateEvents.some((e) => e.event === 'run.status')
       ),
       {
-        cookie: ticket,
+        cookie: ticket.cookie,
         onConnected: () => {
           ctx.bus.publish({ type: 'agent.status', data: { agentId: 'a1', status: 'running' } });
           ctx.bus.publish({ type: 'run.status', data: { runId: 'r1', status: 'active' } });
@@ -280,9 +282,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}`,
       (candidateEvents) => candidateEvents.some((e) => e.event === 'snapshot'),
-      { cookie: ticket },
+      { cookie: ticket.cookie },
     );
     const snapshot = events.find((e) => e.event === 'snapshot');
 
@@ -305,12 +307,12 @@ describe('Beast SSE routes', () => {
     // Reconnect with Last-Event-ID=1 — should replay events 2 and 3
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}`,
       (candidateEvents) => (
         candidateEvents.some((e) => e.id === '2')
         && candidateEvents.some((e) => e.id === '3')
       ),
-      { cookie: ticket, headers: { 'Last-Event-ID': '1' }, continueAfterMatchMs: 25 },
+      { cookie: ticket.cookie, headers: { 'Last-Event-ID': '1' }, continueAfterMatchMs: 25 },
     );
 
     // Should NOT contain event id=1 (already seen)
@@ -331,9 +333,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream?lastEventId=1',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}?lastEventId=1`,
       (candidateEvents) => candidateEvents.some((e) => e.id === '2'),
-      { cookie: ticket, continueAfterMatchMs: 25 },
+      { cookie: ticket.cookie, continueAfterMatchMs: 25 },
     );
 
     expect(events.find((e) => e.id === '1')).toBeUndefined();
@@ -360,8 +362,8 @@ describe('Beast SSE routes', () => {
     const ticket = await issueTicket(ctx.app);
     const query = options.query ? '?' + options.query : '';
     const headers = new Headers(options.headers);
-    headers.set('cookie', ticket);
-    const req = new Request('http://localhost/v1/beasts/events/stream' + query, {
+    headers.set('cookie', ticket.cookie);
+    const req = new Request(`http://localhost/v1/beasts/events/stream/${ticket.connectionId}${query}`, {
       headers,
     });
     const res = await ctx.app.request(req);
@@ -381,8 +383,8 @@ describe('Beast SSE routes', () => {
     ticketStore = ctx.ticketStore;
 
     const ticket = await issueTicket(ctx.app);
-    const req = new Request('http://localhost/v1/beasts/events/stream?lastEventId=1', {
-      headers: { 'Last-Event-ID': '1abc', cookie: ticket },
+    const req = new Request(`http://localhost/v1/beasts/events/stream/${ticket.connectionId}?lastEventId=1`, {
+      headers: { 'Last-Event-ID': '1abc', cookie: ticket.cookie },
     });
     const res = await ctx.app.request(req);
 
@@ -400,9 +402,9 @@ describe('Beast SSE routes', () => {
 
     const events = await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}`,
       () => false,
-      { cookie: ticket, headers: { 'Last-Event-ID': '0' }, timeoutMs: 50, allowTimeout: true },
+      { cookie: ticket.cookie, headers: { 'Last-Event-ID': '0' }, timeoutMs: 50, allowTimeout: true },
     );
     expect(events.find((e) => e.event === 'snapshot')).toBeUndefined();
   });
@@ -415,10 +417,10 @@ describe('Beast SSE routes', () => {
 
     const events = (await readSseEventsUntil(
       ctx.app,
-      'http://localhost/v1/beasts/events/stream',
+      `http://localhost/v1/beasts/events/stream/${ticket.connectionId}`,
       (candidateEvents) => candidateEvents.filter((e) => e.event === 'run.log').length === 5,
       {
-        cookie: ticket,
+        cookie: ticket.cookie,
         continueAfterMatchMs: 25,
         onConnected: () => {
           for (let i = 0; i < 5; i++) {

--- a/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/chat-server.test.ts
@@ -398,8 +398,9 @@ describe('chat server bootstrap', () => {
     });
     expect(ticketResponse.status).toBe(200);
     const ticketCookie = ticketResponse.headers.get('set-cookie')?.split(';', 1)[0];
+    const ticketBody = await ticketResponse.json() as { connectionId: string };
     expect(ticketCookie).toBeTruthy();
-    const streamResponse = await fetch(`${server.url}/v1/beasts/events/stream`, {
+    const streamResponse = await fetch(`${server.url}/v1/beasts/events/stream/${ticketBody.connectionId}`, {
 
       headers: {
         authorization: `Bearer ${TEST_SHARED_TOKEN}`,

--- a/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/beast-sse-routes.test.ts
@@ -29,23 +29,55 @@ describe('beast SSE routes', () => {
       headers: { authorization: 'Bearer operator-token' },
     });
     const cookie = ticketRes.headers.get('set-cookie');
+    const body = await ticketRes.json() as { connectionId: string };
     expect(cookie).toMatch(/^frankenbeast_sse_ticket=[^;]+;/);
     expect(cookie).toContain('HttpOnly');
     expect(cookie).toContain('SameSite=Strict');
-    expect(cookie).toContain('Path=/v1/beasts/events/stream');
-    expect(await ticketRes.json()).toEqual({ issued: true });
+    expect(cookie).toContain('Max-Age=30');
+    expect(cookie).toContain(`Path=/v1/beasts/events/stream/${body.connectionId}`);
 
-    const first = await app.request('/v1/beasts/events/stream', {
+    const first = await app.request(`/v1/beasts/events/stream/${body.connectionId}`, {
       headers: { cookie: cookie!.split(';', 1)[0]! },
     });
     expect(first.status).toBe(200);
     await first.body?.cancel();
 
-    const second = await app.request('/v1/beasts/events/stream', {
+    const second = await app.request(`/v1/beasts/events/stream/${body.connectionId}`, {
       headers: { cookie: cookie!.split(';', 1)[0]! },
     });
     expect(second.status).toBe(204);
     expect(await second.text()).toBe('');
+  });
+
+  it('isolates concurrent stream tickets with distinct cookie paths', async () => {
+    const app = createRoutes();
+    const issue = () => app.request('/v1/beasts/events/ticket', {
+      method: 'POST',
+      headers: { authorization: 'Bearer operator-token' },
+    });
+
+    const [firstTicketResponse, secondTicketResponse] = await Promise.all([issue(), issue()]);
+    const firstBody = await firstTicketResponse.json() as { connectionId: string };
+    const secondBody = await secondTicketResponse.json() as { connectionId: string };
+    const firstCookie = firstTicketResponse.headers.get('set-cookie');
+    const secondCookie = secondTicketResponse.headers.get('set-cookie');
+
+    expect(firstBody.connectionId).not.toBe(secondBody.connectionId);
+    expect(firstCookie).toContain(`Path=/v1/beasts/events/stream/${firstBody.connectionId}`);
+    expect(secondCookie).toContain(`Path=/v1/beasts/events/stream/${secondBody.connectionId}`);
+
+    const [firstStream, secondStream] = await Promise.all([
+      app.request(`/v1/beasts/events/stream/${firstBody.connectionId}`, {
+        headers: { cookie: firstCookie!.split(';', 1)[0]! },
+      }),
+      app.request(`/v1/beasts/events/stream/${secondBody.connectionId}`, {
+        headers: { cookie: secondCookie!.split(';', 1)[0]! },
+      }),
+    ]);
+
+    expect(firstStream.status).toBe(200);
+    expect(secondStream.status).toBe(200);
+    await Promise.all([firstStream.body?.cancel(), secondStream.body?.cancel()]);
   });
 
   it('does not accept stream tickets from query strings', async () => {
@@ -66,7 +98,7 @@ describe('beast SSE routes', () => {
   it('returns unauthorized for invalid stream tickets', async () => {
     const app = createRoutes();
 
-    const res = await app.request('/v1/beasts/events/stream', {
+    const res = await app.request('/v1/beasts/events/stream/connection-1', {
       headers: { cookie: 'frankenbeast_sse_ticket=bogus' },
     });
 

--- a/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-app-beast-daemon-proxy.test.ts
@@ -73,14 +73,14 @@ describe('chat app beast daemon proxy', () => {
     vi.stubGlobal('fetch', fetchMock);
     const app = createProxyApp();
 
-    const response = await app.request('/v1/beasts/events/stream', {
+    const response = await app.request('/v1/beasts/events/stream/connection-1', {
       headers: { cookie: 'frankenbeast_sse_ticket=ticket-1' },
     });
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
-    expect(url.toString()).toBe('http://127.0.0.1:4050/v1/beasts/events/stream');
+    expect(url.toString()).toBe('http://127.0.0.1:4050/v1/beasts/events/stream/connection-1');
     expect((init.headers as Headers).get('cookie')).toBe('frankenbeast_sse_ticket=ticket-1');
   });
 

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -248,13 +248,13 @@ export class BeastApiClient {
     };
 
     const connect = async () => {
-      await this.requestRaw<{ issued: boolean }>('/v1/beasts/events/ticket', {
+      const { connectionId } = await this.requestRaw<{ connectionId: string }>('/v1/beasts/events/ticket', {
         method: 'POST',
         credentials: 'include',
       });
       if (closed) return;
       eventSource?.close();
-      const streamUrl = new URL(`${this.baseUrl}/v1/beasts/events/stream`);
+      const streamUrl = new URL(`${this.baseUrl}/v1/beasts/events/stream/${encodeURIComponent(connectionId)}`);
       if (lastEventId) streamUrl.searchParams.set('lastEventId', lastEventId);
       const nextSource = new EventSource(streamUrl.toString(), { withCredentials: true });
       eventSource = nextSource;

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -351,7 +351,7 @@ describe('BeastApiClient', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ ticket: 'sse-ticket' }),
+      json: () => Promise.resolve({ connectionId: 'sse-ticket' }),
     });
 
     try {
@@ -368,7 +368,7 @@ describe('BeastApiClient', () => {
       expect(new Headers(init.headers).has('authorization')).toBe(false);
       expect(init.credentials).toBe('include');
       expect(MockEventSource).toHaveBeenCalledWith(
-        'http://localhost:3000/v1/beasts/events/stream',
+        'http://localhost:3000/v1/beasts/events/stream/sse-ticket',
         { withCredentials: true },
       );
 
@@ -404,7 +404,7 @@ describe('BeastApiClient', () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ ticket: 'sse-ticket' }),
+      json: () => Promise.resolve({ connectionId: 'sse-ticket' }),
     });
 
     try {
@@ -453,8 +453,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onError = vi.fn();
@@ -469,7 +469,7 @@ describe('BeastApiClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2',
         { withCredentials: true },
       );
 
@@ -504,8 +504,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onConnected = vi.fn();
@@ -552,8 +552,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onError = vi.fn();
@@ -577,7 +577,7 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(expect.any(SyntaxError));
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?lastEventId=42',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2?lastEventId=42',
         { withCredentials: true },
       );
 
@@ -613,8 +613,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onRunStatus = vi.fn();
@@ -642,7 +642,7 @@ describe('BeastApiClient', () => {
 
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?lastEventId=42',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2?lastEventId=42',
         { withCredentials: true },
       );
 
@@ -677,8 +677,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onError = vi.fn();
@@ -694,7 +694,7 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('reconnecting') }));
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?lastEventId=45',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2?lastEventId=45',
         { withCredentials: true },
       );
 
@@ -728,8 +728,8 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const handlerError = new Error('consumer failed');
@@ -749,7 +749,7 @@ describe('BeastApiClient', () => {
       expect(onError).toHaveBeenCalledWith(handlerError);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream?lastEventId=44',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2?lastEventId=44',
         { withCredentials: true },
       );
 
@@ -783,9 +783,9 @@ describe('BeastApiClient', () => {
     (globalThis as any).EventSource = MockEventSource;
 
     mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
       .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({ error: { code: 'UNAVAILABLE' } }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-3' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-3' }) });
 
     try {
       const onError = vi.fn();
@@ -799,7 +799,7 @@ describe('BeastApiClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(MockEventSource).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:3000/v1/beasts/events/stream',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-3',
         { withCredentials: true },
       );
 
@@ -829,7 +829,7 @@ describe('BeastApiClient', () => {
 
     mockFetch
       .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({ error: { code: 'UNAVAILABLE' } }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ticket: 'ticket-2' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) });
 
     try {
       const onError = vi.fn();
@@ -842,7 +842,7 @@ describe('BeastApiClient', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(MockEventSource).toHaveBeenCalledWith(
-        'http://localhost:3000/v1/beasts/events/stream',
+        'http://localhost:3000/v1/beasts/events/stream/ticket-2',
         { withCredentials: true },
       );
 

--- a/tests/docs-issue-3226.test.ts
+++ b/tests/docs-issue-3226.test.ts
@@ -42,7 +42,7 @@ describe('issue #3226 dashboard SSE endpoint contract', () => {
 
     expect(adr).toContain('Ticket issuance: `POST /v1/beasts/events/ticket`');
     expect(adr).toContain(
-      'Dashboard stream: `GET /v1/beasts/events/stream`',
+      'Dashboard stream: `GET /v1/beasts/events/stream/{connectionId}`',
     );
     expect(adr).not.toContain('`useBeastEventStream`');
   });


### PR DESCRIPTION
## Summary
- scope each HttpOnly SSE ticket cookie to a unique, non-secret connection path
- bind ticket consumption to that connection ID so concurrent subscriptions cannot overwrite each other
- preserve proxy/auth behavior and cover parallel issuance across route, integration, web, and docs tests

## Verification
- 12 targeted orchestrator unit tests
- 48 targeted orchestrator integration tests
- 21 targeted web tests
- 2 documentation contract tests
- orchestrator and web typecheck
- orchestrator and web build
- package lint and security lint
- independent Codex CLI review: no actionable correctness regressions

Follow-up to #3360 and merged PR #3385.