### PR TITLE
fix(orchestrator): recover corrupt beast JSON lists

### DIFF
--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -7,7 +7,10 @@ import { DEFAULT_SANDBOX_POLICY, nonRootUserForWorkspace } from './execution/san
 import { ProcessBeastExecutor } from './execution/process-beast-executor.js';
 import { ProcessSupervisor } from './execution/process-supervisor.js';
 import { cleanupAbandonedBeastWorktrees } from './execution/git-worktree-isolation.js';
-import { SQLiteBeastRepository } from './repository/sqlite-beast-repository.js';
+import {
+  BeastRepositoryJsonCorruptionError,
+  SQLiteBeastRepository,
+} from './repository/sqlite-beast-repository.js';
 import { BeastCatalogService } from './services/beast-catalog-service.js';
 import { BeastDispatchService } from './services/beast-dispatch-service.js';
 import { assertDispatcherStartupIntegrity } from './services/dispatcher-startup-integrity.js';
@@ -82,12 +85,19 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     executors,
   });
   reconcileDispatcherQueueAfterRestart(repository);
-  cleanupAbandonedBeastWorktrees({
-    agents: repository.listTrackedAgents(),
-    dryRun: false,
-    projectRoot,
-    runs: repository.listRuns(),
-  });
+  try {
+    cleanupAbandonedBeastWorktrees({
+      agents: repository.listTrackedAgents(),
+      dryRun: false,
+      projectRoot,
+      runs: repository.listRuns(),
+    });
+  } catch (error) {
+    if (!(error instanceof BeastRepositoryJsonCorruptionError)) throw error;
+    console.warn(
+      `Skipping destructive Beast worktree cleanup because persisted JSON is corrupt in ${error.context.table}.${error.context.column} for row ${error.context.rowId}.`,
+    );
+  }
 
   runService = new BeastRunService(repository, catalog, executors, metrics, logStore, { eventBus, capacityPolicy, maintenance });
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -191,12 +191,8 @@ export interface BeastRepositoryJsonCorruptionContext {
 }
 
 export class BeastRepositoryJsonCorruptionError extends Error {
-  constructor(
-    public readonly context: BeastRepositoryJsonCorruptionContext,
-    public override readonly cause: unknown,
-  ) {
-    const causeMessage = cause instanceof Error ? cause.message : String(cause);
-    super(`Corrupt Beast JSON in ${context.table}.${context.column} for row ${context.rowId}: ${causeMessage}`);
+  constructor(public readonly context: BeastRepositoryJsonCorruptionContext) {
+    super(`Corrupt Beast JSON in ${context.table}.${context.column} for row ${context.rowId}`);
     this.name = 'BeastRepositoryJsonCorruptionError';
   }
 }
@@ -1009,11 +1005,11 @@ function parseJsonColumn(
 ): unknown {
   try {
     return JSON.parse(value) as unknown;
-  } catch (error) {
+  } catch {
     throw new BeastRepositoryJsonCorruptionError({
       ...context,
       valueSnippet: '[redacted]',
-    }, error);
+    });
   }
 }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -205,6 +205,13 @@ export interface CorruptJsonRecoveryOptions {
   readonly recoverCorruptJson?: boolean;
 }
 
