### PR TITLE
perf(observer): pre-index allowed tool parameters

### DIFF
--- a/packages/franken-observer/src/evals/deterministic/ToolCallAccuracy.test.ts
+++ b/packages/franken-observer/src/evals/deterministic/ToolCallAccuracy.test.ts
@@ -73,6 +73,24 @@ describe('ToolCallAccuracyEval', () => {
       )
     })
 
+    it('pre-indexes large allowed lists before checking actual params', async () => {
+      const allowed = Array.from({ length: 10_000 }, (_, index) => `param${index}`)
+      allowed.includes = () => {
+        throw new Error('allowed parameters must not be scanned for every actual param')
+      }
+
+      const result = await runner.run(ev, {
+        actual: {
+          tool: 'large_tool',
+          params: { param0: true, param9999: true, hallucinated: true },
+        },
+        schema: { tool: 'large_tool', required: [], allowed },
+      })
+
+      expect(result.status).toBe('fail')
+      expect(result.details?.['ghostParams']).toEqual(['hallucinated'])
+    })
+
     it('reports both missing required and ghost params when both are present', async () => {
       const result = await runner.run(ev, {
         actual: { tool: 'search_web', params: { ghost1: 'a' } },

--- a/packages/franken-observer/src/evals/deterministic/ToolCallAccuracy.ts
+++ b/packages/franken-observer/src/evals/deterministic/ToolCallAccuracy.ts
@@ -37,7 +37,8 @@ export class ToolCallAccuracyEval implements Eval<ToolCallAccuracyInput> {
     }
 
     const missingParams = schema.required.filter(p => !(p in actual.params))
-    const ghostParams = actualParams.filter(p => !schema.allowed.includes(p))
+    const allowedParams = new Set(schema.allowed)
+    const ghostParams = actualParams.filter(p => !allowedParams.has(p))
 
     const issues: string[] = []
     if (missingParams.length > 0) issues.push(`missing required params: ${missingParams.join(', ')}`)


### PR DESCRIPTION
## Summary
- build a `Set` from allowed tool-call parameters once per matching evaluation
- use constant-time membership checks when detecting ghost parameters
- add a 10,000-parameter regression that fails if the allowed array is scanned

## Verification
- `EVAL=true npm run test --workspace @franken/observer -- src/evals/deterministic/ToolCallAccuracy.test.ts` (10 passed)
- `npm run test:eval --workspace @franken/observer` (53 passed)
- `npm run test --workspace @franken/observer` (831 passed)
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)
- `npm run build --workspace @franken/observer`

Closes #2672