### PR TITLE
fix(brain): preserve concurrent SQLite writes

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1728,23 +1728,24 @@ class SqliteWorkingMemory implements IWorkingMemory {
     // stale cache.
     const requestedDeletedKeys = new Set(this.deletedKeys);
     this.loadPersistedSerializedFromDb();
+    const preparedStore = new Map(this.store);
 
     // Incremental writers must absorb rows committed by other connections
     // after this instance was hydrated. Only clear()/restore() intentionally
     // make this instance's complete in-memory state authoritative.
     if (!this.replacePersistedState) {
       for (const [key, serialized] of this.persistedSerialized) {
-        if (this.store.has(key) || requestedDeletedKeys.has(key)) continue;
-        const value = parseStoredWorkingMemoryValue(serialized);
+        if (preparedStore.has(key) || requestedDeletedKeys.has(key)) continue;
+        const value = parseHydratedWorkingMemoryValue(key, serialized);
         if (!isExpiredWorkingMemoryValue(value)) {
-          this.store.set(key, value);
+          preparedStore.set(key, value);
         }
       }
     }
 
     const prepared: Array<[string, unknown, string, number]> = [];
     let total = 0;
-    for (const [key, value] of this.store) {
+    for (const [key, value] of preparedStore) {
       if (isExpiredWorkingMemoryValue(value)) {
         const runtimeSerialized = this.serialized.get(key);
         const persistedSerialized = this.persistedSerialized.get(key);

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1727,19 +1727,23 @@ class SqliteWorkingMemory implements IWorkingMemory {
     // miss externally added keys because deletedKeys would be seeded from a
     // stale cache.
     const requestedDeletedKeys = new Set(this.deletedKeys);
+    const requestedDirtyKeys = new Set(this.dirtyKeys);
     this.loadPersistedSerializedFromDb();
     const preparedStore = new Map(this.store);
 
-    // Incremental writers must absorb rows committed by other connections
-    // after this instance was hydrated. Only clear()/restore() intentionally
-    // make this instance's complete in-memory state authoritative.
+    // Incremental writers preserve only locally changed keys. Clean cached keys
+    // are refreshed from the current persisted snapshot so a stale instance
+    // cannot overwrite another connection's update or resurrect its deletion.
     if (!this.replacePersistedState) {
+      for (const key of preparedStore.keys()) {
+        if (requestedDirtyKeys.has(key) || requestedDeletedKeys.has(key)) continue;
+        if (!this.persistedSerialized.has(key)) preparedStore.delete(key);
+      }
       for (const [key, serialized] of this.persistedSerialized) {
-        if (preparedStore.has(key) || requestedDeletedKeys.has(key)) continue;
+        if (requestedDirtyKeys.has(key) || requestedDeletedKeys.has(key)) continue;
         const value = parseHydratedWorkingMemoryValue(key, serialized);
-        if (!isExpiredWorkingMemoryValue(value)) {
-          preparedStore.set(key, value);
-        }
+        if (isExpiredWorkingMemoryValue(value)) preparedStore.delete(key);
+        else preparedStore.set(key, value);
       }
     }
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1262,6 +1262,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
   private persistedSerialized = new Map<string, string>();
   private dirtyKeys = new Set<string>();
   private deletedKeys = new Set<string>();
+  private replacePersistedState = false;
   private totalBytes = 0;
 
   private static readonly persistedRowOrder = (
@@ -1577,6 +1578,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       throw error;
     }
     if (!hasChanges) {
+      this.replacePersistedState = false;
       return;
     }
     const finalizeFlush = (): void => {
@@ -1591,6 +1593,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
       }
       this.deletedKeys.clear();
       this.dirtyKeys.clear();
+      this.replacePersistedState = false;
     };
 
     if (!this.db.inTransaction) {
@@ -1723,7 +1726,21 @@ class SqliteWorkingMemory implements IWorkingMemory {
     // after this instance was constructed. Without this, clear()/restore() can
     // miss externally added keys because deletedKeys would be seeded from a
     // stale cache.
+    const requestedDeletedKeys = new Set(this.deletedKeys);
     this.loadPersistedSerializedFromDb();
+
+    // Incremental writers must absorb rows committed by other connections
+    // after this instance was hydrated. Only clear()/restore() intentionally
+    // make this instance's complete in-memory state authoritative.
+    if (!this.replacePersistedState) {
+      for (const [key, serialized] of this.persistedSerialized) {
+        if (this.store.has(key) || requestedDeletedKeys.has(key)) continue;
+        const value = parseStoredWorkingMemoryValue(serialized);
+        if (!isExpiredWorkingMemoryValue(value)) {
+          this.store.set(key, value);
+        }
+      }
+    }
 
     const prepared: Array<[string, unknown, string, number]> = [];
     let total = 0;
@@ -1769,6 +1786,11 @@ class SqliteWorkingMemory implements IWorkingMemory {
       total += size;
       prepared.push([key, normalized, serialized, size]);
     }
+    if (prepared.length > this.limits.maxEntries) {
+      throw new WorkingMemoryLimitError(
+        `Working memory has ${prepared.length} entries after refreshing concurrent writes, exceeding maxEntries (${this.limits.maxEntries})`,
+      );
+    }
     if (!Number.isSafeInteger(total) || total > this.limits.maxTotalBytes) {
       throw new WorkingMemoryLimitError(
         `Working memory byte budget exceeded: ${total} bytes, maxTotalBytes is ${this.limits.maxTotalBytes}`,
@@ -1779,7 +1801,13 @@ class SqliteWorkingMemory implements IWorkingMemory {
     this.sizes.clear();
     this.serialized.clear();
     this.dirtyKeys.clear();
-    this.deletedKeys = new Set(this.persistedSerialized.keys());
+    this.deletedKeys = this.replacePersistedState
+      ? new Set(this.persistedSerialized.keys())
+      : new Set(
+          Array.from(requestedDeletedKeys).filter((key) =>
+            this.persistedSerialized.has(key),
+          ),
+        );
     this.totalBytes = total;
     for (const [key, normalized, serialized, size] of prepared) {
       this.store.set(key, normalized);
@@ -2449,6 +2477,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const previousSerialized = new Map(this.serialized);
     const previousDirtyKeys = new Set(this.dirtyKeys);
     const previousDeletedKeys = new Set(this.deletedKeys);
+    const previousReplacePersistedState = this.replacePersistedState;
     const previousTotalBytes = this.totalBytes;
     let mutationApplied = false;
 
@@ -2479,6 +2508,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         this.serialized = previousSerialized;
         this.dirtyKeys = previousDirtyKeys;
         this.deletedKeys = previousDeletedKeys;
+        this.replacePersistedState = previousReplacePersistedState;
         this.totalBytes = previousTotalBytes;
       }
       try {
@@ -2507,6 +2537,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     const previousSerialized = shouldAudit ? new Map(this.serialized) : undefined;
     const previousDirtyKeys = shouldAudit ? new Set(this.dirtyKeys) : undefined;
     const previousDeletedKeys = shouldAudit ? new Set(this.deletedKeys) : undefined;
+    const previousReplacePersistedState = this.replacePersistedState;
     const previousTotalBytes = shouldAudit ? this.totalBytes : undefined;
 
     this.store.clear();
@@ -2514,6 +2545,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
     this.serialized.clear();
     this.dirtyKeys.clear();
     this.deletedKeys = new Set(this.persistedSerialized.keys());
+    this.replacePersistedState = true;
     this.totalBytes = 0;
     if (shouldAudit) {
       try {
@@ -2528,6 +2560,7 @@ class SqliteWorkingMemory implements IWorkingMemory {
         this.serialized = previousSerialized!;
         this.dirtyKeys = previousDirtyKeys!;
         this.deletedKeys = previousDeletedKeys!;
+        this.replacePersistedState = previousReplacePersistedState;
         this.totalBytes = previousTotalBytes!;
         throw error;
       }
@@ -3106,7 +3139,7 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
     });
 
     try {
-      const result = tx() as { id: string };
+      const result = tx.immediate() as { id: string };
       finalizeWorkingMemoryFlush.current?.();
       return result;
     } catch (error) {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 import Database from 'better-sqlite3';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -6616,6 +6617,40 @@ describe('SqliteBrain', () => {
   });
 
   describe('concurrent file-backed stores', () => {
+    it('refreshes clean cached keys before flushing unrelated local changes', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-refresh-'));
+      const dbPath = join(dir, 'brain.db');
+      let stale: SqliteBrain | undefined;
+      let writer: SqliteBrain | undefined;
+      let verifier: SqliteBrain | undefined;
+
+      try {
+        writer = new SqliteBrain(dbPath);
+        writer.working.set('updated-elsewhere', 'old');
+        writer.working.set('deleted-elsewhere', 'present');
+        writer.flush();
+        stale = new SqliteBrain(dbPath);
+
+        writer.working.set('updated-elsewhere', 'new');
+        writer.working.delete('deleted-elsewhere');
+        writer.flush();
+
+        stale.working.set('local-change', 'preserved');
+        stale.flush();
+
+        verifier = new SqliteBrain(dbPath);
+        expect(verifier.working.snapshot()).toEqual({
+          'updated-elsewhere': 'new',
+          'local-change': 'preserved',
+        });
+      } finally {
+        verifier?.close();
+        stale?.close();
+        writer?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('fails closed without mutating runtime state when an external row is corrupt', () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-corrupt-'));
       const dbPath = join(dir, 'brain.db');
@@ -6654,21 +6689,29 @@ describe('SqliteBrain', () => {
     it('preserves simultaneous working, episodic, and recovery writes while snapshots are read', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-'));
       const dbPath = join(dir, 'brain.db');
-      const workerCount = 4;
-      const writesPerWorker = 8;
+      const workerCount = 3;
+      const writesPerWorker = 6;
       const workers: Worker[] = [];
-      const workerModuleUrl = new URL('../../src/sqlite-brain.ts', import.meta.url).href;
+      const workerSourcePath = fileURLToPath(
+        new URL('../../src/sqlite-brain.ts', import.meta.url),
+      );
+      const vitestConfigPath = fileURLToPath(
+        new URL('../../vitest.config.ts', import.meta.url),
+      );
       const workerScript = String.raw`
         const { parentPort, workerData } = require('node:worker_threads');
 
         void (async () => {
-          const { register } = await import('tsx/esm/api');
-          const unregister = register();
-          const { SqliteBrain } = await import(workerData.moduleUrl);
-          unregister();
+          const { createServer } = await import('vite');
+          const vite = await createServer({
+            configFile: workerData.vitestConfigPath,
+            logLevel: 'silent',
+            server: { middlewareMode: true, hmr: false, watch: null },
+          });
+          const { SqliteBrain } = await vite.ssrLoadModule(workerData.sourcePath);
           const brain = new SqliteBrain(workerData.dbPath);
           parentPort.postMessage({ type: 'ready' });
-          parentPort.once('message', (message) => {
+          parentPort.once('message', async (message) => {
             if (message?.type !== 'start') return;
             try {
               for (let index = 0; index < workerData.writesPerWorker; index += 1) {
@@ -6703,9 +6746,11 @@ describe('SqliteBrain', () => {
                 }
               }
               brain.close();
+              await vite.close();
               parentPort.postMessage({ type: 'done' });
             } catch (error) {
               brain.close();
+              await vite.close();
               parentPort.postMessage({
                 type: 'error',
                 message: error instanceof Error ? error.stack ?? error.message : String(error),
@@ -6724,7 +6769,13 @@ describe('SqliteBrain', () => {
         const controls = Array.from({ length: workerCount }, (_, workerId) => {
           const worker = new Worker(workerScript, {
             eval: true,
-            workerData: { dbPath, moduleUrl: workerModuleUrl, workerId, writesPerWorker },
+            workerData: {
+              dbPath,
+              sourcePath: workerSourcePath,
+              vitestConfigPath,
+              workerId,
+              writesPerWorker,
+            },
           });
           workers.push(worker);
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Worker } from 'node:worker_threads';
 import Database from 'better-sqlite3';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { BrainSnapshotSchema } from '@franken/types';
@@ -1647,6 +1648,27 @@ describe('SqliteBrain', () => {
         WorkingMemoryLimitError,
       );
       bounded.close();
+    });
+
+    it('enforces maxEntries when absorbing writes from another connection', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-limit-'));
+      const dbPath = join(dir, 'brain.db');
+      let first: SqliteBrain | undefined;
+      let second: SqliteBrain | undefined;
+
+      try {
+        first = new SqliteBrain(dbPath, { maxEntries: 1 });
+        second = new SqliteBrain(dbPath, { maxEntries: 1 });
+        first.working.set('first', 1);
+        second.working.set('second', 2);
+        second.flush();
+
+        expect(() => first!.flush()).toThrow(WorkingMemoryLimitError);
+      } finally {
+        first?.close();
+        second?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('allows overwriting an existing key at maxEntries', () => {
@@ -6589,6 +6611,161 @@ describe('SqliteBrain', () => {
         ]),
       );
     });
+  });
+
+  describe('concurrent file-backed stores', () => {
+    it('preserves simultaneous working, episodic, and recovery writes while snapshots are read', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-'));
+      const dbPath = join(dir, 'brain.db');
+      const workerCount = 4;
+      const writesPerWorker = 8;
+      const workers: Worker[] = [];
+      const workerModuleUrl = new URL('../../src/sqlite-brain.ts', import.meta.url).href;
+      const workerScript = String.raw`
+        const { parentPort, workerData } = require('node:worker_threads');
+
+        void (async () => {
+          const { register } = await import('tsx/esm/api');
+          const unregister = register();
+          const { SqliteBrain } = await import(workerData.moduleUrl);
+          unregister();
+          const brain = new SqliteBrain(workerData.dbPath);
+          parentPort.postMessage({ type: 'ready' });
+          parentPort.once('message', (message) => {
+            if (message?.type !== 'start') return;
+            try {
+              for (let index = 0; index < workerData.writesPerWorker; index += 1) {
+                const key = 'worker-' + workerData.workerId + '-entry-' + index;
+                brain.working.set(key, { workerId: workerData.workerId, index });
+                brain.flush();
+                brain.episodic.record({
+                  type: 'observation',
+                  step: 'worker-' + workerData.workerId,
+                  summary: 'concurrent event ' + workerData.workerId + ':' + index,
+                  details: { workerId: workerData.workerId, index },
+                  createdAt: new Date(
+                    Date.UTC(2026, 6, 19, 0, workerData.workerId, index),
+                  ).toISOString(),
+                });
+                brain.recovery.checkpoint({
+                  runId: 'concurrent-run-' + workerData.workerId + '-' + index,
+                  phase: 'execution',
+                  step: index,
+                  context: { workerId: workerData.workerId, index },
+                  timestamp: new Date(
+                    Date.UTC(2026, 6, 19, 1, workerData.workerId, index),
+                  ).toISOString(),
+                });
+
+                const roundTrip = JSON.parse(JSON.stringify(brain.serialize()));
+                if (roundTrip.working[key]?.index !== index) {
+                  throw new Error('snapshot lost the worker\'s latest working-memory write');
+                }
+                if (!Array.isArray(roundTrip.episodic)) {
+                  throw new Error('snapshot episodic memory is corrupted');
+                }
+              }
+              brain.close();
+              parentPort.postMessage({ type: 'done' });
+            } catch (error) {
+              brain.close();
+              parentPort.postMessage({
+                type: 'error',
+                message: error instanceof Error ? error.stack ?? error.message : String(error),
+              });
+            }
+          });
+        })().catch((error) => {
+          parentPort.postMessage({
+            type: 'error',
+            message: error instanceof Error ? error.stack ?? error.message : String(error),
+          });
+        });
+      `;
+
+      try {
+        const controls = Array.from({ length: workerCount }, (_, workerId) => {
+          const worker = new Worker(workerScript, {
+            eval: true,
+            workerData: { dbPath, moduleUrl: workerModuleUrl, workerId, writesPerWorker },
+          });
+          workers.push(worker);
+
+          let markReady: (() => void) | undefined;
+          let finish: (() => void) | undefined;
+          let fail: ((error: Error) => void) | undefined;
+          let failReady: ((error: Error) => void) | undefined;
+          let isReady = false;
+          let isDone = false;
+          const ready = new Promise<void>((resolve, reject) => {
+            markReady = resolve;
+            failReady = reject;
+          });
+          const done = new Promise<void>((resolve, reject) => {
+            finish = resolve;
+            fail = reject;
+          });
+          const rejectWorker = (error: Error): void => {
+            if (isReady) fail?.(error);
+            else failReady?.(error);
+          };
+          worker.on('message', (message: { type?: string; message?: string }) => {
+            if (message.type === 'ready') {
+              isReady = true;
+              markReady?.();
+            }
+            if (message.type === 'done') {
+              isDone = true;
+              finish?.();
+            }
+            if (message.type === 'error') {
+              const error = new Error(message.message ?? 'worker failed');
+              rejectWorker(error);
+            }
+          });
+          worker.on('error', (error) => {
+            const normalized: Error = error instanceof Error
+              ? error
+              : new Error(String(error));
+            rejectWorker(normalized);
+          });
+          worker.on('exit', (code) => {
+            if (!isDone) {
+              rejectWorker(new Error(`worker exited before completion with code ${code}`));
+            }
+          });
+          return { worker, ready, done };
+        });
+
+        await Promise.all(controls.map(({ ready }) => ready));
+        for (const { worker } of controls) worker.postMessage({ type: 'start' });
+        await Promise.all(controls.map(({ done }) => done));
+
+        const verifier = new SqliteBrain(dbPath);
+        try {
+          const expectedWrites = workerCount * writesPerWorker;
+          const snapshot = verifier.serialize();
+          expect(() => BrainSnapshotSchema.parse(snapshot)).not.toThrow();
+          expect(Object.keys(snapshot.working)).toHaveLength(expectedWrites);
+          expect(verifier.episodic.count()).toBe(expectedWrites);
+          expect(verifier.recovery.listCheckpoints()).toHaveLength(expectedWrites);
+
+          for (let workerId = 0; workerId < workerCount; workerId += 1) {
+            for (let index = 0; index < writesPerWorker; index += 1) {
+              expect(snapshot.working[`worker-${workerId}-entry-${index}`]).toEqual({
+                workerId,
+                index,
+              });
+            }
+          }
+        } finally {
+          verifier.close();
+        }
+      } finally {
+        await Promise.all(workers.map((worker) => worker.terminate()));
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }, 30_000);
   });
 
   describe('constructor', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1664,6 +1664,8 @@ describe('SqliteBrain', () => {
         second.flush();
 
         expect(() => first!.flush()).toThrow(WorkingMemoryLimitError);
+        expect(first.working.snapshot()).toEqual({ first: 1 });
+        expect(first.working.usage()).toMatchObject({ entries: 1 });
       } finally {
         first?.close();
         second?.close();
@@ -6614,6 +6616,41 @@ describe('SqliteBrain', () => {
   });
 
   describe('concurrent file-backed stores', () => {
+    it('fails closed without mutating runtime state when an external row is corrupt', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-corrupt-'));
+      const dbPath = join(dir, 'brain.db');
+      let instance: SqliteBrain | undefined;
+      let db: Database.Database | undefined;
+
+      try {
+        instance = new SqliteBrain(dbPath);
+        instance.working.set('safe', { preserved: true });
+        instance.flush();
+
+        db = new Database(dbPath);
+        db.prepare(
+          `INSERT INTO working_memory (key, value, updated_at, schema_version) VALUES (?, ?, ?, ?)`,
+        ).run(
+          'external-corrupt',
+          '{not-json',
+          new Date().toISOString(),
+          CURRENT_MEMORY_SCHEMA_VERSION,
+        );
+
+        expect(() => instance!.flush()).toThrow(CorruptWorkingMemoryRowError);
+        expect(instance.working.snapshot()).toEqual({ safe: { preserved: true } });
+        expect(
+          db.prepare(`SELECT value FROM working_memory WHERE key = ?`).get(
+            'external-corrupt',
+          ),
+        ).toEqual({ value: '{not-json' });
+      } finally {
+        db?.close();
+        instance?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('preserves simultaneous working, episodic, and recovery writes while snapshots are read', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-concurrent-'));
       const dbPath = join(dir, 'brain.db');

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -414,6 +414,7 @@
 ## Lessons
 - 2026-07-19 — Docs regression tests should assert exact pinned values from manifest and treat setup commands as gate-narrow/full setup distinctions.
 - 2026-07-19 — Bounded multi-pass LLM flows need one shared deadline propagated through cache/client/adapter layers, explicit subprocess and retry-wait cancellation, and a caller-side abort race for implementations that ignore signals. Preserve the last useful pre-quality artifact on timeout, use deterministic structural confidence for fast paths, avoid resending unchanged repository context, and test 1/2/4-pass paths plus child-process termination.
+- 2026-07-19 — SQLite multi-writer regressions need genuinely independent worker-thread connections, not `Promise.all` around synchronous calls. Acquire write locks with immediate transactions before read-to-write paths, and merge newly persisted working-memory rows for incremental flushes while preserving explicit clear/restore replacement semantics and configured limits.
 
 ## 2026-07-19 — Type export renames and deprecation compatibility
 - When renaming shared public type names for clarity, keep deprecated aliases temporarily (with `@deprecated` JSDoc) for downstream consumers, update docs/tests to use new names, and add targeted tests validating both canonical and deprecated aliases.


### PR DESCRIPTION
## Summary
- exercise simultaneous file-backed brain writes from independent worker threads
- preserve external working-memory rows during incremental flushes while retaining clear/restore replacement semantics
- acquire checkpoint write locks up front to avoid SQLite lock-upgrade failures

## Test Plan
- `npm exec --workspace @franken/brain -- vitest run tests/unit/sqlite-brain.test.ts --reporter=dot -t "preserves simultaneous|enforces maxEntries when absorbing"`
- `npm test --workspace @franken/brain -- --run`
- `npm run typecheck --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm run build --workspace @franken/brain`

Closes #2511