### PR TITLE
perf(observer): cache loop detector comparisons

### DIFF
--- a/packages/franken-observer/src/incident/LoopDetector.test.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.test.ts
@@ -188,6 +188,37 @@ describe('LoopDetector', () => {
     })
   })
 
+  describe('comparison caching', () => {
+    it('normalizes each span once and reuses pairwise fuzzy-match results across scans', () => {
+      const internals = LoopDetector as unknown as {
+        normalizeSpanName(spanName: string): string
+        levenshteinDistance(left: string, right: string): number
+      }
+      const normalizeSpy = vi.spyOn(internals, 'normalizeSpanName')
+      const distanceSpy = vi.spyOn(internals, 'levenshteinDistance')
+      const detector = new LoopDetector({
+        windowSize: 1,
+        repeatThreshold: 3,
+        similarityThreshold: 1,
+        maxGapBetweenRepetitions: 100,
+      })
+
+      detector.check('alpha-aaaa')
+      detector.check('bravo-bbbb')
+      detector.check('charlie-cccc')
+
+      expect(normalizeSpy).toHaveBeenCalledTimes(3)
+      expect(distanceSpy).toHaveBeenCalledTimes(3)
+
+      detector.check('delta-dddd')
+
+      expect(normalizeSpy).toHaveBeenCalledTimes(4)
+      // The fourth scan adds only the three pairs involving the new span;
+      // comparisons among prior history entries are served from the cache.
+      expect(distanceSpy).toHaveBeenCalledTimes(6)
+    })
+  })
+
   describe('event emission', () => {
     it('emits a loop-detected event when a loop is found', () => {
       const detector = new LoopDetector({ windowSize: 2, repeatThreshold: 2 })

--- a/packages/franken-observer/src/incident/LoopDetector.ts
+++ b/packages/franken-observer/src/incident/LoopDetector.ts
@@ -19,6 +19,12 @@ export interface LoopDetectorOptions {
 
 type LoopHandler = (result: LoopDetectionResult) => void
 
+interface CachedSpanName {
+  original: string
+  normalized: string
+  digitMask: string
+}
+
 /**
  * Detects repeating span-name patterns using a sliding-window comparison.
  * Non-blocking: fires event handlers synchronously, never throws.
@@ -30,7 +36,8 @@ export class LoopDetector {
   private readonly maxGapBetweenRepetitions: number
   private readonly historyLimit: number
   private readonly handlers = new Set<LoopHandler>()
-  private history: string[] = []
+  private readonly comparisonCache = new WeakMap<CachedSpanName, WeakMap<CachedSpanName, boolean>>()
+  private history: CachedSpanName[] = []
 
   constructor(options: LoopDetectorOptions = {}) {
     this.windowSize = LoopDetector.validatePositiveInteger('windowSize', options.windowSize ?? 3)
@@ -75,7 +82,12 @@ export class LoopDetector {
   }
 
   check(spanName: string): LoopDetectionResult {
-    this.history.push(spanName)
+    const normalized = LoopDetector.normalizeSpanName(spanName)
+    this.history.push({
+      original: spanName,
+      normalized,
+      digitMask: LoopDetector.maskDigits(normalized),
+    })
     if (this.history.length > this.historyLimit) {
       this.history = this.history.slice(-this.historyLimit)
     }
@@ -122,7 +134,7 @@ export class LoopDetector {
       if (repetitions >= this.repeatThreshold && cursor === this.history.length) {
         return {
           detected: true,
-          detectedPattern: pattern,
+          detectedPattern: pattern.map(span => span.original),
           repetitions,
         }
       }
@@ -131,7 +143,7 @@ export class LoopDetector {
     return { detected: false, detectedPattern: [], repetitions: 0 }
   }
 
-  private findNextPatternStart(pattern: string[], searchStart: number): number | undefined {
+  private findNextPatternStart(pattern: CachedSpanName[], searchStart: number): number | undefined {
     const latestPatternStart = this.history.length - this.windowSize
     const latestAllowedStart = Math.min(
       latestPatternStart,
@@ -147,13 +159,25 @@ export class LoopDetector {
     return undefined
   }
 
-  private windowMatches(pattern: string[], start: number): boolean {
+  private windowMatches(pattern: CachedSpanName[], start: number): boolean {
     return pattern.every((spanName, index) => this.spanNamesMatch(spanName, this.history[start + index]))
   }
 
-  private spanNamesMatch(left: string, right: string): boolean {
-    const normalizedLeft = LoopDetector.normalizeSpanName(left)
-    const normalizedRight = LoopDetector.normalizeSpanName(right)
+  private spanNamesMatch(left: CachedSpanName, right: CachedSpanName): boolean {
+    const cached = this.comparisonCache.get(left)?.get(right)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const matches = this.compareSpanNames(left, right)
+    this.cacheComparison(left, right, matches)
+    this.cacheComparison(right, left, matches)
+    return matches
+  }
+
+  private compareSpanNames(left: CachedSpanName, right: CachedSpanName): boolean {
+    const normalizedLeft = left.normalized
+    const normalizedRight = right.normalized
 
     if (normalizedLeft === normalizedRight) {
       return true
@@ -163,7 +187,7 @@ export class LoopDetector {
     // `iter-1` vs `iter-9`) represent normal progression, not a loop. Without
     // this guard the fuzzy match below would also collapse them into a fake
     // loop because the edit distance is tiny.
-    if (LoopDetector.maskDigits(normalizedLeft) === LoopDetector.maskDigits(normalizedRight)) {
+    if (left.digitMask === right.digitMask) {
       return false
     }
 
@@ -172,6 +196,15 @@ export class LoopDetector {
     }
 
     return LoopDetector.similarity(normalizedLeft, normalizedRight) >= this.similarityThreshold
+  }
+
+  private cacheComparison(left: CachedSpanName, right: CachedSpanName, matches: boolean): void {
+    let comparisons = this.comparisonCache.get(left)
+    if (!comparisons) {
+      comparisons = new WeakMap<CachedSpanName, boolean>()
+      this.comparisonCache.set(left, comparisons)
+    }
+    comparisons.set(right, matches)
   }
 
   private static maskDigits(value: string): string {


### PR DESCRIPTION
## Summary
- normalize and digit-mask each span name once when it enters LoopDetector history
- cache pairwise span-name comparison results with weak references so repeated scans avoid duplicate Levenshtein work
- preserve original span names in detected patterns and add focused bounded-work regression coverage

## Test plan
- `npm test -- --run src/incident/LoopDetector.test.ts`
- `npm test --workspace @franken/observer`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with 6 pre-existing warnings)

Closes #2679