### PR TITLE
fix(config): default chat to Codex provider

### DIFF
--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -218,7 +218,7 @@ Options:
   --base-dir <path>       Project root (default: cwd)
   --base-branch <name>    Git base branch (default: main)
   --budget <usd>          Budget limit in USD (default: 10)
-  --provider <name>       Provider name (default: claude)
+  --provider <name>       Provider name (default: codex)
   --providers <list>      Comma-separated fallback chain (e.g. claude,gemini,aider)
   --trust-provider-command-overrides
                            Explicitly approve trusted repo-configured provider command overrides
@@ -700,7 +700,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     throw new TypeError(`Unexpected argument '${positionals[0]}'. This command does not take positional arguments`);
   }
 
-  const provider = values.provider?.toLowerCase() ?? 'claude';
+  const provider = values.provider?.toLowerCase() ?? 'codex';
 
   const beastExecutionModeRaw = values.mode?.toLowerCase();
   let beastExecutionMode: import('../beasts/types.js').BeastExecutionMode | undefined;

--- a/packages/franken-orchestrator/src/config/orchestrator-config.ts
+++ b/packages/franken-orchestrator/src/config/orchestrator-config.ts
@@ -71,9 +71,9 @@ export const ProviderOverrideSchema = z.object({
 function createProvidersConfigSchema(options: OrchestratorConfigParseOptions = {}) {
   return z.object({
     /** Default provider name. */
-    default: z.string().default('claude'),
+    default: z.string().default('codex'),
     /** Ordered fallback chain of provider names. */
-    fallbackChain: z.array(z.string()).default(['claude', 'codex']),
+    fallbackChain: z.array(z.string()).default(['codex', 'claude']),
     /** Per-provider overrides (command, model, extraArgs). */
     overrides: z.record(z.string(), ProviderOverrideSchema).default(() => ({})),
   }).superRefine((providers, ctx) => {
@@ -207,8 +207,8 @@ const BaseOrchestratorConfigSchema = z.object({
 
   /** Provider configuration. */
   providers: ProvidersConfigSchema.default(() => ({
-    default: 'claude',
-    fallbackChain: ['claude', 'codex'],
+    default: 'codex',
+    fallbackChain: ['codex', 'claude'],
     overrides: {},
   })),
 
@@ -231,8 +231,8 @@ const BaseOrchestratorConfigSchema = z.object({
 function createOrchestratorConfigSchema(options: OrchestratorConfigParseOptions = {}) {
   return BaseOrchestratorConfigSchema.extend({
     providers: createProvidersConfigSchema(options).default(() => ({
-      default: 'claude',
-      fallbackChain: ['claude', 'codex'],
+      default: 'codex',
+      fallbackChain: ['codex', 'claude'],
       overrides: {},
     })),
   }).extend(

--- a/packages/franken-orchestrator/src/network/network-config-paths.ts
+++ b/packages/franken-orchestrator/src/network/network-config-paths.ts
@@ -35,7 +35,7 @@ const NETWORK_CONFIG_PATH_DEFINITIONS = {
   'chat.enabled': { type: 'boolean' },
   'chat.host': { type: 'string' },
   'chat.port': { type: 'number' },
-  'chat.model': { type: 'string' },
+  'chat.model': { type: 'string', unsetOnEmpty: true },
   'beastsDaemon.enabled': { type: 'boolean' },
   'beastsDaemon.host': { type: 'string' },
   'beastsDaemon.port': { type: 'number' },
@@ -75,6 +75,7 @@ type ConfigPathDefinition = {
   type: ConfigValueType;
   values?: readonly string[];
   sensitive?: boolean;
+  unsetOnEmpty?: boolean;
 };
 
 export type NetworkConfigPath = keyof typeof NETWORK_CONFIG_PATH_DEFINITIONS;
@@ -160,8 +161,32 @@ function cloneWithSet<T extends object>(source: T, segments: string[], value: un
   return root as T;
 }
 
+function cloneWithDelete<T extends object>(source: T, segments: string[]): T {
+  const root: Record<string, unknown> = { ...(source as Record<string, unknown>) };
+  let cursor: Record<string, unknown> = root;
+  let sourceCursor: Record<string, unknown> = source as Record<string, unknown>;
+
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index]!;
+    const sourceValue = sourceCursor[segment];
+    if (sourceValue === null || typeof sourceValue !== 'object' || Array.isArray(sourceValue)) {
+      return root as T;
+    }
+    const next = { ...(sourceValue as Record<string, unknown>) };
+    cursor[segment] = next;
+    cursor = next;
+    sourceCursor = sourceValue as Record<string, unknown>;
+  }
+
+  delete cursor[segments[segments.length - 1]!];
+  return root as T;
+}
+
 export function setNetworkConfigValue<T extends object>(config: T, path: string, rawValue: string): T {
-  getPathDefinition(path);
+  const definition = getPathDefinition(path);
+  if (rawValue === '' && definition.unsetOnEmpty) {
+    return cloneWithDelete(config, path.split('.'));
+  }
   const coerced = coerceNetworkConfigValue(path, rawValue);
   return cloneWithSet(config, path.split('.'), coerced);
 }

--- a/packages/franken-orchestrator/src/network/network-config-paths.ts
+++ b/packages/franken-orchestrator/src/network/network-config-paths.ts
@@ -184,7 +184,7 @@ function cloneWithDelete<T extends object>(source: T, segments: string[]): T {
 
 export function setNetworkConfigValue<T extends object>(config: T, path: string, rawValue: string): T {
   const definition = getPathDefinition(path);
-  if (rawValue === '' && definition.unsetOnEmpty) {
+  if (rawValue.trim() === '' && definition.unsetOnEmpty) {
     return cloneWithDelete(config, path.split('.'));
   }
   const coerced = coerceNetworkConfigValue(path, rawValue);

--- a/packages/franken-orchestrator/src/network/network-config.ts
+++ b/packages/franken-orchestrator/src/network/network-config.ts
@@ -91,7 +91,7 @@ export const ChatServiceConfigSchema = z.object({
   enabled: z.boolean().default(true),
   host: HostSchema,
   port: PortSchema.default(3737),
-  model: z.string().min(1).default('claude-sonnet-4-6'),
+  model: z.string().min(1).optional(),
 }).superRefine((value, ctx) => {
   if (value.enabled) requireLoopbackServiceHost(ctx, value.host);
 });
@@ -201,7 +201,6 @@ export const NetworkConfigFieldsSchema = z.object({
     enabled: true,
     host: '127.0.0.1',
     port: 3737,
-    model: 'claude-sonnet-4-6',
   })),
   dashboard: DashboardServiceConfigSchema.default(() => ({
     enabled: true,

--- a/packages/franken-orchestrator/src/network/services/chat-server-service.ts
+++ b/packages/franken-orchestrator/src/network/services/chat-server-service.ts
@@ -24,7 +24,7 @@ export const chatServerService: NetworkServiceDefinition = {
     wsUrl: localPlaintextOrSecureWebSocketUrl(config.chat.host, config.chat.port, '/v1/chat/ws'),
     serviceIdentity: 'chat-server',
     suppressManagedBanner: true,
-    model: config.chat.model,
+    ...(config.chat.model ? { model: config.chat.model } : {}),
     process: {
       command: 'npm',
       args: [

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -40,7 +40,7 @@ export interface ICliProvider {
   readonly name: string;
   readonly command: string;
   /** Cheap model for conversational/chat use. Each provider defines its own. */
-  readonly chatModel: string;
+  readonly chatModel?: string;
   buildArgs(opts: ProviderOpts): string[];
   normalizeOutput(raw: string): string;
   estimateTokens(text: string): number;

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -15,7 +15,6 @@ const RATE_LIMIT_PATTERNS = BASE_RATE_LIMIT_PATTERNS;
 export class CodexProvider implements ICliProvider {
   readonly name = 'codex';
   readonly command = 'codex';
-  readonly chatModel = 'codex-mini';
 
   buildArgs(opts: ProviderOpts): string[] {
     const { sandboxArgs, extraArgs } = resolveCodexSandboxArgs(opts.extraArgs);

--- a/packages/franken-orchestrator/tests/unit/cli/args-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args-providers.test.ts
@@ -17,9 +17,9 @@ describe('parseArgs --provider as string', () => {
     expect(args.provider).toBe('aider');
   });
 
-  it('defaults provider to claude when not specified', () => {
+  it('defaults provider to codex when not specified', () => {
     const args = parseArgs([]);
-    expect(args.provider).toBe('claude');
+    expect(args.provider).toBe('codex');
   });
 
   it('still accepts codex as provider', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -6,7 +6,7 @@ describe('parseArgs', () => {
     const args = parseArgs([]);
     expect(args.subcommand).toBeUndefined();
     expect(args.budget).toBe(10);
-    expect(args.provider).toBe('claude');
+    expect(args.provider).toBe('codex');
     expect(args.noPr).toBe(false);
     expect(args.verbose).toBe(false);
     expect(args.reset).toBe(false);

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader-providers.test.ts
@@ -41,8 +41,8 @@ describe('Config loader providers passthrough', () => {
 
   it('returns default providers config when no file provided', async () => {
     const config = await loadConfig(makeArgs());
-    expect(config.providers.default).toBe('claude');
-    expect(config.providers.fallbackChain).toEqual(['claude', 'codex']);
+    expect(config.providers.default).toBe('codex');
+    expect(config.providers.fallbackChain).toEqual(['codex', 'claude']);
     expect(config.providers.overrides).toEqual({});
   });
 
@@ -181,6 +181,6 @@ describe('Config loader providers passthrough', () => {
     expect(config.maxTotalTokens).toBe(200_000);
     expect(config.providers.default).toBe('aider');
     // Defaults fill in
-    expect(config.providers.fallbackChain).toEqual(['claude', 'codex']);
+    expect(config.providers.fallbackChain).toEqual(['codex', 'claude']);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/config-loader.test.ts
@@ -74,7 +74,7 @@ describe('Config loader', () => {
     const filePath = join(tmpdir(), `missing-beast-default-config-${Date.now()}.json`);
 
     const config = await loadConfig(makeArgs(), filePath);
-    expect(config.chat.model).toBe('claude-sonnet-4-6');
+    expect(config.chat.model).toBeUndefined();
   });
 
   it('ignores a malformed default operator config file for init commands', async () => {
@@ -83,7 +83,7 @@ describe('Config loader', () => {
     await writeFile(filePath, '{"chat": {', 'utf-8');
 
     const config = await loadConfig(makeArgs({ subcommand: 'init' }), filePath);
-    expect(config.chat.model).toBe('claude-sonnet-4-6');
+    expect(config.chat.model).toBeUndefined();
   });
 
   it('throws on a malformed explicit config file for init commands', async () => {

--- a/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/config/orchestrator-config-providers.test.ts
@@ -7,8 +7,8 @@ describe('OrchestratorConfigSchema providers section', () => {
   it('produces sensible defaults when parsed with empty object', () => {
     const config = OrchestratorConfigSchema.parse({});
     expect(config.providers).toBeDefined();
-    expect(config.providers.default).toBe('claude');
-    expect(config.providers.fallbackChain).toEqual(['claude', 'codex']);
+    expect(config.providers.default).toBe('codex');
+    expect(config.providers.fallbackChain).toEqual(['codex', 'claude']);
     expect(config.providers.overrides).toEqual({});
   });
 
@@ -18,7 +18,7 @@ describe('OrchestratorConfigSchema providers section', () => {
     });
     expect(config.providers.default).toBe('gemini');
     // Other defaults still apply
-    expect(config.providers.fallbackChain).toEqual(['claude', 'codex']);
+    expect(config.providers.fallbackChain).toEqual(['codex', 'claude']);
     expect(config.providers.overrides).toEqual({});
   });
 

--- a/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
@@ -63,12 +63,14 @@ describe('network-config-paths', () => {
     expect(next.comms.slack.enabled).toBe(true);
   });
 
-  it('unsets an explicit chat model when assigned an empty value', () => {
+  it('unsets an explicit chat model when assigned an empty or whitespace-only value', () => {
     const configured = applyNetworkConfigSets(defaultConfig(), ['chat.model=claude-sonnet-4-6']);
-    const next = applyNetworkConfigSets(configured, ['chat.model=']);
 
-    expect(next.chat.model).toBeUndefined();
-    expect(Object.hasOwn(next.chat, 'model')).toBe(false);
+    for (const assignment of ['chat.model=', 'chat.model=   ']) {
+      const next = applyNetworkConfigSets(configured, [assignment]);
+      expect(next.chat.model).toBeUndefined();
+      expect(Object.hasOwn(next.chat, 'model')).toBe(false);
+    }
   });
 
   it('classifies secret-ref paths as sensitive', () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-config-paths.test.ts
@@ -63,6 +63,14 @@ describe('network-config-paths', () => {
     expect(next.comms.slack.enabled).toBe(true);
   });
 
+  it('unsets an explicit chat model when assigned an empty value', () => {
+    const configured = applyNetworkConfigSets(defaultConfig(), ['chat.model=claude-sonnet-4-6']);
+    const next = applyNetworkConfigSets(configured, ['chat.model=']);
+
+    expect(next.chat.model).toBeUndefined();
+    expect(Object.hasOwn(next.chat, 'model')).toBe(false);
+  });
+
   it('classifies secret-ref paths as sensitive', () => {
     expect(isSensitiveConfigPath('comms.slack.signingSecretRef')).toBe(true);
     expect(isSensitiveConfigPath('comms.discord.botTokenRef')).toBe(true);

--- a/packages/franken-orchestrator/tests/unit/network/network-config.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-config.test.ts
@@ -16,6 +16,7 @@ describe('NetworkConfigSchema', () => {
     expect(config.chat.enabled).toBe(true);
     expect(config.chat.host).toBe('127.0.0.1');
     expect(config.chat.port).toBe(3737);
+    expect(config.chat.model).toBeUndefined();
     expect(config.dashboard.enabled).toBe(true);
     expect(config.dashboard.port).toBe(5173);
     expect(config.dashboard.apiUrl).toBe('http://127.0.0.1:3737');

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -314,7 +314,6 @@ describe('network-registry', () => {
       port: 4242,
       url: 'http://127.0.0.1:4242',
       wsUrl: 'ws://127.0.0.1:4242/v1/chat/ws',
-      model: 'claude-sonnet-4-6',
     });
     expect(dashboard?.runtimeConfig).toMatchObject({
       host: '127.0.0.1',

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -8,6 +8,10 @@ import { RUN_CONFIG_INTEGRITY_ENV, RUN_CONFIG_INTEGRITY_SECRET_ENV } from '../..
 describe('CodexProvider', () => {
   const provider = new CodexProvider();
 
+  it('lets Codex select its configured default chat model', () => {
+    expect(provider.chatModel).toBeUndefined();
+  });
+
   it('implements ICliProvider', () => {
     const p: ICliProvider = provider;
     expect(p.name).toBe('codex');

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -389,7 +389,7 @@ export interface NetworkStatusResponse {
 
 export interface NetworkConfigResponse {
   network: { mode: string; secureBackend?: string };
-  chat: { model: string; enabled: boolean; host?: string; port?: number };
+  chat: { model?: string | undefined; enabled: boolean; host?: string; port?: number };
   dashboard?: { enabled?: boolean; host?: string; port?: number; apiUrl?: string };
   comms?: { enabled?: boolean };
 }

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -28,7 +28,7 @@ function formStateFromConfig(config: NetworkConfigResponse): NetworkConfigFormSt
     networkMode: config.network.mode,
     secureBackend: config.network.secureBackend ?? 'local-encrypted',
     chatEnabled: config.chat.enabled,
-    chatModel: config.chat.model,
+    chatModel: config.chat.model ?? '',
     chatHost: config.chat.host ?? '',
     chatPort: config.chat.port === undefined ? '' : String(config.chat.port),
     dashboardEnabled: config.dashboard?.enabled ?? false,

--- a/packages/franken-web/src/components/network-config-editor.tsx
+++ b/packages/franken-web/src/components/network-config-editor.tsx
@@ -96,9 +96,6 @@ function validateForm(state: NetworkConfigFormState): string[] {
   if (!SECURE_BACKENDS.includes(state.secureBackend as (typeof SECURE_BACKENDS)[number])) {
     errors.push('Secure backend must be local-encrypted, os-keychain, 1password, or bitwarden.');
   }
-  if (!state.chatModel.trim()) {
-    errors.push('Chat model is required.');
-  }
   if (!state.chatHost.trim()) {
     errors.push('Chat host is required.');
   }

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -81,6 +81,31 @@ describe('NetworkPage', () => {
     expect(onSaveConfig).toHaveBeenCalledWith(['chat.host=0.0.0.0']);
   });
 
+  it('clears an explicit chat model so the provider default can take over', () => {
+    const onSaveConfig = vi.fn();
+
+    render(
+      <NetworkPage
+        config={baseConfig}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Chat model'), { target: { value: '' } });
+    const saveButton = screen.getByRole('button', { name: 'Save config' });
+    expect(saveButton).toHaveProperty('disabled', false);
+    fireEvent.click(saveButton);
+    expect(onSaveConfig).toHaveBeenCalledWith(['chat.model=']);
+  });
+
   it('gates service controls by status and saves all changed config assignments atomically', async () => {
     const onStart = vi.fn().mockResolvedValue(undefined);
     const onStop = vi.fn().mockResolvedValue(undefined);

--- a/packages/franken-web/tests/components/network-page.test.tsx
+++ b/packages/franken-web/tests/components/network-page.test.tsx
@@ -52,6 +52,35 @@ describe('NetworkPage', () => {
     expect(screen.getByRole('button', { name: 'Save config' }).getAttribute('class')).toContain('button--primary');
   });
 
+  it('allows unrelated config changes when the provider supplies the default chat model', () => {
+    const onSaveConfig = vi.fn();
+    const configWithoutModel: NetworkConfigResponse = {
+      ...baseConfig,
+      chat: { enabled: true, host: '127.0.0.1', port: 3737 },
+    };
+
+    render(
+      <NetworkPage
+        config={configWithoutModel}
+        logs={[]}
+        onSelectLogService={vi.fn()}
+        onRefresh={vi.fn()}
+        onRestart={vi.fn()}
+        onSaveConfig={onSaveConfig}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        services={[]}
+        status={{ mode: 'secure', secureBackend: 'local-encrypted' }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Chat host'), { target: { value: '0.0.0.0' } });
+    const saveButton = screen.getByRole('button', { name: 'Save config' });
+    expect(saveButton).toHaveProperty('disabled', false);
+    fireEvent.click(saveButton);
+    expect(onSaveConfig).toHaveBeenCalledWith(['chat.host=0.0.0.0']);
+  });
+
   it('gates service controls by status and saves all changed config assignments atomically', async () => {
     const onStart = vi.fn().mockResolvedValue(undefined);
     const onStop = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- make Codex the default CLI and configured provider
- stop injecting a Claude-specific model into default chat requests so Codex uses its own configured model
- keep explicit `chat.model` overrides supported and make the dashboard tolerate an omitted default model

## Verification
- real `fbeast chat` prompt returned `CODEX_DEFAULT_OK` with default config
- orchestrator: 277 files / 4,147 tests passed
- franken-types: 117 tests passed
- web network page: 12 tests passed
- orchestrator/type package typecheck passed
- orchestrator/types/web lint passed (warnings only)
- full monorepo build passed
- `git diff --check` passed