### PR TITLE
fix(orchestrator): recover local Codex chat startup

### DIFF
--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -57,7 +57,12 @@ export async function resolveManagedChatAttachment(
   const baseUrl = stateUrl
     ? assertLocalPlaintextOrSecureHttpUrl(stateUrl, 'Persisted chat-server URL')
     : localPlaintextOrSecureEndpoint(options.config.chat.host, options.config.chat.port);
-  const healthResponse = await fetchImpl(`${baseUrl}/health`);
+  let healthResponse: Response;
+  try {
+    healthResponse = await fetchImpl(`${baseUrl}/health`);
+  } catch {
+    return undefined;
+  }
   if (!healthResponse.ok) {
     return undefined;
   }

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -20,6 +20,9 @@ export class CodexProvider implements ICliProvider {
   buildArgs(opts: ProviderOpts): string[] {
     const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(opts.extraArgs);
     const args: string[] = ['exec', ...sandboxArgs, '--json', '--color', 'never'];
+    if (opts.chatMode && !extraArgs.includes('--skip-git-repo-check')) {
+      args.push('--skip-git-repo-check');
+    }
     if (opts.model) {
       args.push('--model', opts.model);
     }

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -136,6 +136,20 @@ describe('resolveManagedChatAttachment', () => {
     expect(attachment).toBeUndefined();
   });
 
+  it('falls back to standalone chat when the managed service is unreachable', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-chat-attach-'));
+
+    const attachment = await resolveManagedChatAttachment({
+      config: defaultConfig(),
+      frankenbeastDir: join(workDir, '.fbeast'),
+      fetchImpl: async () => {
+        throw new TypeError('fetch failed');
+      },
+    });
+
+    expect(attachment).toBeUndefined();
+  });
+
   it('ignores stale detached state when healthcheck fails', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-chat-attach-'));
     const frankenbeastDir = join(workDir, '.fbeast');

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -29,6 +29,11 @@ describe('CodexProvider', () => {
     expect(args).not.toContain('--full-auto');
   });
 
+  it('buildArgs allows chat prompts from the isolated non-repository working directory', () => {
+    const args = provider.buildArgs({ chatMode: true });
+    expect(args).toContain('--skip-git-repo-check');
+  });
+
   it('buildArgs includes --color never', () => {
     const args = provider.buildArgs({});
     const idx = args.indexOf('--color');


### PR DESCRIPTION
## Summary
- allow Codex chat-mode prompts from Frankenbeast’s isolated non-repository working directory
- fall back to standalone chat when a stale managed chat endpoint is unreachable
- add regressions for both user-visible startup failures

## Verification
- `npm run test -- --run` (277 files, 4,134 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings)
- `npm run build`
- real `fbeast` smoke exits normally instead of failing in Codex
- real `fbeast chat` reaches the standalone REPL instead of `Fatal: fetch failed`