### PR TITLE
test(observer): focus TraceServer client script coverage

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -16,6 +16,12 @@ function makeTrace(goal: string) {
   return trace
 }
 
+function extractClientScript(html: string): string {
+  const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+  if (!script) throw new Error('Trace viewer HTML did not include its client script')
+  return script
+}
+
 describe('TraceServer', () => {
   let adapter: InMemoryAdapter
   let server: TraceServer
@@ -99,8 +105,7 @@ describe('TraceServer', () => {
 
     it('renders trace rows as keyboard-operable buttons and exposes selection state', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
-      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-      expect(script).toBeDefined()
+      const script = extractClientScript(html)
 
       const sidebar = { innerHTML: '', addEventListener: () => {} }
       const panel = { innerHTML: '' }
@@ -130,7 +135,7 @@ describe('TraceServer', () => {
         loadTraces?: () => Promise<void>
         loadDetail?: (id: string) => Promise<void>
       }
-      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+      new Script(script.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       expect(html).toContain('.trace-item:hover,.trace-item.active,.trace-item[aria-current="true"]{')
       expect(html).toContain('.trace-goal{display:block;')
@@ -148,11 +153,10 @@ describe('TraceServer', () => {
 
     it('escapes template-literal metacharacters in trace text before writing innerHTML', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
-      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-      expect(script).toBeDefined()
+      const script = extractClientScript(html)
 
       const context = createContext({ document: { getElementById: () => ({ addEventListener: () => {} }) } }) as { esc?: (s: string) => string }
-      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+      new Script(script.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       const escaped = context.esc!('goal`);globalThis.__xss=1;//${alert(1)}<img src=x onerror=alert(2)>')
       expect(escaped).not.toContain('`')
@@ -162,8 +166,7 @@ describe('TraceServer', () => {
 
     it('escapes trace IDs when rendering sidebar and detail (XSS via t.id)', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
-      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-      expect(script).toBeDefined()
+      const script = extractClientScript(html)
 
       const maliciousId = '"><img src=x onerror=alert(1)>'
       const sidebar = { innerHTML: '', addEventListener: () => {} }
@@ -195,7 +198,7 @@ describe('TraceServer', () => {
         loadTraces?: () => Promise<void>
         loadDetail?: (id: string) => Promise<void>
       }
-      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+      new Script(script.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       await context.loadTraces!()
       expect(sidebar.innerHTML).not.toContain('<img')
@@ -208,8 +211,7 @@ describe('TraceServer', () => {
 
     it('renders an escaped recoverable error when a trace detail request returns 404', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
-      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-      expect(script).toBeDefined()
+      const script = extractClientScript(html)
 
       const panel = { innerHTML: '' }
       const context = createContext({
@@ -226,7 +228,7 @@ describe('TraceServer', () => {
         }),
         Date,
       }) as { loadDetail?: (id: string) => Promise<void> }
-      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+      new Script(script.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       await expect(context.loadDetail!('stale-trace')).resolves.toBeUndefined()
       expect(panel.innerHTML).toContain('trace not found')
@@ -236,8 +238,7 @@ describe('TraceServer', () => {
 
     it('renders a recoverable error when successful trace JSON has no spans array', async () => {
       const html = await fetch(server.url + '/').then(r => r.text())
-      const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-      expect(script).toBeDefined()
+      const script = extractClientScript(html)
 
       const panel = { innerHTML: '' }
       const context = createContext({
@@ -254,7 +255,7 @@ describe('TraceServer', () => {
         }),
         Date,
       }) as { loadDetail?: (id: string) => Promise<void> }
-      new Script(script!.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
+      new Script(script.replace(/loadTraces\(\)\s*$/, '')).runInContext(context)
 
       await expect(context.loadDetail!('malformed-trace')).resolves.toBeUndefined()
       expect(panel.innerHTML).toContain('Trace details are unavailable')


### PR DESCRIPTION
## Summary
- replace repeated TraceServer client-script existence-only assertions with a typed extraction helper
- keep each test focused on executing and validating real client behavior
- remove unnecessary non-null assertions after script extraction

## Verification
- `npm run test --workspace @franken/observer -- src/ui/TraceServer.test.ts` (28 passed)
- `npm run test --workspace @franken/observer` (830 passed)
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)
- `npm run build --workspace @franken/observer`

Closes #2521