### PR TITLE
fix(web): confirm destructive network service actions

### DIFF
--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -477,6 +477,7 @@ describe('ChatShell route heading', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat' }));
 
     expect(await screen.findByText('insecure')).toBeTruthy();
 
@@ -509,6 +510,7 @@ describe('ChatShell route heading', () => {
     expect(await screen.findByText('chat')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat' }));
     await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
@@ -539,6 +541,7 @@ describe('ChatShell route heading', () => {
     expect(await screen.findByText('chat')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat' }));
     await waitFor(() => expect(networkApiMocks.getStatus).toHaveBeenCalledTimes(2));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
@@ -570,6 +573,7 @@ describe('ChatShell route heading', () => {
     expect(await screen.findByText('chat')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Restart chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat' }));
 
     expect((await screen.findByRole('alert')).textContent).toContain('Unable to restart chat: HTTP 502');
   });

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
 
 interface NetworkServiceItem {
   id: string;
@@ -47,6 +48,64 @@ function canStopOrRestartService(service: NetworkServiceItem): boolean {
 
 function canViewServiceLogs(service: NetworkServiceItem): boolean {
   return !service.inProcess || Boolean(service.hostServiceId);
+}
+
+function ConfirmServiceAction({
+  action,
+  serviceId,
+  disabled,
+  onConfirm,
+}: {
+  action: 'stop' | 'restart';
+  serviceId: string;
+  disabled: boolean;
+  onConfirm(): void;
+}) {
+  const actionLabel = action === 'stop' ? 'Stop' : 'Restart';
+  const consequence = action === 'stop'
+    ? 'Stopping this service will interrupt active sessions that depend on it. The service will remain unavailable until it is started again.'
+    : 'Restarting this service will interrupt active sessions that depend on it while the service restarts.';
+
+  return (
+    <AlertDialog.Root>
+      <AlertDialog.Trigger asChild>
+        <button
+          aria-label={`${actionLabel} ${serviceId}`}
+          className="button button--secondary button--small"
+          disabled={disabled}
+          type="button"
+        >
+          {actionLabel}
+        </button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
+        <AlertDialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-beast-panel border border-beast-border rounded-xl p-6 z-[60] max-w-md">
+          <AlertDialog.Title className="text-beast-text font-semibold">
+            {actionLabel} {serviceId}?
+          </AlertDialog.Title>
+          <AlertDialog.Description className="text-beast-muted text-sm mt-2">
+            {consequence}
+          </AlertDialog.Description>
+          <div className="flex gap-3 mt-4 justify-end">
+            <AlertDialog.Cancel asChild>
+              <button className="button button--secondary button--small" type="button">Cancel</button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <button
+                aria-label={`Confirm ${action} ${serviceId}`}
+                className="px-3 py-1.5 rounded-lg text-sm bg-beast-danger text-white"
+                onClick={onConfirm}
+                type="button"
+              >
+                {actionLabel} service
+              </button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
 }
 
 export function NetworkServiceList({
@@ -141,8 +200,18 @@ export function NetworkServiceList({
                 </button>
               ) : null}
               <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'start', onStart)} aria-label={`Start ${service.id}`} disabled={startDisabled}>Start</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'stop', onStop)} aria-label={`Stop ${service.id}`} disabled={stopOrRestartDisabled}>Stop</button>
-              <button className="button button--secondary button--small" type="button" onClick={() => runAction(service, 'restart', onRestart)} aria-label={`Restart ${service.id}`} disabled={stopOrRestartDisabled}>Restart</button>
+              <ConfirmServiceAction
+                action="stop"
+                serviceId={service.id}
+                disabled={stopOrRestartDisabled}
+                onConfirm={() => runAction(service, 'stop', onStop)}
+              />
+              <ConfirmServiceAction
+                action="restart"
+                serviceId={service.id}
+                disabled={stopOrRestartDisabled}
+                onConfirm={() => runAction(service, 'restart', onRestart)}
+              />
             </div>
           </article>
           );

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -839,6 +839,7 @@ describe('ChatShell', () => {
     render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat-server' }));
 
     await waitFor(() => {
       expect(mockNetworkRestart).toHaveBeenCalledWith('chat-server');
@@ -863,6 +864,7 @@ describe('ChatShell', () => {
     render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat-server' }));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
     await waitFor(() => {
@@ -908,6 +910,7 @@ describe('ChatShell', () => {
     render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Restart chat-server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat-server' }));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
     act(() => {

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -10,6 +10,12 @@ const baseConfig: NetworkConfigResponse = {
   comms: { enabled: false },
 };
 
+function confirmServiceAction(action: 'stop' | 'restart', serviceId: string): void {
+  const label = action === 'stop' ? 'Stop' : 'Restart';
+  fireEvent.click(screen.getByRole('button', { name: `${label} ${serviceId}` }));
+  fireEvent.click(screen.getByRole('button', { name: `Confirm ${action} ${serviceId}` }));
+}
+
 afterEach(cleanup);
 
 describe('NetworkPage', () => {
@@ -106,19 +112,19 @@ describe('NetworkPage', () => {
     expect(onStop).not.toHaveBeenCalledWith('dashboard');
     expect(onRestart).not.toHaveBeenCalledWith('dashboard');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Stop chat-server' }));
+    confirmServiceAction('stop', 'chat-server');
     await waitFor(() => expect(screen.getByText('Stopped chat-server.')).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: 'Restart chat-server' }));
+    confirmServiceAction('restart', 'chat-server');
     await waitFor(() => expect(screen.getByText('Restarted chat-server.')).toBeDefined());
     fireEvent.click(screen.getByRole('button', { name: 'Start dashboard' }));
     await waitFor(() => expect(screen.getByText('Started dashboard.')).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: 'Stop worker' }));
+    confirmServiceAction('stop', 'worker');
     await waitFor(() => expect(screen.getByText('Stopped worker.')).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: 'Restart worker' }));
+    confirmServiceAction('restart', 'worker');
     await waitFor(() => expect(screen.getByText('Restarted worker.')).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: 'Stop degraded-worker' }));
+    confirmServiceAction('stop', 'degraded-worker');
     await waitFor(() => expect(screen.getByText('Stopped degraded-worker.')).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: 'Restart degraded-worker' }));
+    confirmServiceAction('restart', 'degraded-worker');
     await waitFor(() => expect(screen.getByText('Restarted degraded-worker.')).toBeDefined());
     fireEvent.change(screen.getByLabelText('Network mode'), { target: { value: 'insecure' } });
     fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: 'gpt-5' } });
@@ -164,6 +170,7 @@ describe('NetworkPage', () => {
 
     const stopButton = screen.getByRole('button', { name: 'Stop chat-server' });
     fireEvent.click(stopButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm stop chat-server' }));
     fireEvent.click(stopButton);
 
     await waitFor(() => expect(stopButton).toHaveProperty('disabled', true));

--- a/packages/franken-web/tests/components/network-service-list.test.tsx
+++ b/packages/franken-web/tests/components/network-service-list.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NetworkServiceList } from '../../src/components/network-service-list';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const runningService = {
+  id: 'chat-gateway',
+  status: 'running',
+};
+
+function renderServiceList(overrides: Partial<ComponentProps<typeof NetworkServiceList>> = {}) {
+  const handlers = {
+    onSelectLogs: vi.fn(),
+    onStart: vi.fn(),
+    onStop: vi.fn(),
+    onRestart: vi.fn(),
+  };
+
+  render(
+    <NetworkServiceList
+      services={[runningService]}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+
+  return handlers;
+}
+
+describe('NetworkServiceList destructive action confirmations', () => {
+  it('requires a second explicit action before stopping a service', () => {
+    const handlers = renderServiceList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop chat-gateway' }));
+
+    expect(handlers.onStop).not.toHaveBeenCalled();
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('Stop chat-gateway?')).toBeTruthy();
+    expect(screen.getByText(/interrupt active sessions/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(handlers.onStop).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop chat-gateway' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm stop chat-gateway' }));
+
+    expect(handlers.onStop).toHaveBeenCalledTimes(1);
+    expect(handlers.onStop).toHaveBeenCalledWith('chat-gateway');
+  });
+
+  it('supports keyboard cancellation and confirmation before restarting a service', () => {
+    const handlers = renderServiceList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat-gateway' }));
+
+    expect(handlers.onRestart).not.toHaveBeenCalled();
+    expect(screen.getByText('Restart chat-gateway?')).toBeTruthy();
+    expect(screen.getByText(/interrupt active sessions/i)).toBeTruthy();
+
+    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Escape' });
+    expect(handlers.onRestart).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart chat-gateway' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm restart chat-gateway' }));
+
+    expect(handlers.onRestart).toHaveBeenCalledTimes(1);
+    expect(handlers.onRestart).toHaveBeenCalledWith('chat-gateway');
+  });
+});


### PR DESCRIPTION
## Summary
- require explicit confirmation before stopping or restarting network services
- explain that active sessions may be interrupted and stopping leaves the service unavailable
- preserve keyboard-accessible cancellation and update service-action regression coverage

## Test plan
- `npm run test --workspace @franken/web` (669 passed)
- `npm run lint --workspace @franken/web` (passes with 17 pre-existing warnings)
- `npm run typecheck --workspace @franken/web`
- `npm run build --workspace @franken/web`

Closes #2910