### PR TITLE
fix(orchestrator): serialize beast event sequence allocation

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -861,15 +861,15 @@ export class SQLiteBeastRepository {
       );
       for (const { run_id: runId } of duplicateRunIds) {
         const rows = selectRunEvents.all(runId) as Array<{ id: string; sequence: number }>;
-        const seenSequences = new Set<number>();
-        let nextSequence = rows.reduce((maximum, row) => Math.max(maximum, row.sequence), 0);
+        let previousSequence: number | undefined;
         for (const row of rows) {
-          if (seenSequences.has(row.sequence)) {
-            nextSequence += 1;
-            updateRunEventSequence.run(nextSequence, row.id);
-          } else {
-            seenSequences.add(row.sequence);
+          const repairedSequence = previousSequence === undefined
+            ? row.sequence
+            : Math.max(row.sequence, previousSequence + 1);
+          if (repairedSequence !== row.sequence) {
+            updateRunEventSequence.run(repairedSequence, row.id);
           }
+          previousSequence = repairedSequence;
         }
       }
 
@@ -890,11 +890,15 @@ export class SQLiteBeastRepository {
       );
       for (const { agent_id: agentId } of duplicateAgentIds) {
         const rows = selectAgentEvents.all(agentId) as Array<{ id: string; sequence: number }>;
-        for (const [index, row] of rows.entries()) {
-          updateAgentEventSequence.run(-(index + 1), row.id);
-        }
-        for (const [index, row] of rows.entries()) {
-          updateAgentEventSequence.run(index + 1, row.id);
+        let previousSequence: number | undefined;
+        for (const row of rows) {
+          const repairedSequence = previousSequence === undefined
+            ? row.sequence
+            : Math.max(row.sequence, previousSequence + 1);
+          if (repairedSequence !== row.sequence) {
+            updateAgentEventSequence.run(repairedSequence, row.id);
+          }
+          previousSequence = repairedSequence;
         }
       }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -17,7 +17,10 @@ import type {
   TrackedAgentStatus,
 } from '../types.js';
 import { UnknownTrackedAgentError } from '../errors.js';
-import { BEAST_SQLITE_SCHEMA_STATEMENTS } from './sqlite-schema.js';
+import {
+  BEAST_SQLITE_EVENT_UNIQUENESS_INDEX_STATEMENTS,
+  BEAST_SQLITE_SCHEMA_STATEMENTS,
+} from './sqlite-schema.js';
 
 interface CreateRunInput {
   trackedAgentId?: string | undefined;
@@ -233,6 +236,7 @@ export class SQLiteBeastRepository {
     }
 
     this.migrateLegacySchema();
+    this.repairDuplicateEventSequencesAndEnforceUniqueness();
   }
 
   createRun(input: CreateRunInput): BeastRun {
@@ -282,7 +286,7 @@ export class SQLiteBeastRepository {
   }
 
   transaction<T>(fn: () => T): T {
-    return this.db.transaction(fn)();
+    return this.db.transaction(fn).immediate();
   }
 
   getRun(runId: string): BeastRun | undefined {
@@ -836,6 +840,64 @@ export class SQLiteBeastRepository {
     this.ensureColumnExists('beast_runs', 'last_heartbeat_sequence', 'ALTER TABLE beast_runs ADD COLUMN last_heartbeat_sequence INTEGER NOT NULL DEFAULT 0');
     this.ensureColumnExists('tracked_agents', 'module_config', 'ALTER TABLE tracked_agents ADD COLUMN module_config TEXT');
     this.ensureColumnExists('tracked_agents', 'execution_mode', 'ALTER TABLE tracked_agents ADD COLUMN execution_mode TEXT');
+  }
+
+  private repairDuplicateEventSequencesAndEnforceUniqueness(): void {
+    this.db.transaction(() => {
+      const duplicateRunIds = this.db.prepare(
+        `SELECT run_id
+           FROM beast_run_events
+          GROUP BY run_id
+         HAVING COUNT(*) != COUNT(DISTINCT sequence)`,
+      ).all() as Array<{ run_id: string }>;
+      const selectRunEvents = this.db.prepare(
+        `SELECT id
+           FROM beast_run_events
+          WHERE run_id = ?
+          ORDER BY sequence ASC, created_at ASC, id ASC`,
+      );
+      const updateRunEventSequence = this.db.prepare(
+        'UPDATE beast_run_events SET sequence = ? WHERE id = ?',
+      );
+      for (const { run_id: runId } of duplicateRunIds) {
+        const rows = selectRunEvents.all(runId) as Array<{ id: string }>;
+        for (const [index, row] of rows.entries()) {
+          updateRunEventSequence.run(-(index + 1), row.id);
+        }
+        for (const [index, row] of rows.entries()) {
+          updateRunEventSequence.run(index + 1, row.id);
+        }
+      }
+
+      const duplicateAgentIds = this.db.prepare(
+        `SELECT agent_id
+           FROM tracked_agent_events
+          GROUP BY agent_id
+         HAVING COUNT(*) != COUNT(DISTINCT sequence)`,
+      ).all() as Array<{ agent_id: string }>;
+      const selectAgentEvents = this.db.prepare(
+        `SELECT id
+           FROM tracked_agent_events
+          WHERE agent_id = ?
+          ORDER BY sequence ASC, created_at ASC, id ASC`,
+      );
+      const updateAgentEventSequence = this.db.prepare(
+        'UPDATE tracked_agent_events SET sequence = ? WHERE id = ?',
+      );
+      for (const { agent_id: agentId } of duplicateAgentIds) {
+        const rows = selectAgentEvents.all(agentId) as Array<{ id: string }>;
+        for (const [index, row] of rows.entries()) {
+          updateAgentEventSequence.run(-(index + 1), row.id);
+        }
+        for (const [index, row] of rows.entries()) {
+          updateAgentEventSequence.run(index + 1, row.id);
+        }
+      }
+
+      for (const statement of BEAST_SQLITE_EVENT_UNIQUENESS_INDEX_STATEMENTS) {
+        this.db.prepare(statement).run();
+      }
+    }).immediate();
   }
 
   private ensureColumnExists(table: string, column: string, alterStatement: string): void {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -890,15 +890,11 @@ export class SQLiteBeastRepository {
       );
       for (const { agent_id: agentId } of duplicateAgentIds) {
         const rows = selectAgentEvents.all(agentId) as Array<{ id: string; sequence: number }>;
-        const seenSequences = new Set<number>();
-        let nextSequence = rows.reduce((maximum, row) => Math.max(maximum, row.sequence), 0);
-        for (const row of rows) {
-          if (seenSequences.has(row.sequence)) {
-            nextSequence += 1;
-            updateAgentEventSequence.run(nextSequence, row.id);
-          } else {
-            seenSequences.add(row.sequence);
-          }
+        for (const [index, row] of rows.entries()) {
+          updateAgentEventSequence.run(-(index + 1), row.id);
+        }
+        for (const [index, row] of rows.entries()) {
+          updateAgentEventSequence.run(index + 1, row.id);
         }
       }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -851,7 +851,7 @@ export class SQLiteBeastRepository {
          HAVING COUNT(*) != COUNT(DISTINCT sequence)`,
       ).all() as Array<{ run_id: string }>;
       const selectRunEvents = this.db.prepare(
-        `SELECT id
+        `SELECT id, sequence
            FROM beast_run_events
           WHERE run_id = ?
           ORDER BY sequence ASC, created_at ASC, id ASC`,
@@ -860,12 +860,16 @@ export class SQLiteBeastRepository {
         'UPDATE beast_run_events SET sequence = ? WHERE id = ?',
       );
       for (const { run_id: runId } of duplicateRunIds) {
-        const rows = selectRunEvents.all(runId) as Array<{ id: string }>;
-        for (const [index, row] of rows.entries()) {
-          updateRunEventSequence.run(-(index + 1), row.id);
-        }
-        for (const [index, row] of rows.entries()) {
-          updateRunEventSequence.run(index + 1, row.id);
+        const rows = selectRunEvents.all(runId) as Array<{ id: string; sequence: number }>;
+        const seenSequences = new Set<number>();
+        let nextSequence = rows.reduce((maximum, row) => Math.max(maximum, row.sequence), 0);
+        for (const row of rows) {
+          if (seenSequences.has(row.sequence)) {
+            nextSequence += 1;
+            updateRunEventSequence.run(nextSequence, row.id);
+          } else {
+            seenSequences.add(row.sequence);
+          }
         }
       }
 
@@ -876,7 +880,7 @@ export class SQLiteBeastRepository {
          HAVING COUNT(*) != COUNT(DISTINCT sequence)`,
       ).all() as Array<{ agent_id: string }>;
       const selectAgentEvents = this.db.prepare(
-        `SELECT id
+        `SELECT id, sequence
            FROM tracked_agent_events
           WHERE agent_id = ?
           ORDER BY sequence ASC, created_at ASC, id ASC`,
@@ -885,12 +889,16 @@ export class SQLiteBeastRepository {
         'UPDATE tracked_agent_events SET sequence = ? WHERE id = ?',
       );
       for (const { agent_id: agentId } of duplicateAgentIds) {
-        const rows = selectAgentEvents.all(agentId) as Array<{ id: string }>;
-        for (const [index, row] of rows.entries()) {
-          updateAgentEventSequence.run(-(index + 1), row.id);
-        }
-        for (const [index, row] of rows.entries()) {
-          updateAgentEventSequence.run(index + 1, row.id);
+        const rows = selectAgentEvents.all(agentId) as Array<{ id: string; sequence: number }>;
+        const seenSequences = new Set<number>();
+        let nextSequence = rows.reduce((maximum, row) => Math.max(maximum, row.sequence), 0);
+        for (const row of rows) {
+          if (seenSequences.has(row.sequence)) {
+            nextSequence += 1;
+            updateAgentEventSequence.run(nextSequence, row.id);
+          } else {
+            seenSequences.add(row.sequence);
+          }
         }
       }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -397,7 +397,7 @@ export class SQLiteBeastRepository {
       const priorMs = Date.parse(priorHeartbeatAt);
       const nextMs = Date.parse(newHeartbeatAt);
       if (Number.isFinite(priorMs) && Number.isFinite(nextMs) && nextMs <= priorMs) {
-        this.insertEvent(runId, {
+        this.appendEvent(runId, {
           type: 'run.heartbeat.anomaly',
           payload: {
             code: nextMs < priorMs ? 'regressive-heartbeat' : 'duplicate-heartbeat',
@@ -454,7 +454,7 @@ export class SQLiteBeastRepository {
   }
 
   appendEvent(runId: string, input: AppendEventInput): BeastRunEvent {
-    return this.insertEvent(runId, input);
+    return this.db.transaction(() => this.insertEvent(runId, input)).immediate();
   }
 
   private insertEvent(runId: string, input: AppendEventInput): BeastRunEvent {
@@ -652,41 +652,43 @@ export class SQLiteBeastRepository {
   }
 
   appendTrackedAgentEvent(agentId: string, input: AppendTrackedAgentEventInput): TrackedAgentEvent {
-    this.getTrackedAgentOrThrow(agentId);
-    const event: TrackedAgentEvent = {
-      id: prefixedId('agent_event'),
-      agentId,
-      sequence: nextTrackedAgentEventSequence(this.db, agentId),
-      level: input.level,
-      type: input.type,
-      message: input.message,
-      payload: input.payload,
-      createdAt: input.createdAt,
-    };
+    return this.db.transaction(() => {
+      this.getTrackedAgentOrThrow(agentId);
+      const event: TrackedAgentEvent = {
+        id: prefixedId('agent_event'),
+        agentId,
+        sequence: nextTrackedAgentEventSequence(this.db, agentId),
+        level: input.level,
+        type: input.type,
+        message: input.message,
+        payload: input.payload,
+        createdAt: input.createdAt,
+      };
 
-    this.db.prepare(
-      `INSERT INTO tracked_agent_events (
-        id,
-        agent_id,
-        sequence,
-        level,
-        type,
-        message,
-        payload,
-        created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      event.id,
-      event.agentId,
-      event.sequence,
-      event.level,
-      event.type,
-      event.message,
-      JSON.stringify(event.payload),
-      event.createdAt,
-    );
+      this.db.prepare(
+        `INSERT INTO tracked_agent_events (
+          id,
+          agent_id,
+          sequence,
+          level,
+          type,
+          message,
+          payload,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        event.id,
+        event.agentId,
+        event.sequence,
+        event.level,
+        event.type,
+        event.message,
+        JSON.stringify(event.payload),
+        event.createdAt,
+      );
 
-    return event;
+      return event;
+    }).immediate();
   }
 
   listTrackedAgentEvents(agentId: string, options: CorruptJsonRecoveryOptions = {}): TrackedAgentEvent[] {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -45,6 +45,7 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     FOREIGN KEY (attempt_id) REFERENCES beast_run_attempts(id)
   )`,
   'CREATE INDEX IF NOT EXISTS idx_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
+  'CREATE UNIQUE INDEX IF NOT EXISTS uq_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
   `CREATE TABLE IF NOT EXISTS beast_interview_sessions (
     id TEXT PRIMARY KEY,
     definition_id TEXT NOT NULL,
@@ -80,4 +81,5 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     created_at TEXT NOT NULL,
     FOREIGN KEY (agent_id) REFERENCES tracked_agents(id)
   )`,
+  'CREATE UNIQUE INDEX IF NOT EXISTS uq_tracked_agent_events_agent_sequence ON tracked_agent_events(agent_id, sequence)',
 ] as const;

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -45,7 +45,6 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     FOREIGN KEY (attempt_id) REFERENCES beast_run_attempts(id)
   )`,
   'CREATE INDEX IF NOT EXISTS idx_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
-  'CREATE UNIQUE INDEX IF NOT EXISTS uq_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
   `CREATE TABLE IF NOT EXISTS beast_interview_sessions (
     id TEXT PRIMARY KEY,
     definition_id TEXT NOT NULL,
@@ -81,5 +80,9 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     created_at TEXT NOT NULL,
     FOREIGN KEY (agent_id) REFERENCES tracked_agents(id)
   )`,
+] as const;
+
+export const BEAST_SQLITE_EVENT_UNIQUENESS_INDEX_STATEMENTS = [
+  'CREATE UNIQUE INDEX IF NOT EXISTS uq_beast_run_events_run_sequence ON beast_run_events(run_id, sequence)',
   'CREATE UNIQUE INDEX IF NOT EXISTS uq_tracked_agent_events_agent_sequence ON tracked_agent_events(agent_id, sequence)',
 ] as const;

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -699,13 +699,13 @@ describe('SQLiteBeastRepository', () => {
 
     expect(migrated.listEvents(run.id).map((event) => [event.sequence, event.type])).toEqual([
       [1, 'run.first'],
+      [2, 'run.second'],
       [1_000, 'run.later'],
-      [1_001, 'run.second'],
     ]);
     expect(migrated.listTrackedAgentEvents(agent.id).map((event) => [event.sequence, event.type])).toEqual([
       [1, 'agent.dispatch.failed'],
       [2, 'agent.dispatch.recovered'],
-      [3, 'agent.dispatch.failed'],
+      [1_000, 'agent.dispatch.failed'],
     ]);
     expect(migrated.hasUnrecoveredDispatchFailure(agent.id)).toBe(true);
     const migratedDatabase = new Database(databasePath);

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -683,15 +683,15 @@ describe('SQLiteBeastRepository', () => {
         (id, agent_id, sequence, level, type, message, payload, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      'agent_event_duplicate_a', agent.id, 1, 'info', 'agent.first', 'First', '{}', '2026-03-12T00:00:01.000Z',
-      'agent_event_duplicate_b', agent.id, 1, 'info', 'agent.second', 'Second', '{}', '2026-03-12T00:00:02.000Z',
+      'agent_event_duplicate_a', agent.id, 1, 'error', 'agent.dispatch.failed', 'First failure', '{}', '2026-03-12T00:00:01.000Z',
+      'agent_event_duplicate_b', agent.id, 1, 'info', 'agent.dispatch.recovered', 'Recovered', '{}', '2026-03-12T00:00:02.000Z',
     );
     database.prepare(
       `INSERT INTO tracked_agent_events
         (id, agent_id, sequence, level, type, message, payload, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      'agent_event_later', agent.id, 1_000, 'info', 'agent.later', 'Later', '{}', '2026-03-12T00:00:03.000Z',
+      'agent_event_later', agent.id, 1_000, 'error', 'agent.dispatch.failed', 'Later failure', '{}', '2026-03-12T00:00:03.000Z',
     );
     database.close();
 
@@ -703,10 +703,11 @@ describe('SQLiteBeastRepository', () => {
       [1_001, 'run.second'],
     ]);
     expect(migrated.listTrackedAgentEvents(agent.id).map((event) => [event.sequence, event.type])).toEqual([
-      [1, 'agent.first'],
-      [1_000, 'agent.later'],
-      [1_001, 'agent.second'],
+      [1, 'agent.dispatch.failed'],
+      [2, 'agent.dispatch.recovered'],
+      [3, 'agent.dispatch.failed'],
     ]);
+    expect(migrated.hasUnrecoveredDispatchFailure(agent.id)).toBe(true);
     const migratedDatabase = new Database(databasePath);
     expect(migratedDatabase.pragma("index_list('beast_run_events')")).toContainEqual(expect.objectContaining({
       name: 'uq_beast_run_events_run_sequence',

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -674,6 +674,11 @@ describe('SQLiteBeastRepository', () => {
       'event_duplicate_b', run.id, null, 1, 'run.second', '{}', '2026-03-12T00:00:02.000Z',
     );
     database.prepare(
+      `INSERT INTO beast_run_events
+        (id, run_id, attempt_id, sequence, type, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run('event_later', run.id, null, 1_000, 'run.later', '{}', '2026-03-12T00:00:03.000Z');
+    database.prepare(
       `INSERT INTO tracked_agent_events
         (id, agent_id, sequence, level, type, message, payload, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -681,17 +686,26 @@ describe('SQLiteBeastRepository', () => {
       'agent_event_duplicate_a', agent.id, 1, 'info', 'agent.first', 'First', '{}', '2026-03-12T00:00:01.000Z',
       'agent_event_duplicate_b', agent.id, 1, 'info', 'agent.second', 'Second', '{}', '2026-03-12T00:00:02.000Z',
     );
+    database.prepare(
+      `INSERT INTO tracked_agent_events
+        (id, agent_id, sequence, level, type, message, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'agent_event_later', agent.id, 1_000, 'info', 'agent.later', 'Later', '{}', '2026-03-12T00:00:03.000Z',
+    );
     database.close();
 
     const migrated = new SQLiteBeastRepository(databasePath);
 
     expect(migrated.listEvents(run.id).map((event) => [event.sequence, event.type])).toEqual([
       [1, 'run.first'],
-      [2, 'run.second'],
+      [1_000, 'run.later'],
+      [1_001, 'run.second'],
     ]);
     expect(migrated.listTrackedAgentEvents(agent.id).map((event) => [event.sequence, event.type])).toEqual([
       [1, 'agent.first'],
-      [2, 'agent.second'],
+      [1_000, 'agent.later'],
+      [1_001, 'agent.second'],
     ]);
     const migratedDatabase = new Database(databasePath);
     expect(migratedDatabase.pragma("index_list('beast_run_events')")).toContainEqual(expect.objectContaining({

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -415,10 +415,13 @@ describe('SQLiteBeastRepository', () => {
     );
     await concurrent.inserted;
 
-    const appended = repo.appendEvent(run.id, {
-      type: 'run.local',
-      payload: {},
-      createdAt: '2026-03-10T00:00:02.000Z',
+    const appended = repo.transaction(() => {
+      expect(repo.getRun(run.id)).toBeDefined();
+      return repo.appendEvent(run.id, {
+        type: 'run.local',
+        payload: {},
+        createdAt: '2026-03-10T00:00:02.000Z',
+      });
     });
     await concurrent.completed;
 
@@ -634,6 +637,72 @@ describe('SQLiteBeastRepository', () => {
       unique: 1,
     }));
     database.close();
+  });
+
+  it('repairs duplicate event sequences before enforcing unique indexes', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const databasePath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(databasePath);
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-12T00:00:00.000Z',
+    });
+    const agent = repo.createTrackedAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      status: 'initializing',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-12T00:00:00.000Z',
+      updatedAt: '2026-03-12T00:00:00.000Z',
+    });
+    const database = new Database(databasePath);
+    database.prepare('DROP INDEX uq_beast_run_events_run_sequence').run();
+    database.prepare('DROP INDEX uq_tracked_agent_events_agent_sequence').run();
+    database.prepare(
+      `INSERT INTO beast_run_events
+        (id, run_id, attempt_id, sequence, type, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'event_duplicate_a', run.id, null, 1, 'run.first', '{}', '2026-03-12T00:00:01.000Z',
+      'event_duplicate_b', run.id, null, 1, 'run.second', '{}', '2026-03-12T00:00:02.000Z',
+    );
+    database.prepare(
+      `INSERT INTO tracked_agent_events
+        (id, agent_id, sequence, level, type, message, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'agent_event_duplicate_a', agent.id, 1, 'info', 'agent.first', 'First', '{}', '2026-03-12T00:00:01.000Z',
+      'agent_event_duplicate_b', agent.id, 1, 'info', 'agent.second', 'Second', '{}', '2026-03-12T00:00:02.000Z',
+    );
+    database.close();
+
+    const migrated = new SQLiteBeastRepository(databasePath);
+
+    expect(migrated.listEvents(run.id).map((event) => [event.sequence, event.type])).toEqual([
+      [1, 'run.first'],
+      [2, 'run.second'],
+    ]);
+    expect(migrated.listTrackedAgentEvents(agent.id).map((event) => [event.sequence, event.type])).toEqual([
+      [1, 'agent.first'],
+      [2, 'agent.second'],
+    ]);
+    const migratedDatabase = new Database(databasePath);
+    expect(migratedDatabase.pragma("index_list('beast_run_events')")).toContainEqual(expect.objectContaining({
+      name: 'uq_beast_run_events_run_sequence',
+      unique: 1,
+    }));
+    expect(migratedDatabase.pragma("index_list('tracked_agent_events')")).toContainEqual(expect.objectContaining({
+      name: 'uq_tracked_agent_events_agent_sequence',
+      unique: 1,
+    }));
+    migratedDatabase.close();
   });
 
   it('rolls back linked run creation when the tracked agent is unknown', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { Worker } from 'node:worker_threads';
 import Database from 'better-sqlite3';
 import { UnknownTrackedAgentError } from '../../../src/beasts/errors.js';
 import {
@@ -126,6 +127,57 @@ function corruptJsonColumn(
   } finally {
     db.close();
   }
+}
+
+function startConcurrentEventInsert(
+  dbPath: string,
+  sql: string,
+  parameters: readonly unknown[],
+): { readonly inserted: Promise<void>; readonly completed: Promise<void> } {
+  let resolveInserted!: () => void;
+  let rejectInserted!: (error: Error) => void;
+  const inserted = new Promise<void>((resolve, reject) => {
+    resolveInserted = resolve;
+    rejectInserted = reject;
+  });
+
+  const worker = new Worker(`
+    const { parentPort, workerData } = require('node:worker_threads');
+    const Database = require('better-sqlite3');
+    const db = new Database(workerData.dbPath);
+    db.pragma('busy_timeout = 5000');
+    db.prepare('BEGIN IMMEDIATE').run();
+    db.prepare(workerData.sql).run(...workerData.parameters);
+    parentPort.postMessage('inserted');
+    setTimeout(() => {
+      db.prepare('COMMIT').run();
+      db.close();
+      parentPort.postMessage('committed');
+    }, 100);
+  `, {
+    eval: true,
+    workerData: { dbPath, sql, parameters },
+  });
+
+  const completed = new Promise<void>((resolve, reject) => {
+    worker.on('message', (message: unknown) => {
+      if (message === 'inserted') resolveInserted();
+      if (message === 'committed') resolve();
+    });
+    worker.once('error', (error) => {
+      rejectInserted(error);
+      reject(error);
+    });
+    worker.once('exit', (code) => {
+      if (code !== 0) {
+        const error = new Error(`concurrent event writer exited with code ${code}`);
+        rejectInserted(error);
+        reject(error);
+      }
+    });
+  });
+
+  return { inserted, completed };
 }
  
 describe('SQLiteBeastRepository', () => {
@@ -341,6 +393,39 @@ describe('SQLiteBeastRepository', () => {
     });
   });
 
+  it('allocates a run-event sequence after a concurrent writer commits', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const databasePath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(databasePath);
+    const run = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const concurrent = startConcurrentEventInsert(
+      databasePath,
+      `INSERT INTO beast_run_events
+        (id, run_id, attempt_id, sequence, type, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['event_concurrent', run.id, null, 1, 'run.concurrent', '{}', '2026-03-10T00:00:01.000Z'],
+    );
+    await concurrent.inserted;
+
+    const appended = repo.appendEvent(run.id, {
+      type: 'run.local',
+      payload: {},
+      createdAt: '2026-03-10T00:00:02.000Z',
+    });
+    await concurrent.completed;
+
+    expect(appended.sequence).toBe(2);
+    expect(repo.listEvents(run.id).map((event) => event.sequence)).toEqual([1, 2]);
+  });
+
   it('bounds recovered event pages by raw rows scanned and indexes the cursor query', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const databasePath = join(workDir, 'beasts.db');
@@ -364,8 +449,12 @@ describe('SQLiteBeastRepository', () => {
 
     expect(repo.listEvents(run.id, { recoverCorruptJson: true, limit: 3 }).map((event) => event.sequence))
       .toEqual([1, 3]);
-    const indexes = database.pragma("index_list('beast_run_events')") as Array<{ name: string }>;
+    const indexes = database.pragma("index_list('beast_run_events')") as Array<{ name: string; unique: 0 | 1 }>;
     expect(indexes.map((index) => index.name)).toContain('idx_beast_run_events_run_sequence');
+    expect(indexes).toContainEqual(expect.objectContaining({
+      name: 'uq_beast_run_events_run_sequence',
+      unique: 1,
+    }));
     database.close();
   });
 
@@ -493,6 +582,58 @@ describe('SQLiteBeastRepository', () => {
       status: 'dispatching',
       dispatchRunId: run.id,
     });
+  });
+
+  it('allocates a tracked-agent-event sequence after a concurrent writer commits', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const databasePath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(databasePath);
+    const agent = repo.createTrackedAgent({
+      definitionId: 'martin-loop',
+      source: 'dashboard',
+      status: 'initializing',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: {},
+      createdAt: '2026-03-11T00:00:00.000Z',
+      updatedAt: '2026-03-11T00:00:00.000Z',
+    });
+    const concurrent = startConcurrentEventInsert(
+      databasePath,
+      `INSERT INTO tracked_agent_events
+        (id, agent_id, sequence, level, type, message, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'agent_event_concurrent',
+        agent.id,
+        1,
+        'info',
+        'agent.concurrent',
+        'Concurrent event',
+        '{}',
+        '2026-03-11T00:00:01.000Z',
+      ],
+    );
+    await concurrent.inserted;
+
+    const appended = repo.appendTrackedAgentEvent(agent.id, {
+      level: 'info',
+      type: 'agent.local',
+      message: 'Local event',
+      payload: {},
+      createdAt: '2026-03-11T00:00:02.000Z',
+    });
+    await concurrent.completed;
+
+    expect(appended.sequence).toBe(2);
+    expect(repo.listTrackedAgentEvents(agent.id).map((event) => event.sequence)).toEqual([1, 2]);
+    const database = new Database(databasePath);
+    const indexes = database.pragma("index_list('tracked_agent_events')") as Array<{ name: string; unique: 0 | 1 }>;
+    expect(indexes).toContainEqual(expect.objectContaining({
+      name: 'uq_tracked_agent_events_agent_sequence',
+      unique: 1,
+    }));
+    database.close();
   });
 
   it('rolls back linked run creation when the tracked agent is unknown', async () => {


### PR DESCRIPTION
## Summary
- serialize beast run-event and tracked-agent-event sequence allocation with `BEGIN IMMEDIATE` transactions
- add unique SQLite indexes as a final duplicate-sequence guard
- add cross-connection regression tests that hold a concurrent writer transaction open during append

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/beasts/sqlite-beast-repository.test.ts`
- `npm run test --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator -- --quiet`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run build`

Closes #2746
