### PR TITLE
docs(lessons): close bearer token code span

### DIFF
--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -63,7 +63,7 @@
 
 ## 2026-07-16 — Synthetic availability probe review fixes
 - Availability probes should fail closed for real dependencies: do not default provider checks to `node --version` or dashboard checks to a static UI health URL, require explicit provider/backend health targets, and cover missing-target behavior in tests so cron copies cannot produce false-green uptime.
-- For cron/CI probe JSON logs, redact both `key=value` and whitespace-separated secret forms, including split `Authorization: Bearer *** argv sequences, before serializing command details or error messages.
+- For cron/CI probe JSON logs, redact both `key=value` and whitespace-separated secret forms, including split `Authorization: Bearer ***` argv sequences, before serializing command details or error messages.
 - When Codex reaches the normal five-trigger cap but posts new valid findings, fix/reply/resolve them and stop for explicit approval before issuing another `@codex review`; zero unresolved threads plus green CI is not a substitute for a fresh current-head clean.
 
 ## 2026-07-16 — Snapshot diff Codex closeout


### PR DESCRIPTION
## Summary
- close the inline-code span around the redacted bearer-token argv example
- restore readable Markdown rendering for the remainder of the lesson

## Verification
- `git diff --check`
- targeted Python assertion confirms the line contains the closed `` `Authorization: Bearer ***` `` span and balanced backticks

Closes #2822