### PR TITLE
fix(orchestrator): skip malformed skill manifests

### DIFF
--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -47,7 +47,9 @@ function isInvalidSkillManifestError(err: unknown): err is Error {
   return err instanceof SyntaxError || err instanceof ZodError;
 }
 
-function reportInvalidSkill(name: string, err: Error): void {
+function reportInvalidSkill(name: string, err: Error, reportedSkills: Set<string>): void {
+  if (reportedSkills.has(name)) return;
+  reportedSkills.add(name);
   const reason = err instanceof SyntaxError
     ? 'manifest contains malformed JSON'
     : 'manifest failed schema validation';
@@ -108,6 +110,7 @@ function requireSecurityReviewByDefault(
 
 export class SkillManager {
   private readonly enabledSkills: Set<string>;
+  private readonly reportedInvalidSkills = new Set<string>();
   private readonly skillsDirRoot: string;
   private readonly skillsDirReal: string;
 
@@ -241,7 +244,7 @@ export class SkillManager {
         } catch (err) {
           if (isUnsafeSkillPathError(err)) return null;
           if (isInvalidSkillManifestError(err)) {
-            reportInvalidSkill(e.name, err);
+            reportInvalidSkill(e.name, err, this.reportedInvalidSkills);
             return null;
           }
           throw err;
@@ -395,19 +398,22 @@ export class SkillManager {
   loadForProvider(provider: ILlmProvider): ProviderSkillConfig {
     const translator = new ProviderSkillTranslator();
     const enabledNames = this.getEnabledSkills();
+    const usesCliMcpConfig = provider.type === 'claude-cli'
+      || provider.type === 'codex-cli'
+      || provider.type === 'gemini-cli';
     const inputs = enabledNames.flatMap((name) => {
       try {
         const context = this.readContext(name);
         return [{
           name,
           mcpConfig: this.readMcpConfig(name) ?? { mcpServers: {} },
-          tools: this.readTools(name),
+          tools: usesCliMcpConfig ? [] : this.readTools(name),
           ...(context !== null ? { context } : {}),
         }];
       } catch (err) {
         if (isUnsafeSkillPathError(err)) return [];
         if (isInvalidSkillManifestError(err)) {
-          reportInvalidSkill(name, err);
+          reportInvalidSkill(name, err, this.reportedInvalidSkills);
           return [];
         }
         throw err;

--- a/packages/franken-orchestrator/src/skills/skill-manager.ts
+++ b/packages/franken-orchestrator/src/skills/skill-manager.ts
@@ -24,6 +24,7 @@ import type {
   ProviderSkillConfig,
 } from '@franken/types';
 import { McpConfigSchema, SkillToolManifestSchema } from '@franken/types';
+import { ZodError } from 'zod';
 import type { SkillConfigStore } from './skill-config-store.js';
 import { ProviderSkillTranslator } from './provider-skill-translator.js';
 
@@ -40,6 +41,17 @@ function unsafePathError(path: string, reason: string): Error {
 
 export function isUnsafeSkillPathError(err: unknown): boolean {
   return err instanceof Error && err.message.startsWith('Unsafe skill path ');
+}
+
+function isInvalidSkillManifestError(err: unknown): err is Error {
+  return err instanceof SyntaxError || err instanceof ZodError;
+}
+
+function reportInvalidSkill(name: string, err: Error): void {
+  const reason = err instanceof SyntaxError
+    ? 'manifest contains malformed JSON'
+    : 'manifest failed schema validation';
+  console.warn(`[SkillManager] Skipping invalid skill '${name}': ${reason}`);
 }
 
 function assertContainedPath(candidate: string, root: string, label: string): void {
@@ -228,6 +240,10 @@ export class SkillManager {
           return this.readSkillInfo(e.name);
         } catch (err) {
           if (isUnsafeSkillPathError(err)) return null;
+          if (isInvalidSkillManifestError(err)) {
+            reportInvalidSkill(e.name, err);
+            return null;
+          }
           throw err;
         }
       })
@@ -379,14 +395,23 @@ export class SkillManager {
   loadForProvider(provider: ILlmProvider): ProviderSkillConfig {
     const translator = new ProviderSkillTranslator();
     const enabledNames = this.getEnabledSkills();
-    const inputs = enabledNames.map((name) => {
-      const context = this.readContext(name);
-      return {
-        name,
-        mcpConfig: this.readMcpConfig(name) ?? { mcpServers: {} },
-        tools: this.readTools(name),
-        ...(context !== null ? { context } : {}),
-      };
+    const inputs = enabledNames.flatMap((name) => {
+      try {
+        const context = this.readContext(name);
+        return [{
+          name,
+          mcpConfig: this.readMcpConfig(name) ?? { mcpServers: {} },
+          tools: this.readTools(name),
+          ...(context !== null ? { context } : {}),
+        }];
+      } catch (err) {
+        if (isUnsafeSkillPathError(err)) return [];
+        if (isInvalidSkillManifestError(err)) {
+          reportInvalidSkill(name, err);
+          return [];
+        }
+        throw err;
+      }
     });
     return translator.translate(provider, inputs);
   }

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, linkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { McpConfigSchema } from '@franken/types';
+import { McpConfigSchema, type ILlmProvider } from '@franken/types';
 import { SkillManager } from '../../../src/skills/skill-manager.js';
 
 describe('SkillManager', () => {
@@ -72,6 +72,56 @@ describe('SkillManager', () => {
       symlinkSync(join(tempDir, 'outside-mcp.json'), join(skillsDir, 'poisoned', 'mcp.json'));
 
       expect(manager.listInstalled().map((skill) => skill.name)).toEqual(['github']);
+    });
+
+    it.each([
+      ['malformed JSON', '{"mcpServers":', 'manifest contains malformed JSON'],
+      [
+        'schema-invalid JSON',
+        JSON.stringify({ mcpServers: { broken: { command: '' } } }),
+        'manifest failed schema validation',
+      ],
+    ])('skips a skill with %s and reports it without hiding valid skills', async (_case, manifest, reason) => {
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+      mkdirSync(join(skillsDir, 'broken'), { recursive: true });
+      writeFileSync(join(skillsDir, 'broken', 'mcp.json'), manifest);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      expect(manager.listInstalled().map((skill) => skill.name)).toEqual(['github']);
+      expect(warn).toHaveBeenCalledWith(
+        `[SkillManager] Skipping invalid skill 'broken': ${reason}`,
+      );
+
+      warn.mockRestore();
+    });
+  });
+
+  describe('loadForProvider()', () => {
+    it('loads valid enabled skills when another enabled MCP manifest is malformed', async () => {
+      manager = new SkillManager(skillsDir, new Set(['github', 'broken']));
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+      mkdirSync(join(skillsDir, 'broken'), { recursive: true });
+      writeFileSync(join(skillsDir, 'broken', 'mcp.json'), '{"mcpServers":');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = manager.loadForProvider({ type: 'claude-cli' } as ILlmProvider);
+      const translated = JSON.parse(result.filesToWrite![0]!.content);
+      expect(Object.keys(translated.mcpServers)).toEqual(['github']);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("Skipping invalid skill 'broken'"));
+
+      warn.mockRestore();
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-manager.test.ts
@@ -100,6 +100,18 @@ describe('SkillManager', () => {
 
       warn.mockRestore();
     });
+
+    it('reports a persistently invalid skill only once', () => {
+      mkdirSync(join(skillsDir, 'broken'), { recursive: true });
+      writeFileSync(join(skillsDir, 'broken', 'mcp.json'), '{"mcpServers":');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      manager.listInstalled();
+      manager.listInstalled();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
   });
 
   describe('loadForProvider()', () => {
@@ -122,6 +134,23 @@ describe('SkillManager', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("Skipping invalid skill 'broken'"));
 
       warn.mockRestore();
+    });
+
+    it('keeps CLI MCP skills loadable when their unused tools manifest is malformed', async () => {
+      manager = new SkillManager(skillsDir, new Set(['github']));
+      await manager.install({
+        name: 'github',
+        description: 'GH',
+        provider: 'cli',
+        installConfig: { command: 'npx' },
+        authFields: [],
+      });
+      writeFileSync(join(skillsDir, 'github', 'tools.json'), '{"broken":');
+
+      const result = manager.loadForProvider({ type: 'claude-cli' } as ILlmProvider);
+      const translated = JSON.parse(result.filesToWrite![0]!.content);
+
+      expect(Object.keys(translated.mcpServers)).toEqual(['github']);
     });
   });
 


### PR DESCRIPTION
## Summary
- isolate malformed JSON and schema-invalid skill manifests during installed-skill listing
- preserve valid enabled skills during provider translation when another manifest is invalid
- emit skill-scoped diagnostics without exposing raw manifest contents

## Test plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/skills/skill-manager.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run build`
- full orchestrator suite: 4,121 passed; one unrelated timeout passed on isolated rerun (48/48)

Closes #3189