### PR TITLE
fix(live-bench): quarantine malformed candidate tasks

### DIFF
--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -29,7 +29,8 @@ Key exports:
 
 | Export | Purpose |
 | --- | --- |
-| `loadCorpus`, `loadTaskFile` | Load benchmark task definitions from a corpus root. |
+| `loadCorpus`, `loadTaskFile` | Strictly load benchmark task definitions from a corpus root. |
+| `loadCorpusWithDiagnostics` | Load valid tasks while quarantining malformed candidate-tier files in a structured diagnostics result. Core and stress task errors remain fatal. |
 | `BenchmarkTaskSchema` | Validate benchmark task JSON with Zod. |
 | `ToolCallEvidenceSchema` | Validate a single tool-call evidence record. |
 | `ToolCallEvidenceManifestSchema`, `serializeToolCallEvidence` | Validate and serialize the full tool-call evidence artifact array. |
@@ -49,7 +50,7 @@ npm exec --workspace=@franken/live-bench -- fbeast-live-bench list <corpus-root>
 npm exec --workspace=@franken/live-bench -- fbeast-live-bench learning-regression <fixture-root> <baseline-results.json> <candidate-results.json> --min-pass-rate 1 --min-delta 0
 ```
 
-`list` loads the corpus root and prints the benchmark task ids, one per line. Use it as a lightweight sanity check before a live benchmark run.
+`list` loads the corpus root and prints the benchmark task ids, one per line. Malformed files under the candidate tier are skipped so valid tasks remain listable; a deterministic JSON quarantine summary is written to stderr with each path and validation error. Invalid core or stress tasks remain fatal. Use the command as a lightweight sanity check before a live benchmark run.
 
 `learning-regression` is a dry-run promotion gate for learned workflow changes. It loads `*.workflow.json` fixtures that include representative task transcripts, expected decisions, and prohibited actions; compares baseline and candidate result JSON; and prints a JSON report with per-fixture pass/fail state, score deltas, missing decisions, prohibited actions observed, and examples. A candidate is promotable only when the report meets the documented thresholds, typically `--min-pass-rate 1 --min-delta 0` or stricter.
 

--- a/packages/live-bench/src/cli/main.ts
+++ b/packages/live-bench/src/cli/main.ts
@@ -5,7 +5,7 @@ function printLine(...args: unknown[]): void {
 }
 
 
-import { loadCorpus } from '../corpus/loader.js';
+import { loadCorpusWithDiagnostics } from '../corpus/loader.js';
 import {
   evaluateWorkflowRegression,
   loadWorkflowRegressionCandidateResults,
@@ -35,9 +35,16 @@ if (command === 'list') {
     process.exit(2);
   }
 
-  const tasks = loadCorpus(corpusRoot);
-  for (const task of tasks) {
+  const result = loadCorpusWithDiagnostics(corpusRoot);
+  for (const task of result.tasks) {
     printLine(task.taskId);
+  }
+  if (result.quarantined.length > 0) {
+    console.error(JSON.stringify({
+      type: 'live-bench-corpus-quarantine',
+      count: result.quarantined.length,
+      tasks: result.quarantined,
+    }, null, 2));
   }
   process.exit(0);
 }

--- a/packages/live-bench/src/corpus/loader.ts
+++ b/packages/live-bench/src/corpus/loader.ts
@@ -1,7 +1,18 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { BenchmarkTaskSchema } from './schema.js';
 import type { BenchmarkTask, CorpusTier } from '../types.js';
+
+export interface QuarantinedCorpusTask {
+  path: string;
+  tier: 'candidate';
+  error: string;
+}
+
+export interface CorpusLoadDiagnostics {
+  tasks: BenchmarkTask[];
+  quarantined: QuarantinedCorpusTask[];
+}
 
 export function loadTaskFile(path: string): BenchmarkTask {
   try {
@@ -24,6 +35,51 @@ export function loadCorpus(root: string, tiers?: readonly CorpusTier[]): Benchma
   return tasks.sort((a, b) => a.taskId.localeCompare(b.taskId));
 }
 
+export function loadCorpusWithDiagnostics(root: string, tiers?: readonly CorpusTier[]): CorpusLoadDiagnostics {
+  const allowed = tiers ? new Set<CorpusTier>(tiers) : undefined;
+  const tasks: BenchmarkTask[] = [];
+  const quarantined: QuarantinedCorpusTask[] = [];
+
+  for (const path of taskFiles(root).sort((a, b) => a.localeCompare(b))) {
+    let parsed: unknown;
+    try {
+      parsed = readTaskJson(path);
+    } catch (error) {
+      if (isCandidatePath(root, path)) {
+        quarantined.push(candidateQuarantine(path, error));
+        continue;
+      }
+      throw invalidTaskError(path, error);
+    }
+
+    let tier: CorpusTier;
+    try {
+      tier = validatedTaskTier(parsed);
+    } catch (error) {
+      throw invalidTaskError(path, error);
+    }
+    if (allowed && !allowed.has(tier)) {
+      continue;
+    }
+
+    try {
+      tasks.push(BenchmarkTaskSchema.parse(parsed) as BenchmarkTask);
+    } catch (error) {
+      if (tier === 'candidate') {
+        quarantined.push(candidateQuarantine(path, error));
+        continue;
+      }
+      throw invalidTaskError(path, error);
+    }
+  }
+
+  assertUniqueTaskIds(tasks);
+  return {
+    tasks: tasks.sort((a, b) => a.taskId.localeCompare(b.taskId)),
+    quarantined,
+  };
+}
+
 function assertUniqueTaskIds(tasks: readonly BenchmarkTask[]): void {
   const seen = new Set<string>();
   for (const task of tasks) {
@@ -40,16 +96,35 @@ function readTaskJson(path: string): unknown {
 
 function readValidatedTaskTier(path: string): CorpusTier {
   try {
-    const parsed = readTaskJson(path) as { tier?: unknown };
-    const tier = parsed.tier;
-    if (tier === 'core' || tier === 'candidate' || tier === 'stress') {
-      return tier;
-    }
-    throw new Error(`Invalid benchmark task tier: ${String(tier)}`);
+    return validatedTaskTier(readTaskJson(path));
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`Invalid benchmark task ${path}: ${detail}`);
+    throw invalidTaskError(path, error);
   }
+}
+
+function validatedTaskTier(parsed: unknown): CorpusTier {
+  const tier = (parsed as { tier?: unknown }).tier;
+  if (tier === 'core' || tier === 'candidate' || tier === 'stress') {
+    return tier;
+  }
+  throw new Error(`Invalid benchmark task tier: ${String(tier)}`);
+}
+
+function isCandidatePath(root: string, path: string): boolean {
+  return relative(root, path).split(sep)[0] === 'candidate';
+}
+
+function candidateQuarantine(path: string, error: unknown): QuarantinedCorpusTask {
+  return {
+    path,
+    tier: 'candidate',
+    error: invalidTaskError(path, error).message,
+  };
+}
+
+function invalidTaskError(path: string, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Invalid benchmark task ${path}: ${detail}`);
 }
 
 function taskFiles(dir: string): string[] {

--- a/packages/live-bench/src/corpus/loader.ts
+++ b/packages/live-bench/src/corpus/loader.ts
@@ -56,6 +56,10 @@ export function loadCorpusWithDiagnostics(root: string, tiers?: readonly CorpusT
     try {
       tier = validatedTaskTier(parsed);
     } catch (error) {
+      if (isCandidatePath(root, path)) {
+        quarantined.push(candidateQuarantine(path, error));
+        continue;
+      }
       throw invalidTaskError(path, error);
     }
     if (allowed && !allowed.has(tier)) {

--- a/packages/live-bench/src/index.ts
+++ b/packages/live-bench/src/index.ts
@@ -18,7 +18,13 @@ export {
   serializeToolCallEvidence,
 } from './evidence/tool-call-evidence.js';
 export { BenchmarkTaskSchema } from './corpus/schema.js';
-export { loadCorpus, loadTaskFile } from './corpus/loader.js';
+export {
+  loadCorpus,
+  loadCorpusWithDiagnostics,
+  loadTaskFile,
+  type CorpusLoadDiagnostics,
+  type QuarantinedCorpusTask,
+} from './corpus/loader.js';
 export {
   WorkflowRegressionCandidateResultSchema,
   WorkflowRegressionCandidateResultsSchema,

--- a/packages/live-bench/tests/cli-smoke.test.ts
+++ b/packages/live-bench/tests/cli-smoke.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -79,6 +79,48 @@ describe('live-bench CLI smoke coverage', () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout.split('\n').filter(Boolean)).toEqual(['alpha-task', 'zeta-task']);
+    } finally {
+      rmSync(corpusDir, { recursive: true, force: true });
+    }
+  }, 35_000);
+
+  it('lists valid tasks and emits structured diagnostics for quarantined candidate files', () => {
+    const corpusDir = mkdtempSync(join(tmpdir(), 'live-bench-quarantine-corpus-'));
+    const candidateDir = join(corpusDir, 'candidate');
+    const coreDir = join(corpusDir, 'core');
+    mkdirSync(candidateDir, { recursive: true });
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(join(candidateDir, 'broken.task.json'), '{not-json', 'utf8');
+    writeFileSync(join(coreDir, 'valid.task.json'), JSON.stringify({
+      taskId: 'valid-core-task',
+      tier: 'core',
+      taskClass: 'workflow-critical',
+      projectFixture: 'project',
+      prompt: 'run check',
+      expectedArtifacts: ['artifacts/out.txt'],
+      requiredChecks: [{ type: 'file-exists', path: 'artifacts/out.txt' }],
+      timeoutMs: 60_000,
+      allowedNondeterminism: [],
+      baselineSupported: true,
+    }));
+
+    try {
+      const result = runCli(['list', corpusDir]);
+      const diagnostics = JSON.parse(result.stderr) as {
+        type: string;
+        count: number;
+        tasks: Array<{ path: string; tier: string; error: string }>;
+      };
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('valid-core-task\n');
+      expect(diagnostics).toMatchObject({
+        type: 'live-bench-corpus-quarantine',
+        count: 1,
+        tasks: [{ tier: 'candidate' }],
+      });
+      expect(diagnostics.tasks[0]?.path).toContain(join('candidate', 'broken.task.json'));
+      expect(diagnostics.tasks[0]?.error).toContain('Invalid benchmark task');
     } finally {
       rmSync(corpusDir, { recursive: true, force: true });
     }

--- a/packages/live-bench/tests/corpus-loader.test.ts
+++ b/packages/live-bench/tests/corpus-loader.test.ts
@@ -51,6 +51,11 @@ describe('corpus loader', () => {
       tier: 'candidate',
       requiredChecks: [{ type: 'unknown-check' }],
     });
+    const invalidTierPath = writeTask(root, 'candidate/invalid-tier.task.json', {
+      ...validTask,
+      taskId: 'invalid-tier',
+      tier: 'canidate',
+    });
     writeTask(root, 'candidate/z.task.json', { ...validTask, taskId: 'z-task', tier: 'candidate' });
     writeTask(root, 'core/a.task.json', { ...validTask, taskId: 'a-task' });
 
@@ -59,6 +64,7 @@ describe('corpus loader', () => {
     expect(result.tasks.map((task) => task.taskId)).toEqual(['a-task', 'z-task']);
     expect(result.quarantined).toEqual([
       expect.objectContaining({ path: invalidSchemaPath, tier: 'candidate' }),
+      expect.objectContaining({ path: invalidTierPath, tier: 'candidate' }),
       expect.objectContaining({ path: malformedJsonPath, tier: 'candidate' }),
     ]);
     expect(result.quarantined.every((entry) => entry.error.startsWith('Invalid benchmark task '))).toBe(true);

--- a/packages/live-bench/tests/corpus-loader.test.ts
+++ b/packages/live-bench/tests/corpus-loader.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
-import { loadCorpus, loadTaskFile } from '../src/corpus/loader.js';
+import { loadCorpus, loadCorpusWithDiagnostics, loadTaskFile } from '../src/corpus/loader.js';
 
 function tempCorpus(): string {
   return mkdtempSync(join(tmpdir(), 'live-bench-corpus-'));
@@ -38,6 +38,39 @@ describe('corpus loader', () => {
       tier: 'core',
       requiredChecks: [{ type: 'file-exists', path: 'README.md' }],
     });
+  });
+
+  it('quarantines malformed candidate tasks while returning valid corpus entries and structured diagnostics', () => {
+    const root = tempCorpus();
+    const malformedJsonPath = join(root, 'candidate/malformed.task.json');
+    mkdirSync(join(malformedJsonPath, '..'), { recursive: true });
+    writeFileSync(malformedJsonPath, '{not-json', 'utf8');
+    const invalidSchemaPath = writeTask(root, 'candidate/invalid-schema.task.json', {
+      ...validTask,
+      taskId: 'invalid-schema',
+      tier: 'candidate',
+      requiredChecks: [{ type: 'unknown-check' }],
+    });
+    writeTask(root, 'candidate/z.task.json', { ...validTask, taskId: 'z-task', tier: 'candidate' });
+    writeTask(root, 'core/a.task.json', { ...validTask, taskId: 'a-task' });
+
+    const result = loadCorpusWithDiagnostics(root);
+
+    expect(result.tasks.map((task) => task.taskId)).toEqual(['a-task', 'z-task']);
+    expect(result.quarantined).toEqual([
+      expect.objectContaining({ path: invalidSchemaPath, tier: 'candidate' }),
+      expect.objectContaining({ path: malformedJsonPath, tier: 'candidate' }),
+    ]);
+    expect(result.quarantined.every((entry) => entry.error.startsWith('Invalid benchmark task '))).toBe(true);
+  });
+
+  it('keeps strict corpus loading backward compatible', () => {
+    const root = tempCorpus();
+    const malformedJsonPath = join(root, 'candidate/malformed.task.json');
+    mkdirSync(join(malformedJsonPath, '..'), { recursive: true });
+    writeFileSync(malformedJsonPath, '{not-json', 'utf8');
+
+    expect(() => loadCorpus(root)).toThrow(/Invalid benchmark task/);
   });
 
   it('loads matching tiers sorted by task id without validating unselected tiers', () => {


### PR DESCRIPTION
## Summary
- add a diagnostic corpus loader that skips malformed candidate-tier tasks while keeping core/stress failures strict
- make `fbeast-live-bench list` print valid task IDs and emit a structured JSON quarantine summary on stderr
- preserve the existing strict `loadCorpus` API and document both loading modes

## Test Plan
- `npm test` (123 passed, 1 skipped live test)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #3071