### PR TITLE
fix(web): announce approval queue changes

### DIFF
--- a/packages/franken-web/src/components/approval-card.tsx
+++ b/packages/franken-web/src/components/approval-card.tsx
@@ -56,52 +56,55 @@ export function ApprovalCard({
   onApprove,
   onReject,
 }: ApprovalCardProps) {
-  if (!pending) {
-    return (
-      <section className="rail-card" aria-label="Pending approval">
-        <div className="rail-card__header">
-          <p className="eyebrow">Approvals</p>
-          <h2>Queue</h2>
-        </div>
-        <p className="rail-card__empty">No approval required.</p>
-      </section>
-    );
-  }
-
   const approvalDescription = approval?.description ?? description ?? '';
   const effectiveSessionId = approval?.sessionId ?? sessionId ?? undefined;
 
   return (
-    <section className="rail-card rail-card--approval" aria-label="Pending approval" aria-busy={resolving}>
+    <section
+      className={`rail-card${pending ? ' rail-card--approval' : ''}`}
+      aria-label="Pending approval"
+    >
       <div className="rail-card__header">
         <p className="eyebrow">Approvals</p>
-        <h2>Approval Required</h2>
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <h2>{pending ? 'Approval Required' : 'Queue'}</h2>
+        </div>
       </div>
-      <p className="approval-card__description">{approvalDescription}</p>
-      <dl className="approval-card__details" aria-label="Approval context">
-        <DetailRow label="Tool" children={approval?.tool} />
-        <DetailRow label="Command" children={approval?.command} />
-        <DetailRow label="Risk" children={approval?.risk} />
-        <DetailRow label="Requested" children={approval?.requestedAt ? formatRequestedAt(approval.requestedAt) : undefined} />
-        <DetailRow label="Affected files" children={approval?.affectedFiles} />
-        <DetailRow label="Session" children={effectiveSessionId} />
-      </dl>
-      {resolving ? (
-        <p className="approval-card__status" role="status">
-          Waiting for approval response…
-        </p>
-      ) : null}
-      {error ? (
-        <p className="approval-card__error" role="alert">
-          {error}
-        </p>
-      ) : null}
-      <div className="approval-card__actions">
-        <button className="button button--primary" disabled={resolving} onClick={onApprove}>
-          {resolving ? 'Submitting…' : 'Approve'}
-        </button>
-        <button className="button button--secondary" disabled={resolving} onClick={onReject}>Reject</button>
-      </div>
+      {!pending ? (
+        <p className="rail-card__empty">No approval required.</p>
+      ) : (
+        <div aria-busy={resolving}>
+          <p className="approval-card__description">{approvalDescription}</p>
+          <dl className="approval-card__details" aria-label="Approval context">
+            <DetailRow label="Tool" children={approval?.tool} />
+            <DetailRow label="Command" children={approval?.command} />
+            <DetailRow label="Risk" children={approval?.risk} />
+            <DetailRow label="Requested" children={approval?.requestedAt ? formatRequestedAt(approval.requestedAt) : undefined} />
+            <DetailRow label="Affected files" children={approval?.affectedFiles} />
+            <DetailRow label="Session" children={effectiveSessionId} />
+          </dl>
+          {resolving ? (
+            <p className="approval-card__status" role="status">
+              Waiting for approval response…
+            </p>
+          ) : null}
+          {error ? (
+            <p className="approval-card__error" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="approval-card__actions">
+            <button className="button button--primary" disabled={resolving} onClick={onApprove}>
+              {resolving ? 'Submitting…' : 'Approve'}
+            </button>
+            <button className="button button--secondary" disabled={resolving} onClick={onReject}>Reject</button>
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/franken-web/tests/components/approval-card.test.tsx
+++ b/packages/franken-web/tests/components/approval-card.test.tsx
@@ -42,6 +42,47 @@ describe('ApprovalCard', () => {
     expect(screen.getByText(/Requested/)).toBeTruthy();
   });
 
+  it('announces queue changes without moving keyboard focus', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    const { rerender } = render(
+      <>
+        <button>Keep focus</button>
+        <ApprovalCard
+          pending={false}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      </>,
+    );
+
+    const focusTarget = screen.getByRole('button', { name: 'Keep focus' });
+    focusTarget.focus();
+    const queueStatus = screen.getByRole('status');
+
+    expect(queueStatus.getAttribute('aria-live')).toBe('polite');
+    expect(queueStatus.getAttribute('aria-atomic')).toBe('true');
+    expect(queueStatus.textContent).toBe('Queue');
+
+    rerender(
+      <>
+        <button>Keep focus</button>
+        <ApprovalCard
+          pending
+          approval={{ description: 'Approve deploy', requestedAt: '2026-03-09T00:00:02Z' }}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      </>,
+    );
+
+    expect(screen.getByRole('status')).toBe(queueStatus);
+    expect(queueStatus.textContent).toBe('Approval Required');
+    expect(document.activeElement).toBe(focusTarget);
+    expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reject/i })).toBeTruthy();
+  });
+
   it('disables actions while resolving and exposes inline errors for retry', () => {
     const onApprove = vi.fn();
     const onReject = vi.fn();
@@ -60,7 +101,7 @@ describe('ApprovalCard', () => {
 
     expect(onApprove).not.toHaveBeenCalled();
     expect(onReject).not.toHaveBeenCalled();
-    expect(screen.getByRole('status').textContent).toContain('Waiting for approval response');
+    expect(screen.getByText('Waiting for approval response…').getAttribute('role')).toBe('status');
 
     rerender(
       <ApprovalCard


### PR DESCRIPTION
## Summary
- keep the approval queue status region mounted across empty and pending states
- announce queue heading changes politely and atomically without moving keyboard focus
- keep submission busy state scoped away from the queue announcement

## Test plan
- `npm test -- --run tests/components/approval-card.test.tsx`
- `npm test` (packages/franken-web; 667 tests)
- `npm run typecheck` (packages/franken-web)
- `npm run lint` (packages/franken-web; 0 errors, 17 existing warnings)
- `npm run build` (packages/franken-web)

Closes #3124