### PR TITLE
fix(observer): multiply token counts before rate scaling

### DIFF
--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -338,6 +338,20 @@ describe('PrometheusAdapter', () => {
       )
     })
 
+    it('multiplies small token counts by the rate before scaling to millions', async () => {
+      const adapter = new PrometheusAdapter({
+        pricingTable: {
+          'small-usage-model': { promptPerMillion: 15, completionPerMillion: 0 },
+        },
+      })
+
+      await adapter.flush(makeTrace('small-usage-model', 1, 0))
+
+      expect(adapter.scrape()).toContain(
+        'franken_observer_cost_usd_total{model="small-usage-model"} 0.000015',
+      )
+    })
+
     it('omits cost metrics when no pricingTable is provided', async () => {
       const adapter = new PrometheusAdapter()
       await adapter.flush(makeTrace('claude-sonnet-4-6', 500, 200))

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -137,8 +137,8 @@ export class PrometheusAdapter implements ExportAdapter {
         if (this.pricingTable?.[model]) {
           const pricing = this.pricingTable[model]
           const cost =
-            (prompt / 1_000_000) * pricing.promptPerMillion +
-            (completion / 1_000_000) * pricing.completionPerMillion
+            (prompt * pricing.promptPerMillion) / 1_000_000 +
+            (completion * pricing.completionPerMillion) / 1_000_000
           this.costCounters.set(model, (this.costCounters.get(model) ?? 0) + cost)
         }
       }

--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -29,6 +29,20 @@ describe('CostCalculator', () => {
       expect(cost).toBeCloseTo(expected, 8)
     })
 
+    it('multiplies small token counts by the rate before scaling to millions', () => {
+      const calc = new CostCalculator({
+        'small-usage-model': { promptPerMillion: 15, completionPerMillion: 0 },
+      })
+
+      const cost = calc.calculate({
+        model: 'small-usage-model',
+        promptTokens: 1,
+        completionTokens: 0,
+      })
+
+      expect(cost).toBe((1 * 15) / 1_000_000)
+    })
+
     it('returns 0 for an unknown model', () => {
       const quietCalc = new CostCalculator(DEFAULT_PRICING, {
         onUnknownModel: () => {},

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -39,8 +39,8 @@ export class CostCalculator {
       return 0
     }
     return (
-      (entry.promptTokens / 1_000_000) * model.promptPerMillion +
-      (entry.completionTokens / 1_000_000) * model.completionPerMillion
+      (entry.promptTokens * model.promptPerMillion) / 1_000_000 +
+      (entry.completionTokens * model.completionPerMillion) / 1_000_000
     )
   }
 


### PR DESCRIPTION
## Summary
- multiply token counts by per-million rates before dividing in both observer cost paths
- add exact small-token regression coverage for CostCalculator and Prometheus metrics

## Verification
- npm test -- --run src/cost/CostCalculator.test.ts src/adapters/prometheus/PrometheusAdapter.test.ts
- npm test (830 tests)
- npm run typecheck
- npm run build
- npm run lint (0 errors; 6 pre-existing warnings)

Closes #2680