+export interface BeastRunProcessReference {
+  readonly id: string;
+  readonly trackedAgentId?: string | undefined;
+  readonly status: BeastRunStatus;
+  readonly currentAttemptId?: string | undefined;
+}
+
 export class SQLiteBeastRepository {
   private readonly db: Database.Database;
 
@@ -279,6 +286,18 @@ export class SQLiteBeastRepository {
   listRuns(options: CorruptJsonRecoveryOptions = {}): BeastRun[] {
     const rows = this.db.prepare('SELECT * FROM beast_runs ORDER BY created_at DESC, id DESC').all() as BeastRunRow[];
     return mapRowsRecoveringCorruptJson(rows, mapRun, options);
+  }
+
+  listRunProcessReferences(): BeastRunProcessReference[] {
+    const rows = this.db.prepare(
+      'SELECT id, tracked_agent_id, status, current_attempt_id FROM beast_runs ORDER BY created_at DESC, id DESC',
+    ).all() as Array<Pick<BeastRunRow, 'id' | 'tracked_agent_id' | 'status' | 'current_attempt_id'>>;
+    return rows.map((row) => ({
+      id: row.id,
+      ...(row.tracked_agent_id ? { trackedAgentId: row.tracked_agent_id } : {}),
+      status: row.status,
+      ...(row.current_attempt_id ? { currentAttemptId: row.current_attempt_id } : {}),
+    }));
   }
 
   createAttempt(runId: string, input: CreateAttemptInput): BeastRunAttempt {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -201,6 +201,10 @@ export class BeastRepositoryJsonCorruptionError extends Error {
   }
 }
 
+export interface CorruptJsonRecoveryOptions {
+  readonly recoverCorruptJson?: boolean;
+}
+
 export class SQLiteBeastRepository {
   private readonly db: Database.Database;
 
@@ -272,9 +276,9 @@ export class SQLiteBeastRepository {
     return row ? mapRun(row) : undefined;
   }
 
-  listRuns(): BeastRun[] {
+  listRuns(options: CorruptJsonRecoveryOptions = {}): BeastRun[] {
     const rows = this.db.prepare('SELECT * FROM beast_runs ORDER BY created_at DESC, id DESC').all() as BeastRunRow[];
-    return rows.map(mapRun);
+    return mapRowsRecoveringCorruptJson(rows, mapRun, options);
   }
 
   createAttempt(runId: string, input: CreateAttemptInput): BeastRunAttempt {
@@ -285,11 +289,11 @@ export class SQLiteBeastRepository {
     return this.transaction(() => this.insertAttempt(runId, input));
   }
 
-  listAttempts(runId: string): BeastRunAttempt[] {
+  listAttempts(runId: string, options: CorruptJsonRecoveryOptions = {}): BeastRunAttempt[] {
     const rows = this.db.prepare(
       'SELECT * FROM beast_run_attempts WHERE run_id = ? ORDER BY attempt_number ASC',
     ).all(runId) as BeastAttemptRow[];
-    return rows.map(mapAttempt);
+    return mapRowsRecoveringCorruptJson(rows, mapAttempt, options);
   }
 
   getAttempt(attemptId: string): BeastRunAttempt | undefined {
@@ -462,11 +466,11 @@ export class SQLiteBeastRepository {
     return event;
   }
 
-  listEvents(runId: string): BeastRunEvent[] {
+  listEvents(runId: string, options: CorruptJsonRecoveryOptions = {}): BeastRunEvent[] {
     const rows = this.db.prepare(
       'SELECT * FROM beast_run_events WHERE run_id = ? ORDER BY sequence ASC',
     ).all(runId) as BeastEventRow[];
-    return rows.map(mapEvent);
+    return mapRowsRecoveringCorruptJson(rows, mapEvent, options);
   }
 
   createTrackedAgent(input: CreateTrackedAgentInput): TrackedAgent {
@@ -519,9 +523,9 @@ export class SQLiteBeastRepository {
     return agent;
   }
 
-  getTrackedAgent(agentId: string): TrackedAgent | undefined {
+  getTrackedAgent(agentId: string, options: CorruptJsonRecoveryOptions = {}): TrackedAgent | undefined {
     const row = this.db.prepare('SELECT * FROM tracked_agents WHERE id = ?').get(agentId) as TrackedAgentRow | undefined;
-    return row ? mapTrackedAgent(row) : undefined;
+    return row ? mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0] : undefined;
   }
 
   requireTrackedAgent(agentId: string): TrackedAgent {
@@ -532,11 +536,11 @@ export class SQLiteBeastRepository {
     return agent;
   }
 
-  listTrackedAgents(): TrackedAgent[] {
+  listTrackedAgents(options: CorruptJsonRecoveryOptions = {}): TrackedAgent[] {
     const rows = this.db.prepare(
       'SELECT * FROM tracked_agents ORDER BY created_at DESC, id DESC',
     ).all() as TrackedAgentRow[];
-    return rows.map(mapTrackedAgent);
+    return mapRowsRecoveringCorruptJson(rows, mapTrackedAgent, options);
   }
 
   updateTrackedAgent(agentId: string, patch: UpdateTrackedAgentPatch): TrackedAgent {
@@ -618,12 +622,12 @@ export class SQLiteBeastRepository {
     return event;
   }
 
-  listTrackedAgentEvents(agentId: string): TrackedAgentEvent[] {
+  listTrackedAgentEvents(agentId: string, options: CorruptJsonRecoveryOptions = {}): TrackedAgentEvent[] {
     this.getTrackedAgentOrThrow(agentId);
     const rows = this.db.prepare(
       'SELECT * FROM tracked_agent_events WHERE agent_id = ? ORDER BY sequence ASC',
     ).all(agentId) as TrackedAgentEventRow[];
-    return rows.map(mapTrackedAgentEvent);
+    return mapRowsRecoveringCorruptJson(rows, mapTrackedAgentEvent, options);
   }
 
   listActiveDispatchFailureAgentIds(): string[] {
@@ -989,9 +993,34 @@ function parseJsonColumn(
   } catch (error) {
     throw new BeastRepositoryJsonCorruptionError({
       ...context,
-      valueSnippet: value.slice(0, 120),
+      valueSnippet: '[redacted]',
     }, error);
   }
+}
+
+function mapRowsRecoveringCorruptJson<Row, Value>(
+  rows: readonly Row[],
+  mapper: (row: Row) => Value,
+  options: CorruptJsonRecoveryOptions,
+): Value[] {
+  if (!options.recoverCorruptJson) {
+    return rows.map(mapper);
+  }
+
+  const values: Value[] = [];
+  for (const row of rows) {
+    try {
+      values.push(mapper(row));
+    } catch (error) {
+      if (!(error instanceof BeastRepositoryJsonCorruptionError)) {
+        throw error;
+      }
+      console.warn(
+        `Skipping corrupt Beast JSON in ${error.context.table}.${error.context.column} for row ${error.context.rowId}; persisted row was left unchanged for repair.`,
+      );
+    }
+  }
+  return values;
 }
 
 function mapTrackedAgentEvent(row: TrackedAgentEventRow): TrackedAgentEvent {

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -77,7 +77,7 @@ export class AgentService {
   }
 
   listAgents(): TrackedAgent[] {
-    return this.repository.listTrackedAgents();
+    return this.repository.listTrackedAgents({ recoverCorruptJson: true });
   }
 
   getCapacityReservationState(): CapacityReservationState | undefined {
@@ -114,7 +114,7 @@ export class AgentService {
   getAgentDetail(agentId: string): TrackedAgentDetail {
     return {
       agent: this.getAgent(agentId),
-      events: this.repository.listTrackedAgentEvents(agentId),
+      events: this.repository.listTrackedAgentEvents(agentId, { recoverCorruptJson: true }),
     };
   }
 
@@ -168,7 +168,7 @@ export class AgentService {
   }
 
   private activeCapacityItems(): CapacityReservationWorkItem[] {
-    return this.listAgents()
+    return this.repository.listTrackedAgents()
       .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')

--- a/packages/franken-orchestrator/src/beasts/services/agent-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/agent-service.ts
@@ -1,5 +1,6 @@
 import type {
   BeastExecutionMode,
+  BeastRun,
   ModuleConfig,
   TrackedAgent,
   TrackedAgentEvent,
@@ -7,7 +8,10 @@ import type {
 } from '../types.js';
 import { isoNow } from '@franken/types';
 import { DeletedTrackedAgentError, UnknownTrackedAgentError } from '../errors.js';
-import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
+import {
+  BeastRepositoryJsonCorruptionError,
+  SQLiteBeastRepository,
+} from '../repository/sqlite-beast-repository.js';
 import type {
   CapacityReservationDecision,
   CapacityReservationPolicy,
@@ -81,7 +85,7 @@ export class AgentService {
   }
 
   getCapacityReservationState(): CapacityReservationState | undefined {
-    return this.options.capacityPolicy?.describe(this.activeCapacityItems());
+    return this.options.capacityPolicy?.describe(this.activeCapacityItems(true));
   }
 
   canStartInitConfig(initConfig: Readonly<Record<string, unknown>>): CapacityReservationDecision {
@@ -167,13 +171,21 @@ export class AgentService {
     });
   }
 
-  private activeCapacityItems(): CapacityReservationWorkItem[] {
-    return this.repository.listTrackedAgents()
+  private activeCapacityItems(recoverCorruptJson = false): CapacityReservationWorkItem[] {
+    return this.repository.listTrackedAgents({ recoverCorruptJson })
       .filter((agent) => agent.status === 'dispatching'
         || agent.status === 'awaiting_approval'
         || agent.status === 'running')
       .map((agent) => {
-        const linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
+        let linkedRun: BeastRun | undefined;
+        try {
+          linkedRun = agent.dispatchRunId ? this.repository.getRun(agent.dispatchRunId) : undefined;
+        } catch (error) {
+          if (!recoverCorruptJson || !(error instanceof BeastRepositoryJsonCorruptionError)) throw error;
+          console.warn(
+            `Using tracked-agent capacity fallback after corrupt Beast JSON in ${error.context.table}.${error.context.column} for row ${error.context.rowId}; persisted state was left unchanged for operator repair.`,
+          );
+        }
         return capacityItemFromConfig(agent.id, linkedRun?.configSnapshot ?? agent.initConfig);
       });
   }

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -40,7 +40,7 @@ export class BeastRunService {
 
   listRuns(): BeastRun[] {
     const redactedAgentIds = new Set(this.repository.listDispatchFailureHistoryAgentIds());
-    return this.repository.listRuns().map((run) => (
+    return this.repository.listRuns({ recoverCorruptJson: true }).map((run) => (
       run.trackedAgentId && redactedAgentIds.has(run.trackedAgentId)
         ? { ...run, configSnapshot: {} }
         : run
@@ -64,15 +64,16 @@ export class BeastRunService {
 
   listAttempts(runId: string) {
     const run = this.requireRun(runId);
-    const attempts = this.repository.listAttempts(runId);
+    const attempts = this.repository.listAttempts(runId, { recoverCorruptJson: true });
     if (!this.hasDispatchFailureHistory(run)) return attempts;
     return attempts.map((attempt) => ({ ...attempt, executorMetadata: undefined }));
   }
 
   listEvents(runId: string) {
     const run = this.requireRun(runId);
-    if (!this.hasDispatchFailureHistory(run)) return this.repository.listEvents(runId);
-    return this.repository.listEvents(runId).map(redactDispatchFailureEvent);
+    const events = this.repository.listEvents(runId, { recoverCorruptJson: true });
+    if (!this.hasDispatchFailureHistory(run)) return events;
+    return events.map(redactDispatchFailureEvent);
   }
 
   async readLogs(runId: string): Promise<string[]> {

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -39,8 +39,16 @@ export class BeastRunService {
   ) {}
 
   listRuns(): BeastRun[] {
+    return this.listRunsFromRepository();
+  }
+
+  listRunsForResponse(): BeastRun[] {
+    return this.listRunsFromRepository(true);
+  }
+
+  private listRunsFromRepository(recoverCorruptJson = false): BeastRun[] {
     const redactedAgentIds = new Set(this.repository.listDispatchFailureHistoryAgentIds());
-    return this.repository.listRuns({ recoverCorruptJson: true }).map((run) => (
+    return this.repository.listRuns({ recoverCorruptJson }).map((run) => (
       run.trackedAgentId && redactedAgentIds.has(run.trackedAgentId)
         ? { ...run, configSnapshot: {} }
         : run
@@ -63,15 +71,31 @@ export class BeastRunService {
   }
 
   listAttempts(runId: string) {
+    return this.listAttemptsFromRepository(runId);
+  }
+
+  listAttemptsForResponse(runId: string) {
+    return this.listAttemptsFromRepository(runId, true);
+  }
+
+  private listAttemptsFromRepository(runId: string, recoverCorruptJson = false) {
     const run = this.requireRun(runId);
-    const attempts = this.repository.listAttempts(runId, { recoverCorruptJson: true });
+    const attempts = this.repository.listAttempts(runId, { recoverCorruptJson });
     if (!this.hasDispatchFailureHistory(run)) return attempts;
     return attempts.map((attempt) => ({ ...attempt, executorMetadata: undefined }));
   }
 
   listEvents(runId: string) {
+    return this.listEventsFromRepository(runId);
+  }
+
+  listEventsForResponse(runId: string) {
+    return this.listEventsFromRepository(runId, true);
+  }
+
+  private listEventsFromRepository(runId: string, recoverCorruptJson = false) {
     const run = this.requireRun(runId);
-    const events = this.repository.listEvents(runId, { recoverCorruptJson: true });
+    const events = this.repository.listEvents(runId, { recoverCorruptJson });
     if (!this.hasDispatchFailureHistory(run)) return events;
     return events.map(redactDispatchFailureEvent);
   }

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
 import type { BeastRun, BeastRunAttempt, BeastRunStatus, TrackedAgentStatus } from '../types.js';
-import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
+import {
+  BeastRepositoryJsonCorruptionError,
+  SQLiteBeastRepository,
+} from '../repository/sqlite-beast-repository.js';
 import { isoNow } from '@franken/types';
 
 export type DispatcherQueueReconciliationCode =
@@ -41,6 +44,22 @@ export interface DispatcherQueueReconciliationOptions {
 
 const ACTIVE_RUN_STATUSES = new Set<BeastRunStatus>(['queued', 'interviewing', 'running', 'pending_approval']);
 const TERMINAL_RUN_STATUSES = new Set<BeastRunStatus>(['completed', 'failed', 'stopped']);
+const CORRUPT_ATTEMPT = Symbol('corrupt-attempt');
+
+function getAttemptForReconciliation(
+  repository: SQLiteBeastRepository,
+  attemptId: string,
+): BeastRunAttempt | undefined | typeof CORRUPT_ATTEMPT {
+  try {
+    return repository.getAttempt(attemptId);
+  } catch (error) {
+    if (!(error instanceof BeastRepositoryJsonCorruptionError)) throw error;
+    console.warn(
+      `Skipping restart reconciliation for corrupt Beast JSON in ${error.context.table}.${error.context.column} for row ${error.context.rowId}; persisted state was left unchanged for operator repair.`,
+    );
+    return CORRUPT_ATTEMPT;
+  }
+}
 
 export function reconcileDispatcherQueueAfterRestart(
   repository: SQLiteBeastRepository,
@@ -76,7 +95,7 @@ export function reconcileDispatcherQueueAfterRestart(
       });
     }
 
-    for (const run of repository.listRuns()) {
+    for (const run of repository.listRuns({ recoverCorruptJson: true })) {
       if (TERMINAL_RUN_STATUSES.has(run.status)) {
         const finding = reconcileTerminalRun(repository, run, reconciledAt);
         if (finding) findings.push(finding);
@@ -87,7 +106,10 @@ export function reconcileDispatcherQueueAfterRestart(
         continue;
       }
 
-      const currentAttempt = run.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
+      const currentAttempt = run.currentAttemptId
+        ? getAttemptForReconciliation(repository, run.currentAttemptId)
+        : undefined;
+      if (currentAttempt === CORRUPT_ATTEMPT) continue;
       const finding = reconcileActiveRun(
         repository,
         run,
@@ -106,7 +128,7 @@ export function reconcileDispatcherQueueAfterRestart(
   });
 
   return {
-    checkedRuns: repository.listRuns().length,
+    checkedRuns: repository.listRuns({ recoverCorruptJson: true }).length,
     findings,
     changedRuns,
     duplicateLiveAgentRunCount: findings.filter((finding) => finding.code === 'duplicate-live-agent-run').length,
@@ -283,9 +305,10 @@ function detectDuplicateLiveAgentRuns(
   isProcessGroupAlive: (pid: number) => boolean,
 ): DispatcherQueueReconciliationFinding[] {
   const liveRunsByAgent = new Map<string, Array<{ run: BeastRun; attempt: BeastRunAttempt; pid: number }>>();
-  for (const run of repository.listRuns()) {
+  for (const run of repository.listRuns({ recoverCorruptJson: true })) {
     if (!run.trackedAgentId || run.status !== 'running' || !run.currentAttemptId) continue;
-    const attempt = repository.getAttempt(run.currentAttemptId);
+    const attempt = getAttemptForReconciliation(repository, run.currentAttemptId);
+    if (attempt === CORRUPT_ATTEMPT) continue;
     const pid = attempt?.pid;
     if (!attempt || typeof pid !== 'number' || pid <= 0 || !attemptOwnsLiveProcess(
       attempt,
@@ -321,7 +344,7 @@ function syncTrackedAgentIfRunOwnsDispatch(
   updatedAt: string,
 ): boolean {
   if (!run.trackedAgentId) return false;
-  const agent = repository.getTrackedAgent(run.trackedAgentId);
+  const agent = repository.getTrackedAgent(run.trackedAgentId, { recoverCorruptJson: true });
   if (!agent || agent.status === 'deleted') return false;
   if (agent.dispatchRunId && agent.dispatchRunId !== run.id) return false;
   if (agent.status === status && agent.dispatchRunId === run.id) return false;
@@ -336,7 +359,7 @@ function syncTrackedAgent(
   updatedAt: string,
 ): void {
   if (!run.trackedAgentId) return;
-  const agent = repository.getTrackedAgent(run.trackedAgentId);
+  const agent = repository.getTrackedAgent(run.trackedAgentId, { recoverCorruptJson: true });
   if (!agent || agent.status === 'deleted') return;
   if (agent.status === status && agent.dispatchRunId === run.id) return;
   repository.updateTrackedAgent(run.trackedAgentId, {

--- a/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
+++ b/packages/franken-orchestrator/src/beasts/services/dispatcher-queue-reconciliation.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import type { BeastRun, BeastRunAttempt, BeastRunStatus, TrackedAgentStatus } from '../types.js';
 import {
   BeastRepositoryJsonCorruptionError,
+  type BeastRunProcessReference,
   SQLiteBeastRepository,
 } from '../repository/sqlite-beast-repository.js';
 import { isoNow } from '@franken/types';
@@ -128,7 +129,7 @@ export function reconcileDispatcherQueueAfterRestart(
   });
 
   return {
-    checkedRuns: repository.listRuns({ recoverCorruptJson: true }).length,
+    checkedRuns: repository.listRunProcessReferences().length,
     findings,
     changedRuns,
     duplicateLiveAgentRunCount: findings.filter((finding) => finding.code === 'duplicate-live-agent-run').length,
@@ -304,8 +305,8 @@ function detectDuplicateLiveAgentRuns(
   getProcessStartTimeTicks: (pid: number) => string | undefined,
   isProcessGroupAlive: (pid: number) => boolean,
 ): DispatcherQueueReconciliationFinding[] {
-  const liveRunsByAgent = new Map<string, Array<{ run: BeastRun; attempt: BeastRunAttempt; pid: number }>>();
-  for (const run of repository.listRuns({ recoverCorruptJson: true })) {
+  const liveRunsByAgent = new Map<string, Array<{ run: BeastRunProcessReference; attempt: BeastRunAttempt; pid: number }>>();
+  for (const run of repository.listRunProcessReferences()) {
     if (!run.trackedAgentId || run.status !== 'running' || !run.currentAttemptId) continue;
     const attempt = getAttemptForReconciliation(repository, run.currentAttemptId);
     if (attempt === CORRUPT_ATTEMPT) continue;

--- a/packages/franken-orchestrator/src/http/routes/agent-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/agent-routes.ts
@@ -246,12 +246,11 @@ export function agentRoutes(deps: AgentRoutesDeps): Hono {
     try {
       const detail = deps.agents.getAgentDetail(agentId);
       const redactDispatchFailure = deps.agents.hasDispatchFailureHistory(agentId);
-      const hasDispatchFailureHistory = detail.events.some((event) => event.type === 'agent.dispatch.failed');
       return c.json({
         data: {
           ...detail,
           agent: redactDispatchFailure ? redactDispatchFailedAgentResponse(detail.agent) : detail.agent,
-          events: redactDispatchFailedAgentEvents(detail.events, hasDispatchFailureHistory),
+          events: redactDispatchFailedAgentEvents(detail.events, redactDispatchFailure),
         },
       });
     } catch (error) {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -72,7 +72,7 @@ function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDep
   if (!run || run.executionMode !== 'container') {
     return [];
   }
-  return deps.runs.listAttempts(run.id);
+  return deps.runs.listAttemptsForResponse(run.id);
 }
 
 function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunResponse | undefined {
@@ -284,7 +284,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   app.get('/v1/beasts/runs', (c) => {
     return c.json({
       data: {
-        runs: deps.runs.listRuns().map((run) => (
+        runs: deps.runs.listRunsForResponse().map((run) => (
           runWithContainerFields(run, attemptsForContainerRun(run, deps))
         )),
       },
@@ -297,12 +297,12 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     if (!run) {
       throw beastRunNotFound(runId);
     }
-    const attempts = deps.runs.listAttempts(runId);
+    const attempts = deps.runs.listAttemptsForResponse(runId);
     return c.json({
       data: {
         run: runWithContainerFields(deps.runs.sanitizeRunForResponse(run), attempts),
         attempts,
-        events: deps.runs.listEvents(runId),
+        events: deps.runs.listEventsForResponse(runId),
       },
     });
   });
@@ -312,7 +312,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     try {
       return c.json({
         data: {
-          events: deps.runs.listEvents(runId),
+          events: deps.runs.listEventsForResponse(runId),
         },
       });
     } catch (error) {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -48,7 +48,9 @@ function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAtt
   if (!run || run.executionMode !== 'container') {
     return run;
   }
-  const currentAttempt = attempts.find((attempt) => attempt.id === run.currentAttemptId) ?? attempts.at(-1);
+  const currentAttempt = run.currentAttemptId
+    ? attempts.find((attempt) => attempt.id === run.currentAttemptId)
+    : attempts.at(-1);
   const metadata = currentAttempt?.executorMetadata;
   if (!metadata) {
     return run;

--- a/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/agent-routes.test.ts
@@ -20,6 +20,7 @@ import { agentRoutes } from '../../../src/http/routes/agent-routes.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { SseConnectionTicketStore } from '../../../src/beasts/events/sse-connection-ticket.js';
+import Database from 'better-sqlite3';
 
 import { testCredential } from '../../support/test-credentials.js';
 
@@ -1551,7 +1552,8 @@ describe('agent routes integration', () => {
 
   it('does not expose unexpected dispatch exception details in logs, events, or responses', async () => {
     mkdirSync(TMP, { recursive: true });
-    const repository = new SQLiteBeastRepository(join(TMP, 'redacted-dispatch-errors.db'));
+    const dbPath = join(TMP, 'redacted-dispatch-errors.db');
+    const repository = new SQLiteBeastRepository(dbPath);
     const agents = new AgentService(repository, () => '2026-03-11T00:00:00.000Z');
     const exceptionSecret = 'dispatch-secret-value-1234567890';
     const requestSecret = 'request-secret-value-0987654321';
@@ -1643,6 +1645,11 @@ describe('agent routes integration', () => {
       message: 'Linked Beast run run_historical-secret-link',
       payload: { runId: 'run_historical-secret-link' },
     });
+    const db = new Database(dbPath);
+    db.prepare('UPDATE tracked_agent_events SET payload = ? WHERE agent_id = ? AND type = ?')
+      .run('{"secret":"must-not-leak"', responseBody.error.details.agentId, 'agent.dispatch.failed');
+    db.close();
+    const corruptWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const detailResponse = await app.request(`/v1/beasts/agents/${responseBody.error.details.agentId}`, { headers });
     expect(detailResponse.status).toBe(200);
     const detail = await detailResponse.json() as {
@@ -1651,6 +1658,8 @@ describe('agent routes integration', () => {
     expect(detail.data.agent).not.toHaveProperty('dispatchRunId');
     expect(detail.data.agent).not.toHaveProperty('name');
     expect(JSON.stringify(detail.data.events)).not.toContain('run_historical-secret-link');
+    expect(corruptWarn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    corruptWarn.mockRestore();
 
     const patchResponse = await app.request(`/v1/beasts/agents/${responseBody.error.details.agentId}/config`, {
       method: 'PATCH',

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -20,6 +20,7 @@ import { ContainerBeastExecutor } from '../../../src/beasts/execution/container-
 import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-policy.js';
 import type { BeastProcessSpec } from '../../../src/beasts/types.js';
 import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
+import Database from 'better-sqlite3';
 
 import { testCredential } from '../../support/test-credentials.js';
 
@@ -563,6 +564,43 @@ describe('beast routes', () => {
       containerImage: 'fbeast/sandbox:test',
       dockerCommand: 'docker',
     });
+  });
+
+  it('does not expose stale container metadata when the current attempt metadata is corrupt', async () => {
+    const { app, operatorToken, repository } = createBeastApp();
+    const run = repository.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'container',
+      configSnapshot: { objective: 'avoid stale container metadata' },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-19T00:00:00.000Z',
+    });
+    repository.createAttempt(run.id, {
+      status: 'stopped',
+      executorMetadata: { containerId: 'stale-container', containerName: 'stale-name' },
+    });
+    const current = repository.createAttempt(run.id, {
+      status: 'running',
+      executorMetadata: { containerId: 'current-container' },
+    });
+    repository.updateRun(run.id, { status: 'running', currentAttemptId: current.id, attemptCount: 2 });
+    const db = new Database(join(TMP, 'beasts.db'));
+    db.prepare('UPDATE beast_run_attempts SET executor_metadata = ? WHERE id = ?')
+      .run('raw-current-attempt-secret', current.id);
+    db.close();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const response = await app.request(`/v1/beasts/runs/${run.id}`, {
+      headers: { authorization: `Bearer ${operatorToken}` },
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { run: Record<string, unknown> } };
+    expect(body.data.run).not.toHaveProperty('containerId');
+    expect(body.data.run).not.toHaveProperty('containerName');
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('raw-current-attempt-secret'));
+    warn.mockRestore();
   });
 
   it('does not require attempts when listing stale process-mode runs', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/agent-service-capacity.test.ts
@@ -1,7 +1,8 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { AgentService } from '../../../src/beasts/services/agent-service.js';
 import { CapacityReservationPolicy } from '../../../src/beasts/services/capacity-reservation-policy.js';
@@ -60,5 +61,33 @@ describe('AgentService capacity reservations', () => {
         },
       ],
     });
+  });
+
+  it('keeps capacity summaries available when another tracked agent has corrupt JSON', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-agent-capacity-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    const service = new AgentService(repo, () => '2026-07-15T00:00:00.000Z', {
+      capacityPolicy: new CapacityReservationPolicy({ totalSlots: 2, reservations: [] }),
+    });
+    const healthy = service.createAgent({
+      definitionId: 'martin-loop', source: 'dashboard', createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} }, initConfig: { labels: ['feature'] },
+    });
+    const corrupt = service.createAgent({
+      definitionId: 'martin-loop', source: 'dashboard', createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} }, initConfig: { labels: ['security'] },
+    });
+    service.updateAgent(healthy.id, { status: 'running' });
+    service.updateAgent(corrupt.id, { status: 'running' });
+    const db = new Database(dbPath);
+    db.prepare('UPDATE tracked_agents SET init_config = ? WHERE id = ?').run('{"secret":"must-not-leak"', corrupt.id);
+    db.close();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(service.getCapacityReservationState()).toMatchObject({ usedSlots: 1, freeSlots: 1 });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked_agents.init_config for row ${corrupt.id}`));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    warn.mockRestore();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-run-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
 import { BeastCatalogService } from '../../../src/beasts/services/beast-catalog-service.js';
 import { BeastDispatchService } from '../../../src/beasts/services/beast-dispatch-service.js';
 import { BeastRunService } from '../../../src/beasts/services/beast-run-service.js';
@@ -21,6 +22,37 @@ describe('BeastRunService', () => {
     if (workDir) {
       await rm(workDir, { recursive: true, force: true });
     }
+  });
+
+  it('keeps operational attempt reads strict while response reads omit corrupt attempts', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beast-run-service-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    const runs = new BeastRunService(
+      repo,
+      new BeastCatalogService(),
+      {} as never,
+      new PrometheusBeastMetrics(),
+      new BeastLogStore(join(workDir, 'logs')),
+    );
+    const run = repo.createRun({
+      definitionId: 'martin-loop', definitionVersion: 1, executionMode: 'process',
+      configSnapshot: { objective: 'strict attempt existence' }, dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator', createdAt: '2026-07-19T00:00:00.000Z',
+    });
+    const corruptAttempt = repo.createAttempt(run.id, {
+      status: 'running', executorMetadata: { token: 'must-not-leak' },
+    });
+    const db = new Database(dbPath);
+    db.prepare('UPDATE beast_run_attempts SET executor_metadata = ? WHERE id = ?')
+      .run('{"token":"must-not-leak"', corruptAttempt.id);
+    db.close();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(() => runs.listAttempts(run.id)).toThrow();
+    expect(runs.listAttemptsForResponse(run.id)).toEqual([]);
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    warn.mockRestore();
   });
 
   it('stops a running beast and preserves the durable run row', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -1,9 +1,17 @@
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const processExecutorConstructor = vi.hoisted(() => vi.fn());
+const cleanupAbandonedBeastWorktrees = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/beasts/execution/git-worktree-isolation.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../src/beasts/execution/git-worktree-isolation.js')>(),
+  cleanupAbandonedBeastWorktrees,
+}));
 
 vi.mock('../../../src/beasts/execution/process-beast-executor.js', () => ({
   ProcessBeastExecutor: class ProcessBeastExecutorMock {
@@ -25,6 +33,7 @@ describe('createBeastServices', () => {
     delete process.env.FBEAST_AGENT_CAPACITY_RESERVATIONS;
     delete process.env.FBEAST_AGENT_CAPACITY_RELEASED_RESERVATIONS;
     processExecutorConstructor.mockClear();
+    cleanupAbandonedBeastWorktrees.mockClear();
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
       tempDir = undefined;
@@ -82,6 +91,48 @@ describe('createBeastServices', () => {
       expect(restartedServices.ticketStore.consume(ticket, 'operator-token-123')).toBe('valid');
     } finally {
       restartedServices.dispose();
+    }
+  });
+
+  it('starts but suppresses destructive worktree cleanup when persisted run JSON is corrupt', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
+    const beastsDb = join(tempDir, 'beast.db');
+    const repo = new SQLiteBeastRepository(beastsDb);
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { healthy: true },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:00.000Z',
+    });
+    repo.close();
+    const db = new Database(beastsDb);
+    try {
+      db.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
+        .run('{"token":"must-not-leak"', run.id);
+    } finally {
+      db.close();
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
+
+    const services = createBeastServices({
+      beastsDb,
+      beastLogsDir: join(tempDir, 'logs'),
+      root: tempDir,
+    });
+
+    try {
+      expect(cleanupAbandonedBeastWorktrees).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(
+        `Skipping destructive Beast worktree cleanup because persisted JSON is corrupt in beast_runs.config_snapshot for row ${run.id}`,
+      ));
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    } finally {
+      services.dispose();
+      warn.mockRestore();
     }
   });
 

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -203,6 +204,58 @@ describe('dispatcher queue reconciliation after restart', () => {
         payload: expect.objectContaining({ code: 'stale-running-attempt-failed' }),
       }),
     ]));
+  });
+
+  it('continues restart reconciliation when an active attempt has corrupt JSON', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'corrupt attempt worker');
+    const run = repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'recover startup', chunkDirectory: '.' },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-20T00:00:01.000Z',
+    });
+    const attempt = repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 4242,
+      startedAt: '2026-03-20T00:01:00.000Z',
+      executorMetadata: { processGroupOwned: true },
+    });
+    repo.updateRun(run.id, { status: 'running' });
+
+    const db = new Database(dbPath);
+    try {
+      db.prepare('UPDATE beast_run_attempts SET executor_metadata = ? WHERE id = ?')
+        .run('{"token":"must-not-leak"', attempt.id);
+    } finally {
+      db.close();
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => true,
+    });
+
+    expect(report.findings).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ runId: run.id }),
+    ]));
+    expect(repo.getRun(run.id)).toMatchObject({
+      status: 'running',
+      currentAttemptId: attempt.id,
+    });
+    expect(() => repo.getAttempt(attempt.id)).toThrow();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(
+      `beast_run_attempts.executor_metadata for row ${attempt.id}`,
+    ));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    warn.mockRestore();
   });
 
   it('does not relink an agent to an older queued run when a newer run already owns dispatch', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/dispatcher-queue-reconciliation.test.ts
@@ -362,6 +362,50 @@ describe('dispatcher queue reconciliation after restart', () => {
     expect(repo.listEvents(runTwo.id).some(event => event.type === 'run.reconciliation.duplicate_live_agent_run')).toBe(true);
   });
 
+  it('includes runs with corrupt config snapshots in duplicate live-process detection', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = createRepo(workDir);
+    const agent = createAgent(repo, 'duplicate corrupt-config worker');
+    const runs = ['first', 'second'].map((objective, index) => repo.createRun({
+      trackedAgentId: agent.id,
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective },
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: `2026-03-20T00:00:0${index + 1}.000Z`,
+    }));
+    runs.forEach((run, index) => repo.createAttempt(run.id, {
+      status: 'running',
+      pid: 3000 + index,
+      executorMetadata: {
+        processGroupOwned: true,
+        processGroupLeaderPid: 3000 + index,
+        processStartTimeTicks: `${3000 + index}-start`,
+      },
+    }));
+    const db = new Database(dbPath);
+    db.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
+      .run('{"secret":"must-not-leak"', runs[0]!.id);
+    db.close();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const report = reconcileDispatcherQueueAfterRestart(repo, {
+      now: () => '2026-03-20T00:05:00.000Z',
+      isPidAlive: () => true,
+      getProcessStartTimeTicks: (pid) => `${pid}-start`,
+    });
+
+    expect(report.checkedRuns).toBe(2);
+    expect(report.duplicateLiveAgentRunCount).toBe(2);
+    expect(report.findings.filter(finding => finding.code === 'duplicate-live-agent-run').map(finding => finding.runId))
+      .toEqual(expect.arrayContaining(runs.map(run => run.id)));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('must-not-leak'));
+    warn.mockRestore();
+  });
+
   it('fails closed when a live PID does not match the attempt process ownership metadata', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-dispatcher-reconcile-'));
     const repo = createRepo(workDir);

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -111,10 +111,16 @@ function seedCorruptJsonFixture(repo: SQLiteBeastRepository): CorruptJsonFixture
   };
 }
 
-function corruptJsonColumn(dbPath: string, table: string, column: string, rowId: string): void {
+function corruptJsonColumn(
+  dbPath: string,
+  table: string,
+  column: string,
+  rowId: string,
+  value = '{malformed json',
+): void {
   const db = new Database(dbPath);
   try {
-    db.prepare(`UPDATE ${table} SET ${column} = ? WHERE id = ?`).run('{malformed json', rowId);
+    db.prepare(`UPDATE ${table} SET ${column} = ? WHERE id = ?`).run(value, rowId);
   } finally {
     db.close();
   }
@@ -505,13 +511,23 @@ describe('SQLiteBeastRepository', () => {
       name: 'beast_run_attempts.executor_metadata',
       table: 'beast_run_attempts',
       column: 'executor_metadata',
-      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listAttempts(ids.runId),
+      recovers: true,
+      strictExercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listAttempts(ids.runId),
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listAttempts(
+        ids.runId,
+        { recoverCorruptJson: true },
+      ),
     },
     {
       name: 'beast_run_events.payload',
       table: 'beast_run_events',
       column: 'payload',
-      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listEvents(ids.runId),
+      recovers: true,
+      strictExercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listEvents(ids.runId),
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listEvents(
+        ids.runId,
+        { recoverCorruptJson: true },
+      ),
     },
     {
       name: 'beast_interview_sessions.answers',
@@ -529,7 +545,9 @@ describe('SQLiteBeastRepository', () => {
       name: 'tracked_agents.init_config',
       table: 'tracked_agents',
       column: 'init_config',
-      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.getTrackedAgent(ids.agentId),
+      recovers: true,
+      strictExercise: (repo: SQLiteBeastRepository) => () => repo.listTrackedAgents(),
+      exercise: (repo: SQLiteBeastRepository) => () => repo.listTrackedAgents({ recoverCorruptJson: true }),
     },
     {
       name: 'tracked_agents.module_config',
@@ -541,34 +559,92 @@ describe('SQLiteBeastRepository', () => {
       name: 'tracked_agent_events.payload',
       table: 'tracked_agent_events',
       column: 'payload',
-      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listTrackedAgentEvents(ids.agentId),
+      recovers: true,
+      strictExercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => (
+        repo.listTrackedAgentEvents(ids.agentId)
+      ),
+      exercise: (repo: SQLiteBeastRepository, ids: CorruptJsonFixtureIds) => () => repo.listTrackedAgentEvents(
+        ids.agentId,
+        { recoverCorruptJson: true },
+      ),
     },
-  ])('reports structured data-corruption details for corrupt $name JSON', async ({ table, column, exercise }) => {
+  ])('handles corrupt $name JSON with structured diagnostics', async ({
+    table,
+    column,
+    exercise,
+    recovers,
+    strictExercise,
+  }) => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const dbPath = join(workDir, 'beasts.db');
     const repo = new SQLiteBeastRepository(dbPath);
     const ids = seedCorruptJsonFixture(repo);
     corruptJsonColumn(dbPath, table, column, ids.rowIdFor(table));
 
-    expect(exercise(repo, ids)).toThrow(BeastRepositoryJsonCorruptionError);
+    if (recovers) {
+      if (!strictExercise) throw new Error(`missing strict exercise for ${table}.${column}`);
+      expect(strictExercise(repo, ids)).toThrow(BeastRepositoryJsonCorruptionError);
 
-    try {
-      exercise(repo, ids)();
-      throw new Error('expected corrupt JSON read to throw');
-    } catch (error) {
-      expect(error).toBeInstanceOf(BeastRepositoryJsonCorruptionError);
-      const corruption = error as BeastRepositoryJsonCorruptionError;
-      expect(corruption.context).toMatchObject({
-        table,
-        column,
-        rowId: ids.rowIdFor(table),
-        valueSnippet: '{malformed json',
-      });
-      expect(corruption.message).toContain(`${table}.${column}`);
-      expect(corruption.message).toContain(ids.rowIdFor(table));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(exercise(repo, ids)()).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`${table}.${column} for row ${ids.rowIdFor(table)}`));
+      warn.mockRestore();
+    } else {
+      expect(exercise(repo, ids)).toThrow(BeastRepositoryJsonCorruptionError);
+
+      try {
+        exercise(repo, ids)();
+        throw new Error('expected corrupt JSON read to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BeastRepositoryJsonCorruptionError);
+        const corruption = error as BeastRepositoryJsonCorruptionError;
+        expect(corruption.context).toMatchObject({
+          table,
+          column,
+          rowId: ids.rowIdFor(table),
+          valueSnippet: '[redacted]',
+        });
+        expect(corruption.message).toContain(`${table}.${column}`);
+        expect(corruption.message).toContain(ids.rowIdFor(table));
+      }
     }
 
     expect(repo.getRun(ids.healthyRunId)?.configSnapshot).toEqual({ healthy: true });
+  });
+
+  it('keeps healthy runs listable without leaking or mutating a corrupt JSON value', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    const ids = seedCorruptJsonFixture(repo);
+    const corruptValue = '{"token":"super-secret-token"';
+    corruptJsonColumn(dbPath, 'beast_runs', 'config_snapshot', ids.runId, corruptValue);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => repo.listRuns()).toThrow(BeastRepositoryJsonCorruptionError);
+    expect(repo.listRuns({ recoverCorruptJson: true }).map((run) => run.id)).toEqual([ids.healthyRunId]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`beast_runs.config_snapshot for row ${ids.runId}`));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('super-secret-token'));
+
+    const db = new Database(dbPath);
+    try {
+      const stored = db.prepare('SELECT config_snapshot FROM beast_runs WHERE id = ?').get(ids.runId) as {
+        config_snapshot: string;
+      };
+      expect(stored.config_snapshot).toBe(corruptValue);
+    } finally {
+      db.close();
+    }
+
+    expect(() => repo.getRun(ids.runId)).toThrow(BeastRepositoryJsonCorruptionError);
+    try {
+      repo.getRun(ids.runId);
+    } catch (error) {
+      const corruption = error as BeastRepositoryJsonCorruptionError;
+      expect(corruption.context.valueSnippet).not.toContain('super-secret-token');
+    }
+
+    warn.mockRestore();
   });
 
   it('migrates legacy beast_runs tables that predate tracked_agent_id', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -617,7 +617,7 @@ describe('SQLiteBeastRepository', () => {
     const dbPath = join(workDir, 'beasts.db');
     const repo = new SQLiteBeastRepository(dbPath);
     const ids = seedCorruptJsonFixture(repo);
-    const corruptValue = '{"token":"super-secret-token"';
+    const corruptValue = 'super-secret-token';
     corruptJsonColumn(dbPath, 'beast_runs', 'config_snapshot', ids.runId, corruptValue);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -642,6 +642,8 @@ describe('SQLiteBeastRepository', () => {
     } catch (error) {
       const corruption = error as BeastRepositoryJsonCorruptionError;
       expect(corruption.context.valueSnippet).not.toContain('super-secret-token');
+      expect(corruption.message).not.toContain('super-secret-token');
+      expect((corruption as Error & { cause?: unknown }).cause).toBeUndefined();
     }
 
     warn.mockRestore();


### PR DESCRIPTION
## Summary
- add explicit response-safe recovery for corrupt JSON collection rows while preserving strict operational repository reads
- redact persisted values from corruption diagnostics and preserve failed-agent history redaction when payload JSON is corrupt
- keep shutdown strict and retain minimally decoded runs for restart reconciliation and duplicate-live-process detection
- add focused regression coverage for response recovery, capacity accounting, redaction, and strict operational predicates

## Verification
- full orchestrator suite: 4109 tests passed
- orchestrator typecheck passed
- orchestrator dependency build passed
- changed-file ESLint passed
- git diff --check passed

Closes #2749