### PR TITLE
fix(observer): stabilize cost accumulation

### DIFF
--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -141,6 +141,23 @@ describe('CostCalculator', () => {
       expect(cost).toBeCloseTo(expected, 6)
     })
 
+    it('preserves low-order costs when summing mixed magnitudes', () => {
+      const calc = new CostCalculator({
+        expensive: { promptPerMillion: 10_000_000_000_000_000, completionPerMillion: 0 },
+        inexpensive: { promptPerMillion: 100_000, completionPerMillion: 0 },
+      })
+      const entries = [
+        { model: 'expensive', promptTokens: 1_000_000, completionTokens: 0 },
+        ...Array.from({ length: 20 }, () => ({
+          model: 'inexpensive',
+          promptTokens: 1,
+          completionTokens: 0,
+        })),
+      ]
+
+      expect(calc.totalCost(entries)).toBe(10_000_000_000_000_002)
+    })
+
     it('returns 0 for an empty list', () => {
       const calc = new CostCalculator(DEFAULT_PRICING)
       expect(calc.totalCost([])).toBe(0)

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -45,6 +45,23 @@ export class CostCalculator {
   }
 
   totalCost(entries: TokenRecord[]): number {
-    return entries.reduce((sum, entry) => sum + this.calculate(entry), 0)
+    let sum = 0
+    let compensation = 0
+
+    for (const entry of entries) {
+      const cost = this.calculate(entry)
+      const next = sum + cost
+
+      // Neumaier summation preserves low-order costs that direct addition loses
+      // when a snapshot mixes values with very different magnitudes.
+      if (Math.abs(sum) >= Math.abs(cost)) {
+        compensation += (sum - next) + cost
+      } else {
+        compensation += (cost - next) + sum
+      }
+      sum = next
+    }
+
+    return sum + compensation
   }
 }


### PR DESCRIPTION
## Summary
- replace direct floating-point cost reduction with compensated Neumaier summation
- add a regression covering mixed-magnitude costs that previously lost low-order values

## Test Plan
- `npm run test --workspace @franken/observer` (838 passed)
- `npm run lint --workspace @franken/observer` (0 errors; 6 pre-existing warnings)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`

Closes #3349