### PR TITLE
fix(observer): index ordered SQLite trace queries

### DIFF
--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -277,16 +277,32 @@ describe('SQLiteAdapter', () => {
       ])
     })
 
-    it('creates a composite index for trace detail span ordering', () => {
+    it('creates indexes for ordered trace and span queries', () => {
       const raw = new Database(dbPath)
-      const indexes = raw.prepare("PRAGMA index_list('spans')").all() as Array<{ name: string }>
-      const columns = indexes.map(index => ({
+      const traceIndexes = raw.prepare("PRAGMA index_list('traces')").all() as Array<{ name: string }>
+      const spanIndexes = raw.prepare("PRAGMA index_list('spans')").all() as Array<{ name: string }>
+      const indexColumns = (tableIndexes: Array<{ name: string }>) => tableIndexes.map(index => ({
         name: index.name,
         columns: (raw.prepare(`PRAGMA index_info('${index.name}')`).all() as Array<{ name: string }>).map(row => row.name),
       }))
+
+      expect(indexColumns(traceIndexes)).toContainEqual({ name: 'idx_traces_startedAt', columns: ['startedAt'] })
+      expect(indexColumns(spanIndexes)).toContainEqual({ name: 'idx_spans_traceId_startedAt', columns: ['traceId', 'startedAt'] })
+      raw.close()
+    })
+
+    it('adds the ordered trace index when opening an existing database', () => {
+      adapter.close()
+      const raw = new Database(dbPath)
+      raw.exec('DROP INDEX IF EXISTS idx_traces_startedAt')
       raw.close()
 
-      expect(columns).toContainEqual({ name: 'idx_spans_traceId_startedAt', columns: ['traceId', 'startedAt'] })
+      adapter = new SQLiteAdapter(dbPath)
+
+      const reopened = new Database(dbPath)
+      const indexes = reopened.prepare("PRAGMA index_list('traces')").all() as Array<{ name: string }>
+      reopened.close()
+      expect(indexes.map(index => index.name)).toContain('idx_traces_startedAt')
     })
   })
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -7,6 +7,7 @@ import Database from 'better-sqlite3'
 import { TraceContext } from '../../core/TraceContext.js'
 import { SpanLifecycle } from '../../core/SpanLifecycle.js'
 import { SQLiteAdapter } from './SQLiteAdapter.js'
+import { SELECT_TRACE_SUMMARIES } from './schema.js'
 
 function tempDbPath() {
   return join(tmpdir(), `franken-observer-test-${randomUUID()}.db`)
@@ -303,6 +304,15 @@ describe('SQLiteAdapter', () => {
       const indexes = reopened.prepare("PRAGMA index_list('traces')").all() as Array<{ name: string }>
       reopened.close()
       expect(indexes.map(index => index.name)).toContain('idx_traces_startedAt')
+    })
+
+    it('uses the ordered trace index for trace summaries without a temporary sort', () => {
+      const raw = new Database(dbPath)
+      const plan = raw.prepare(`EXPLAIN QUERY PLAN ${SELECT_TRACE_SUMMARIES}`).all() as Array<{ detail: string }>
+      raw.close()
+
+      expect(plan.some(row => row.detail.includes('USING INDEX idx_traces_startedAt'))).toBe(true)
+      expect(plan.some(row => row.detail.includes('USE TEMP B-TREE FOR ORDER BY'))).toBe(false)
     })
   })
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -45,7 +45,7 @@ describe('SQLiteAdapter', () => {
       'busy_timeout = 5000',
       'journal_mode = WAL',
       'foreign_keys = ON',
-      "index_list('spans')",
+      "index_list('traces')",
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
@@ -54,8 +54,8 @@ describe('SQLiteAdapter', () => {
 
   it('executes schema DDL only once when multiple adapters open the same initialized database', () => {
     pragmaMock.mockImplementation((statement: string) => {
-      if (statement === "index_list('spans')") {
-        return execMock.mock.calls.length === 0 ? [] : [{ name: 'idx_spans_traceId_startedAt' }]
+      if (statement === "index_list('traces')") {
+        return execMock.mock.calls.length === 0 ? [] : [{ name: 'idx_traces_startedAt' }]
       }
       return undefined
     })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -59,7 +59,7 @@ interface FlushedSpanState {
   thoughtBlocksJson: string
 }
 
-const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_spans_traceId_startedAt'
+const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_traces_startedAt'
 
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
@@ -299,9 +299,9 @@ export class SQLiteAdapter implements ExportAdapter {
       this.withSqliteLockRetrySync('initialize SQLite adapter', () => {
         this.db.pragma('journal_mode = WAL')
         this.db.pragma('foreign_keys = ON')
-        const spanIndexes = this.db.pragma("index_list('spans')") as Array<{ name?: unknown }>
-        const schemaInitialized = Array.isArray(spanIndexes)
-          && spanIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
+        const traceIndexes = this.db.pragma("index_list('traces')") as Array<{ name?: unknown }>
+        const schemaInitialized = Array.isArray(traceIndexes)
+          && traceIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
         if (!schemaInitialized) {
           this.db.exec(CREATE_TABLES)
         }

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -24,6 +24,7 @@ export const CREATE_TABLES = `
 
   CREATE INDEX IF NOT EXISTS idx_spans_traceId ON spans(traceId);
   CREATE INDEX IF NOT EXISTS idx_spans_traceId_startedAt ON spans(traceId, startedAt);
+  CREATE INDEX IF NOT EXISTS idx_traces_startedAt ON traces(startedAt);
 `
 
 export const UPSERT_TRACE = `

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -62,10 +62,8 @@ export const SELECT_TRACE_SUMMARIES = `
     traces.goal,
     traces.status,
     traces.startedAt,
-    COUNT(spans.traceId) AS spanCount
+    (SELECT COUNT(*) FROM spans WHERE spans.traceId = traces.id) AS spanCount
   FROM traces
-  LEFT JOIN spans ON spans.traceId = traces.id
-  GROUP BY traces.id
   ORDER BY traces.startedAt ASC
 `
 


### PR DESCRIPTION
## Summary
- add an index for trace queries ordered by `startedAt`
- use the new final schema index as the idempotent migration sentinel so existing databases receive it
- cover fresh-schema index columns and existing-database migration

## Test plan
- `npm test` in `packages/franken-observer` (837 passed)
- `INTEGRATION=true npm test -- --run src/adapters/sqlite/SQLiteAdapter.integration.test.ts` (17 passed)
- `npm run typecheck` in `packages/franken-observer`
- `npm run lint` in `packages/franken-observer` (0 errors; 6 pre-existing warnings)
- `npm run build` in `packages/franken-observer`

Closes #3351