### PR TITLE
fix(security): fail closed on approval audit errors

### DIFF
--- a/packages/franken-orchestrator/src/chat/approval-audit-log.ts
+++ b/packages/franken-orchestrator/src/chat/approval-audit-log.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { constants } from 'node:fs';
-import { mkdir, readFile, open, chmod } from 'node:fs/promises';
+import { mkdir, open, chmod } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { isoNow } from '@franken/types';
 
@@ -193,10 +193,19 @@ export class FileApprovalAuditLog implements ApprovalAuditLog {
 
   private async readEntries(): Promise<ApprovalAuditEntry[]> {
     let raw: string;
+    let file;
     try {
-      raw = await readFile(this.path, 'utf8');
-    } catch {
-      return [];
+      file = await open(this.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+    try {
+      raw = await file.readFile({ encoding: 'utf8' });
+    } finally {
+      await file.close();
     }
 
     const entries: ApprovalAuditEntry[] = [];

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -637,7 +637,29 @@ export class ChatSocketController {
       }
       throw error;
     }
-    if (await this.hasConsumedApproval(session, runtimeInput)) {
+    let approvalConsumed: boolean;
+    try {
+      approvalConsumed = await this.hasConsumedApproval(session, runtimeInput);
+    } catch {
+      session.pendingApproval = null;
+      session.state = 'rejected';
+      session.updatedAt = nowIso();
+      this.sessionStore.save(session);
+      const timestamp = nowIso();
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_AUDIT_UNAVAILABLE',
+        message: 'The approval audit log could not be read; recreate the approval request before retrying.',
+        timestamp,
+      });
+      this.emit(peer, {
+        type: 'turn.approval.resolved',
+        approved: false,
+        timestamp,
+      });
+      return;
+    }
+    if (approvalConsumed) {
       await this.recordApprovalReplay(session, runtimeInput, 'approval was already consumed', connectionRequester(peer, this.connections));
       session.pendingApproval = null;
       session.state = 'rejected';
@@ -739,16 +761,12 @@ export class ChatSocketController {
   private async hasConsumedApproval(session: ChatSession, command: string): Promise<boolean> {
     const pendingApproval = session.pendingApproval;
     if (!pendingApproval) return false;
-    try {
-      return await this.approvalAuditLog.hasConsumedApproval({
-        sessionId: session.id,
-        projectId: session.projectId,
-        token: approvalAuditToken(session, command),
-        commandHash: commandSha256(command),
-      });
-    } catch {
-      return false;
-    }
+    return this.approvalAuditLog.hasConsumedApproval({
+      sessionId: session.id,
+      projectId: session.projectId,
+      token: approvalAuditToken(session, command),
+      commandHash: commandSha256(command),
+    });
   }
 
   private async recordApprovalDecision(

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -1431,8 +1431,9 @@ describe('ws chat server', () => {
       sessionId: session.id,
     };
     store.save(session);
-    const auditLog = new FileApprovalAuditLog(join(TMP, 'hitl-approval-audit.jsonl'));
-    vi.spyOn(auditLog, 'hasConsumedApproval').mockRejectedValue(new Error('audit log unavailable'));
+    const auditPath = join(TMP, 'unreadable-audit-path');
+    mkdirSync(auditPath, { recursive: true });
+    const auditLog = new FileApprovalAuditLog(auditPath);
     const secret = createSessionTokenSecret();
     const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
     const execute = vi.fn();

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -1418,6 +1418,64 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('fails closed when the approval audit log cannot be read', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      tool: 'execution',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const auditLog = new FileApprovalAuditLog(join(TMP, 'hitl-approval-audit.jsonl'));
+    vi.spyOn(auditLog, 'hasConsumedApproval').mockRejectedValue(new Error('audit log unavailable'));
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const execute = vi.fn();
+    const runtime = new ChatRuntime({
+      engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+      turnRunner: new TurnRunner({ execute }),
+    });
+    const controller = new ChatSocketController({
+      runtime,
+      sessionStore: store,
+      tokenSecret: secret,
+      approvalAuditLog: auditLog,
+    });
+    const { peer, sent } = createPeer();
+
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await expect(controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+    }))).resolves.toBeUndefined();
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(store.get(session.id)?.state).toBe('rejected');
+    expect(store.get(session.id)?.pendingApproval).toBeNull();
+    const events = sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.error',
+      code: 'APPROVAL_AUDIT_UNAVAILABLE',
+      message: 'The approval audit log could not be read; recreate the approval request before retrying.',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'turn.approval.resolved',
+      approved: false,
+    }));
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('does not retry approved work when live event delivery fails', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/chat/approval-audit-log.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/approval-audit-log.test.ts
@@ -133,6 +133,26 @@ describe('FileApprovalAuditLog', () => {
     }
   });
 
+  it('treats a missing log as empty but propagates other read failures', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'franken-approval-audit-'));
+    try {
+      const input = {
+        sessionId: 'chat-1',
+        projectId: 'proj-1',
+        token: 'approval-token-1',
+        commandHash: commandSha256('git push origin HEAD'),
+      };
+
+      const missing = new FileApprovalAuditLog(join(dir, 'missing.jsonl'));
+      await expect(missing.hasConsumedApproval(input)).resolves.toBe(false);
+
+      const unreadable = new FileApprovalAuditLog(dir);
+      await expect(unreadable.hasConsumedApproval(input)).rejects.toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('separates a corrupt partial tail before appending replay-protecting entries', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'franken-approval-audit-'));
     try {
@@ -174,6 +194,12 @@ describe('FileApprovalAuditLog', () => {
       await symlink(outsidePath, logPath);
 
       const log = new FileApprovalAuditLog(logPath);
+      await expect(log.hasConsumedApproval({
+        sessionId: 'chat-1',
+        projectId: 'proj-1',
+        token: 'approval-token-1',
+        commandHash: commandSha256('git push origin HEAD'),
+      })).rejects.toThrow();
       await expect(log.recordExecution({
         sessionId: 'chat-1',
         projectId: 'proj-1',


### PR DESCRIPTION
## Summary
- fail closed when the WebSocket approval replay audit lookup errors
- reject and consume the stale approval without executing its command
- emit a distinct `APPROVAL_AUDIT_UNAVAILABLE` error instructing the client to recreate approval
- add a regression test covering audit-log read failure

## Test plan
- `npm test -- --run tests/integration/chat/ws-chat-server.test.ts`
- `npm test` (4,195 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; pre-existing warnings)
- `npm run build`

Closes #3194