### PR TITLE
perf(observer): avoid repeated SQLite schema DDL

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -45,8 +45,7 @@ describe('SQLiteAdapter', () => {
       'busy_timeout = 5000',
       'journal_mode = WAL',
       'foreign_keys = ON',
-      'user_version',
-      'user_version = 1',
+      "index_list('spans')",
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
@@ -54,10 +53,10 @@ describe('SQLiteAdapter', () => {
   })
 
   it('executes schema DDL only once when multiple adapters open the same initialized database', () => {
-    let schemaVersion = 0
     pragmaMock.mockImplementation((statement: string) => {
-      if (statement === 'user_version') return schemaVersion
-      if (statement === 'user_version = 1') schemaVersion = 1
+      if (statement === "index_list('spans')") {
+        return execMock.mock.calls.length === 0 ? [] : [{ name: 'idx_spans_traceId_startedAt' }]
+      }
       return undefined
     })
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -34,6 +34,7 @@ function sqliteBusyError(): Error & { code: string } {
 describe('SQLiteAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    pragmaMock.mockReset()
   })
 
   it('configures WAL, foreign keys, and a busy timeout so concurrent writers wait for locks', () => {
@@ -44,10 +45,29 @@ describe('SQLiteAdapter', () => {
       'busy_timeout = 5000',
       'journal_mode = WAL',
       'foreign_keys = ON',
+      'user_version',
+      'user_version = 1',
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
     adapter.close()
+  })
+
+  it('executes schema DDL only once when multiple adapters open the same initialized database', () => {
+    let schemaVersion = 0
+    pragmaMock.mockImplementation((statement: string) => {
+      if (statement === 'user_version') return schemaVersion
+      if (statement === 'user_version = 1') schemaVersion = 1
+      return undefined
+    })
+
+    const first = new SQLiteAdapter('/tmp/shared-traces.db')
+    const second = new SQLiteAdapter('/tmp/shared-traces.db')
+
+    expect(execMock).toHaveBeenCalledTimes(1)
+
+    first.close()
+    second.close()
   })
 
   it('validates retry options before opening a database handle', () => {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -59,7 +59,7 @@ interface FlushedSpanState {
   thoughtBlocksJson: string
 }
 
-const SQLITE_SCHEMA_VERSION = 1
+const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_spans_traceId_startedAt'
 
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
@@ -299,10 +299,11 @@ export class SQLiteAdapter implements ExportAdapter {
       this.withSqliteLockRetrySync('initialize SQLite adapter', () => {
         this.db.pragma('journal_mode = WAL')
         this.db.pragma('foreign_keys = ON')
-        const schemaVersion = this.db.pragma('user_version', { simple: true })
-        if (typeof schemaVersion !== 'number' || schemaVersion < SQLITE_SCHEMA_VERSION) {
+        const spanIndexes = this.db.pragma("index_list('spans')") as Array<{ name?: unknown }>
+        const schemaInitialized = Array.isArray(spanIndexes)
+          && spanIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
+        if (!schemaInitialized) {
           this.db.exec(CREATE_TABLES)
-          this.db.pragma(`user_version = ${SQLITE_SCHEMA_VERSION}`)
         }
       })
     } catch (error) {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -59,6 +59,8 @@ interface FlushedSpanState {
   thoughtBlocksJson: string
 }
 
+const SQLITE_SCHEMA_VERSION = 1
+
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
   maxFlushedSpanSnapshots?: number
@@ -297,7 +299,11 @@ export class SQLiteAdapter implements ExportAdapter {
       this.withSqliteLockRetrySync('initialize SQLite adapter', () => {
         this.db.pragma('journal_mode = WAL')
         this.db.pragma('foreign_keys = ON')
-        this.db.exec(CREATE_TABLES)
+        const schemaVersion = this.db.pragma('user_version', { simple: true })
+        if (typeof schemaVersion !== 'number' || schemaVersion < SQLITE_SCHEMA_VERSION) {
+          this.db.exec(CREATE_TABLES)
+          this.db.pragma(`user_version = ${SQLITE_SCHEMA_VERSION}`)
+        }
       })
     } catch (error) {
       this.db.close()


### PR DESCRIPTION
## Summary
- mark the current observer SQLite schema with `PRAGMA user_version` after first-time setup
- skip the full idempotent schema DDL block for later adapter instances on the same initialized database
- cover repeated construction with a focused regression test

## Verification
- `npm test` (`@franken/observer`: 832 passed)
- `npm run typecheck` (`@franken/observer`)
- `npm run build` (`@franken/observer`)
- `npm run lint` (`@franken/observer`: 0 errors, 6 pre-existing warnings)

Closes #2677