### PR TITLE
fix(orchestrator): protect unauthenticated dashboard streams

### DIFF
--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -133,9 +133,11 @@ async function createProxyResponse(
   const targetUrl = resolveProxyTargetUrl(apiTarget, sourceUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  const hadUpstreamProxyMetadata = headers.has('x-forwarded-host') || headers.has('x-forwarded-proto');
   const trustedRemoteAddress = headers.get(TRUSTED_REMOTE_ADDRESS_HEADER);
   headers.delete(TRUSTED_REMOTE_ADDRESS_HEADER);
-  if (trustedRemoteAddress) {
+  if (trustedRemoteAddress
+    && (headers.has('x-forwarded-for') || headers.has('x-real-ip') || !hadUpstreamProxyMetadata)) {
     const forwardedFor = headers.get('x-forwarded-for');
     headers.set('x-forwarded-for', forwardedFor
       ? `${forwardedFor}, ${trustedRemoteAddress}`

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -11,6 +11,7 @@ import { createSecretStore } from '../network/secret-store.js';
 const SERVICE_IDENTITY = 'dashboard-web';
 const LOCAL_HTTP_PROTOCOL = 'http:';
 const RESERVED_PREFIXES = ['/api', '/v1', '/webhooks', '/comms'];
+const TRUSTED_REMOTE_ADDRESS_HEADER = 'x-frankenbeast-remote-address';
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
   '.gif': 'image/gif',
@@ -132,6 +133,14 @@ async function createProxyResponse(
   const targetUrl = resolveProxyTargetUrl(apiTarget, sourceUrl);
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
+  const trustedRemoteAddress = headers.get(TRUSTED_REMOTE_ADDRESS_HEADER);
+  headers.delete(TRUSTED_REMOTE_ADDRESS_HEADER);
+  if (trustedRemoteAddress) {
+    const forwardedFor = headers.get('x-forwarded-for');
+    headers.set('x-forwarded-for', forwardedFor
+      ? `${forwardedFor}, ${trustedRemoteAddress}`
+      : trustedRemoteAddress);
+  }
   headers.set('x-forwarded-host', sourceUrl.host);
   headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
   if (options.operatorToken) {
@@ -453,7 +462,11 @@ export async function startDashboardStaticServer(options: DashboardStaticServerO
     });
     void readIncomingBody(req)
       .then(async (body) => {
-        const requestInit: RequestInit = { headers: headersFromIncoming(req.headers) };
+        const headers = headersFromIncoming(req.headers);
+        if (req.socket.remoteAddress) {
+          headers.set(TRUSTED_REMOTE_ADDRESS_HEADER, req.socket.remoteAddress);
+        }
+        const requestInit: RequestInit = { headers };
         if (body) {
           requestInit.body = body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as BodyInit;
         }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -91,7 +91,8 @@ function safeTokenCompare(a: string, b: string): boolean {
 function isLoopbackAddress(address: string): boolean {
   const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
   const ipv4MappedAddress = normalized.match(/^::ffff:(127(?:\.\d{1,3}){3})$/)?.[1];
-  return isLoopbackHost(ipv4MappedAddress ?? normalized);
+  const canonicalIpv4MappedLoopback = /^(?:::ffff:|0:0:0:0:0:ffff:)7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(normalized);
+  return canonicalIpv4MappedLoopback || isLoopbackHost(ipv4MappedAddress ?? normalized);
 }
 
 function isForwardedForLoopback(forwardedFor: string | undefined): boolean {
@@ -122,16 +123,20 @@ function isLoopbackDashboardRequest(c: Context): boolean {
   const hostname = new URL(c.req.url).hostname;
   const trustedRemoteAddress = c.req.header(TRUSTED_REMOTE_ADDRESS_HEADER);
   const realIp = c.req.header('x-real-ip');
-  const forwardedHostIsLoopback = isForwardedHostLoopback(c.req.header('x-forwarded-host'));
-  const forwardedForIsLoopback = isForwardedForLoopback(c.req.header('x-forwarded-for'));
+  const forwardedHost = c.req.header('x-forwarded-host');
+  const forwardedFor = c.req.header('x-forwarded-for');
+  const forwardedHostIsLoopback = isForwardedHostLoopback(forwardedHost);
+  const forwardedForIsLoopback = isForwardedForLoopback(forwardedFor);
   const realIpIsLoopback = realIp === undefined || isLoopbackAddress(realIp);
+  const proxyHasClientAddress = forwardedHost === undefined || forwardedFor !== undefined || realIp !== undefined;
 
   if (trustedRemoteAddress !== undefined) {
     return isLoopbackAddress(trustedRemoteAddress)
       && isLoopbackAddress(hostname)
       && forwardedHostIsLoopback
       && forwardedForIsLoopback
-      && realIpIsLoopback;
+      && realIpIsLoopback
+      && proxyHasClientAddress;
   }
 
   // Direct Hono callers do not have a Node socket address. Production Node
@@ -139,7 +144,8 @@ function isLoopbackDashboardRequest(c: Context): boolean {
   return isLoopbackAddress(hostname)
     && forwardedHostIsLoopback
     && forwardedForIsLoopback
-    && realIpIsLoopback;
+    && realIpIsLoopback
+    && proxyHasClientAddress;
 }
 
 function authenticateTicketRequest(c: Context, operatorToken: string): Response | undefined {

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -125,10 +125,12 @@ function isLoopbackDashboardRequest(c: Context): boolean {
   const realIp = c.req.header('x-real-ip');
   const forwardedHost = c.req.header('x-forwarded-host');
   const forwardedFor = c.req.header('x-forwarded-for');
+  const forwardedProto = c.req.header('x-forwarded-proto');
   const forwardedHostIsLoopback = isForwardedHostLoopback(forwardedHost);
   const forwardedForIsLoopback = isForwardedForLoopback(forwardedFor);
   const realIpIsLoopback = realIp === undefined || isLoopbackAddress(realIp);
-  const proxyHasClientAddress = forwardedHost === undefined || forwardedFor !== undefined || realIp !== undefined;
+  const hasProxyMetadata = forwardedHost !== undefined || forwardedProto !== undefined;
+  const proxyHasClientAddress = !hasProxyMetadata || forwardedFor !== undefined || realIp !== undefined;
 
   if (trustedRemoteAddress !== undefined) {
     return isLoopbackAddress(trustedRemoteAddress)

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -17,6 +17,7 @@ import type { SloDashboard } from '../../availability/slo-dashboard.js';
 const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
 const DASHBOARD_HEARTBEAT_MS = 30_000;
 const DASHBOARD_SSE_TICKET_SCOPE = 'dashboard';
+const TRUSTED_REMOTE_ADDRESS_HEADER = 'x-frankenbeast-remote-address';
 
 export interface DashboardRouteDeps {
   skillManager: SkillManager;
@@ -86,6 +87,40 @@ function safeTokenCompare(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+function isLoopbackAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  return normalized === 'localhost'
+    || normalized === '127.0.0.1'
+    || normalized === '::1'
+    || normalized === '::ffff:127.0.0.1';
+}
+
+function isForwardedForLoopback(forwardedFor: string | undefined): boolean {
+  if (forwardedFor === undefined) return true;
+  return forwardedFor
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean)
+    .every(isLoopbackAddress);
+}
+
+function isLoopbackDashboardRequest(c: Context): boolean {
+  const hostname = new URL(c.req.url).hostname;
+  const trustedRemoteAddress = c.req.header(TRUSTED_REMOTE_ADDRESS_HEADER);
+  const realIp = c.req.header('x-real-ip');
+
+  if (trustedRemoteAddress !== undefined) {
+    return isLoopbackAddress(trustedRemoteAddress)
+      && isLoopbackAddress(hostname)
+      && isForwardedForLoopback(c.req.header('x-forwarded-for'))
+      && (realIp === undefined || isLoopbackAddress(realIp));
+  }
+
+  // Direct Hono callers do not have a Node socket address. Production Node
+  // requests always receive the trusted peer header in http-server-utils.
+  return isLoopbackAddress(hostname);
+}
+
 function authenticateTicketRequest(c: Context, operatorToken: string): Response | undefined {
   const headerToken = extractOperatorToken(c.req.header('Authorization'))
     ?? c.req.header('x-frankenbeast-operator-token')
@@ -150,6 +185,14 @@ export function createDashboardRoutes(deps: DashboardRouteDeps): Hono {
   // GET /api/dashboard/events — ticket-authenticated SSE stream for real-time dashboard updates
   app.get('/events', (c) => {
     const ticket = c.req.query('ticket');
+    if (!operatorToken && !isLoopbackDashboardRequest(c)) {
+      return c.json({
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Dashboard events require operator authentication or a loopback-only request',
+        },
+      }, 403);
+    }
     if (operatorToken) {
       if (!ticketStore || !ticket) {
         return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired ticket' } }, 401);

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -111,7 +111,7 @@ function isForwardedHostLoopback(forwardedHost: string | undefined): boolean {
     .filter(Boolean)
     .every((host) => {
       try {
-        return isLoopbackAddress(new URL(`http://${host}`).hostname);
+        return isLoopbackAddress(new URL(`https://${host}`).hostname);
       } catch {
         return false;
       }

--- a/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/dashboard-routes.ts
@@ -13,6 +13,7 @@ import {
 } from './dashboard-status.js';
 import type { MaintenanceModeState } from '../../beasts/services/maintenance-mode-service.js';
 import type { SloDashboard } from '../../availability/slo-dashboard.js';
+import { isLoopbackHost } from '../../network/network-config.js';
 
 const DASHBOARD_SNAPSHOT_POLL_MS = 1_000;
 const DASHBOARD_HEARTBEAT_MS = 30_000;
@@ -89,10 +90,8 @@ function safeTokenCompare(a: string, b: string): boolean {
 
 function isLoopbackAddress(address: string): boolean {
   const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
-  return normalized === 'localhost'
-    || normalized === '127.0.0.1'
-    || normalized === '::1'
-    || normalized === '::ffff:127.0.0.1';
+  const ipv4MappedAddress = normalized.match(/^::ffff:(127(?:\.\d{1,3}){3})$/)?.[1];
+  return isLoopbackHost(ipv4MappedAddress ?? normalized);
 }
 
 function isForwardedForLoopback(forwardedFor: string | undefined): boolean {
@@ -104,21 +103,43 @@ function isForwardedForLoopback(forwardedFor: string | undefined): boolean {
     .every(isLoopbackAddress);
 }
 
+function isForwardedHostLoopback(forwardedHost: string | undefined): boolean {
+  if (forwardedHost === undefined) return true;
+  return forwardedHost
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean)
+    .every((host) => {
+      try {
+        return isLoopbackAddress(new URL(`http://${host}`).hostname);
+      } catch {
+        return false;
+      }
+    });
+}
+
 function isLoopbackDashboardRequest(c: Context): boolean {
   const hostname = new URL(c.req.url).hostname;
   const trustedRemoteAddress = c.req.header(TRUSTED_REMOTE_ADDRESS_HEADER);
   const realIp = c.req.header('x-real-ip');
+  const forwardedHostIsLoopback = isForwardedHostLoopback(c.req.header('x-forwarded-host'));
+  const forwardedForIsLoopback = isForwardedForLoopback(c.req.header('x-forwarded-for'));
+  const realIpIsLoopback = realIp === undefined || isLoopbackAddress(realIp);
 
   if (trustedRemoteAddress !== undefined) {
     return isLoopbackAddress(trustedRemoteAddress)
       && isLoopbackAddress(hostname)
-      && isForwardedForLoopback(c.req.header('x-forwarded-for'))
-      && (realIp === undefined || isLoopbackAddress(realIp));
+      && forwardedHostIsLoopback
+      && forwardedForIsLoopback
+      && realIpIsLoopback;
   }
 
   // Direct Hono callers do not have a Node socket address. Production Node
   // requests always receive the trusted peer header in http-server-utils.
-  return isLoopbackAddress(hostname);
+  return isLoopbackAddress(hostname)
+    && forwardedHostIsLoopback
+    && forwardedForIsLoopback
+    && realIpIsLoopback;
 }
 
 function authenticateTicketRequest(c: Context, operatorToken: string): Response | undefined {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -322,6 +322,37 @@ describe('dashboard routes', () => {
       expect(res.status).toBe(401);
     });
 
+    it.each([
+      {
+        name: 'external host',
+        url: 'https://dashboard.example.com/events',
+        headers: {},
+      },
+      {
+        name: 'external peer',
+        url: 'http://localhost/events',
+        headers: { 'x-frankenbeast-remote-address': '203.0.113.10' },
+      },
+      {
+        name: 'external forwarded client',
+        url: 'http://localhost/events',
+        headers: {
+          'x-frankenbeast-remote-address': '127.0.0.1',
+          'x-forwarded-for': '203.0.113.10',
+        },
+      },
+    ])('rejects unauthenticated dashboard streams from an $name', async ({ url, headers }) => {
+      const deps = createMockDeps();
+      deps.operatorToken = undefined;
+      deps.ticketStore = undefined;
+      const app = createDashboardRoutes(deps);
+
+      const res = await app.request(url, { headers });
+      if (res.status === 200) await res.body?.cancel();
+
+      expect(res.status).toBe(403);
+    });
+
     it('preserves unauthenticated local-dev streams when no operator token is configured', async () => {
       const deps = createMockDeps();
       deps.operatorToken = undefined;

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -334,6 +334,14 @@ describe('dashboard routes', () => {
         headers: { 'x-frankenbeast-remote-address': '203.0.113.10' },
       },
       {
+        name: 'external forwarded host',
+        url: 'http://localhost/events',
+        headers: {
+          'x-frankenbeast-remote-address': '127.0.0.1',
+          'x-forwarded-host': 'dashboard.example.com',
+        },
+      },
+      {
         name: 'external forwarded client',
         url: 'http://localhost/events',
         headers: {
@@ -341,7 +349,7 @@ describe('dashboard routes', () => {
           'x-forwarded-for': '203.0.113.10',
         },
       },
-    ])('rejects unauthenticated dashboard streams from an $name', async ({ url, headers }) => {
+    ] satisfies Array<{ name: string; url: string; headers: Record<string, string> }>)('rejects unauthenticated dashboard streams from an $name', async ({ url, headers }) => {
       const deps = createMockDeps();
       deps.operatorToken = undefined;
       deps.ticketStore = undefined;
@@ -353,20 +361,23 @@ describe('dashboard routes', () => {
       expect(res.status).toBe(403);
     });
 
-    it('preserves unauthenticated local-dev streams when no operator token is configured', async () => {
-      const deps = createMockDeps();
-      deps.operatorToken = undefined;
-      deps.ticketStore = undefined;
-      const app = createDashboardRoutes(deps);
+    it.each(['/events', 'http://127.0.0.2/events'])(
+      'preserves unauthenticated local-dev streams when no operator token is configured on %s',
+      async (url) => {
+        const deps = createMockDeps();
+        deps.operatorToken = undefined;
+        deps.ticketStore = undefined;
+        const app = createDashboardRoutes(deps);
 
-      const ticketRes = await app.request('/events/ticket', { method: 'POST' });
-      expect(ticketRes.status).toBe(200);
-      expect(await ticketRes.json()).toEqual({ ticket: null });
+        const ticketRes = await app.request('/events/ticket', { method: 'POST' });
+        expect(ticketRes.status).toBe(200);
+        expect(await ticketRes.json()).toEqual({ ticket: null });
 
-      const res = await app.request('/events');
-      expect(res.headers.get('content-type')).toContain('text/event-stream');
-      await res.body?.cancel();
-    });
+        const res = await app.request(url);
+        expect(res.headers.get('content-type')).toContain('text/event-stream');
+        await res.body?.cancel();
+      },
+    );
 
     it('returns SSE content-type with a valid ticket', async () => {
       const deps = createMockDeps();

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -322,7 +322,7 @@ describe('dashboard routes', () => {
       expect(res.status).toBe(401);
     });
 
-    it.each([
+    it.each<{ name: string; url: string; headers: Record<string, string> }>([
       {
         name: 'external host',
         url: 'https://dashboard.example.com/events',
@@ -342,6 +342,14 @@ describe('dashboard routes', () => {
         },
       },
       {
+        name: 'proxy without client address',
+        url: 'http://localhost/events',
+        headers: {
+          'x-frankenbeast-remote-address': '127.0.0.1',
+          'x-forwarded-host': 'localhost',
+        },
+      },
+      {
         name: 'external forwarded client',
         url: 'http://localhost/events',
         headers: {
@@ -349,7 +357,7 @@ describe('dashboard routes', () => {
           'x-forwarded-for': '203.0.113.10',
         },
       },
-    ] satisfies Array<{ name: string; url: string; headers: Record<string, string> }>)('rejects unauthenticated dashboard streams from an $name', async ({ url, headers }) => {
+    ])('rejects unauthenticated dashboard streams from an $name', async ({ url, headers }) => {
       const deps = createMockDeps();
       deps.operatorToken = undefined;
       deps.ticketStore = undefined;
@@ -361,7 +369,7 @@ describe('dashboard routes', () => {
       expect(res.status).toBe(403);
     });
 
-    it.each(['/events', 'http://127.0.0.2/events'])(
+    it.each(['/events', 'http://127.0.0.2/events', 'http://[::ffff:127.0.0.1]/events'])(
       'preserves unauthenticated local-dev streams when no operator token is configured on %s',
       async (url) => {
         const deps = createMockDeps();

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-routes.test.ts
@@ -350,6 +350,14 @@ describe('dashboard routes', () => {
         },
       },
       {
+        name: 'proxy with only forwarded protocol',
+        url: 'http://localhost/events',
+        headers: {
+          'x-frankenbeast-remote-address': '127.0.0.1',
+          'x-forwarded-proto': 'https',
+        },
+      },
+      {
         name: 'external forwarded client',
         url: 'http://localhost/events',
         headers: {

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -184,6 +184,27 @@ describe('dashboard static server', () => {
     expect(headers.get('authorization')).toBeNull();
   });
 
+  it('does not synthesize a client address when an upstream proxy omits it', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock;
+
+    await createDashboardStaticResponse(
+      new Request('http://localhost/api/dashboard/events', {
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-frankenbeast-remote-address': '127.0.0.1',
+        },
+      }),
+      staticDir,
+      { apiTarget: 'http://127.0.0.1:4242' },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(new Headers(init.headers).get('x-forwarded-for')).toBeNull();
+  });
+
   it('loads dashboard operator token from network config even when provider trust metadata is unapproved', async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), 'franken-dashboard-config-'));
     dirs.push(projectRoot);
@@ -361,7 +382,8 @@ describe('dashboard static server', () => {
     dirs.push(staticDir);
     let forwardedFor: string | undefined;
     const backend = createServer((req, res) => {
-      forwardedFor = req.headers['x-forwarded-for'];
+      const value = req.headers['x-forwarded-for'];
+      forwardedFor = typeof value === 'string' ? value : value?.join(', ');
       res.setHeader('content-type', 'text/event-stream');
       res.write('data: ready\\n\\n');
       setTimeout(() => res.end(), 25);

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -164,7 +164,11 @@ describe('dashboard static server', () => {
     const proxied = await createDashboardStaticResponse(
       new Request('https://dashboard.example.com/v1/chat/sessions', {
         method: 'POST',
-        headers: { origin: 'https://dashboard.example.com' },
+        headers: {
+          origin: 'https://dashboard.example.com',
+          'x-forwarded-for': '127.0.0.1',
+          'x-frankenbeast-remote-address': '203.0.113.10',
+        },
       }),
       staticDir,
       { apiTarget: 'http://127.0.0.1:4242' },
@@ -175,6 +179,8 @@ describe('dashboard static server', () => {
     const headers = new Headers(init.headers);
     expect(headers.get('x-forwarded-host')).toBe('dashboard.example.com');
     expect(headers.get('x-forwarded-proto')).toBe('https');
+    expect(headers.get('x-forwarded-for')).toBe('127.0.0.1, 203.0.113.10');
+    expect(headers.get('x-frankenbeast-remote-address')).toBeNull();
     expect(headers.get('authorization')).toBeNull();
   });
 
@@ -353,7 +359,9 @@ describe('dashboard static server', () => {
   it('streams proxied event responses without buffering until the backend closes', async () => {
     const staticDir = await createDashboardDist();
     dirs.push(staticDir);
-    const backend = createServer((_req, res) => {
+    let forwardedFor: string | undefined;
+    const backend = createServer((req, res) => {
+      forwardedFor = req.headers['x-forwarded-for'];
       res.setHeader('content-type', 'text/event-stream');
       res.write('data: ready\\n\\n');
       setTimeout(() => res.end(), 25);
@@ -378,6 +386,7 @@ describe('dashboard static server', () => {
       const body = await response.text();
 
       expect(body).toContain('data: ready');
+      expect(forwardedFor).toMatch(/^(?:::ffff:)?127\.0\.0\.1$/);
     } finally {
       await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
       await new Promise<void>((resolveClose) => backend.close(() => resolveClose()));

--- a/packages/franken-web/tests/vite-config.test.ts
+++ b/packages/franken-web/tests/vite-config.test.ts
@@ -27,6 +27,9 @@ describe('vite dev proxy configuration', () => {
     expect(CONFIG_SOURCE).toContain('if (operatorToken)');
     expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-host', req.headers.host)");
     expect(CONFIG_SOURCE).toContain("proxyReq.setHeader('x-forwarded-proto', requestProtocol(req))");
+    expect(CONFIG_SOURCE).toContain('appendProxyPeerAddress(proxyReq, req)');
+    expect(CONFIG_SOURCE).toContain("req.headers['x-forwarded-for']");
+    expect(CONFIG_SOURCE).toContain("req.headers['x-forwarded-proto'] !== undefined");
     expect(CONFIG_SOURCE).not.toContain('headers: { authorization');
     expect(CONFIG_SOURCE).not.toContain('operatorProxy(');
   });

--- a/packages/franken-web/vite.config.ts
+++ b/packages/franken-web/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, loadEnv, type ProxyOptions } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
-import type { IncomingMessage } from 'node:http';
+import type { ClientRequest, IncomingMessage } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { parsePackageMetadata } from './src/config/package-metadata';
 import { assertNoBrowserOperatorToken, assertSecureProxyTarget, loadProxyEnv, loadProxyOperatorToken } from './vite-env';
@@ -66,6 +66,26 @@ function requestProtocol(req: IncomingMessage): 'http' | 'https' {
   return (req.socket as { encrypted?: boolean }).encrypted ? 'https' : 'http';
 }
 
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : value?.join(', ');
+}
+
+function appendProxyPeerAddress(proxyReq: ClientRequest, req: IncomingMessage): void {
+  const forwardedFor = firstHeaderValue(req.headers['x-forwarded-for']);
+  const hasUpstreamClientAddress = forwardedFor !== undefined || req.headers['x-real-ip'] !== undefined;
+  const hasUpstreamProxyMetadata = req.headers['x-forwarded-host'] !== undefined
+    || req.headers['x-forwarded-proto'] !== undefined;
+  const remoteAddress = req.socket.remoteAddress;
+
+  if (remoteAddress && (hasUpstreamClientAddress || !hasUpstreamProxyMetadata)) {
+    proxyReq.setHeader('x-forwarded-for', forwardedFor
+      ? `${forwardedFor}, ${remoteAddress}`
+      : remoteAddress);
+  } else {
+    proxyReq.removeHeader('x-forwarded-for');
+  }
+}
+
 function withServerSideOperatorAuth(target: string, operatorToken: string, extra: ProxyOptions = {}): ProxyOptions {
   return {
     target,
@@ -80,6 +100,7 @@ function withServerSideOperatorAuth(target: string, operatorToken: string, extra
     },
     configure(proxy) {
       proxy.on('proxyReq', (proxyReq, req) => {
+        appendProxyPeerAddress(proxyReq, req);
         if (operatorToken) {
           proxyReq.setHeader('authorization', `Bearer ${operatorToken}`);
         }


### PR DESCRIPTION
## Summary
- fail closed when an unauthenticated dashboard SSE request is not loopback-only
- validate trusted peer, host, and proxy address metadata before preserving local-development streams
- cover external hosts, direct peers, forwarded clients, and loopback local development

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/http/dashboard-routes.test.ts`
- `npm run test --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run build`

Closes #3358