### PR TITLE
fix(brain): define public package exports

### DIFF
--- a/packages/franken-brain/package.json
+++ b/packages/franken-brain/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/franken-brain/tests/unit/package-exports.test.ts
+++ b/packages/franken-brain/tests/unit/package-exports.test.ts
@@ -30,7 +30,9 @@ describe('@franken/brain package exports', () => {
 
     const rootResolution = resolveFromConsumer('@franken/brain');
     expect(rootResolution.status).toBe(0);
-    expect(rootResolution.stdout).toMatch(/\/@franken\/brain\/dist\/index\.js$/);
+    expect(rootResolution.stdout).toMatch(
+      /\/(?:packages\/franken-brain|node_modules\/@franken\/brain)\/dist\/index\.js$/,
+    );
 
     const deepResolution = resolveFromConsumer('@franken/brain/package.json');
     expect(deepResolution.status).not.toBe(0);

--- a/packages/franken-brain/tests/unit/package-exports.test.ts
+++ b/packages/franken-brain/tests/unit/package-exports.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const repositoryRoot = resolve(packageRoot, '../..');
+
+function resolveFromConsumer(specifier: string) {
+  return spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', `process.stdout.write(import.meta.resolve(${JSON.stringify(specifier)}))`],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  );
+}
+
+describe('@franken/brain package exports', () => {
+  it('exposes only the public root import and type declarations', () => {
+    const manifest = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+      exports?: unknown;
+    };
+
+    expect(manifest.exports).toEqual({
+      '.': {
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+      },
+    });
+
+    const rootResolution = resolveFromConsumer('@franken/brain');
+    expect(rootResolution.status).toBe(0);
+    expect(rootResolution.stdout).toMatch(/\/@franken\/brain\/dist\/index\.js$/);
+
+    const deepResolution = resolveFromConsumer('@franken/brain/package.json');
+    expect(deepResolution.status).not.toBe(0);
+    expect(deepResolution.stderr).toContain('ERR_PACKAGE_PATH_NOT_EXPORTED');
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit root-only exports map for `@franken/brain`
- verify consumer root resolution targets `dist/index.js`
- verify unsupported deep imports are blocked and type declarations remain mapped

## Test plan
- `npm run test --workspace @franken/brain` (311 tests)
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/brain`
- `npm run typecheck --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm pack --workspace @franken/brain --dry-run --json`

Closes #2882