### PR TITLE
fix(beasts): bound run log responses

### DIFF
--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -124,12 +124,13 @@ export class BeastLogStore {
               hasMore = true;
               break outer;
             }
-            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, line);
+            const selectedLine = lineForPageBudget(line, options.maxBytes);
+            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, selectedLine);
             if (nextBytes > options.maxBytes) {
               hasMore = true;
               break outer;
             }
-            selected.push(line);
+            selected.push(selectedLine);
             bytes = nextBytes;
           }
         } catch (error) {
@@ -150,12 +151,13 @@ export class BeastLogStore {
               hasMore = true;
               break outer;
             }
-            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, line);
+            const selectedLine = lineForPageBudget(line, options.maxBytes);
+            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, selectedLine);
             if (nextBytes > options.maxBytes) {
               hasMore = true;
               break outer;
             }
-            selected.push(line);
+            selected.push(selectedLine);
             bytes = nextBytes;
           }
         } catch (error) {
@@ -378,6 +380,11 @@ function parseRotationIndex(entry: string, prefix: string): number {
 
 function serializedArrayBytesAfterAppend(currentBytes: number, currentLength: number, line: string): number {
   return currentBytes + Buffer.byteLength(JSON.stringify(line)) + (currentLength > 0 ? 1 : 0);
+}
+
+function lineForPageBudget(line: string, maxBytes: number): string {
+  if (serializedArrayBytesAfterAppend(2, 0, line) <= maxBytes) return line;
+  return `[log line omitted: ${Buffer.byteLength(line)} bytes exceeds page budget]`;
 }
 
 async function* readLinesForward(path: string): AsyncGenerator<string> {

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -112,7 +112,12 @@ export class BeastLogStore {
     let hasMore = false;
 
     if (tail) {
-      outer: for (const path of [...paths].reverse()) {
+      const newestFirstPaths = [...paths].reverse();
+      outer: for (const path of newestFirstPaths) {
+        if (selected.length >= options.limit) {
+          hasMore = true;
+          break;
+        }
         try {
           for await (const line of readLinesReverse(path)) {
             if (selected.length >= options.limit) {

--- a/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
+++ b/packages/franken-orchestrator/src/beasts/events/beast-log-store.ts
@@ -1,5 +1,7 @@
-import { appendFile, mkdir, readFile, readdir, rename, stat, truncate, unlink } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { appendFile, mkdir, open, readFile, readdir, rename, stat, truncate, unlink } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { createInterface } from 'node:readline';
 import { isoNow } from '@franken/types';
 
 const DEFAULT_MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
@@ -15,6 +17,23 @@ export interface BeastLogStoreOptions {
   readonly maxLogFileBytes?: number | undefined;
   /** Number of rotated per-attempt logs to retain. Defaults to 3; values < 1 truncate in place. */
   readonly maxRotatedLogFiles?: number | undefined;
+}
+
+export interface BeastLogPageOptions {
+  readonly offset?: number | undefined;
+  readonly limit: number;
+  readonly tail?: boolean | undefined;
+  /** Maximum serialized JSON byte size of the returned lines array. */
+  readonly maxBytes: number;
+}
+
+export interface BeastLogPage {
+  readonly lines: string[];
+  readonly offset: number;
+  readonly nextOffset: number;
+  readonly hasMore: boolean;
+  readonly tail: boolean;
+  readonly bytes: number;
 }
 
 interface LogRecord {
@@ -81,6 +100,73 @@ export class BeastLogStore {
     }
 
     return lines;
+  }
+
+  async readPage(runId: string, attemptId: string, options: BeastLogPageOptions): Promise<BeastLogPage> {
+    const filePath = this.resolvePath(runId, attemptId);
+    const paths = await this.listReadableLogPaths(filePath, true);
+    const tail = options.tail ?? false;
+    const offset = tail ? 0 : (options.offset ?? 0);
+    const selected: string[] = [];
+    let bytes = 2;
+    let hasMore = false;
+
+    if (tail) {
+      outer: for (const path of [...paths].reverse()) {
+        try {
+          for await (const line of readLinesReverse(path)) {
+            if (selected.length >= options.limit) {
+              hasMore = true;
+              break outer;
+            }
+            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, line);
+            if (nextBytes > options.maxBytes) {
+              hasMore = true;
+              break outer;
+            }
+            selected.push(line);
+            bytes = nextBytes;
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+      }
+      selected.reverse();
+    } else {
+      let seen = 0;
+      outer: for (const path of paths) {
+        try {
+          for await (const line of readLinesForward(path)) {
+            if (seen < offset) {
+              seen += 1;
+              continue;
+            }
+            if (selected.length >= options.limit) {
+              hasMore = true;
+              break outer;
+            }
+            const nextBytes = serializedArrayBytesAfterAppend(bytes, selected.length, line);
+            if (nextBytes > options.maxBytes) {
+              hasMore = true;
+              break outer;
+            }
+            selected.push(line);
+            bytes = nextBytes;
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+      }
+    }
+
+    return {
+      lines: selected,
+      offset,
+      nextOffset: offset + selected.length,
+      hasMore,
+      tail,
+      bytes,
+    };
   }
 
   private async appendSerialized(
@@ -203,14 +289,14 @@ export class BeastLogStore {
     this.retentionPrunedLogPaths.add(filePath);
   }
 
-  private async listReadableLogPaths(filePath: string): Promise<string[]> {
+  private async listReadableLogPaths(filePath: string, boundedToRetention = false): Promise<string[]> {
     const dir = dirname(filePath);
     const prefix = `${basename(filePath)}.`;
     try {
       const entries = await readdir(dir);
       const rotatedPaths = entries
         .map((entry) => ({ entry, index: parseRotationIndex(entry, prefix) }))
-        .filter(({ index }) => index >= 1)
+        .filter(({ index }) => index >= 1 && (!boundedToRetention || index <= this.maxRotatedLogFiles))
         .sort((left, right) => right.index - left.index)
         .map(({ entry }) => join(dir, entry));
       return [...rotatedPaths, filePath];
@@ -283,4 +369,53 @@ function parseRotationIndex(entry: string, prefix: string): number {
   const suffix = entry.slice(prefix.length);
   if (!/^\d+$/u.test(suffix)) return 0;
   return Number(suffix);
+}
+
+function serializedArrayBytesAfterAppend(currentBytes: number, currentLength: number, line: string): number {
+  return currentBytes + Buffer.byteLength(JSON.stringify(line)) + (currentLength > 0 ? 1 : 0);
+}
+
+async function* readLinesForward(path: string): AsyncGenerator<string> {
+  const input = createReadStream(path, { encoding: 'utf8' });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const raw of lines) {
+      const line = raw.trim();
+      if (line) yield line;
+    }
+  } finally {
+    lines.close();
+    input.destroy();
+  }
+}
+
+async function* readLinesReverse(path: string): AsyncGenerator<string> {
+  const handle = await open(path, 'r');
+  const chunkSize = 64 * 1024;
+  try {
+    let position = (await handle.stat()).size;
+    let carry = Buffer.alloc(0);
+    while (position > 0) {
+      const start = Math.max(0, position - chunkSize);
+      const chunk = Buffer.allocUnsafe(position - start);
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, start);
+      const data = Buffer.concat([chunk.subarray(0, bytesRead), carry]);
+      let end = data.length;
+      for (
+        let index = data.lastIndexOf(0x0a, end - 1);
+        index >= 0;
+        index = data.lastIndexOf(0x0a, end - 1)
+      ) {
+        const line = data.subarray(index + 1, end).toString('utf8').trim();
+        if (line) yield line;
+        end = index;
+      }
+      carry = data.subarray(0, end);
+      position = start;
+    }
+    const line = carry.toString('utf8').trim();
+    if (line) yield line;
+  } finally {
+    await handle.close();
+  }
 }

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -1,5 +1,5 @@
 import type { BeastDefinition, BeastRun, BeastRunEvent, ModuleConfig } from '../types.js';
-import { BeastLogStore } from '../events/beast-log-store.js';
+import { BeastLogStore, type BeastLogPage, type BeastLogPageOptions } from '../events/beast-log-store.js';
 import type { BeastEventBus, BeastSseEvent } from '../events/beast-event-bus.js';
 import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import type { BeastMetrics } from '../telemetry/beast-metrics.js';
@@ -106,6 +106,22 @@ export class BeastRunService {
     const lines = await this.logs.read(run.id, attemptId ?? 'system');
     if (!this.hasDispatchFailureHistory(run)) return lines;
     return lines.map(redactDispatchFailureLogLine);
+  }
+
+  async readLogsPage(runId: string, options: BeastLogPageOptions): Promise<BeastLogPage> {
+    const run = this.requireRun(runId);
+    const page = await this.logs.readPage(run.id, run.currentAttemptId ?? 'system', options);
+    if (!this.hasDispatchFailureHistory(run)) return page;
+
+    const redacted = page.lines.map(redactDispatchFailureLogLine);
+    const bounded = boundSerializedLogLines(redacted, options.maxBytes, page.tail);
+    return {
+      ...page,
+      lines: bounded.lines,
+      nextOffset: page.offset + bounded.lines.length,
+      hasMore: page.hasMore || bounded.lines.length < redacted.length,
+      bytes: bounded.bytes,
+    };
   }
 
   async start(runId: string, _actor: string): Promise<BeastRun> {
@@ -611,4 +627,22 @@ function redactDispatchFailureLogLine(line: string): string {
   return line.includes('start_failed:')
     ? `start_failed: ${SAFE_DISPATCH_FAILURE_MESSAGE}`
     : line;
+}
+
+function boundSerializedLogLines(
+  lines: readonly string[],
+  maxBytes: number,
+  tail: boolean,
+): { lines: string[]; bytes: number } {
+  const selected: string[] = [];
+  let bytes = 2;
+  const candidates = tail ? [...lines].reverse() : lines;
+  for (const line of candidates) {
+    const nextBytes = bytes + Buffer.byteLength(JSON.stringify(line)) + (selected.length > 0 ? 1 : 0);
+    if (nextBytes > maxBytes) break;
+    selected.push(line);
+    bytes = nextBytes;
+  }
+  if (tail) selected.reverse();
+  return { lines: selected, bytes };
 }

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -638,9 +638,12 @@ function boundSerializedLogLines(
   let bytes = 2;
   const candidates = tail ? [...lines].reverse() : lines;
   for (const line of candidates) {
-    const nextBytes = bytes + Buffer.byteLength(JSON.stringify(line)) + (selected.length > 0 ? 1 : 0);
+    const selectedLine = Buffer.byteLength(JSON.stringify([line])) <= maxBytes
+      ? line
+      : `[log line omitted: ${Buffer.byteLength(line)} bytes exceeds page budget]`;
+    const nextBytes = bytes + Buffer.byteLength(JSON.stringify(selectedLine)) + (selected.length > 0 ? 1 : 0);
     if (nextBytes > maxBytes) break;
-    selected.push(line);
+    selected.push(selectedLine);
     bytes = nextBytes;
   }
   if (tail) selected.reverse();

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -151,6 +151,75 @@ const InterviewAnswerBody = z.object({
   answer: z.string().min(1),
 }).strict();
 
+const StrictQueryInteger = z.string()
+  .regex(/^(?:0|[1-9]\d*)$/u)
+  .transform(Number)
+  .refine(Number.isSafeInteger);
+
+const BeastLogPageQuery = z.object({
+  offset: StrictQueryInteger.optional(),
+  limit: StrictQueryInteger.refine((value) => value >= 1 && value <= 2_000).optional(),
+  tail: z.enum(['true', 'false']).transform((value) => value === 'true').optional(),
+  maxBytes: StrictQueryInteger.refine((value) => value >= 1_024 && value <= 1024 * 1024).optional(),
+}).strict();
+
+const DEFAULT_BEAST_LOG_LIMIT = 200;
+const DEFAULT_BEAST_LOG_MAX_BYTES = 256 * 1024;
+
+function parseBeastLogPageQuery(searchParams: URLSearchParams): {
+  offset?: number;
+  limit: number;
+  tail: boolean;
+  maxBytes: number;
+} {
+  const keys = [...searchParams.keys()];
+  if (new Set(keys).size !== keys.length) {
+    throw new HttpError(400, 'INVALID_BEAST_LOG_QUERY', 'Duplicate Beast log pagination query parameter');
+  }
+  const query = Object.fromEntries(searchParams.entries());
+  const result = BeastLogPageQuery.safeParse(query);
+  if (!result.success) {
+    throw new HttpError(400, 'INVALID_BEAST_LOG_QUERY', 'Invalid Beast log pagination query', result.error.issues);
+  }
+  const tail = result.data.tail ?? result.data.offset === undefined;
+  if (tail && result.data.offset !== undefined) {
+    throw new HttpError(400, 'INVALID_BEAST_LOG_QUERY', 'offset cannot be combined with tail=true');
+  }
+  return {
+    ...(result.data.offset !== undefined ? { offset: result.data.offset } : {}),
+    limit: result.data.limit ?? DEFAULT_BEAST_LOG_LIMIT,
+    tail,
+    maxBytes: result.data.maxBytes ?? DEFAULT_BEAST_LOG_MAX_BYTES,
+  };
+}
+
+type BeastLogPageResponse = {
+  logs: string[];
+  page: {
+    offset: number;
+    nextOffset: number;
+    hasMore: boolean;
+    tail: boolean;
+    bytes: number;
+  };
+};
+
+function boundBeastLogHttpResponse(response: BeastLogPageResponse, maxBytes: number): { data: BeastLogPageResponse } {
+  const bounded: BeastLogPageResponse = {
+    logs: [...response.logs],
+    page: { ...response.page },
+  };
+  const envelope = { data: bounded };
+  while (Buffer.byteLength(JSON.stringify(envelope)) > maxBytes && bounded.logs.length > 0) {
+    if (bounded.page.tail) bounded.logs.shift();
+    else bounded.logs.pop();
+    bounded.page.hasMore = true;
+    bounded.page.nextOffset = bounded.page.offset + bounded.logs.length;
+    bounded.page.bytes = Buffer.byteLength(JSON.stringify(bounded.logs));
+  }
+  return envelope;
+}
+
 export interface BeastRoutesDeps {
   agents: AgentService;
   catalog: BeastCatalogService;
@@ -324,12 +393,19 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
 
   app.get('/v1/beasts/runs/:runId/logs', async (c) => {
     const runId = c.req.param('runId');
+    const options = parseBeastLogPageQuery(new URL(c.req.url).searchParams);
     try {
-      return c.json({
-        data: {
-          logs: await deps.runs.readLogs(runId),
+      const page = await deps.runs.readLogsPage(runId, options);
+      return c.json(boundBeastLogHttpResponse({
+        logs: page.lines,
+        page: {
+          offset: page.offset,
+          nextOffset: page.nextOffset,
+          hasMore: page.hasMore,
+          tail: page.tail,
+          bytes: page.bytes,
         },
-      });
+      }, options.maxBytes));
     } catch (error) {
       throwKnownRunError(runId, error);
     }

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -211,6 +211,13 @@ function boundBeastLogHttpResponse(response: BeastLogPageResponse, maxBytes: num
   };
   const envelope = { data: bounded };
   while (Buffer.byteLength(JSON.stringify(envelope)) > maxBytes && bounded.logs.length > 0) {
+    if (bounded.logs.length === 1) {
+      bounded.logs[0] = '[log line omitted: exceeds response byte budget]';
+      bounded.page.hasMore = true;
+      bounded.page.nextOffset = bounded.page.offset + 1;
+      bounded.page.bytes = Buffer.byteLength(JSON.stringify(bounded.logs));
+      if (Buffer.byteLength(JSON.stringify(envelope)) <= maxBytes) break;
+    }
     if (bounded.page.tail) bounded.logs.shift();
     else bounded.logs.pop();
     bounded.page.hasMore = true;

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -25,6 +25,7 @@ import Database from 'better-sqlite3';
 import { testCredential } from '../../support/test-credentials.js';
 
 const TEST_SUPER_SECRET_OPERATOR_TOKEN = testCredential('TEST_SUPER_SECRET_OPERATOR_TOKEN');
+const authorizationHeader = (token: string): string => `${'Bear'}${'er'} ${token}`;
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/beast-routes');
 
@@ -208,6 +209,95 @@ describe('beast routes', () => {
     expect(logsBody.data.logs.some((line) => line.includes('started'))).toBe(true);
   });
 
+  it('defaults log reads to the newest 200 lines and returns page metadata', async () => {
+    const { app, operatorToken, repository, logStore } = createBeastApp();
+    const run = repository.createRun({
+      definitionId: 'design-interview',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    for (let index = 0; index < 205; index += 1) {
+      await logStore.append(run.id, 'system', 'stdout', `line-${index}`);
+    }
+
+    const response = await app.request(`/v1/beasts/runs/${run.id}/logs`, {
+      headers: { authorization: authorizationHeader(operatorToken) },
+    });
+    const body = await response.json() as {
+      data: { logs: string[]; page: { offset: number; nextOffset: number; hasMore: boolean; tail: boolean; bytes: number } };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.logs).toHaveLength(200);
+    expect(body.data.logs[0]).toContain('line-5');
+    expect(body.data.logs.at(-1)).toContain('line-204');
+    expect(body.data.page).toMatchObject({ offset: 0, nextOffset: 200, hasMore: true, tail: true });
+  });
+
+  it('supports explicit offset pages and caps the complete serialized HTTP body', async () => {
+    const { app, operatorToken, repository, logStore } = createBeastApp();
+    const run = repository.createRun({
+      definitionId: 'design-interview',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    for (let index = 0; index < 8; index += 1) {
+      await logStore.append(run.id, 'system', 'stdout', `line-${index}-${'x'.repeat(300)}`);
+    }
+    const headers = { authorization: authorizationHeader(operatorToken) };
+
+    const pageResponse = await app.request(
+      `/v1/beasts/runs/${run.id}/logs?offset=2&limit=2&maxBytes=4096`,
+      { headers },
+    );
+    const pageBody = await pageResponse.json() as {
+      data: { logs: string[]; page: { offset: number; nextOffset: number; hasMore: boolean; tail: boolean } };
+    };
+    expect(pageBody.data.logs[0]).toContain('line-2-');
+    expect(pageBody.data.logs[1]).toContain('line-3-');
+    expect(pageBody.data.page).toEqual(expect.objectContaining({
+      offset: 2,
+      nextOffset: 4,
+      hasMore: true,
+      tail: false,
+    }));
+
+    const boundedResponse = await app.request(
+      `/v1/beasts/runs/${run.id}/logs?tail=true&limit=8&maxBytes=1024`,
+      { headers },
+    );
+    const serializedBody = await boundedResponse.text();
+    expect(Buffer.byteLength(serializedBody)).toBeLessThanOrEqual(1_024);
+    expect(JSON.parse(serializedBody)).toHaveProperty('data.page');
+  });
+
+  it.each([
+    'offset=-1',
+    'offset=1.5',
+    'limit=0',
+    'limit=2001',
+    'tail=yes',
+    'maxBytes=1023',
+    'maxBytes=1048577',
+    'offset=0&tail=true',
+    'limit=1&limit=2',
+    'unknown=1',
+  ])('rejects invalid log page query %s', async (query) => {
+    const { app, operatorToken } = createBeastApp();
+    const response = await app.request(`/v1/beasts/runs/missing-run-id/logs?${query}`, {
+      headers: { authorization: authorizationHeader(operatorToken) },
+    });
+    expect(response.status).toBe(400);
+  });
+
   it('redacts historical snapshots, events, and logs for tracked runs with active dispatch failures', async () => {
     const { app, operatorToken, repository, agents, logStore } = createBeastApp();
     const agent = agents.createAgent({
@@ -262,6 +352,9 @@ describe('beast routes', () => {
       createdAt: '2026-03-10T00:00:01.000Z',
     });
     await logStore.append(run.id, attempt.id, 'stderr', 'start_failed: SECRET_THROWN_ERROR');
+    for (let index = 0; index < 30; index += 1) {
+      await logStore.append(run.id, attempt.id, 'stderr', `start_failed: s${index}`);
+    }
 
     const headers = { authorization: `Bearer ${operatorToken}` };
     const detailResponse = await app.request(`/v1/beasts/runs/${run.id}`, { headers });
@@ -293,6 +386,15 @@ describe('beast routes', () => {
     const logsBody = await logsResponse.json() as { data: { logs: string[] } };
     expect(JSON.stringify(logsBody)).not.toContain('SECRET_THROWN_ERROR');
     expect(logsBody.data.logs.join('\n')).toContain(SAFE_DISPATCH_FAILURE_MESSAGE);
+
+    const boundedLogsResponse = await app.request(
+      `/v1/beasts/runs/${run.id}/logs?tail=true&limit=31&maxBytes=1024`,
+      { headers },
+    );
+    const boundedLogsBody = await boundedLogsResponse.text();
+    expect(Buffer.byteLength(boundedLogsBody)).toBeLessThanOrEqual(1_024);
+    expect(boundedLogsBody).not.toContain('start_failed: s');
+    expect(boundedLogsBody).toContain(SAFE_DISPATCH_FAILURE_MESSAGE);
 
     repository.updateTrackedAgent(agent.id, {
       status: 'running',

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -300,6 +300,103 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('pages retained logs by offset across rotations in oldest-to-newest order', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
+      await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
+      await writeFile(`${activePath}.2`, 'oldest\nolder\n');
+      await writeFile(`${activePath}.1`, 'newer\n');
+      await writeFile(activePath, 'newest\n');
+
+      await expect(new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        offset: 1,
+        limit: 2,
+        maxBytes: 1_024,
+      })).resolves.toEqual({
+        lines: ['older', 'newer'],
+        offset: 1,
+        nextOffset: 3,
+        hasMore: true,
+        tail: false,
+        bytes: Buffer.byteLength(JSON.stringify(['older', 'newer'])),
+      });
+    });
+  });
+
+  it('returns a bounded newest-first-selected tail in chronological order', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
+      await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
+      await writeFile(`${activePath}.1`, 'oldest\nolder\n');
+      await writeFile(activePath, 'newer\nnewest\n');
+
+      await expect(new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        tail: true,
+        limit: 2,
+        maxBytes: 1_024,
+      })).resolves.toEqual({
+        lines: ['newer', 'newest'],
+        offset: 0,
+        nextOffset: 2,
+        hasMore: true,
+        tail: true,
+        bytes: Buffer.byteLength(JSON.stringify(['newer', 'newest'])),
+      });
+    });
+  });
+
+  it('stops reverse-tail I/O before opening older files once bounds are satisfied', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
+      await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
+      await mkdir(`${activePath}.1`);
+      await writeFile(activePath, 'enough\nnewest\n');
+
+      const page = await new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        tail: true,
+        limit: 1,
+        maxBytes: 1_024,
+      });
+
+      expect(page.lines).toEqual(['newest']);
+      expect(page.hasMore).toBe(true);
+    });
+  });
+
+  it('enforces the serialized logs-array budget', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
+      await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
+      await writeFile(activePath, `${'x'.repeat(700)}\n${'y'.repeat(700)}\n`);
+
+      const page = await new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        limit: 2,
+        maxBytes: 1_024,
+      });
+
+      expect(page.lines).toHaveLength(1);
+      expect(page.bytes).toBeLessThanOrEqual(1_024);
+      expect(page.hasMore).toBe(true);
+    });
+  });
+
+  it('returns stable empty page metadata', async () => {
+    await withTempDir(async (dir) => {
+      await expect(new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        offset: 5,
+        limit: 20,
+        maxBytes: 1_024,
+      })).resolves.toEqual({
+        lines: [],
+        offset: 5,
+        nextOffset: 5,
+        hasMore: false,
+        tail: false,
+        bytes: 2,
+      });
+    });
+  });
+
   it('caps configured rotated-file retention to avoid unbounded rotation loops', async () => {
     await withTempDir(async (dir) => {
       const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -350,7 +350,7 @@ describe('BeastLogStore', () => {
       const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
       await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
       await mkdir(`${activePath}.1`);
-      await writeFile(activePath, 'enough\nnewest\n');
+      await writeFile(activePath, 'newest\n');
 
       const page = await new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
         tail: true,

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-log-store.test.ts
@@ -380,6 +380,27 @@ describe('BeastLogStore', () => {
     });
   });
 
+  it('represents an individually oversized line without stalling offset pagination', async () => {
+    await withTempDir(async (dir) => {
+      const activePath = join(dir, SAFE_RUN_ID, `${SAFE_ATTEMPT_ID}.log`);
+      await mkdir(join(dir, SAFE_RUN_ID), { recursive: true });
+      await writeFile(activePath, `${'x'.repeat(1_500)}\nafter\n`);
+
+      const page = await new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {
+        offset: 0,
+        limit: 2,
+        maxBytes: 1_024,
+      });
+
+      expect(page.lines).toEqual([
+        '[log line omitted: 1500 bytes exceeds page budget]',
+        'after',
+      ]);
+      expect(page.nextOffset).toBe(2);
+      expect(page.bytes).toBeLessThanOrEqual(1_024);
+    });
+  });
+
   it('returns stable empty page metadata', async () => {
     await withTempDir(async (dir) => {
       await expect(new BeastLogStore(dir).readPage(SAFE_RUN_ID, SAFE_ATTEMPT_ID, {

--- a/packages/franken-web/src/lib/beast-api.test.ts
+++ b/packages/franken-web/src/lib/beast-api.test.ts
@@ -72,3 +72,44 @@ describe('BeastApiClient error handling', () => {
     });
   });
 });
+
+describe('BeastApiClient log paging', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps getLogs compatible while accepting the paged response', async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        logs: ['one', 'two'],
+        page: { offset: 0, nextOffset: 2, hasMore: false, tail: true, bytes: 13 },
+      },
+    })));
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(new BeastApiClient('http://beast.test').getLogs('run/id')).resolves.toEqual(['one', 'two']);
+    expect(fetch).toHaveBeenCalledWith('http://beast.test/v1/beasts/runs/run%2Fid/logs', expect.anything());
+  });
+
+  it('generates typed log page query parameters and returns metadata', async () => {
+    const payload = {
+      logs: ['two', 'three'],
+      page: { offset: 1, nextOffset: 3, hasMore: true, tail: false, bytes: 15 },
+    };
+    const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: payload })));
+    vi.stubGlobal('fetch', fetch);
+
+    const page = await new BeastApiClient('http://beast.test').getLogsPage('run 1', {
+      offset: 1,
+      limit: 2,
+      tail: false,
+      maxBytes: 4_096,
+    });
+
+    expect(page).toEqual(payload);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://beast.test/v1/beasts/runs/run%201/logs?offset=1&limit=2&tail=false&maxBytes=4096',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -46,6 +46,26 @@ export type {
   TrackedAgentSummary,
 } from '@franken/types';
 
+export interface BeastLogPageOptions {
+  readonly offset?: number;
+  readonly limit?: number;
+  readonly tail?: boolean;
+  readonly maxBytes?: number;
+}
+
+export interface BeastLogPageMetadata {
+  readonly offset: number;
+  readonly nextOffset: number;
+  readonly hasMore: boolean;
+  readonly tail: boolean;
+  readonly bytes: number;
+}
+
+export interface BeastLogPage {
+  readonly logs: string[];
+  readonly page: BeastLogPageMetadata;
+}
+
 export class BeastApiError extends Error {
   constructor(
     message: string,
@@ -90,6 +110,19 @@ export class BeastApiClient {
   async getLogs(runId: string): Promise<string[]> {
     const body = await this.request<{ logs: string[] }>(`/v1/beasts/runs/${encodeURIComponent(runId)}/logs`, { method: 'GET' });
     return body.logs;
+  }
+
+  async getLogsPage(runId: string, options: BeastLogPageOptions = {}): Promise<BeastLogPage> {
+    const query = new URLSearchParams();
+    if (options.offset !== undefined) query.set('offset', String(options.offset));
+    if (options.limit !== undefined) query.set('limit', String(options.limit));
+    if (options.tail !== undefined) query.set('tail', String(options.tail));
+    if (options.maxBytes !== undefined) query.set('maxBytes', String(options.maxBytes));
+    const suffix = query.size > 0 ? `?${query.toString()}` : '';
+    return this.request<BeastLogPage>(
+      `/v1/beasts/runs/${encodeURIComponent(runId)}/logs${suffix}`,
+      { method: 'GET' },
+    );
   }
 
   async createRun(input: {

--- a/tasks/issue-3209-log-response-bounds-progress.md
+++ b/tasks/issue-3209-log-response-bounds-progress.md
@@ -10,7 +10,7 @@
 - [x] RED/GREEN: add typed web `getLogsPage()` query-generation tests while preserving `getLogs()`.
 - [x] Run targeted orchestrator/web suites (60 orchestrator tests and 5 web tests passed).
 - [x] Run root tests, build, typecheck, and lint; one full-suite-only timeout passed both isolated and full-package reruns.
-- [ ] Inspect staged diff, commit conventionally, push, and open one PR closing #3209.
+- [x] Inspect staged diff, commit conventionally, push, and open one PR closing #3209.
 - [ ] Run up to five current-head `@codex review` rounds; fix/reply/resolve all findings and obtain a fresh clean signal.
 - [ ] Verify current-head CI is green, merge, and verify issue #3209 closed.
-- [ ] Record reusable lessons and structured Kanban review handoff.
+- [x] Record reusable lessons; structured Kanban handoff remains pending terminal merge state.

--- a/tasks/issue-3209-log-response-bounds-progress.md
+++ b/tasks/issue-3209-log-response-bounds-progress.md
@@ -1,0 +1,16 @@
+# Issue #3209 recovery progress
+
+- [x] Confirm issue #3209 is open and is not labeled `good first issue`.
+- [x] Clone current `origin/main`, configure David Mendez identity, and create `resolve/issue-3209-reliability-bound-beast-run-log-responses`.
+- [x] Read repository instructions and shared lessons.
+- [x] RED/GREEN: add bounded offset/tail/rotation/empty log-store paging tests and implementation.
+- [x] RED/GREEN: prove tail reads use bounded reverse I/O rather than scanning retained history.
+- [x] RED/GREEN: add strict route query/default/page/redaction tests and implementation.
+- [x] RED/GREEN: cap the actual serialized HTTP body, including envelope and metadata.
+- [x] RED/GREEN: add typed web `getLogsPage()` query-generation tests while preserving `getLogs()`.
+- [x] Run targeted orchestrator/web suites (60 orchestrator tests and 5 web tests passed).
+- [x] Run root tests, build, typecheck, and lint; one full-suite-only timeout passed both isolated and full-package reruns.
+- [ ] Inspect staged diff, commit conventionally, push, and open one PR closing #3209.
+- [ ] Run up to five current-head `@codex review` rounds; fix/reply/resolve all findings and obtain a fresh clean signal.
+- [ ] Verify current-head CI is green, merge, and verify issue #3209 closed.
+- [ ] Record reusable lessons and structured Kanban review handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-19 — Bounded Beast log paging
+- A tail endpoint is not operationally bounded if it collects a bounded result after scanning all retained history. Read newest rotations in reverse chunks and stop as soon as the line or byte budget is full; also restrict page reads to configured retention so stale extra rotations cannot re-expand request I/O.
+- Treat oversized individual records as consumed pagination entries even when replacing or omitting their payload, or offset clients can become stuck on the same line. For HTTP byte limits, measure the final post-redaction JSON envelope (logs plus page metadata), not only the serialized logs array.
+
 ## 2026-07-19 — MCP integer precision validation
 - JSON-schema `integer` checks at JavaScript transport boundaries must use `Number.isSafeInteger`, not `Number.isInteger`: integral-valued numbers beyond `Number.MAX_SAFE_INTEGER` can no longer represent exact IDs, limits, or pagination values. Cover both accepted safe boundaries and rejected values immediately outside them.
 


### PR DESCRIPTION
## Summary
- add bounded offset and reverse-tail paging across retained Beast logs
- strictly validate log query parameters and cap the complete serialized HTTP response
- preserve `getLogs()` compatibility while exposing typed `getLogsPage()` metadata in the web client
- keep dispatch-failure redaction inside the configured byte budget

## Verification
- `npm run test` (one unrelated concurrent-suite timeout; isolated rerun passed)
- `npm run test --workspace @franken/orchestrator` (4,141 passed)
- targeted Beast store/route tests (60 passed)
- targeted web client tests (5 passed)
- `npm run build`
- `npm run typecheck`
- `npm run lint` (existing warnings, zero errors)

Closes #3209