### PR TITLE
feat(web): terminal-style chat transcript and conversational interview

### DIFF
--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -213,7 +213,7 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
   );
 
   return (
-    <section className="rail-card" aria-label="Activity">
+    <section className="rail-card terminal-activity" aria-label="Activity">
       <div className="rail-card__header">
         <p className="eyebrow">Activity</p>
         <h2>Runtime Events</h2>

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -16,7 +16,7 @@ function isContainerRuntimeUnavailable(status: BeastContainerRuntimeStatus | und
 }
 
 export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
-  const { stepValues, setStepValues } = useBeastStore();
+  const { stepValues, setStepValues, wizardMode } = useBeastStore();
   const values = (stepValues[1] ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
   const workflows = getEffectiveCatalog(catalog);
   const selectedWorkflow = workflows.find((entry) => entry.id === values.workflowType);
@@ -115,6 +115,7 @@ export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
           prompts={selectedWorkflow.interviewPrompts}
           getValue={(prompt) => getPromptValue(values, prompt)}
           onChange={(key, value) => updateField(key, value)}
+          sequentialReveal={wizardMode === 'wizard'}
         />
       )}
     </div>
@@ -122,7 +123,11 @@ export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
 }
 
 function isPromptAnswered(prompt: BeastInterviewPrompt, value: unknown): boolean {
-  if (prompt.kind === 'boolean') return true;
+  if (prompt.kind === 'boolean') {
+    // Wizard validation treats an untouched required checkbox as missing
+    // (isBlankCatalogValue(undefined)), so only a real boolean counts.
+    return !prompt.required || typeof value === 'boolean';
+  }
   return typeof value === 'string' && value.trim().length > 0;
 }
 
