### PR TITLE
fix(observer): batch SQLite adapter drains

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -193,6 +193,45 @@ describe('BatchAdapter — buffering', () => {
 // ── drain() ───────────────────────────────────────────────────────────────────
 
 describe('BatchAdapter — drain()', () => {
+  it('uses the inner adapter bulk flush capability once per drain', async () => {
+    const flush = vi.fn(async () => undefined)
+    const flushBatch = vi.fn(async () => undefined)
+    const inner: ExportAdapter = {
+      flush,
+      flushBatch,
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+    const first = makeTrace('bulk-a')
+    const second = makeTrace('bulk-b')
+
+    await batch.flush(first)
+    await batch.flush(second)
+    await batch.drain()
+
+    expect(flushBatch).toHaveBeenCalledOnce()
+    expect(flushBatch).toHaveBeenCalledWith([first, second])
+    expect(flush).not.toHaveBeenCalled()
+    expect(await batch.listTraceIds()).toEqual([])
+  })
+
+  it('retains the entire batch when an atomic bulk flush fails', async () => {
+    const traces = [makeTrace('bulk-fail-a'), makeTrace('bulk-fail-b')]
+    const inner: ExportAdapter = {
+      async flush() { throw new Error('individual flush should not run') },
+      async flushBatch() { throw new Error('batch transaction rolled back') },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })
+
+    for (const trace of traces) await batch.flush(trace)
+
+    await expect(batch.drain()).rejects.toThrow('batch transaction rolled back')
+    expect((await batch.listTraceIds()).sort()).toEqual(['bulk-fail-a', 'bulk-fail-b'])
+  })
+
   it('flushes all buffered traces to the inner adapter', async () => {
     const inner = new InMemoryAdapter()
     const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 100 })

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -365,6 +365,30 @@ describe('BatchAdapter — drain()', () => {
     expect(await batch.listTraceIds()).toEqual(['old'])
   })
 
+  it('does not include stale bulk failures in a new size-triggered flush', async () => {
+    const oldFailure = deferred()
+    const calls: string[][] = []
+    const inner: ExportAdapter = {
+      async flush() { throw new Error('individual flush should not run') },
+      async flushBatch(traces) {
+        calls.push(traces.map(trace => trace.id))
+        if (traces.some(trace => trace.id === 'old')) return oldFailure.promise
+      },
+      async queryByTraceId() { return null },
+      async listTraceIds() { return [] },
+    }
+    const batch = new BatchAdapter({ adapter: inner, maxBatchSize: 1 })
+
+    const oldFlush = batch.flush(makeTrace('old'))
+    const newFlush = batch.flush(makeTrace('new'))
+
+    oldFailure.reject(new Error('old batch failed'))
+    await expect(oldFlush).rejects.toThrow('old batch failed')
+    await expect(newFlush).resolves.toBeUndefined()
+    expect(calls).toEqual([['old'], ['new']])
+    expect(await batch.listTraceIds()).toEqual(['old'])
+  })
+
   it('surfaces failures from follow-up size-triggered drains after the older drain succeeds', async () => {
     const oldSuccess = deferred()
     const inner: ExportAdapter = {

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -156,6 +156,16 @@ export class BatchAdapter implements ExportAdapter {
   private async drainBufferedTraces(batch: Trace[]): Promise<void> {
     if (batch.length === 0) return
 
+    if (this.inner.flushBatch !== undefined) {
+      await this.inner.flushBatch(batch)
+      for (const trace of batch) {
+        const index = this.buffer.indexOf(trace)
+        if (index !== -1) this.buffer.splice(index, 1)
+      }
+      if (this.buffer.length === 0 && this.timer !== null) setTimerRefState(this.timer, false)
+      return
+    }
+
     const results = await Promise.allSettled(batch.map(t => this.inner.flush(t)))
     const failures: unknown[] = []
 

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -138,19 +138,40 @@ export class BatchAdapter implements ExportAdapter {
     try {
       await currentDrain
     } catch {
-      if (this.buffer.length > 0) {
-        try {
-          await this.drain()
-        } catch (error) {
-          if (this.buffer.includes(triggerTrace)) {
-            throw error instanceof Error ? error : new Error(String(error))
-          }
+      try {
+        await this.drainBufferedTrace(triggerTrace)
+      } catch (error) {
+        if (this.buffer.includes(triggerTrace)) {
+          throw error instanceof Error ? error : new Error(String(error))
         }
       }
       return
     }
 
     if (this.buffer.length >= this.maxBatchSize) await this.drain()
+  }
+
+  private async drainBufferedTrace(trace: Trace): Promise<void> {
+    while (this.buffer.includes(trace)) {
+      if (this.drainPromise !== null) {
+        const activeDrain = this.drainPromise
+        try {
+          await activeDrain
+        } catch {
+          // This trace was queued after the failed drain, so its result is independent.
+        }
+        if (this.drainPromise === activeDrain) this.drainPromise = null
+        continue
+      }
+
+      const followUpDrain = Promise.resolve().then(() => this.drainBufferedTraces([trace]))
+      this.drainPromise = followUpDrain
+      try {
+        await followUpDrain
+      } finally {
+        if (this.drainPromise === followUpDrain) this.drainPromise = null
+      }
+    }
   }
 
   private async drainBufferedTraces(batch: Trace[]): Promise<void> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -141,6 +141,25 @@ describe('SQLiteAdapter', () => {
     expect(upsertSpanRun).toHaveBeenCalledWith(expect.objectContaining({ metadata: '{}' }))
   })
 
+  it('flushes a batch in one SQLite transaction', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (traces: unknown) => fn(traces))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const first = TraceContext.createTrace('first')
+    const second = TraceContext.createTrace('second')
+
+    await adapter.flushBatch([first, second])
+
+    expect(transactionMock).toHaveBeenCalledOnce()
+    expect(upsertTraceRun).toHaveBeenCalledTimes(2)
+    expect(upsertTraceRun.mock.calls.map(call => call[0].goal)).toEqual(['first', 'second'])
+  })
+
   it('retries transient SQLite lock failures with bounded backoff and diagnostics', async () => {
     const sleep = vi.fn().mockResolvedValue(undefined)
     const diagnostics = vi.fn()

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -160,6 +160,36 @@ describe('SQLiteAdapter', () => {
     expect(upsertTraceRun.mock.calls.map(call => call[0].goal)).toEqual(['first', 'second'])
   })
 
+  it('persists the last duplicate span snapshot within a batch', async () => {
+    const upsertTraceRun = vi.fn()
+    const upsertSpanRun = vi.fn()
+    prepareMock.mockReturnValue({ run: vi.fn() })
+    prepareMock
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+      .mockReturnValueOnce({ run: upsertTraceRun })
+      .mockReturnValueOnce({ run: upsertSpanRun })
+    transactionMock.mockImplementation(fn => (traces: unknown) => fn(traces))
+
+    const adapter = new SQLiteAdapter('/tmp/traces.db')
+    const trace = TraceContext.createTrace('duplicate snapshots')
+    const span = TraceContext.startSpan(trace, { name: 'first' })
+    TraceContext.endSpan(span)
+    await adapter.flush(trace)
+
+    const intermediate = structuredClone(trace)
+    intermediate.spans[0]!.metadata.version = 1
+    const reverted = structuredClone(trace)
+
+    await adapter.flushBatch([intermediate, reverted])
+
+    expect(upsertSpanRun.mock.calls.map(call => call[0].metadata)).toEqual([
+      '{}',
+      '{"version":1}',
+      '{}',
+    ])
+  })
+
   it('retries transient SQLite lock failures with bounded backoff and diagnostics', async () => {
     const sleep = vi.fn().mockResolvedValue(undefined)
     const diagnostics = vi.fn()

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -314,45 +314,54 @@ export class SQLiteAdapter implements ExportAdapter {
 
   async flush(trace: Trace): Promise<void> {
     const snapshot = snapshotTrace(trace)
-    return this.enqueueSqliteWrite(() => this.flushNow(snapshot))
+    return this.enqueueSqliteWrite(() => this.flushNow([snapshot]))
   }
 
-  private async flushNow(trace: Trace): Promise<void> {
-    warnIfTraceHasActiveSpans(trace, 'SQLiteAdapter')
-    const flushedInTransaction = await this.withSqliteLockRetry('flush trace transaction', () => {
+  async flushBatch(traces: Trace[]): Promise<void> {
+    if (traces.length === 0) return
+    const snapshots = traces.map(snapshotTrace)
+    return this.enqueueSqliteWrite(() => this.flushNow(snapshots))
+  }
+
+  private async flushNow(traces: Trace[]): Promise<void> {
+    for (const trace of traces) warnIfTraceHasActiveSpans(trace, 'SQLiteAdapter')
+    const operation = traces.length === 1 ? 'flush trace transaction' : 'flush trace batch transaction'
+    const flushedInTransaction = await this.withSqliteLockRetry(operation, () => {
       const upsertTrace = this.db.prepare(UPSERT_TRACE)
       const upsertSpan = this.db.prepare(UPSERT_SPAN)
       const flushed: Span[] = []
 
-      const transaction = this.db.transaction((t: Trace) => {
-        upsertTrace.run({
-          id: t.id,
-          goal: t.goal,
-          status: t.status,
-          startedAt: t.startedAt,
-          endedAt: t.endedAt ?? null,
-        })
-        for (const span of t.spans) {
-          if (!this.shouldFlushSpan(span)) continue
-
-          upsertSpan.run({
-            id: span.id,
-            traceId: span.traceId,
-            parentSpanId: span.parentSpanId ?? null,
-            name: span.name,
-            status: span.status,
-            startedAt: span.startedAt,
-            endedAt: span.endedAt ?? null,
-            durationMs: span.durationMs ?? null,
-            errorMessage: span.errorMessage ?? null,
-            metadata: JSON.stringify(span.metadata),
-            thoughtBlocks: JSON.stringify(span.thoughtBlocks),
+      const transaction = this.db.transaction((batch: Trace[]) => {
+        for (const trace of batch) {
+          upsertTrace.run({
+            id: trace.id,
+            goal: trace.goal,
+            status: trace.status,
+            startedAt: trace.startedAt,
+            endedAt: trace.endedAt ?? null,
           })
-          flushed.push(span)
+          for (const span of trace.spans) {
+            if (!this.shouldFlushSpan(span)) continue
+
+            upsertSpan.run({
+              id: span.id,
+              traceId: span.traceId,
+              parentSpanId: span.parentSpanId ?? null,
+              name: span.name,
+              status: span.status,
+              startedAt: span.startedAt,
+              endedAt: span.endedAt ?? null,
+              durationMs: span.durationMs ?? null,
+              errorMessage: span.errorMessage ?? null,
+              metadata: JSON.stringify(span.metadata),
+              thoughtBlocks: JSON.stringify(span.thoughtBlocks),
+            })
+            flushed.push(span)
+          }
         }
       })
 
-      transaction(trace)
+      transaction(traces)
       return flushed
     })
     for (const span of flushedInTransaction) {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -332,6 +332,7 @@ export class SQLiteAdapter implements ExportAdapter {
       const flushed: Span[] = []
 
       const transaction = this.db.transaction((batch: Trace[]) => {
+        const batchFlushedSpans = new Map<string, FlushedSpanState>()
         for (const trace of batch) {
           upsertTrace.run({
             id: trace.id,
@@ -341,7 +342,10 @@ export class SQLiteAdapter implements ExportAdapter {
             endedAt: trace.endedAt ?? null,
           })
           for (const span of trace.spans) {
-            if (!this.shouldFlushSpan(span)) continue
+            const batchKey = `${span.traceId}\0${span.id}`
+            const previous = batchFlushedSpans.get(batchKey)
+              ?? this.flushedSpans.get(span.traceId)?.get(span.id)
+            if (!this.shouldFlushSpan(span, previous)) continue
 
             upsertSpan.run({
               id: span.id,
@@ -357,6 +361,7 @@ export class SQLiteAdapter implements ExportAdapter {
               thoughtBlocks: JSON.stringify(span.thoughtBlocks),
             })
             flushed.push(span)
+            batchFlushedSpans.set(batchKey, this.toFlushedSpanState(span))
           }
         }
       })
@@ -369,9 +374,10 @@ export class SQLiteAdapter implements ExportAdapter {
     }
   }
 
-  private shouldFlushSpan(span: Span): boolean {
-    const byTrace = this.flushedSpans.get(span.traceId)
-    const previous = byTrace?.get(span.id)
+  private shouldFlushSpan(
+    span: Span,
+    previous = this.flushedSpans.get(span.traceId)?.get(span.id),
+  ): boolean {
     if (previous === undefined) return true
 
     // Active spans are still mutable: metadata/thought blocks can grow and the
@@ -398,6 +404,21 @@ export class SQLiteAdapter implements ExportAdapter {
     return previous.thoughtBlocksJson !== JSON.stringify(span.thoughtBlocks)
   }
 
+  private toFlushedSpanState(span: Span): FlushedSpanState {
+    return {
+      status: span.status,
+      endedAt: span.endedAt,
+      durationMs: span.durationMs,
+      errorMessage: span.errorMessage,
+      metadata: span.metadata,
+      metadataKeyCount: Object.keys(span.metadata).length,
+      metadataJson: JSON.stringify(span.metadata),
+      thoughtBlocks: span.thoughtBlocks,
+      thoughtBlockCount: span.thoughtBlocks.length,
+      thoughtBlocksJson: JSON.stringify(span.thoughtBlocks),
+    }
+  }
+
   private rememberFlushedSpan(span: Span): void {
     if (this.maxFlushedSpanSnapshots === 0) return
 
@@ -409,18 +430,7 @@ export class SQLiteAdapter implements ExportAdapter {
     if (!byTrace.has(span.id)) {
       this.flushedSpanSnapshotCount += 1
     }
-    byTrace.set(span.id, {
-      status: span.status,
-      endedAt: span.endedAt,
-      durationMs: span.durationMs,
-      errorMessage: span.errorMessage,
-      metadata: span.metadata,
-      metadataKeyCount: Object.keys(span.metadata).length,
-      metadataJson: JSON.stringify(span.metadata),
-      thoughtBlocks: span.thoughtBlocks,
-      thoughtBlockCount: span.thoughtBlocks.length,
-      thoughtBlocksJson: JSON.stringify(span.thoughtBlocks),
-    })
+    byTrace.set(span.id, this.toFlushedSpanState(span))
     this.pruneFlushedSpanSnapshots(span.traceId)
   }
 

--- a/packages/franken-observer/src/export/ExportAdapter.ts
+++ b/packages/franken-observer/src/export/ExportAdapter.ts
@@ -27,6 +27,11 @@ export function warnIfTraceHasActiveSpans(trace: Trace, destination = 'export'):
 export interface ExportAdapter {
   /** Persist a completed trace. Implementations should upsert. */
   flush(trace: Trace): Promise<void>
+  /**
+   * Persist multiple completed traces as one backend operation when supported.
+   * Implementations should make the batch atomic; callers fall back to flush().
+   */
+  flushBatch?(traces: Trace[]): Promise<void>
   /** Retrieve a trace by id. Returns null if not found. */
   queryByTraceId(traceId: string): Promise<Trace | null>
   /** List all stored trace ids. */

--- a/tasks/issue-3352-progress.md
+++ b/tasks/issue-3352-progress.md
@@ -1,0 +1,9 @@
+# Issue 3352 progress
+
+- [x] Verify issue is open and not labeled `good first issue`
+- [x] Read shared project lessons and inspect BatchAdapter/SQLiteAdapter paths
+- [x] Add failing regressions for bulk drain delegation and one SQLite transaction per batch
+- [x] Implement optional bulk flush contract and SQLite atomic batch persistence
+- [x] Run focused observer tests, typecheck, lint, and build
+- [ ] Commit, push, open a one-issue PR, and drive CI/Codex to current-head clean
+- [ ] Merge, verify issue closure, and record reusable lessons


### PR DESCRIPTION
## Summary
- add an optional bulk-flush capability to export adapters
- have BatchAdapter use atomic bulk flushes when supported
- persist SQLite drain batches in one queued transaction while preserving rollback/retry semantics

## Test plan
- `npm run test --workspace @franken/observer -- src/adapters/batch/BatchAdapter.test.ts src/adapters/sqlite/SQLiteAdapter.test.ts`
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run test --workspace @franken/observer`
- `INTEGRATION=true npm run test --workspace @franken/observer -- src/adapters/sqlite/SQLiteAdapter.integration.test.ts`

Closes #3352