### PR TITLE
fix(mcp): reject unsafe integer arguments

### DIFF
--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -590,6 +590,35 @@ describe('createMcpServer', () => {
     expect(calls).toEqual([{ limit: 100 }]);
   });
 
+  it('accepts only safe integers at JavaScript precision boundaries', async () => {
+    const calls: unknown[] = [];
+    const tool: ToolDef = {
+      name: 'identify',
+      description: 'identify',
+      inputSchema: {
+        type: 'object',
+        properties: { id: { type: 'integer', description: 'id' } },
+        required: ['id'],
+      },
+      handler: async (args) => {
+        calls.push(args);
+        return { content: [{ type: 'text' as const, text: 'ok' }] };
+      },
+    };
+    const srv = createMcpServer('t', '1', [tool]);
+
+    expect(await srv.callTool('identify', { id: Number.MAX_SAFE_INTEGER })).not.toHaveProperty('isError');
+    expect(await srv.callTool('identify', { id: Number.MIN_SAFE_INTEGER })).not.toHaveProperty('isError');
+    expect((await srv.callTool('identify', { id: Number.MAX_SAFE_INTEGER + 1 })).content[0]!.text).toContain('must be integer');
+    expect((await srv.callTool('identify', { id: Number.MIN_SAFE_INTEGER - 1 })).content[0]!.text).toContain('must be integer');
+    expect((await srv.callTool('identify', { id: Infinity })).isError).toBe(true);
+    expect((await srv.callTool('identify', { id: Number.NaN })).isError).toBe(true);
+    expect(calls).toEqual([
+      { id: Number.MAX_SAFE_INTEGER },
+      { id: Number.MIN_SAFE_INTEGER },
+    ]);
+  });
+
   it('enforces array item bounds before invoking the handler', async () => {
     const calls: unknown[] = [];
     const tool: ToolDef = {

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -853,7 +853,7 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
 
 function acceptsSchemaType(type: string | readonly string[], value: unknown, actual: string): boolean {
   const allowedTypes = typeof type === 'string' ? [type] : type;
-  return allowedTypes.some((candidate) => (candidate === 'integer' ? Number.isInteger(value) : actual === candidate));
+  return allowedTypes.some((candidate) => (candidate === 'integer' ? Number.isSafeInteger(value) : actual === candidate));
 }
 
 function typeDescription(type: string | readonly string[]): string {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — MCP integer precision validation
+- JSON-schema `integer` checks at JavaScript transport boundaries must use `Number.isSafeInteger`, not `Number.isInteger`: integral-valued numbers beyond `Number.MAX_SAFE_INTEGER` can no longer represent exact IDs, limits, or pagination values. Cover both accepted safe boundaries and rejected values immediately outside them.
+
 ## 2026-07-19 — Live-bench run cleanup TOCTOU hardening
 - For destructive cleanup in attacker-writable directory trees, preflight `lstat`/`realpath` checks are not enough: on POSIX, open the trusted root and each descendant with `O_DIRECTORY|O_NOFOLLOW`, compare root and quarantined leaf device/inode identities, address rename/removal through stable descriptor paths, and keep the recreated run-leaf descriptor open while populating it.
 - Create quarantine entries beside the anchored leaf parent so rename stays on one filesystem, and avoid followable path mutations such as `chmod(path)` between creation and a no-follow open. Use `lstat`-based existence checks so dangling symlinks fail closed; when a platform lacks searchable Linux `/proc/self/fd` paths and no equivalent safe primitive is available, reject secure provisioning rather than restoring path-based TOCTOU cleanup.


### PR DESCRIPTION
## Summary
- require MCP `integer` schema arguments to be JavaScript safe integers
- cover accepted safe boundaries and rejection beyond both precision boundaries
- verify non-finite integer values never reach handlers

## Test plan
- `npm run test --workspace @franken/mcp-suite -- src/shared/server-factory.test.ts`
- `npm run test --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build`

Closes #3000