### PR TITLE
fix(observer): make trace rows keyboard accessible

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -132,6 +132,7 @@ describe('TraceServer', () => {
       }
       new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
+      expect(html).toContain('.trace-goal{display:block;')
       await context.loadTraces!()
       expect(html).toContain('<nav id="sidebar" aria-label="Traces">')
       expect(sidebar.innerHTML).toContain('<button type="button" class="trace-item"')
@@ -139,6 +140,9 @@ describe('TraceServer', () => {
 
       await context.loadDetail!('trace-1')
       expect(attributes.get('aria-current')).toBe('true')
+
+      await context.loadTraces!()
+      expect(sidebar.innerHTML).toContain('data-id="trace-1" aria-current="true"')
     })
 
     it('escapes template-literal metacharacters in trace text before writing innerHTML', async () => {

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -132,6 +132,7 @@ describe('TraceServer', () => {
       }
       new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
+      expect(html).toContain('.trace-item:hover,.trace-item.active,.trace-item[aria-current="true"]{')
       expect(html).toContain('.trace-goal{display:block;')
       await context.loadTraces!()
       expect(html).toContain('<nav id="sidebar" aria-label="Traces">')

--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -97,6 +97,50 @@ describe('TraceServer', () => {
       expect(html).not.toMatch(/<link\s[^>]*rel=["']stylesheet["']/i)
     })
 
+    it('renders trace rows as keyboard-operable buttons and exposes selection state', async () => {
+      const html = await fetch(server.url + '/').then(r => r.text())
+      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+      expect(script).toBeDefined()
+
+      const sidebar = { innerHTML: '', addEventListener: () => {} }
+      const panel = { innerHTML: '' }
+      const attributes = new Map<string, string>()
+      const traceItem = {
+        dataset: { id: 'trace-1' },
+        classList: { toggle: () => {} },
+        setAttribute: (name: string, value: string) => attributes.set(name, value),
+      }
+      const context = createContext({
+        document: {
+          getElementById: (id: string) => id === 'sidebar' ? sidebar : panel,
+          querySelectorAll: () => [traceItem],
+        },
+        fetch: (url: string) => Promise.resolve(url === '/api/traces'
+          ? {
+              json: () => Promise.resolve({
+                traces: [{ id: 'trace-1', goal: 'Inspect me', status: 'completed', spanCount: 0, startedAt: 0 }],
+              }),
+            }
+          : {
+              ok: true,
+              json: () => Promise.resolve({ id: 'trace-1', goal: 'Inspect me', status: 'completed', spans: [] }),
+            }),
+        Date,
+      }) as {
+        loadTraces?: () => Promise<void>
+        loadDetail?: (id: string) => Promise<void>
+      }
+      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+
+      await context.loadTraces!()
+      expect(html).toContain('<nav id="sidebar" aria-label="Traces">')
+      expect(sidebar.innerHTML).toContain('<button type="button" class="trace-item"')
+      expect(sidebar.innerHTML).toContain('aria-current="false"')
+
+      await context.loadDetail!('trace-1')
+      expect(attributes.get('aria-current')).toBe('true')
+    })
+
     it('escapes template-literal metacharacters in trace text before writing innerHTML', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
       const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -170,7 +170,7 @@ header button:hover{background:#2a2a2a}
 main{display:flex;flex:1;overflow:hidden}
 #sidebar{width:280px;border-right:1px solid #2a2a2a;overflow-y:auto;flex-shrink:0}
 .trace-item{display:block;width:100%;padding:.65rem 1rem;cursor:pointer;border:0;border-bottom:1px solid #1c1c1c;background:transparent;color:inherit;font:inherit;text-align:left}
-.trace-item:hover,.trace-item.active{background:#161616}
+.trace-item:hover,.trace-item.active,.trace-item[aria-current="true"]{background:#161616}
 .trace-item:focus-visible{outline:2px solid #60a5fa;outline-offset:-2px}
 .trace-goal{display:block;font-size:.825rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .trace-meta{font-size:.7rem;color:#555;margin-top:.2rem;display:flex;gap:.4rem}

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -169,8 +169,9 @@ header button{margin-left:auto;font-size:.75rem;background:#1e1e1e;color:#aaa;bo
 header button:hover{background:#2a2a2a}
 main{display:flex;flex:1;overflow:hidden}
 #sidebar{width:280px;border-right:1px solid #2a2a2a;overflow-y:auto;flex-shrink:0}
-.trace-item{padding:.65rem 1rem;cursor:pointer;border-bottom:1px solid #1c1c1c}
+.trace-item{display:block;width:100%;padding:.65rem 1rem;cursor:pointer;border:0;border-bottom:1px solid #1c1c1c;background:transparent;color:inherit;font:inherit;text-align:left}
 .trace-item:hover,.trace-item.active{background:#161616}
+.trace-item:focus-visible{outline:2px solid #60a5fa;outline-offset:-2px}
 .trace-goal{font-size:.825rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .trace-meta{font-size:.7rem;color:#555;margin-top:.2rem;display:flex;gap:.4rem}
 #panel{flex:1;overflow-y:auto;padding:1.5rem}
@@ -193,7 +194,7 @@ td{padding:.4rem .6rem;border-bottom:1px solid #1a1a1a;font-variant-numeric:tabu
   <button onclick="loadTraces()">↺ Refresh</button>
 </header>
 <main>
-  <div id="sidebar"><p class="empty" style="padding:1rem;font-size:.8rem">Loading…</p></div>
+  <nav id="sidebar" aria-label="Traces"><p class="empty" style="padding:1rem;font-size:.8rem">Loading…</p></nav>
   <div id="panel"><p class="empty">Select a trace to inspect.</p></div>
 </main>
 <script>
@@ -219,14 +220,14 @@ async function loadTraces(){
   const {traces} = await fetch('/api/traces').then(r=>r.json())
   if(!traces.length){sidebar.innerHTML='<p class="empty" style="padding:1rem;font-size:.8rem">No traces yet.</p>';return}
   sidebar.innerHTML = traces.map(t=>\`
-    <div class="trace-item" data-id="\${esc(t.id)}">
-      <div class="trace-goal">\${esc(t.goal)}</div>
-      <div class="trace-meta">
+    <button type="button" class="trace-item" data-id="\${esc(t.id)}" aria-current="false">
+      <span class="trace-goal">\${esc(t.goal)}</span>
+      <span class="trace-meta">
         \${badge(t.status)}
         <span>\${t.spanCount} span\${t.spanCount!==1?'s':''}</span>
         <span>\${fmtTime(t.startedAt)}</span>
-      </div>
-    </div>\`).join('')
+      </span>
+    </button>\`).join('')
 }
 
 sidebar.addEventListener('click', e=>{
@@ -235,7 +236,11 @@ sidebar.addEventListener('click', e=>{
 })
 
 async function loadDetail(id){
-  document.querySelectorAll('.trace-item').forEach(el=>el.classList.toggle('active',el.dataset.id===id))
+  document.querySelectorAll('.trace-item').forEach(el=>{
+    const selected = el.dataset.id===id
+    el.classList.toggle('active',selected)
+    el.setAttribute('aria-current',String(selected))
+  })
   let response
   let t
   try {

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -172,7 +172,7 @@ main{display:flex;flex:1;overflow:hidden}
 .trace-item{display:block;width:100%;padding:.65rem 1rem;cursor:pointer;border:0;border-bottom:1px solid #1c1c1c;background:transparent;color:inherit;font:inherit;text-align:left}
 .trace-item:hover,.trace-item.active{background:#161616}
 .trace-item:focus-visible{outline:2px solid #60a5fa;outline-offset:-2px}
-.trace-goal{font-size:.825rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.trace-goal{display:block;font-size:.825rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .trace-meta{font-size:.7rem;color:#555;margin-top:.2rem;display:flex;gap:.4rem}
 #panel{flex:1;overflow-y:auto;padding:1.5rem}
 #panel h2{font-size:1rem;margin-bottom:.4rem}
@@ -200,6 +200,7 @@ td{padding:.4rem .6rem;border-bottom:1px solid #1a1a1a;font-variant-numeric:tabu
 <script>
 const sidebar = document.getElementById('sidebar')
 const panel   = document.getElementById('panel')
+let selectedTraceId = null
 
 function esc(s){
   return String(s??'')
@@ -220,7 +221,7 @@ async function loadTraces(){
   const {traces} = await fetch('/api/traces').then(r=>r.json())
   if(!traces.length){sidebar.innerHTML='<p class="empty" style="padding:1rem;font-size:.8rem">No traces yet.</p>';return}
   sidebar.innerHTML = traces.map(t=>\`
-    <button type="button" class="trace-item" data-id="\${esc(t.id)}" aria-current="false">
+    <button type="button" class="trace-item" data-id="\${esc(t.id)}" aria-current="\${String(t.id)===selectedTraceId}">
       <span class="trace-goal">\${esc(t.goal)}</span>
       <span class="trace-meta">
         \${badge(t.status)}
@@ -236,6 +237,7 @@ sidebar.addEventListener('click', e=>{
 })
 
 async function loadDetail(id){
+  selectedTraceId = id
   document.querySelectorAll('.trace-item').forEach(el=>{
     const selected = el.dataset.id===id
     el.classList.toggle('active',selected)


### PR DESCRIPTION
## Summary
- render TraceServer trace rows as native buttons in a labelled navigation region
- expose the current trace through `aria-current` and preserve visible selected styling
- add a visible keyboard focus indicator and regression coverage

## Test plan
- `npm run test --workspace @franken/observer -- src/ui/TraceServer.test.ts`
- `npm test --workspace @franken/observer` (828 tests)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)

Closes #2994