### PR TITLE
fix(mcp-suite): define typed package exports

### DIFF
--- a/packages/franken-mcp-suite/README.md
+++ b/packages/franken-mcp-suite/README.md
@@ -258,6 +258,10 @@ All three clients are supported:
 
 ## Programmatic usage
 
+The package root is the only supported programmatic import. Internal files are
+not public subpaths, so import APIs from `@franken/mcp-suite` rather than from
+`@franken/mcp-suite/dist/*`.
+
 ```typescript
 import { createBrainAdapter, createGovernorAdapter, createFirewallAdapter } from '@franken/mcp-suite';
 

--- a/packages/franken-mcp-suite/package.json
+++ b/packages/franken-mcp-suite/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "fbeast": "./dist/cli/main.js",
     "fbeast-mcp": "./dist/beast.js",

--- a/packages/franken-mcp-suite/src/shared/package-exports.test.ts
+++ b/packages/franken-mcp-suite/src/shared/package-exports.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+type PackageManifest = {
+  main?: string;
+  types?: string;
+  exports?: Record<string, unknown>;
+};
+
+function readPackageJson(): PackageManifest {
+  return JSON.parse(
+    readFileSync(join(packageRoot, "package.json"), "utf8"),
+  ) as PackageManifest;
+}
+
+describe("package exports", () => {
+  it("publishes only the typed root entry point", () => {
+    const manifest = readPackageJson();
+
+    expect(manifest.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+    });
+    expect(manifest.main).toBe("dist/index.js");
+    expect(manifest.types).toBe("dist/index.d.ts");
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit typed root export for `@franken/mcp-suite`
- document the package root as the supported programmatic import boundary
- guard the manifest contract with a focused package test

## Test plan
- `npm test -- --run` (590 tests)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (passes with 27 pre-existing warnings)
- pack smoke: root import resolves, deep import fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and all 13 CLI bin targets exist

Closes #2884