### PR TITLE
fix(orchestrator): surface skill health probe diagnostics

### DIFF
--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -362,10 +362,31 @@ function formatHealthDiagnostic(
     ...(stderr.byteLength > 0 ? [`stderr: ${stderr.toString('utf8').trim()}`] : []),
     ...(stdout.byteLength > 0 ? [`stdout: ${stdout.toString('utf8').trim()}`] : []),
   ].join('\n');
-  const sanitized = details
-    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '')
-    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '');
-  return redactSensitiveText(sanitized);
+  return redactSensitiveText(sanitizeTerminalText(details));
+}
+
+function sanitizeTerminalText(text: string): string {
+  const withoutEscapes = text
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, '')
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '');
+  const normalized: string[] = [];
+  for (const character of withoutEscapes) {
+    if (character === '\b') {
+      if (normalized.at(-1) !== '\n') {
+        normalized.pop();
+      }
+      continue;
+    }
+    if (character === '\r') {
+      normalized.push('\n');
+      continue;
+    }
+    if (/^[\u0000-\u0007\u000B\u000C\u000E-\u001F\u007F]$/u.test(character)) {
+      continue;
+    }
+    normalized.push(character);
+  }
+  return normalized.join('');
 }
 
 async function mapWithConcurrency<Item, Result>(

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import type { McpConfig } from '@franken/types';
+import { redactSensitiveText } from '../logging/redaction.js';
 
 export type McpHealthStatus = 'connected' | 'error' | 'unknown';
 
@@ -29,9 +30,15 @@ const SKIPPED_HEALTH_CHECK_MESSAGE =
   'MCP health probe skipped because the per-check limit of 20 servers was exceeded';
 const INCOMPLETE_HANDSHAKE_MESSAGE =
   'MCP initialize handshake was not completed before the command exited';
+const HEALTH_CHECK_TIMEOUT_MESSAGE =
+  'MCP initialize handshake timed out';
 
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const HEALTH_CHECK_TERMINATION_GRACE_MS = 250;
+/** Maximum retained prefix for each child-process output stream. */
+const MAX_HEALTH_DIAGNOSTIC_BYTES = 4096;
+/** Bound incomplete protocol data while allowing normal MCP initialize responses. */
+const MAX_MCP_PROTOCOL_BUFFER_BYTES = 1024 * 1024;
 /** Maximum number of MCP child-process health probes running at once. */
 const MAX_CONCURRENT_MCP_HEALTH_PROBES = 4;
 /** Maximum number of child processes spawned by one trusted status check. */
@@ -162,6 +169,8 @@ export class SkillHealthChecker {
       let proc: ChildProcessWithoutNullStreams;
       let settled = false;
       let stdoutBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+      let stdoutDiagnosticTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+      let stderrDiagnosticTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
       let timer: NodeJS.Timeout;
 
       const settle = (
@@ -233,17 +242,36 @@ export class SkillHealthChecker {
 
         timer = setTimeout(() => {
           // Timeout without MCP readiness signal — cannot confirm connectivity.
-          settle('unknown');
+          settle('unknown', {
+            error: formatHealthDiagnostic(
+              HEALTH_CHECK_TIMEOUT_MESSAGE,
+              stderrDiagnosticTail,
+              stdoutDiagnosticTail,
+            ),
+          });
         }, HEALTH_CHECK_TIMEOUT_MS);
 
-        proc.on('error', () => {
-          settle('error', { killRunningProcess: false });
+        proc.on('error', (error: Error) => {
+          settle('error', {
+            killRunningProcess: false,
+            error: formatHealthDiagnostic(
+              `Failed to start MCP server: ${error.message}`,
+              stderrDiagnosticTail,
+              stdoutDiagnosticTail,
+            ),
+          });
         });
 
         proc.on('close', (code) => {
           settle(code === 0 ? 'unknown' : 'error', {
             killRunningProcess: false,
-            ...(code === 0 ? { error: INCOMPLETE_HANDSHAKE_MESSAGE } : {}),
+            error: formatHealthDiagnostic(
+              code === 0
+                ? INCOMPLETE_HANDSHAKE_MESSAGE
+                : `MCP server exited with code ${code ?? 'unknown'}`,
+              stderrDiagnosticTail,
+              stdoutDiagnosticTail,
+            ),
           });
         });
 
@@ -255,17 +283,35 @@ export class SkillHealthChecker {
         });
 
         proc.stdout.on('data', (chunk: Buffer | string) => {
+          const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8');
+          stdoutDiagnosticTail = appendBoundedDiagnostic(stdoutDiagnosticTail, chunkBuffer);
           stdoutBuffer = Buffer.concat([
             stdoutBuffer,
-            Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8'),
+            chunkBuffer,
           ]);
+          if (stdoutBuffer.byteLength > MAX_MCP_PROTOCOL_BUFFER_BYTES) {
+            stdoutBuffer = stdoutBuffer.subarray(-MAX_MCP_PROTOCOL_BUFFER_BYTES);
+          }
           const messages = readMcpMessages(stdoutBuffer);
           stdoutBuffer = messages.remaining;
           if (messages.messages.some(isFailedInitializeResponse)) {
-            settle('error');
+            settle('error', {
+              error: formatHealthDiagnostic(
+                'MCP initialize request failed',
+                stderrDiagnosticTail,
+                stdoutDiagnosticTail,
+              ),
+            });
           } else if (messages.messages.some(isSuccessfulInitializeResponse)) {
             settle('connected');
           }
+        });
+
+        proc.stderr.on('data', (chunk: Buffer | string) => {
+          stderrDiagnosticTail = appendBoundedDiagnostic(
+            stderrDiagnosticTail,
+            Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8'),
+          );
         });
 
         proc.stdin.write(formatMcpMessage({
@@ -281,11 +327,45 @@ export class SkillHealthChecker {
             },
           },
         }));
-      } catch {
-        resolve({ status: 'error' });
+      } catch (error) {
+        resolve({
+          status: 'error',
+          error: formatHealthDiagnostic(
+            `Failed to start MCP server: ${error instanceof Error ? error.message : String(error)}`,
+            stderrDiagnosticTail,
+            stdoutDiagnosticTail,
+          ),
+        });
       }
     });
   }
