### PR TITLE
test(root): validate aggregate task wiring

### DIFF
--- a/tests/helpers/verification-task-wiring.ts
+++ b/tests/helpers/verification-task-wiring.ts
@@ -1,0 +1,28 @@
+type ScriptMap = Record<string, unknown>;
+type TurboTaskMap = Record<string, unknown>;
+
+const REQUIRED_TASKS = ['build', 'test'] as const;
+
+export const validateVerificationTaskWiring = (
+  scripts: ScriptMap,
+  turboTasks: TurboTaskMap,
+): void => {
+  for (const task of REQUIRED_TASKS) {
+    const expectedScript = `turbo run ${task}`;
+    if (scripts[task] !== expectedScript) {
+      throw new Error(
+        `Verification script "${task}" must be wired to "${expectedScript}"`,
+      );
+    }
+
+    const turboTask = turboTasks[task];
+    if (
+      !Object.hasOwn(turboTasks, task) ||
+      typeof turboTask !== 'object' ||
+      turboTask === null ||
+      Array.isArray(turboTask)
+    ) {
+      throw new Error(`Turbo task "${task}" must be defined as an object`);
+    }
+  }
+};

--- a/tests/verify-everything-meta.test.ts
+++ b/tests/verify-everything-meta.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { validateVerificationTaskWiring } from './helpers/verification-task-wiring.js';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const VERIFY_EVERYTHING_TEST = resolve(ROOT, 'tests/verify-everything.test.ts');
@@ -12,5 +13,37 @@ describe('verify-everything test boundaries', () => {
     for (const pipeline of ['build', 'test']) {
       expect(source).not.toContain(['npx', 'turbo', 'run', pipeline].join(' '));
     }
+  });
+
+  it('rejects missing and stale aggregate verification scripts', () => {
+    expect(() =>
+      validateVerificationTaskWiring(
+        { build: 'turbo run build' },
+        { build: {}, test: {} },
+      ),
+    ).toThrow(/test.*turbo run test/i);
+
+    expect(() =>
+      validateVerificationTaskWiring(
+        { build: 'turbo run compile', test: 'turbo run test' },
+        { build: {}, test: {} },
+      ),
+    ).toThrow(/build.*turbo run build/i);
+  });
+
+  it('rejects aggregate scripts whose Turbo tasks are missing or invalid', () => {
+    expect(() =>
+      validateVerificationTaskWiring(
+        { build: 'turbo run build', test: 'turbo run test' },
+        { build: {} },
+      ),
+    ).toThrow(/Turbo task.*test/i);
+
+    expect(() =>
+      validateVerificationTaskWiring(
+        { build: 'turbo run build', test: 'turbo run test' },
+        { build: {}, test: undefined },
+      ),
+    ).toThrow(/Turbo task.*test/i);
   });
 });

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getWorkspacePackageDirNames } from "./helpers/workspaces.js";
+import { validateVerificationTaskWiring } from "./helpers/verification-task-wiring.js";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const exec = (command: string, args: string[]) =>
@@ -23,6 +24,14 @@ type NpmLsPackage = {
   invalid?: boolean;
   missing?: boolean;
   problems?: string[];
+};
+
+type RootPackageJson = {
+  scripts?: Record<string, unknown>;
+};
+
+type TurboConfig = {
+  tasks?: Record<string, unknown>;
 };
 
 const toOutput = (value: string | Buffer | undefined) =>
@@ -59,6 +68,24 @@ const assertFrankenTypesResolved = (result: NpmLsResult) => {
 };
 
 describe("Chunk 10: full verification pass", () => {
+  describe("aggregate task wiring", () => {
+    it("wires build and test scripts to defined Turbo tasks", () => {
+      const packageJson = JSON.parse(
+        readFileSync(resolve(ROOT, "package.json"), "utf8"),
+      ) as RootPackageJson;
+      const turboConfig = JSON.parse(
+        readFileSync(resolve(ROOT, "turbo.json"), "utf8"),
+      ) as TurboConfig;
+
+      expect(() =>
+        validateVerificationTaskWiring(
+          packageJson.scripts ?? {},
+          turboConfig.tasks ?? {},
+        ),
+      ).not.toThrow();
+    });
+  });
+
   describe("verification command portability", () => {
     it("does not rely on shell pipeline parsing in the default suite", () => {
       const source = readFileSync(import.meta.filename, "utf8");


### PR DESCRIPTION
## Summary
- parse the root package and Turbo configurations in verify-everything
- require build/test scripts to map to their matching Turbo tasks
- cover missing, stale, and invalid task wiring without recursively running Turbo

## Test Plan
- npm run test:root
- npm run typecheck
- npm run lint
- npm run build

Closes #3420