### PR TITLE
fix(types): share branded critique score contract

### DIFF
--- a/packages/franken-critique/package.json
+++ b/packages/franken-critique/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.type-tests.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/franken-critique/src/evaluators/adr-compliance.ts
+++ b/packages/franken-critique/src/evaluators/adr-compliance.ts
@@ -1,5 +1,6 @@
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
 import type { MemoryPort } from '../types/contracts.js';
+import { createScore } from '../types/common.js';
 
 const RELEVANCE_THRESHOLD = 0.7;
 const TOP_K = 5;
@@ -31,7 +32,7 @@ export class ADRComplianceEvaluator implements Evaluator {
     }
 
     const hasHighRelevance = adrs.some((a) => a.relevanceScore >= RELEVANCE_THRESHOLD);
-    const score = hasHighRelevance ? 0.5 : 1;
+    const score = createScore(hasHighRelevance ? 0.5 : 1);
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -5,6 +5,7 @@ import type {
   EvaluationFinding,
 } from './evaluator.js';
 import { stripCommentsAndStringLiterals } from './source-sanitizer.js';
+import { createScore } from '../types/common.js';
 
 const MAX_PARAMS = 5;
 const MAX_NESTING = 4;
@@ -602,7 +603,7 @@ export class ComplexityEvaluator implements Evaluator {
       return {
         evaluatorName: this.name,
         verdict: 'pass',
-        score: 1,
+        score: createScore(1),
         findings: [],
       };
     }
@@ -614,7 +615,7 @@ export class ComplexityEvaluator implements Evaluator {
     this.checkNestingDepth(sanitizedContent, findings);
     this.checkFunctionLength(sanitizedContent, findings);
 
-    const score = Math.max(0, 1 - findings.length * 0.25);
+    const score = createScore(Math.max(0, 1 - findings.length * 0.25));
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -4,6 +4,7 @@ import type {
   EvaluationResult,
   EvaluationFinding,
 } from './evaluator.js';
+import { createScore } from '../types/common.js';
 
 const COMMENT_LINE_PATTERN = /^\s*\/\//;
 const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
@@ -1008,7 +1009,7 @@ export class ConcisenessEvaluator implements Evaluator {
       return {
         evaluatorName: this.name,
         verdict: 'pass',
-        score: 1,
+        score: createScore(1),
         findings: [],
       };
     }
@@ -1018,7 +1019,7 @@ export class ConcisenessEvaluator implements Evaluator {
     this.checkCommentRatio(input.content, findings);
     this.checkTodoComments(input.content, findings);
 
-    const score = Math.max(0, 1 - findings.length * 0.2);
+    const score = createScore(Math.max(0, 1 - findings.length * 0.2));
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/factuality.ts
+++ b/packages/franken-critique/src/evaluators/factuality.ts
@@ -1,5 +1,6 @@
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
 import type { MemoryPort } from '../types/contracts.js';
+import { createScore } from '../types/common.js';
 
 const RELEVANCE_THRESHOLD = 0.7;
 const TOP_K = 5;
@@ -30,7 +31,9 @@ export class FactualityEvaluator implements Evaluator {
       }
     }
 
-    const score = findings.length === 0 ? 1 : Math.max(0.3, 1 - findings.length * 0.15);
+    const score = createScore(
+      findings.length === 0 ? 1 : Math.max(0.3, 1 - findings.length * 0.15),
+    );
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/ghost-dependency.ts
+++ b/packages/franken-critique/src/evaluators/ghost-dependency.ts
@@ -6,6 +6,7 @@ import type {
   EvaluationResult,
   EvaluationFinding,
 } from './evaluator.js';
+import { createScore } from '../types/common.js';
 
 const IDENTIFIER_PATTERN = /[A-Za-z0-9_$]/;
 const QUOTE_CHARS = new Set(["'", '"', '`']);
@@ -62,7 +63,7 @@ export class GhostDependencyEvaluator implements Evaluator {
       }
     }
 
-    const score = findings.length === 0 ? 1 : 0;
+    const score = createScore(findings.length === 0 ? 1 : 0);
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/logic-loop.ts
+++ b/packages/franken-critique/src/evaluators/logic-loop.ts
@@ -2,6 +2,7 @@ import { Parser, parse } from 'acorn';
 import { tsPlugin } from 'acorn-typescript';
 import type { Node } from 'acorn';
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import { createScore } from '../types/common.js';
 
 // Keywords that legitimately exit (or suspend) a loop. `await`/`yield` cover
 // intentional async event loops such as `while (true) { await queue.next(); }`.
