### PR TITLE
chore(eslint): enable type-aware promise linting

### DIFF
--- a/eslint.workspace.config.js
+++ b/eslint.workspace.config.js
@@ -8,6 +8,19 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettierConfig,
   {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/*.integration.test.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     rules: {
       'radix': ['error', 'always'],
       'prefer-const': 'warn',

--- a/packages/franken-brain/eslint.config.js
+++ b/packages/franken-brain/eslint.config.js
@@ -8,6 +8,19 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettierConfig,
   {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/*.integration.test.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     rules: {
       'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',

--- a/packages/franken-critique/eslint.config.js
+++ b/packages/franken-critique/eslint.config.js
@@ -8,6 +8,19 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettierConfig,
   {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/*.integration.test.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     rules: {
       'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',

--- a/packages/franken-orchestrator/eslint.config.js
+++ b/packages/franken-orchestrator/eslint.config.js
@@ -8,6 +8,19 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettierConfig,
   {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/*.integration.test.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     rules: {
       'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'warn',

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1690,6 +1690,21 @@ type NetworkPaths = Pick<ReturnType<typeof getProjectPaths>, 'frankenbeastDir' |
 
 type BeastDaemonPaths = ReturnType<typeof getProjectPaths>;
 
+export async function handleBeastDaemonShutdown(
+  close: () => Promise<void>,
+  exit: (code: number) => unknown = (code) => process.exit(code),
+  reportError: (message: string, error: unknown) => void = (message, error) => console.error(message, error),
+): Promise<void> {
+  try {
+    await close();
+  } catch (error) {
+    reportError('Beast daemon shutdown failed:', error);
+    exit(1);
+    return;
+  }
+  exit(0);
+}
+
 async function runBeastDaemonCommand(
   args: CliArgs,
   config: OrchestratorConfig,
@@ -1733,7 +1748,7 @@ async function runBeastDaemonCommand(
     await daemon.close();
   };
   const onSignal = (): void => {
-    void shutdown().then(() => process.exit(0));
+    void handleBeastDaemonShutdown(shutdown);
   };
   process.once('SIGINT', onSignal);
   process.once('SIGTERM', onSignal);

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -255,7 +255,7 @@ vi.mock('node:readline', () => ({
 
 // ── Import run.ts exports (main() is guarded, call explicitly in tests) ──
 
-import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, resolveEffectivePreflightProvider, resolveEffectivePreflightProviders, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, validateStateDirBeforeScaffold, resolveScaffoldStateDir, runNetworkCommand } from '../../../src/cli/run.js';
+import { resolvePhases, createStdinIO, main, resolveDashboardAllowedOrigins, runDirectCli, shouldForceDirectCliExit, discoverResumeTarget, inferResumeBaseBranch, checkProviderCliAvailability, assertAnyProviderCliAvailable, resolveEffectivePreflightProvider, resolveEffectivePreflightProviders, buildDashboardProviderSnapshot, formatMissingRunPlanGuidance, shouldShowMissingRunPlanGuidance, defaultRunPlanNeedsGuidance, validateStateDirBeforeScaffold, resolveScaffoldStateDir, runNetworkCommand, handleBeastDaemonShutdown } from '../../../src/cli/run.js';
 import { loadConfig } from '../../../src/cli/config-loader.js';
 import { scaffoldFrankenbeast, resolveProjectRoot, getProjectPaths, readActivePlanName, writeActivePlanName } from '../../../src/cli/project-root.js';
 import { resolveBaseBranch } from '../../../src/cli/base-branch.js';
@@ -1073,6 +1073,30 @@ describe('runDirectCli', () => {
     expect(exit).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith('Fatal:', 'boom');
     errorSpy.mockRestore();
+  });
+});
+
+describe('handleBeastDaemonShutdown', () => {
+  it('exits zero after closing the daemon', async () => {
+    const close = vi.fn(async () => undefined);
+    const exit = vi.fn();
+
+    await handleBeastDaemonShutdown(close, exit);
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('reports daemon close failures and exits non-zero', async () => {
+    const closeError = new Error('daemon close failed');
+    const close = vi.fn(async () => Promise.reject(closeError));
+    const exit = vi.fn();
+    const reportError = vi.fn();
+
+    await handleBeastDaemonShutdown(close, exit, reportError);
+
+    expect(reportError).toHaveBeenCalledWith('Beast daemon shutdown failed:', closeError);
+    expect(exit).toHaveBeenCalledWith(1);
   });
 });
 

--- a/packages/franken-planner/eslint.config.js
+++ b/packages/franken-planner/eslint.config.js
@@ -8,6 +8,19 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettierConfig,
   {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/*.integration.test.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     rules: {
       'radix': ['error', 'always'],
       '@typescript-eslint/no-explicit-any': 'error',

--- a/tasks/issue-2314-progress.md
+++ b/tasks/issue-2314-progress.md
@@ -6,5 +6,6 @@
 - [x] Enable type-aware `no-floating-promises` linting across workspace configs with the smallest viable configuration.
 - [x] Fix the beasts-daemon signal shutdown rejection path.
 - [x] Run targeted tests and relevant lint/typecheck/build checks.
-- [ ] Commit, push, open a PR closing #2314, and run CI plus current-head Codex review.
+- [x] Commit the implementation locally.
+- [ ] Push, open a PR closing #2314, and run CI plus current-head Codex review.
 - [ ] Merge after all gates pass and record durable lessons if useful.

--- a/tasks/issue-2314-progress.md
+++ b/tasks/issue-2314-progress.md
@@ -1,0 +1,10 @@
+# Issue 2314 Progress
+
+- [x] Verify issue is open and not labeled `good first issue`.
+- [x] Create isolated issue worktree and read shared lessons.
+- [x] Add failing regressions for type-aware lint configuration and daemon shutdown rejection handling.
+- [x] Enable type-aware `no-floating-promises` linting across workspace configs with the smallest viable configuration.
+- [x] Fix the beasts-daemon signal shutdown rejection path.
+- [x] Run targeted tests and relevant lint/typecheck/build checks.
+- [ ] Commit, push, open a PR closing #2314, and run CI plus current-head Codex review.
+- [ ] Merge after all gates pass and record durable lessons if useful.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-20 — Incremental type-aware ESLint adoption
+- Enable type-aware rules in a dedicated TypeScript source override with `projectService: true` and an explicit `tsconfigRootDir`; source-adjacent tests excluded from package tsconfig files must be ignored by that override or ESLint fails before rule evaluation.
+- A targeted rule such as `@typescript-eslint/no-floating-promises` can establish type-aware coverage without enabling the entire strict preset at once. Treat surfaced promises as real call-site decisions: await work that must finish, use `void` only for intentional fire-and-forget, and add rejection handling for shutdown paths.
+
 ## 2026-07-20 — Bounded Beast event paging through corrupt rows
 - Recovery pagination must bound raw rows scanned, not only healthy rows returned. Return the last scanned raw sequence plus an indexed `hasMore` probe so a short or empty page can advance past corrupt rows without turning one request into a full-history scan.
 - Before wiring a new paginated endpoint into dashboard hydration, trace which detail field the UI actually renders. Do not eagerly collect every page for an unused compatibility field; keep the bounded endpoint available for intentional consumers and preserve fast detail loading.

--- a/tests/workspaces.test.ts
+++ b/tests/workspaces.test.ts
@@ -597,6 +597,41 @@ describe("npm workspaces configuration", () => {
       }
     });
 
+    it("enables type-aware floating promise checks in every workspace", () => {
+      const rootConfig = readFileSync(
+        join(ROOT, "eslint.workspace.config.js"),
+        "utf8",
+      );
+
+      expect(rootConfig).toContain("projectService: true");
+      expect(rootConfig).toContain(
+        "'@typescript-eslint/no-floating-promises': 'error'",
+      );
+
+      for (const path of packageJsonPaths) {
+        const packageDir = path.replace(/\/package\.json$/, "");
+        const packageConfig = readFileSync(
+          join(ROOT, packageDir, "eslint.config.js"),
+          "utf8",
+        );
+        const inheritsWorkspaceConfig = packageConfig.includes(
+          "eslint.workspace.config.js",
+        );
+
+        expect(
+          inheritsWorkspaceConfig || packageConfig.includes("projectService: true"),
+          `${packageDir} must enable type-aware linting`,
+        ).toBe(true);
+        expect(
+          inheritsWorkspaceConfig ||
+            packageConfig.includes(
+              "'@typescript-eslint/no-floating-promises': 'error'",
+            ),
+          `${packageDir} must reject floating promises`,
+        ).toBe(true);
+      }
+    });
+
     it("keeps every Number.parseInt call explicit about its radix", () => {
       const missingRadixLocations = collectSourceFiles(ROOT).flatMap((path) => {
         const source = ts.createSourceFile(


### PR DESCRIPTION
## Summary
- enable type-aware ESLint parsing and `@typescript-eslint/no-floating-promises` across all TypeScript workspaces
- await daemon shutdown and report close failures before exiting
- add focused shutdown-path and workspace-config regression coverage

## Verification
- `npm run test:root -- --run tests/workspaces.test.ts`
- `npm test --workspace @franken/orchestrator -- --run tests/unit/cli/run.test.ts`
- `npm run lint`
- `npm run build`
- `npm run typecheck --workspace @franken/orchestrator`
- `git diff --check origin/main...HEAD`

Closes #2314