### PR TITLE
fix(beasts): paginate run event API

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -201,6 +201,11 @@ export interface CorruptJsonRecoveryOptions {
   readonly recoverCorruptJson?: boolean;
 }
 
+export interface ListBeastRunEventsOptions extends CorruptJsonRecoveryOptions {
+  readonly afterSequence?: number;
+  readonly limit?: number;
+}
+
 export interface BeastRunProcessReference {
   readonly id: string;
   readonly trackedAgentId?: string | undefined;
@@ -481,10 +486,27 @@ export class SQLiteBeastRepository {
     return event;
   }
 
-  listEvents(runId: string, options: CorruptJsonRecoveryOptions = {}): BeastRunEvent[] {
-    const rows = this.db.prepare(
-      'SELECT * FROM beast_run_events WHERE run_id = ? ORDER BY sequence ASC',
-    ).all(runId) as BeastEventRow[];
+  listEvents(runId: string, options: ListBeastRunEventsOptions = {}): BeastRunEvent[] {
+    if (options.afterSequence !== undefined
+      && (!Number.isSafeInteger(options.afterSequence) || options.afterSequence < 0)) {
+      throw new RangeError('afterSequence must be a non-negative safe integer');
+    }
+    if (options.limit !== undefined
+      && (!Number.isSafeInteger(options.limit) || options.limit < 1)) {
+      throw new RangeError('limit must be a positive safe integer');
+    }
+    const clauses = ['run_id = ?'];
+    const parameters: Array<string | number> = [runId];
+    if (options.afterSequence !== undefined) {
+      clauses.push('sequence > ?');
+      parameters.push(options.afterSequence);
+    }
+    let sql = `SELECT * FROM beast_run_events WHERE ${clauses.join(' AND ')} ORDER BY sequence ASC`;
+    if (options.limit !== undefined) {
+      sql += ' LIMIT ?';
+      parameters.push(options.limit);
+    }
+    const rows = this.db.prepare(sql).all(...parameters) as BeastEventRow[];
     return mapRowsRecoveringCorruptJson(rows, mapEvent, options);
   }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -495,6 +495,22 @@ export class SQLiteBeastRepository {
       && (!Number.isSafeInteger(options.limit) || options.limit < 1)) {
       throw new RangeError('limit must be a positive safe integer');
     }
+    if (options.limit !== undefined && options.recoverCorruptJson) {
+      const events: BeastRunEvent[] = [];
+      let cursor = options.afterSequence ?? 0;
+      while (events.length < options.limit) {
+        const batchLimit = options.limit - events.length;
+        const rows = this.db.prepare(
+          'SELECT * FROM beast_run_events WHERE run_id = ? AND sequence > ? ORDER BY sequence ASC LIMIT ?',
+        ).all(runId, cursor, batchLimit) as BeastEventRow[];
+        if (rows.length === 0) break;
+        events.push(...mapRowsRecoveringCorruptJson(rows, mapEvent, options));
+        cursor = rows[rows.length - 1]!.sequence;
+        if (rows.length < batchLimit) break;
+      }
+      return events;
+    }
+
     const clauses = ['run_id = ?'];
     const parameters: Array<string | number> = [runId];
     if (options.afterSequence !== undefined) {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -44,6 +44,7 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     FOREIGN KEY (run_id) REFERENCES beast_runs(id),
     FOREIGN KEY (attempt_id) REFERENCES beast_run_attempts(id)
   )`,
+  'CREATE INDEX IF NOT EXISTS idx_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
   `CREATE TABLE IF NOT EXISTS beast_interview_sessions (
     id TEXT PRIMARY KEY,
     definition_id TEXT NOT NULL,

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -93,6 +93,29 @@ export class BeastRunService {
     return this.listEventsFromRepository(runId, true);
   }
 
+  listEventPageForResponse(runId: string, afterSequence: number, limit: number) {
+    const run = this.requireRun(runId);
+    let events = this.repository.listEvents(runId, {
+      recoverCorruptJson: true,
+      afterSequence,
+      limit: limit + 1,
+    });
+    if (this.hasDispatchFailureHistory(run)) {
+      events = events.map(redactDispatchFailureEvent);
+    }
+    const hasMore = events.length > limit;
+    const pageEvents = hasMore ? events.slice(0, limit) : events;
+    return {
+      events: pageEvents,
+      page: {
+        limit,
+        afterSequence,
+        nextAfterSequence: hasMore ? pageEvents.at(-1)?.sequence ?? null : null,
+        hasMore,
+      },
+    };
+  }
+
   private listEventsFromRepository(runId: string, recoverCorruptJson = false) {
     const run = this.requireRun(runId);
     const events = this.repository.listEvents(runId, { recoverCorruptJson });

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -44,6 +44,26 @@ type BeastRunResponse = BeastRun & {
   readonly workspaceContainerPath?: unknown;
 };
 
+const DEFAULT_BEAST_EVENT_PAGE_LIMIT = 100;
+const MAX_BEAST_EVENT_PAGE_LIMIT = 500;
+
+function parseBeastEventPagination(query: Record<string, string>): { afterSequence: number; limit: number } {
+  const afterSequenceRaw = query.afterSequence ?? '0';
+  const limitRaw = query.limit ?? String(DEFAULT_BEAST_EVENT_PAGE_LIMIT);
+  const isUnsignedInteger = (value: string): boolean => /^(0|[1-9]\d*)$/.test(value);
+  const afterSequence = isUnsignedInteger(afterSequenceRaw) ? Number(afterSequenceRaw) : Number.NaN;
+  const limit = isUnsignedInteger(limitRaw) ? Number(limitRaw) : Number.NaN;
+  if (!Number.isSafeInteger(afterSequence) || afterSequence < 0
+    || !Number.isSafeInteger(limit) || limit < 1 || limit > MAX_BEAST_EVENT_PAGE_LIMIT) {
+    throw new HttpError(
+      400,
+      'INVALID_BEAST_EVENT_PAGINATION',
+      `afterSequence must be a non-negative integer and limit must be between 1 and ${MAX_BEAST_EVENT_PAGE_LIMIT}`,
+    );
+  }
+  return { afterSequence, limit };
+}
+
 function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAttempt[]): BeastRunResponse | undefined {
   if (!run || run.executionMode !== 'container') {
     return run;
@@ -304,18 +324,17 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       data: {
         run: runWithContainerFields(deps.runs.sanitizeRunForResponse(run), attempts),
         attempts,
-        events: deps.runs.listEventsForResponse(runId),
+        events: deps.runs.listEventPageForResponse(runId, 0, DEFAULT_BEAST_EVENT_PAGE_LIMIT).events,
       },
     });
   });
 
   app.get('/v1/beasts/runs/:runId/events', (c) => {
     const runId = c.req.param('runId');
+    const { afterSequence, limit } = parseBeastEventPagination(c.req.query());
     try {
       return c.json({
-        data: {
-          events: deps.runs.listEventsForResponse(runId),
-        },
+        data: deps.runs.listEventPageForResponse(runId, afterSequence, limit),
       });
     } catch (error) {
       throwKnownRunError(runId, error);

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -208,6 +208,98 @@ describe('beast routes', () => {
     expect(logsBody.data.logs.some((line) => line.includes('started'))).toBe(true);
   });
 
+  it('returns bounded run event pages in sequence order', async () => {
+    const { app, operatorToken, repository } = createBeastApp();
+    const run = repository.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    for (let sequence = 1; sequence <= 101; sequence += 1) {
+      repository.appendEvent(run.id, {
+        type: `run.event.${sequence}`,
+        payload: { sequence },
+        createdAt: new Date(Date.UTC(2026, 2, 10, 0, 0, sequence)).toISOString(),
+      });
+    }
+    const headers = { authorization: `Bearer ${operatorToken}` };
+
+    const defaultResponse = await app.request(`/v1/beasts/runs/${run.id}/events`, { headers });
+    expect(defaultResponse.status).toBe(200);
+    const defaultPage = await defaultResponse.json() as {
+      data: {
+        events: Array<{ sequence: number }>;
+        page: { limit: number; afterSequence: number; nextAfterSequence: number | null; hasMore: boolean };
+      };
+    };
+    expect(defaultPage.data.events).toHaveLength(100);
+    expect(defaultPage.data.page).toEqual({
+      limit: 100,
+      afterSequence: 0,
+      nextAfterSequence: 100,
+      hasMore: true,
+    });
+
+    const detailResponse = await app.request(`/v1/beasts/runs/${run.id}`, { headers });
+    const detail = await detailResponse.json() as { data: { events: Array<{ sequence: number }> } };
+    expect(detail.data.events).toHaveLength(100);
+
+    const firstResponse = await app.request(`/v1/beasts/runs/${run.id}/events?limit=2`, { headers });
+    expect(firstResponse.status).toBe(200);
+    const first = await firstResponse.json() as {
+      data: {
+        events: Array<{ sequence: number }>;
+        page: { limit: number; afterSequence: number; nextAfterSequence: number | null; hasMore: boolean };
+      };
+    };
+    expect(first.data.events.map((event) => event.sequence)).toEqual([1, 2]);
+    expect(first.data.page).toEqual({
+      limit: 2,
+      afterSequence: 0,
+      nextAfterSequence: 2,
+      hasMore: true,
+    });
+
+    const secondResponse = await app.request(
+      `/v1/beasts/runs/${run.id}/events?limit=2&afterSequence=${first.data.page.nextAfterSequence}`,
+      { headers },
+    );
+    const second = await secondResponse.json() as typeof first;
+    expect(second.data.events.map((event) => event.sequence)).toEqual([3, 4]);
+    expect(second.data.page).toEqual({
+      limit: 2,
+      afterSequence: 2,
+      nextAfterSequence: 4,
+      hasMore: true,
+    });
+
+    const finalResponse = await app.request(`/v1/beasts/runs/${run.id}/events?limit=2&afterSequence=100`, { headers });
+    const finalPage = await finalResponse.json() as typeof first;
+    expect(finalPage.data.events.map((event) => event.sequence)).toEqual([101]);
+    expect(finalPage.data.page).toEqual({
+      limit: 2,
+      afterSequence: 100,
+      nextAfterSequence: null,
+      hasMore: false,
+    });
+
+    const invalidResponses = await Promise.all([
+      app.request(`/v1/beasts/runs/${run.id}/events?limit=501`, { headers }),
+      app.request(`/v1/beasts/runs/${run.id}/events?afterSequence=`, { headers }),
+      app.request(`/v1/beasts/runs/${run.id}/events?limit=2.5`, { headers }),
+    ]);
+    for (const response of invalidResponses) {
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: { code: 'INVALID_BEAST_EVENT_PAGINATION' },
+      });
+    }
+  });
+
   it('redacts historical snapshots, events, and logs for tracked runs with active dispatch failures', async () => {
     const { app, operatorToken, repository, agents, logStore } = createBeastApp();
     const agent = agents.createAgent({

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -339,6 +339,34 @@ describe('SQLiteBeastRepository', () => {
     });
   });
 
+  it('keeps recovered event pages full across corrupt rows and indexes the cursor query', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const databasePath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(databasePath);
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const events = Array.from({ length: 4 }, (_, index) => repo.appendEvent(run.id, {
+      type: `run.event.${index + 1}`,
+      payload: { sequence: index + 1 },
+      createdAt: `2026-03-10T00:00:0${index + 1}.000Z`,
+    }));
+    const database = new Database(databasePath);
+    database.prepare('UPDATE beast_run_events SET payload = ? WHERE id = ?').run('{invalid', events[1]!.id);
+
+    expect(repo.listEvents(run.id, { recoverCorruptJson: true, limit: 3 }).map((event) => event.sequence))
+      .toEqual([1, 3, 4]);
+    const indexes = database.pragma("index_list('beast_run_events')") as Array<{ name: string }>;
+    expect(indexes.map((index) => index.name)).toContain('idx_beast_run_events_run_sequence');
+    database.close();
+  });
+
   it('creates, lists, and loads tracked agents', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -331,6 +331,7 @@ describe('SQLiteBeastRepository', () => {
     expect(event1.sequence).toBe(1);
     expect(event2.sequence).toBe(2);
     expect(repo.listEvents(run.id)).toEqual([event1, event2]);
+    expect(repo.listEvents(run.id, { afterSequence: 1, limit: 1 })).toEqual([event2]);
     expect(repo.getRun(run.id)).toMatchObject({
       status: 'stopped',
       latestExitCode: 137,

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -188,6 +188,18 @@ export interface BeastRunEvent {
   createdAt: string;
 }
 
+export interface BeastRunEventPageInfo {
+  limit: number;
+  afterSequence: number;
+  nextAfterSequence: number | null;
+  hasMore: boolean;
+}
+
+export interface BeastRunEventPage {
+  events: BeastRunEvent[];
+  page: BeastRunEventPageInfo;
+}
+
 export interface BeastRunAttempt {
   id: string;
   runId: string;

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -125,6 +125,12 @@ Path-style fields entered in the dashboard are normalized client-side before sub
 
 Execution controls (`start`, `stop`, `restart`, `kill`) still target Beast runs after a tracked agent has dispatched.
 
+### Beast run event pagination
+
+`GET /v1/beasts/runs/:runId/events` returns events in ascending sequence order and never performs an unbounded API read. Use the optional `limit` query parameter (default `100`, maximum `500`) and pass the response's non-null `page.nextAfterSequence` back as `afterSequence` to request the next page. The response includes `page.hasMore`; when it is `false`, `nextAfterSequence` is `null`. Invalid, negative, or over-limit pagination values return `400 INVALID_BEAST_EVENT_PAGINATION`.
+
+The dashboard API client exposes the same contract through `BeastApiClient.getRunEvents(runId, { limit, afterSequence })`. Run-detail responses retain a compatibility `events` array, bounded to the first default page; consumers that need later events must page through the dedicated event endpoint.
+
 ### Read-only degraded mode
 
 When Beast daemon health detects dependency read failures, or when an operator manually enters degraded mode with `POST /v1/beasts/availability/degraded`, the daemon reports `status: "degraded"` and an `availability` object from `/health`. Read-only diagnostics such as `/health`, `/v1/beasts/catalog`, `/v1/beasts/runs`, `/v1/beasts/agents`, run events/logs, dashboard snapshots, and SSE tickets remain available so operators can inspect state during partial outages.

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -401,13 +401,12 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
           const detail = await client.getAgent(currentAgentId);
           if (!cancelled) {
             if (detail.agent.dispatchRunId) {
-              const [run, events, logs] = await Promise.all([
+              const [run, logs] = await Promise.all([
                 client.getRun(detail.agent.dispatchRunId),
-                client.getAllRunEvents(detail.agent.dispatchRunId),
                 client.getLogs(detail.agent.dispatchRunId),
               ]);
               if (!cancelled) {
-                setBeastAgentDetail({ ...detail, run: { ...run, events, logs } });
+                setBeastAgentDetail({ ...detail, run: { ...run, logs } });
               }
             } else {
               setBeastAgentDetail({ ...detail, run: null });

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -7,6 +7,7 @@ import type {
   BeastEventHandlers,
   BeastExecutionMode,
   BeastRunDetail,
+  BeastRunEventPage,
   BeastRunSummary,
   BeastSseAgentEvent,
   BeastSseAgentStatusEvent,
@@ -31,6 +32,7 @@ export type {
   BeastEventHandlers,
   BeastExecutionMode,
   BeastRunDetail,
+  BeastRunEventPage,
   BeastRunSummary,
   BeastSseAgentEvent,
   BeastSseAgentStatusEvent,
@@ -81,6 +83,17 @@ export class BeastApiClient {
 
   async getRun(runId: string): Promise<Omit<BeastRunDetail, 'logs'> & { run: BeastRunSummary }> {
     return this.request(`/v1/beasts/runs/${encodeURIComponent(runId)}`, { method: 'GET' });
+  }
+
+  async getRunEvents(
+    runId: string,
+    options: { limit?: number; afterSequence?: number } = {},
+  ): Promise<BeastRunEventPage> {
+    const query = new URLSearchParams();
+    if (options.limit !== undefined) query.set('limit', String(options.limit));
+    if (options.afterSequence !== undefined) query.set('afterSequence', String(options.afterSequence));
+    const suffix = query.size > 0 ? `?${query.toString()}` : '';
+    return this.request(`/v1/beasts/runs/${encodeURIComponent(runId)}/events${suffix}`, { method: 'GET' });
   }
 
   async getAgent(agentId: string): Promise<TrackedAgentDetail> {

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -7,7 +7,6 @@ import type {
   BeastEventHandlers,
   BeastExecutionMode,
   BeastRunDetail,
-  BeastRunEvent,
   BeastRunEventPage,
   BeastRunSummary,
   BeastSseAgentEvent,
@@ -115,21 +114,6 @@ export class BeastApiClient {
     if (options.afterSequence !== undefined) query.set('afterSequence', String(options.afterSequence));
     const suffix = query.size > 0 ? `?${query.toString()}` : '';
     return this.request(`/v1/beasts/runs/${encodeURIComponent(runId)}/events${suffix}`, { method: 'GET' });
-  }
-
-  async getAllRunEvents(runId: string): Promise<BeastRunEvent[]> {
-    const events: BeastRunEvent[] = [];
-    let afterSequence = 0;
-    while (true) {
-      const page = await this.getRunEvents(runId, { limit: 500, afterSequence });
-      events.push(...page.events);
-      if (!page.page.hasMore) return events;
-      const nextAfterSequence = page.page.nextAfterSequence;
-      if (nextAfterSequence === null || nextAfterSequence <= afterSequence) {
-        throw new Error('Beast run event pagination did not advance');
-      }
-      afterSequence = nextAfterSequence;
-    }
   }
 
   async getAgent(agentId: string): Promise<TrackedAgentDetail> {

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -124,7 +124,6 @@ const mockGetRun = vi.fn().mockResolvedValue({
   attempts: [],
   events: [],
 });
-const mockGetAllRunEvents = vi.fn().mockResolvedValue([]);
 
 const mockGetLogs = vi.fn().mockResolvedValue(['started from chat']);
 const mockCreateAgent = vi.fn().mockResolvedValue({
@@ -288,7 +287,6 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     getContainerRuntimeStatus: typeof mockGetContainerRuntimeStatus;
     getAgent: typeof mockGetAgent;
     getRun: typeof mockGetRun;
-    getAllRunEvents: typeof mockGetAllRunEvents;
     getLogs: typeof mockGetLogs;
     createAgent: typeof mockCreateAgent;
     deleteAgent: typeof mockDeleteAgent;
@@ -310,7 +308,6 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     this.getContainerRuntimeStatus = mockGetContainerRuntimeStatus;
     this.getAgent = mockGetAgent;
     this.getRun = mockGetRun;
-    this.getAllRunEvents = mockGetAllRunEvents;
     this.getLogs = mockGetLogs;
     this.createAgent = mockCreateAgent;
     this.deleteAgent = mockDeleteAgent;
@@ -520,8 +517,6 @@ afterEach(() => {
     attempts: [],
     events: [],
   });
-  mockGetAllRunEvents.mockReset();
-  mockGetAllRunEvents.mockResolvedValue([]);
 });
 
 describe('buildInitAction', () => {
@@ -561,16 +556,6 @@ describe('buildInitAction', () => {
 });
 
 describe('ChatShell', () => {
-  it('hydrates the selected Beast run from the paginated event API', async () => {
-    window.location.hash = '#/beasts';
-
-    render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
-
-    await waitFor(() => {
-      expect(mockGetAllRunEvents).toHaveBeenCalledWith('run-1');
-    });
-  });
-
   it('renders Frankenbeast branding and keeps the version in the sidebar footer', () => {
     const { container } = render(<ChatShell baseUrl="http://localhost:3000" projectId="test-project" version="0.9.0" />);
     const nav = container.querySelector('[aria-label="Dashboard navigation"]');

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -192,42 +192,6 @@ describe('BeastApiClient', () => {
     );
   });
 
-  it('loads complete run event history across bounded pages', async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          data: {
-            events: [{ id: 'event-1', runId: 'run-1', sequence: 1, type: 'run.started', payload: {}, createdAt: '2026-03-10T00:00:01.000Z' }],
-            page: { limit: 500, afterSequence: 0, nextAfterSequence: 1, hasMore: true },
-          },
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          data: {
-            events: [{ id: 'event-2', runId: 'run-1', sequence: 2, type: 'run.finished', payload: {}, createdAt: '2026-03-10T00:00:02.000Z' }],
-            page: { limit: 500, afterSequence: 1, nextAfterSequence: null, hasMore: false },
-          },
-        }),
-      });
-
-    const events = await client.getAllRunEvents('run-1');
-
-    expect(events.map((event) => event.sequence)).toEqual([1, 2]);
-    expect(mockFetch).toHaveBeenNthCalledWith(
-      1,
-      'http://localhost:3000/v1/beasts/runs/run-1/events?limit=500&afterSequence=0',
-      expect.objectContaining({ method: 'GET' }),
-    );
-    expect(mockFetch).toHaveBeenNthCalledWith(
-      2,
-      'http://localhost:3000/v1/beasts/runs/run-1/events?limit=500&afterSequence=1',
-      expect.objectContaining({ method: 'GET' }),
-    );
-  });
-
   it('resumes a tracked agent through the agent-specific endpoint', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -172,6 +172,26 @@ describe('BeastApiClient', () => {
     );
   });
 
+  it('requests later bounded Beast run event pages', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: {
+          events: [{ id: 'event-3', runId: 'run-1', sequence: 3, type: 'run.finished', payload: {}, createdAt: '2026-03-10T00:00:03.000Z' }],
+          page: { limit: 25, afterSequence: 2, nextAfterSequence: null, hasMore: false },
+        },
+      }),
+    });
+
+    const page = await client.getRunEvents('run-1', { limit: 25, afterSequence: 2 });
+
+    expect(page.events.map((event) => event.sequence)).toEqual([3]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/beasts/runs/run-1/events?limit=25&afterSequence=2',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('resumes a tracked agent through the agent-specific endpoint', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/tasks/issue-3208-progress.md
+++ b/tasks/issue-3208-progress.md
@@ -6,7 +6,7 @@
 - [x] Implement bounded sequence pagination with a hard maximum and later-page cursor.
 - [x] Bound run-detail compatibility events and document the pagination contract.
 - [x] Run focused tests, full lint/typecheck/build, and relevant tests for the initial implementation.
-- [x] Add review regressions for dashboard event hydration and bounded corrupt-row recovery.
-- [x] Implement paginated dashboard hydration and raw-row-bounded recovery cursors.
+- [x] Investigate dashboard event usage and add a bounded corrupt-row recovery regression.
+- [x] Implement raw-row-bounded recovery cursors without blocking details on unused event history.
 - [x] Re-run full lint, typecheck, build, and tests after review fixes and base reconciliation.
 - [ ] Commit, push, open PR, pass CI and current-head Codex review, merge.

--- a/tasks/issue-3208-progress.md
+++ b/tasks/issue-3208-progress.md
@@ -1,0 +1,9 @@
+# Issue #3208 progress
+
+- [x] Verify live issue scope, labels, duplicate PRs, and isolated branch/worktree.
+- [x] Read shared project lessons and inspect route, service, repository, shared types, client, and tests.
+- [x] Add failing pagination tests for repository, HTTP API, and web client.
+- [x] Implement bounded sequence pagination with a hard maximum and later-page cursor.
+- [x] Bound run-detail compatibility events and document the pagination contract.
+- [x] Run focused tests, full lint/typecheck/build, and relevant tests.
+- [ ] Commit, push, open PR, pass CI and current-head Codex review, merge.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-20 — Bounded Beast event paging through corrupt rows
+- Recovery pagination must bound raw rows scanned, not only healthy rows returned. Return the last scanned raw sequence plus an indexed `hasMore` probe so a short or empty page can advance past corrupt rows without turning one request into a full-history scan.
+- Before wiring a new paginated endpoint into dashboard hydration, trace which detail field the UI actually renders. Do not eagerly collect every page for an unused compatibility field; keep the bounded endpoint available for intentional consumers and preserve fast detail loading.
+
 ## 2026-07-19 — Bounded Beast log paging
 - A tail endpoint is not operationally bounded if it collects a bounded result after scanning all retained history. Read newest rotations in reverse chunks and stop as soon as the line or byte budget is full; also restrict page reads to configured retention so stale extra rotations cannot re-expand request I/O.
 - Treat oversized individual records as consumed pagination entries even when replacing or omitting their payload, or offset clients can become stuck on the same line. For HTTP byte limits, measure the final post-redaction JSON envelope (logs plus page metadata), not only the serialized logs array.


### PR DESCRIPTION
## Summary
- page Beast run events by monotonically increasing sequence with bounded defaults and a hard maximum
- expose continuation metadata and a typed web client method while bounding compatibility run-detail responses
- validate malformed pagination values and document the contract

## Test plan
- `npm run test --workspace @franken/orchestrator` (277 files, 4,136 tests)
- `npm run test --workspace @franken/web` (75 files, 670 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #3208