### PR TITLE
docs(readme): link package map before architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Frankenbeast is currently organized as 10 npm workspace packages under `packages
 
 The diagrams below use current package names or implementation-surface names, and the package inventory table remains the authoritative workspace map.
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full interconnection diagram.
+Start with the [current workspace package inventory](#current-workspace-packages) for the package-name source of truth, then see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full interconnection diagram.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary
- link the current workspace package inventory before the architecture diagram
- keep the package inventory explicit as the package-name source of truth

## Verification
- `git diff --check`
- verified the inventory link precedes the architecture link and targets the existing `#current-workspace-packages` anchor

Closes #3402