@@ -136,12 +141,17 @@ function InterviewTranscript({
   prompts,
   getValue,
   onChange,
+  sequentialReveal,
 }: {
   prompts: readonly BeastInterviewPrompt[];
   getValue: (prompt: BeastInterviewPrompt) => unknown;
   onChange: (key: string, value: string | boolean) => void;
+  /** Form view renders every prompt at once; only wizard mode reveals turns. */
+  sequentialReveal: boolean;
 }) {
-  const firstBlocking = prompts.findIndex((prompt) => prompt.required && !isPromptAnswered(prompt, getValue(prompt)));
+  const firstBlocking = sequentialReveal
+    ? prompts.findIndex((prompt) => prompt.required && !isPromptAnswered(prompt, getValue(prompt)))
+    : -1;
   const visible = firstBlocking === -1 ? prompts : prompts.slice(0, firstBlocking + 1);
   const remaining = prompts.length - visible.length;
 

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -111,16 +111,63 @@ export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
       </fieldset>
 
       {selectedWorkflow && (
-        <div className="space-y-4">
-          {selectedWorkflow.interviewPrompts.map((prompt) => (
+        <InterviewTranscript
+          prompts={selectedWorkflow.interviewPrompts}
+          getValue={(prompt) => getPromptValue(values, prompt)}
+          onChange={(key, value) => updateField(key, value)}
+        />
+      )}
+    </div>
+  );
+}
+
+function isPromptAnswered(prompt: BeastInterviewPrompt, value: unknown): boolean {
+  if (prompt.kind === 'boolean') return true;
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Interview prompts presented as a conversational transcript: each question is
+ * an interviewer turn, and the next question is revealed once the previous
+ * required one is answered. Earlier answers stay rendered and editable, so the
+ * underlying labeled controls (and wizard validation) are unchanged.
+ */
+function InterviewTranscript({
+  prompts,
+  getValue,
+  onChange,
+}: {
+  prompts: readonly BeastInterviewPrompt[];
+  getValue: (prompt: BeastInterviewPrompt) => unknown;
+  onChange: (key: string, value: string | boolean) => void;
+}) {
+  const firstBlocking = prompts.findIndex((prompt) => prompt.required && !isPromptAnswered(prompt, getValue(prompt)));
+  const visible = firstBlocking === -1 ? prompts : prompts.slice(0, firstBlocking + 1);
+  const remaining = prompts.length - visible.length;
+
+  return (
+    <div className="interview-transcript" role="group" aria-label="Beast interview">
+      {visible.map((prompt, index) => {
+        const value = getValue(prompt);
+        const answered = isPromptAnswered(prompt, value) && (index < visible.length - 1 || firstBlocking === -1);
+        return (
+          <div
+            key={prompt.key}
+            className={`interview-turn ${answered ? 'interview-turn--answered' : 'interview-turn--active'}`}
+            data-step={`${index + 1}/${prompts.length}`}
+          >
             <CatalogPromptField
-              key={prompt.key}
               prompt={prompt}
-              value={getPromptValue(values, prompt)}
-              onChange={(value) => updateField(prompt.key, value)}
+              value={value}
+              onChange={(next) => onChange(prompt.key, next)}
             />
-          ))}
-        </div>
+          </div>
+        );
+      })}
+      {remaining > 0 && (
+        <p className="interview-transcript__pending">
+          {remaining} more question{remaining === 1 ? '' : 's'} after this one
+        </p>
       )}
     </div>
   );

--- a/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.test.tsx
@@ -149,10 +149,12 @@ describe('WizardDialog validation', () => {
     renderWizard();
 
     fireEvent.click(screen.getByRole('radio', { name: /Martin Loop/ }));
-    expect(screen.getByText(/Browser directory pickers cannot provide server paths/i)).toBeTruthy();
 
+    // Interview prompts reveal conversationally: the directory prompt (and its
+    // picker hint) appears once the earlier required answers are provided.
     fireEvent.change(screen.getByLabelText(/Which provider should run the martin loop/i), { target: { value: 'codex' } });
     fireEvent.change(screen.getByLabelText(/What should the martin loop accomplish/i), { target: { value: 'Run chunks' } });
+    expect(screen.getByText(/Browser directory pickers cannot provide server paths/i)).toBeTruthy();
     fireEvent.change(screen.getByLabelText(/Which chunk directory should MartinLoop execute from/i), {
       target: { value: 'C:\\fakepath\\chunks' },
     });

--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -146,7 +146,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
   }
 
   return (
-    <form className="composer" onSubmit={handleSubmit} aria-label="Message composer">
+    <form className="composer terminal-composer" onSubmit={handleSubmit} aria-label="Message composer">
       <label className="composer__field">
         <span className="eyebrow">Dispatch Input</span>
         <textarea

--- a/packages/franken-web/src/components/transcript-pane.tsx
+++ b/packages/franken-web/src/components/transcript-pane.tsx
@@ -18,7 +18,7 @@ export function TranscriptPane({ messages, onRetryMessage, resetKey, retryDisabl
   );
 
   return (
-    <section className="transcript-pane" aria-label="Transcript">
+    <section className="transcript-pane terminal-chat" aria-label="Transcript">
       <div className="transcript-pane__header">
         <div>
           <p className="eyebrow">Command Console</p>

--- a/packages/franken-web/src/main.tsx
+++ b/packages/franken-web/src/main.tsx
@@ -4,6 +4,7 @@ import { App } from './app';
 import { AppErrorBoundary } from './components/app-error-boundary';
 import './styles/tailwind.css';
 import './styles/app.css';
+import './styles/terminal.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/packages/franken-web/src/styles/terminal.css
+++ b/packages/franken-web/src/styles/terminal.css
@@ -1,0 +1,391 @@
+/*
+ * Terminal transcript theme, scoped to the chat + interview surfaces via the
+ * .terminal-chat / .terminal-composer / .terminal-activity / .interview-transcript
+ * roots. Nothing here targets global selectors, so the rest of the dashboard is
+ * unaffected.
+ */
+
+.terminal-chat,
+.terminal-composer,
+.terminal-activity,
+.interview-transcript {
+  --term-bg: #0d1117;
+  --term-panel: #10151c;
+  --term-border: #29313c;
+  --term-text: #e6edf3;
+  --term-muted: #8b949e;
+  --term-accent: #3fb950;
+  --term-user: #58a6ff;
+  --term-beast: #d2a8ff;
+  --term-error: #f85149;
+  --term-mono: ui-monospace, 'SFMono-Regular', 'JetBrains Mono', Menlo, Consolas, monospace;
+  font-family: var(--term-mono);
+}
+
+/* ---------- transcript ---------- */
+
+.terminal-chat {
+  background: var(--term-bg);
+  border: 1px solid var(--term-border);
+  border-radius: 8px;
+  color: var(--term-text);
+}
+
+.terminal-chat .transcript-pane__header {
+  border-bottom: 1px solid var(--term-border);
+  padding: 0.5rem 0.9rem;
+}
+
+.terminal-chat .transcript-pane__header .eyebrow {
+  color: var(--term-accent);
+  font-family: var(--term-mono);
+  letter-spacing: 0.08em;
+}
+
+.terminal-chat .transcript-pane__header .eyebrow::before {
+  content: '● ';
+  color: var(--term-accent);
+}
+
+.terminal-chat .transcript-pane__header h2 {
+  font-family: var(--term-mono);
+  font-size: 0.95rem;
+  color: var(--term-text);
+}
+
+.terminal-chat .transcript-pane__meta {
+  color: var(--term-muted);
+  font-size: 0.72rem;
+}
+
+.terminal-chat .transcript-pane__body {
+  background: var(--term-bg);
+  padding: 0.75rem 0.9rem;
+}
+
+.terminal-chat .empty-state {
+  color: var(--term-muted);
+  border: 1px dashed var(--term-border);
+  background: transparent;
+}
+
+/* turns: flat, prefix-glyphed lines instead of cards */
+.terminal-chat .message-card {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0.35rem 0 0.55rem;
+  border-bottom: none;
+}
+
+.terminal-chat .message-card__meta {
+  gap: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+
+.terminal-chat .message-card__role {
+  font-family: var(--term-mono);
+  font-size: 0.78rem;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  background: transparent;
+  padding: 0;
+}
+
+.terminal-chat .message-card--user .message-card__role {
+  color: var(--term-user);
+}
+
+.terminal-chat .message-card--user .message-card__role::before {
+  content: '> ';
+}
+
+.terminal-chat .message-card--assistant .message-card__role {
+  color: var(--term-beast);
+}
+
+.terminal-chat .message-card--assistant .message-card__role::before {
+  content: '✦ ';
+}
+
+.terminal-chat .message-card__tier,
+.terminal-chat .message-card__receipt {
+  background: transparent;
+  border: 1px solid var(--term-border);
+  border-radius: 4px;
+  color: var(--term-muted);
+  font-family: var(--term-mono);
+  font-size: 0.66rem;
+  padding: 0 0.35rem;
+}
+
+.terminal-chat .message-card__content {
+  color: var(--term-text);
+  font-family: var(--term-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  padding-left: 1.15rem;
+}
+
+.terminal-chat .message-card__error {
+  color: var(--term-error);
+  font-family: var(--term-mono);
+  font-size: 0.78rem;
+  padding-left: 1.15rem;
+}
+
+.terminal-chat .message-card--typing .message-card__content::after {
+  content: '▋';
+  color: var(--term-accent);
+  animation: term-blink 1s steps(2, start) infinite;
+  margin-left: 0.15rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-chat .message-card--typing .message-card__content::after {
+    animation: none;
+  }
+}
+
+@keyframes term-blink {
+  to {
+    visibility: hidden;
+  }
+}
+
+.terminal-chat .scroll-jump-button {
+  font-family: var(--term-mono);
+  background: var(--term-panel);
+  border: 1px solid var(--term-border);
+  color: var(--term-accent);
+}
+
+/* ---------- composer ---------- */
+
+.terminal-composer {
+  background: var(--term-bg);
+  border: 1px solid var(--term-border);
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+  color: var(--term-text);
+}
+
+.terminal-composer .composer__field {
+  position: relative;
+}
+
+.terminal-composer .composer__field > .eyebrow {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.terminal-composer .composer__field::before {
+  content: '❯';
+  position: absolute;
+  left: 0.65rem;
+  top: 0.62rem;
+  color: var(--term-accent);
+  font-family: var(--term-mono);
+  font-size: 0.9rem;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.terminal-composer .composer__textarea {
+  background: var(--term-panel);
+  border: 1px solid var(--term-border);
+  border-radius: 6px;
+  color: var(--term-text);
+  font-family: var(--term-mono);
+  font-size: 0.84rem;
+  padding-left: 1.9rem;
+  caret-color: var(--term-accent);
+}
+
+.terminal-composer .composer__textarea::placeholder {
+  color: var(--term-muted);
+}
+
+.terminal-composer .composer__textarea:focus {
+  outline: none;
+  border-color: var(--term-accent);
+  box-shadow: 0 0 0 1px var(--term-accent);
+}
+
+.terminal-composer .composer__help {
+  color: var(--term-muted);
+  font-family: var(--term-mono);
+  font-size: 0.7rem;
+}
+
+.terminal-composer .composer__footer {
+  border-top: 1px solid var(--term-border);
+  margin-top: 0.5rem;
+  padding-top: 0.45rem;
+}
+
+.terminal-composer .composer__status {
+  color: var(--term-muted);
+  font-family: var(--term-mono);
+  font-size: 0.7rem;
+}
+
+.terminal-composer .composer__status > span:not(.composer__status-message)::before {
+  content: '· ';
+  color: var(--term-accent);
+}
+
+.terminal-composer .composer__error {
+  border: 1px solid var(--term-error);
+  border-radius: 6px;
+  color: var(--term-error);
+  font-family: var(--term-mono);
+  background: transparent;
+}
+
+.terminal-composer .button {
+  font-family: var(--term-mono);
+}
+
+.terminal-composer .button--primary {
+  background: var(--term-accent);
+  border-color: var(--term-accent);
+  color: #04150a;
+}
+
+.terminal-composer .button--secondary {
+  background: transparent;
+  border: 1px solid var(--term-border);
+  color: var(--term-text);
+}
+
+/* ---------- activity rail ---------- */
+
+.terminal-activity {
+  background: var(--term-bg);
+  border: 1px solid var(--term-border);
+  color: var(--term-text);
+}
+
+.terminal-activity .eyebrow {
+  color: var(--term-accent);
+  font-family: var(--term-mono);
+}
+
+.terminal-activity .rail-card__empty {
+  color: var(--term-muted);
+  font-family: var(--term-mono);
+  font-size: 0.75rem;
+}
+
+.terminal-activity .activity-event {
+  background: transparent;
+  border: none;
+  border-left: 2px solid var(--term-border);
+  border-radius: 0;
+  padding: 0.3rem 0 0.3rem 0.6rem;
+}
+
+.terminal-activity .activity-event__title {
+  font-family: var(--term-mono);
+  font-size: 0.78rem;
+  color: var(--term-text);
+}
+
+.terminal-activity .activity-event__title::before {
+  content: '▸ ';
+  color: var(--term-accent);
+}
+
+.terminal-activity .activity-event--danger {
+  border-left-color: var(--term-error);
+}
+
+.terminal-activity .activity-event--warning {
+  border-left-color: #d29922;
+}
+
+.terminal-activity .activity-event__type,
+.terminal-activity .activity-event__summary,
+.terminal-activity .activity-event__timestamp {
+  font-family: var(--term-mono);
+  color: var(--term-muted);
+  font-size: 0.7rem;
+}
+
+.terminal-activity .activity-event__chip {
+  background: transparent;
+  border: 1px solid var(--term-border);
+  border-radius: 4px;
+  font-family: var(--term-mono);
+  font-size: 0.64rem;
+  color: var(--term-muted);
+}
+
+/* ---------- interview transcript (beast wizard) ---------- */
+
+.interview-transcript {
+  background: var(--term-bg);
+  border: 1px solid var(--term-border);
+  border-radius: 8px;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.interview-turn {
+  padding-left: 0.15rem;
+}
+
+.interview-turn label {
+  color: var(--term-beast);
+  font-family: var(--term-mono);
+  font-size: 0.8rem;
+}
+
+.interview-turn::before {
+  content: '✦ question ' attr(data-step);
+  display: block;
+  color: var(--term-beast);
+  font-family: var(--term-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.3rem;
+}
+
+.interview-turn input[type='text'],
+.interview-turn textarea,
+.interview-turn select {
+  background: var(--term-panel) !important;
+  border-color: var(--term-border) !important;
+  color: var(--term-text) !important;
+  font-family: var(--term-mono);
+  font-size: 0.82rem;
+}
+
+.interview-turn--answered {
+  opacity: 0.85;
+}
+
+.interview-turn--active input[type='text'],
+.interview-turn--active textarea,
+.interview-turn--active select {
+  border-color: var(--term-accent) !important;
+}
+
+.interview-transcript__pending {
+  color: var(--term-muted);
+  font-family: var(--term-mono);
+  font-size: 0.72rem;
+}
+
+.interview-transcript__pending::before {
+  content: '⠿ ';
+  color: var(--term-accent);
+}

--- a/packages/franken-web/src/styles/terminal.css
+++ b/packages/franken-web/src/styles/terminal.css
@@ -302,7 +302,7 @@
   color: var(--term-accent);
 }
 
-.terminal-activity .activity-event--danger {
+.terminal-activity .activity-event--error {
   border-left-color: var(--term-error);
 }
 

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -81,7 +81,14 @@ describe('StepWorkflow', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
     render(<StepWorkflow />);
     expect(screen.getByPlaceholderText(/design interview should produce/i)).toBeTruthy();
+    // Later interview questions reveal conversationally once the first
+    // required answer is provided.
+    expect(screen.queryByLabelText(/design document be written/i)).toBeNull();
+    expect(screen.getByText(/1 more question after this one/i)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText(/design interview produce/i), { target: { value: 'Draft billing design' } });
     expect(screen.getByLabelText(/design document be written/i)).toBeTruthy();
+    expect(screen.queryByText(/more question/i)).toBeNull();
   });
 
   it('collects backend design-interview fields', () => {

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -91,6 +91,16 @@ describe('StepWorkflow', () => {
     expect(screen.queryByText(/more question/i)).toBeNull();
   });
 
+  it('renders all interview prompts at once in form view', () => {
+    useBeastStore.getState().toggleWizardMode();
+    useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
+    render(<StepWorkflow />);
+
+    expect(screen.getByLabelText(/design interview produce/i)).toBeTruthy();
+    expect(screen.getByLabelText(/design document be written/i)).toBeTruthy();
+    expect(screen.queryByText(/more question/i)).toBeNull();
+  });
+
   it('collects backend design-interview fields', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'design-interview' });
     render(<StepWorkflow />);


### PR DESCRIPTION
## Summary

Makes the chat and beast-interview surfaces feel like CLI agent UIs (Claude Code / Codex style):

- **Chat transcript**: monospace dark-terminal palette, role-prefixed turns (`>` user, `✦` beast), flat line-based layout instead of cards, blinking-cursor typing indicator (respects `prefers-reduced-motion`), terminal-styled model/receipt chips.
- **Composer**: `❯` prompt prefix, monospace input with accent caret, thin `·`-separated status line, terminal-styled buttons and error banner.
- **Activity rail**: events as `▸` rows with severity-colored left rules.
- **Beast interview (wizard)**: prompts now present conversationally — each question renders as an interviewer turn (`✦ question n/m`), and the next question reveals once the previous required answer is provided; earlier answers stay editable inline. A trailing "N more questions after this one" line telegraphs progress.

## Dashboard safety

All styling is in a new `terminal.css`, scoped exclusively under `.terminal-chat` / `.terminal-composer` / `.terminal-activity` / `.interview-transcript` class roots added to the existing components. No global selectors, no changes to `app.css`, no component API changes. Wizard validation logic and the labeled controls (`getByLabelText` contracts) are unchanged — the interview reveal is purely presentational plus a slice of visible prompts.

## Testing

- Full `@franken/web` suite: **669/669 pass** (two runs to confirm stability)
- Two tests updated to the intended reveal flow; one new assertion covers reveal + progress hint
- `npm run typecheck` and full monorepo `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)