### PR TITLE
test(planner): prove same-wave concurrency

### DIFF
--- a/packages/franken-planner/tests/unit/planners/parallel.test.ts
+++ b/packages/franken-planner/tests/unit/planners/parallel.test.ts
@@ -88,23 +88,27 @@ describe('ParallelPlanner — happy path', () => {
     expect(executor).toHaveBeenCalledWith(task);
   });
 
-  it('executes independent tasks concurrently in the same wave', async () => {
+  it('starts every ready task before waiting for same-wave work to finish', async () => {
     const a = makeTask('a');
     const b = makeTask('b');
     const graph = PlanGraph.empty().addTask(a).addTask(b);
-
-    const callOrder: string[] = [];
-    const executor = vi.fn().mockImplementation((task: Task) => {
-      callOrder.push(task.id);
-      return Promise.resolve(success(task.id));
+    let releaseWave: (() => void) | undefined;
+    const waveBarrier = new Promise<void>((resolve) => {
+      releaseWave = resolve;
+    });
+    const executor = vi.fn().mockImplementation(async (task: Task) => {
+      await waveBarrier;
+      return success(task.id);
     });
 
-    const result = await new ParallelPlanner().execute(graph, { executor });
+    const execution = new ParallelPlanner().execute(graph, { executor });
+    try {
+      expect(executor).toHaveBeenCalledTimes(2);
+    } finally {
+      releaseWave?.();
+    }
 
-    expect(result.status).toBe('completed');
-    expect(executor).toHaveBeenCalledTimes(2);
-    expect(callOrder).toContain(createTaskId('a'));
-    expect(callOrder).toContain(createTaskId('b'));
+    await expect(execution).resolves.toMatchObject({ status: 'completed' });
   });
 
   it('limits same-wave task execution to the configured concurrency', async () => {


### PR DESCRIPTION
## Summary
- replace the call-order-only parallel planner assertion with a same-wave barrier
- require both ready tasks to start before either task is released
- prove the test fails against a deliberately serialized `for...of await` mutation

## Test Plan
- `npm test` (`@franken/planner`: 242 passed)
- `npm run typecheck` (`@franken/planner`)
- `npm run build` (`@franken/planner`)
- `npm run lint` (`@franken/planner`)
- mutation check: serialized same-wave execution fails the new assertion (2 expected calls, 1 observed)

Closes #2514