+}
+
+function appendBoundedDiagnostic(
+  current: Buffer<ArrayBufferLike>,
+  chunk: Buffer<ArrayBufferLike>,
+): Buffer<ArrayBufferLike> {
+  const remainingBytes = MAX_HEALTH_DIAGNOSTIC_BYTES - current.byteLength;
+  if (remainingBytes <= 0) {
+    return current;
+  }
+  return Buffer.concat([current, chunk.subarray(0, remainingBytes)]);
+}
+
+function formatHealthDiagnostic(
+  summary: string,
+  stderr: Buffer<ArrayBufferLike>,
+  stdout: Buffer<ArrayBufferLike>,
+): string {
+  const details = [
+    summary,
+    ...(stderr.byteLength > 0 ? [`stderr: ${stderr.toString('utf8').trim()}`] : []),
+    ...(stdout.byteLength > 0 ? [`stdout: ${stdout.toString('utf8').trim()}`] : []),
+  ].join('\n');
+  const sanitized = details
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '\uFFFD');
+  return redactSensitiveText(sanitized);
 }
 
 async function mapWithConcurrency<Item, Result>(

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -362,13 +362,18 @@ function formatHealthDiagnostic(
     ...(stderr.byteLength > 0 ? [`stderr: ${stderr.toString('utf8').trim()}`] : []),
     ...(stdout.byteLength > 0 ? [`stdout: ${stdout.toString('utf8').trim()}`] : []),
   ].join('\n');
-  return redactSensitiveText(sanitizeTerminalText(details));
+  const sanitized = sanitizeTerminalText(details);
+  const assignmentValuesRedacted = sanitized.replace(
+    /(=\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu,
+    '$1<redacted>',
+  );
+  return redactSensitiveText(assignmentValuesRedacted);
 }
 
 function sanitizeTerminalText(text: string): string {
   const withoutEscapes = text
     .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, '')
-    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '');
+    .replace(/(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]/gu, '');
   const normalized: string[] = [];
   for (const character of withoutEscapes) {
     if (character === '\b') {
@@ -381,7 +386,7 @@ function sanitizeTerminalText(text: string): string {
       normalized.push('\n');
       continue;
     }
-    if (/^[\u0000-\u0007\u000B\u000C\u000E-\u001F\u007F]$/u.test(character)) {
+    if (/^[\u0000-\u0007\u000B\u000C\u000E-\u001F\u007F-\u009F]$/u.test(character)) {
       continue;
     }
     normalized.push(character);

--- a/packages/franken-orchestrator/src/skills/skill-health-checker.ts
+++ b/packages/franken-orchestrator/src/skills/skill-health-checker.ts
@@ -289,11 +289,11 @@ export class SkillHealthChecker {
             stdoutBuffer,
             chunkBuffer,
           ]);
+          const messages = readMcpMessages(stdoutBuffer);
+          stdoutBuffer = messages.remaining;
           if (stdoutBuffer.byteLength > MAX_MCP_PROTOCOL_BUFFER_BYTES) {
             stdoutBuffer = stdoutBuffer.subarray(-MAX_MCP_PROTOCOL_BUFFER_BYTES);
           }
-          const messages = readMcpMessages(stdoutBuffer);
-          stdoutBuffer = messages.remaining;
           if (messages.messages.some(isFailedInitializeResponse)) {
             settle('error', {
               error: formatHealthDiagnostic(
@@ -364,7 +364,7 @@ function formatHealthDiagnostic(
   ].join('\n');
   const sanitized = details
     .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '')
-    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '\uFFFD');
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '');
   return redactSensitiveText(sanitized);
 }
 

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -607,6 +607,28 @@ describe('SkillHealthChecker', () => {
     expect(diagnostic).not.toContain('\u0000');
   });
 
+  it('applies terminal backspace semantics before redacting diagnostics', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', 'API_X\bKEY=do-not-expose');
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('backspace', {
+      mcpServers: { backspace: { command: 'backspace-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(diagnostic).toContain('API_KEY=<redacted>');
+    expect(diagnostic).not.toContain('do-not-expose');
+    expect(diagnostic).not.toContain('\b');
+  });
+
   it('does not retain a sensitive value past the diagnostic bound', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -256,7 +256,11 @@ describe('SkillHealthChecker', () => {
 
     expect(result.status).toBe('unknown');
     expect(result.serverStatuses).toEqual([
-      { serverName: 'silent', status: 'unknown' },
+      {
+        serverName: 'silent',
+        status: 'unknown',
+        error: 'MCP initialize handshake timed out',
+      },
     ]);
     expect(proc.kill).toHaveBeenCalledTimes(1);
   });
@@ -482,6 +486,99 @@ describe('SkillHealthChecker', () => {
     };
     const result = await checker.getStatus('bad', config, { trustMcpServerCommands: true });
     expect(result.status).toBe('error');
+    expect(result.serverStatuses[0]).toMatchObject({
+      status: 'error',
+      error: 'Failed to start MCP server: not found',
+    });
+  });
+
+  it('returns sanitized stderr diagnostics when a trusted command exits non-zero', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', 'startup failed: API_TOKEN=do-not-expose');
+        proc.exitCode = 7;
+        proc.emit('close', 7);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('broken', {
+      mcpServers: { broken: { command: 'broken-server' } },
+    }, { trustMcpServerCommands: true });
+
+    expect(result.serverStatuses[0]).toMatchObject({
+      status: 'error',
+      error: 'MCP server exited with code 7\nstderr: startup failed: API_TOKEN=<redacted>',
+    });
+    expect(result.serverStatuses[0]?.error).not.toContain('do-not-expose');
+  });
+
+  it('bounds long stderr diagnostics without retaining data beyond 4096 bytes', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', `old-prefix-${'x'.repeat(5000)}-recent-tail`);
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('noisy', {
+      mcpServers: { noisy: { command: 'noisy-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(Buffer.byteLength(diagnostic, 'utf8')).toBeLessThanOrEqual(4160);
+    expect(diagnostic).toContain('old-prefix');
+    expect(diagnostic).not.toContain('-recent-tail');
+  });
+
+  it('redacts sensitive assignments before exposing ANSI-normalized diagnostics', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', 'API_\u001b[31mTOKEN=do-not-expose');
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('ansi', {
+      mcpServers: { ansi: { command: 'ansi-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(diagnostic).toContain('API_TOKEN=<redacted>');
+    expect(diagnostic).not.toContain('do-not-expose');
+    expect(diagnostic).not.toContain('\u001b');
+  });
+
+  it('does not retain a sensitive value past the diagnostic bound', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', `API_TOKEN=${'s'.repeat(5000)}-secret-tail`);
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('long-secret', {
+      mcpServers: { 'long-secret': { command: 'long-secret-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(diagnostic).toContain('API_TOKEN=<redacted>');
+    expect(diagnostic).not.toContain('-secret-tail');
+    expect(Buffer.byteLength(diagnostic, 'utf8')).toBeLessThanOrEqual(4160);
   });
 });
 

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -629,6 +629,31 @@ describe('SkillHealthChecker', () => {
     expect(diagnostic).not.toContain('\b');
   });
 
+  it('redacts assignment values despite malformed and C1 terminal sequences', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit(
+          'data',
+          'API_\u001b[31TOKEN=first-secret C1_\u009B31mTOKEN=second-secret',
+        );
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('malformed-controls', {
+      mcpServers: { malformed: { command: 'malformed-controls-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(diagnostic).not.toContain('first-secret');
+    expect(diagnostic).not.toContain('second-secret');
+    expect(diagnostic.match(/<redacted>/gu)).toHaveLength(2);
+  });
+
   it('does not retain a sensitive value past the diagnostic bound', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();

--- a/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/skill-health-checker.test.ts
@@ -123,6 +123,32 @@ describe('SkillHealthChecker', () => {
     expect(proc.kill).toHaveBeenCalledTimes(1);
   });
 
+  it('parses a complete initialize response before bounding later stdout', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    proc.stdin.write.mockImplementation(() => {
+      setTimeout(() => {
+        proc.stdout.emit('data', `${formatMcpMessage({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            serverInfo: { name: 'chatty-server', version: '1.0.0' },
+          },
+        })}${'x'.repeat(1024 * 1024 + 1)}`);
+      }, 10);
+      return true;
+    });
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(proc);
+
+    const result = await checker.getStatus('chatty', {
+      mcpServers: { chatty: { command: 'node', args: ['server.js'] } },
+    }, { trustMcpServerCommands: true });
+
+    expect(result.status).toBe('connected');
+  });
+
   it('defers stdin EPIPE to an unknown clean-exit result', async () => {
     const { spawn } = await import('node:child_process');
     const proc = makeMockProcess();
@@ -557,6 +583,28 @@ describe('SkillHealthChecker', () => {
     expect(diagnostic).toContain('API_TOKEN=<redacted>');
     expect(diagnostic).not.toContain('do-not-expose');
     expect(diagnostic).not.toContain('\u001b');
+  });
+
+  it('redacts sensitive assignments obfuscated with non-ANSI controls', async () => {
+    const { spawn } = await import('node:child_process');
+    const proc = makeMockProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      setTimeout(() => {
+        proc.stderr.emit('data', 'API_\u0000KEY=do-not-expose');
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      }, 10);
+      return proc;
+    });
+
+    const result = await checker.getStatus('controls', {
+      mcpServers: { controls: { command: 'controls-server' } },
+    }, { trustMcpServerCommands: true });
+    const diagnostic = result.serverStatuses[0]?.error ?? '';
+
+    expect(diagnostic).toContain('API_KEY=<redacted>');
+    expect(diagnostic).not.toContain('do-not-expose');
+    expect(diagnostic).not.toContain('\u0000');
   });
 
   it('does not retain a sensitive value past the diagnostic bound', async () => {


### PR DESCRIPTION
## Summary
- surface missing-command, non-zero exit, timeout, and MCP initialization diagnostics from trusted skill health probes
- bound captured subprocess output and sanitize control sequences before applying the shared secret redactor
- cap incomplete MCP protocol buffering and add regression coverage for stderr, redaction, ANSI obfuscation, and oversized secrets

## Test plan
- `npm run test --workspace @franken/orchestrator` (277 files, 4123 tests passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run build` (10 packages)
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `codex review --uncommitted` (no actionable regressions)

Closes #3180