@@ -909,7 +910,7 @@ export class LogicLoopEvaluator implements Evaluator {
     }
 
     const uniqueFindings = dedupeFindings(findings);
-    const score = uniqueFindings.length === 0 ? 1 : 0;
+    const score = createScore(uniqueFindings.length === 0 ? 1 : 0);
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/reflection-evaluator.ts
+++ b/packages/franken-critique/src/evaluators/reflection-evaluator.ts
@@ -4,6 +4,7 @@ import type {
   EvaluationResult,
   EvaluationFinding,
 } from './evaluator.js';
+import { createScore } from '../types/common.js';
 
 export interface ReflectionCompletionOptions {
   maxTokens?: number;
@@ -44,7 +45,7 @@ export class ReflectionEvaluator implements Evaluator {
     );
 
     const severity = this.parseSeverity(reflection);
-    const score = Math.max(0, 1 - (severity - 1) / 9); // 1→1.0, 10→0.0
+    const score = createScore(Math.max(0, 1 - (severity - 1) / 9)); // 1→1.0, 10→0.0
 
     const finding: EvaluationFinding = {
       message: reflection,

--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -6,6 +6,7 @@ import type {
   EvaluationFinding,
 } from './evaluator.js';
 import type { GuardrailsPort } from '../types/contracts.js';
+import { createScore } from '../types/common.js';
 
 const MAX_SAFETY_PATTERN_LENGTH = 1_000;
 const MAX_ALTERNATIVE_PREFIX_TOKENS = MAX_SAFETY_PATTERN_LENGTH;
@@ -102,11 +103,13 @@ export class SafetyEvaluator implements Evaluator {
     const warningCount = findings.filter(
       (f) => f.severity === 'warning',
     ).length;
-    const score = hasBlock
-      ? 0
-      : warningCount > 0
-        ? Math.max(0, 1 - warningCount * 0.2)
-        : 1;
+    const score = createScore(
+      hasBlock
+        ? 0
+        : warningCount > 0
+          ? Math.max(0, 1 - warningCount * 0.2)
+          : 1,
+    );
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/evaluators/scalability.ts
+++ b/packages/franken-critique/src/evaluators/scalability.ts
@@ -1,4 +1,5 @@
 import type { Evaluator, EvaluationInput, EvaluationResult, EvaluationFinding } from './evaluator.js';
+import { createScore } from '../types/common.js';
 
 const HARDCODED_URL_PATTERN = /["'](https?:\/\/(?:localhost|127\.0\.0\.1)[^"']*)["']/g;
 const HARDCODED_IP_PATTERN = /["'](\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})["']/g;
@@ -50,7 +51,7 @@ export class ScalabilityEvaluator implements Evaluator {
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
     if (!input.content.trim()) {
-      return { evaluatorName: this.name, verdict: 'pass', score: 1, findings: [] };
+      return { evaluatorName: this.name, verdict: 'pass', score: createScore(1), findings: [] };
     }
 
     const findings: EvaluationFinding[] = [];
@@ -59,7 +60,7 @@ export class ScalabilityEvaluator implements Evaluator {
     this.checkHardcodedIPs(input.content, findings);
     this.checkHardcodedPorts(input.content, findings);
 
-    const score = Math.max(0, 1 - findings.length * 0.25);
+    const score = createScore(Math.max(0, 1 - findings.length * 0.25));
 
     return {
       evaluatorName: this.name,

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -2,6 +2,7 @@
 // Public API barrel export
 
 // Types — common
+export { createScore } from './types/common.js';
 export type {
   Severity,
   Verdict,

--- a/packages/franken-critique/src/loop/critique-loop.ts
+++ b/packages/franken-critique/src/loop/critique-loop.ts
@@ -1,4 +1,4 @@
-import type { EvaluationInput, EvaluationFinding } from '../types/evaluation.js';
+import type { EvaluationInput, CritiquePipelineResult } from '../types/evaluation.js';
 import type {
   CircuitBreaker,
   LoopConfig,
@@ -121,7 +121,7 @@ export class CritiqueLoop {
   }
 
   private buildCorrection(
-    critiqueResult: { readonly overallScore: number; readonly results: readonly { readonly findings: readonly EvaluationFinding[] }[] },
+    critiqueResult: CritiquePipelineResult,
     iterationCount: number,
   ): CorrectionRequest {
     const allFindings = critiqueResult.results.flatMap((r) => r.findings);

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -1,5 +1,6 @@
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
 import type { Evaluator, EvaluationInput, EvaluationResult, CritiquePipelineResult } from '../types/evaluation.js';
+import { createScore } from '../types/common.js';
 
 const SAFETY_EVALUATOR_NAME = 'safety';
 
@@ -18,7 +19,7 @@ function createEvaluatorExceptionResult(evaluator: Evaluator): EvaluationResult 
   return {
     evaluatorName: evaluator.name,
     verdict: 'fail',
-    score: 0,
+    score: createScore(0),
     findings: [
       {
         message: `Evaluator "${evaluator.name}" failed because an internal evaluator error occurred.`,
@@ -43,7 +44,7 @@ export class CritiquePipeline {
 
   async run(input: EvaluationInput): Promise<CritiquePipelineResult> {
     if (this.evaluators.length === 0) {
-      return { verdict: 'pass', overallScore: 1, results: [], shortCircuited: false };
+      return { verdict: 'pass', overallScore: createScore(1), results: [], shortCircuited: false };
     }
 
     const results: EvaluationResult[] = [];
@@ -73,7 +74,9 @@ export class CritiquePipeline {
       }
     }
 
-    const overallScore = results.reduce((sum, r) => sum + r.score, 0) / results.length;
+    const overallScore = createScore(
+      results.reduce((sum, r) => sum + r.score, 0) / results.length,
+    );
     const hasFailure = results.some((r) => r.verdict === 'fail');
     const hasWarning = results.some(
       (r) => r.verdict === 'warn' || (r.verdict === 'pass' && hasWarningFinding(r)),

--- a/packages/franken-critique/src/types/common.ts
+++ b/packages/franken-critique/src/types/common.ts
@@ -1,13 +1,5 @@
 // Shared types re-exported from @franken/types
-export type { SessionId, TaskId } from '@franken/types';
-export { createSessionId, createTaskId } from '@franken/types';
+export type { Score, SessionId, TaskId } from '@franken/types';
+export { createScore, createSessionId, createTaskId } from '@franken/types';
 export type { Verdict } from '@franken/types';
 export type { CritiqueSeverity as Severity } from '@franken/types';
-
-/**
- * Normalized score between 0 and 1.
- * 0 = worst, 1 = best.
- */
-export type Score = number;
-
-// SessionId is intentionally the branded @franken/types SessionId.

--- a/packages/franken-critique/tests/types/shared-common.type-test.ts
+++ b/packages/franken-critique/tests/types/shared-common.type-test.ts
@@ -1,0 +1,36 @@
+import { createScore, createSessionId } from '@franken/types';
+import type {
+  Score as SharedScore,
+  SessionId as SharedSessionId,
+} from '@franken/types';
+import type {
+  Score as CritiqueScore,
+  SessionId as CritiqueSessionId,
+} from '../../src/types/common.js';
+
+type Equal<Left, Right> = [Left] extends [Right]
+  ? [Right] extends [Left]
+    ? true
+    : false
+  : false;
+type Assert<Condition extends true> = Condition;
+
+type ScoreUsesSharedContract = Assert<Equal<CritiqueScore, SharedScore>>;
+type SessionIdUsesSharedContract = Assert<
+  Equal<CritiqueSessionId, SharedSessionId>
+>;
+
+const score: CritiqueScore = createScore(0.5);
+const sessionId: CritiqueSessionId = createSessionId('critique-session');
+
+// @ts-expect-error A critique Score must not accept an unbranded number.
+const unbrandedScore: CritiqueScore = 0.5;
+// @ts-expect-error A critique SessionId must not accept an unbranded string.
+const unbrandedSessionId: CritiqueSessionId = 'critique-session';
+
+void (0 as unknown as ScoreUsesSharedContract);
+void (0 as unknown as SessionIdUsesSharedContract);
+void score;
+void sessionId;
+void unbrandedScore;
+void unbrandedSessionId;

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import {
-  createSessionId,
-} from '@franken/types';
-import type { ProviderCritiqueFinding } from '@franken/types';
+import { createSessionId } from '@franken/types';
+import type { ProviderCritiqueFinding, Score as SharedScore } from '@franken/types';
+import { createScore } from '@franken/critique';
 import type {
   CritiquePipelineResult,
   CritiqueResult,
   LessonRollbackWorkflow,
   AgentImprovementScorecard,
   LessonFeedbackWeighting,
+  Score,
   SessionId,
 } from '@franken/critique';
 
@@ -19,15 +19,16 @@ describe('public critique type contracts', () => {
       severity: 7,
       message: 'Missing error handling',
     };
+    const score = createScore(0.75);
 
     const pipelineResult: CritiquePipelineResult = {
       verdict: 'warn',
-      overallScore: 0.75,
+      overallScore: score,
       results: [
         {
           evaluatorName: providerFinding.evaluator,
           verdict: 'warn',
-          score: 0.75,
+          score,
           findings: [
             {
               message: providerFinding.message,
@@ -47,6 +48,16 @@ describe('public critique type contracts', () => {
     expect(legacyAlias.results[0]?.findings[0]?.message).toBe(
       providerFinding.message,
     );
+  });
+
+  it('uses the shared branded score contract for critique results', () => {
+    const score = createScore(0.75);
+
+    expectTypeOf(score).toEqualTypeOf<Score>();
+    expectTypeOf<Score>().toEqualTypeOf<SharedScore>();
+    // @ts-expect-error Score must be constructed through the shared constructor.
+    const unbrandedScore: Score = 0.75;
+    expect(unbrandedScore).toBe(0.75);
   });
 
   it('uses the branded @franken/types SessionId contract for critique sessions', () => {

--- a/packages/franken-critique/tsconfig.type-tests.json
+++ b/packages/franken-critique/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "tests/types/**/*.type-test.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -16,6 +16,10 @@ export {
   createTraceId,
 } from './ids.js';
 
+// Normalized score
+export type { Score } from './score.js';
+export { createScore } from './score.js';
+
 export type { SeededRandom } from './deterministic.js';
 export {
   deterministicUuid,

--- a/packages/franken-types/src/score.ts
+++ b/packages/franken-types/src/score.ts
@@ -1,0 +1,16 @@
+/** A normalized score between 0 and 1. */
+declare const scoreBrand: unique symbol;
+export type Score = number & { readonly [scoreBrand]: 'Score' };
+
+/**
+ * Creates a branded normalized score.
+ *
+ * @throws {RangeError} when value is not finite or outside the inclusive 0-1 range.
+ */
+export function createScore(value: number): Score {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError('Score must be a finite number between 0 and 1');
+  }
+
+  return value as Score;
+}

--- a/packages/franken-types/tests/score.test.ts
+++ b/packages/franken-types/tests/score.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createScore } from '../src/index.js';
+import type { Score } from '../src/index.js';
+
+describe('Score', () => {
+  it('brands normalized scores created through the shared constructor', () => {
+    const score = createScore(0.75);
+
+    expectTypeOf(score).toEqualTypeOf<Score>();
+    expect(score).toBe(0.75);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -0.01, 1.01])(
+    'rejects an invalid normalized score: %s',
+    (value) => {
+      expect(() => createScore(value)).toThrow(RangeError);
+    },
+  );
+
+  it('does not accept unbranded numbers as scores', () => {
+    // @ts-expect-error Score must be constructed through createScore.
+    const score: Score = 0.5;
+
+    expect(score).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- add a branded normalized `Score` contract and validated constructor to `@franken/types`
- re-export and use the shared `SessionId`/`Score` contracts throughout `@franken/critique`
- add compile-time and public runtime regressions preventing local aliases from returning

## Test plan
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/types`
- `npm run lint --workspace @franken/types`
- `npm run test --workspace @franken/types -- --run tests/score.test.ts`
- `npm run build --workspace @franken/critique`
- `npm run typecheck --workspace @franken/critique`
- `npm run lint --workspace @franken/critique`
- `npm run test --workspace @franken/critique -- --run tests/unit/types/public-contracts.test.ts`
- `npm run test:integration --workspace @franken/critique`

Closes #2367