### PR TITLE
fix(orchestrator): verify recovered process identity

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -12,7 +12,7 @@ import {
   type GitWorktreeIsolationConfig,
 } from './git-worktree-isolation.js';
 import { wallClockNow } from '@franken/types';
-import type { ProcessSupervisorLike } from './process-supervisor.js';
+import type { ProcessSignalOptions, ProcessSupervisorLike } from './process-supervisor.js';
 import { classifyWorkerCrash } from './worker-crash-classification.js';
 import { SAFE_DISPATCH_FAILURE_MESSAGE } from '../services/dispatch-failure-message.js';
 import type { BeastDefinition, BeastProcessSpec, BeastRun, BeastRunAttempt, BeastRunStatus, ModuleConfig } from '../types.js';
@@ -363,40 +363,17 @@ function readProcessStartTimeTicks(pid: number): ProcessStartTimeReadResult {
   }
 }
 
-function processGroupExists(pid: number): boolean {
-  if (pid <= 0 || process.platform === 'win32') {
-    return false;
-  }
-  try {
-    process.kill(-pid, 0);
-    return true;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === 'EPERM';
-  }
-}
-
-function attemptOwnsProcessGroup(attempt: BeastRunAttempt): boolean {
-  const expectedStartTime = attempt.executorMetadata?.processStartTimeTicks;
+function processSignalOptions(attempt: BeastRunAttempt): ProcessSignalOptions {
   const pid = attempt.pid;
-  if (
-    typeof pid !== 'number'
-    || attempt.executorMetadata?.processGroupOwned !== true
-    || attempt.executorMetadata?.processGroupLeaderPid !== pid
-  ) {
-    return false;
-  }
-  if (typeof expectedStartTime !== 'string') {
-    return false;
-  }
-  const actualStartTime = readProcessStartTimeTicks(pid);
-  if (actualStartTime.status === 'matched') {
-    return actualStartTime.ticks === expectedStartTime;
-  }
-  if (actualStartTime.status === 'leader_absent') {
-    return processGroupExists(pid);
-  }
-  return false;
+  const expectedStartTimeTicks = attempt.executorMetadata?.processStartTimeTicks;
+  const processGroupOwned = typeof pid === 'number'
+    && attempt.executorMetadata?.processGroupOwned === true
+    && attempt.executorMetadata?.processGroupLeaderPid === pid;
+
+  return {
+    processGroupOwned,
+    ...(typeof expectedStartTimeTicks === 'string' ? { expectedStartTimeTicks } : {}),
+  };
 }
 
 function ensureSecureRunConfigDirectory(configDir: string, owner: RunConfigSnapshotOwner | undefined, rootDir: string): void {
@@ -887,7 +864,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
 
       this.stoppingAttempts.add(attemptId);
       try {
-        await this.supervisor.stop(attempt.pid, { processGroupOwned: attemptOwnsProcessGroup(attempt) });
+        await this.supervisor.stop(attempt.pid, processSignalOptions(attempt));
       } catch (error) {
         this.exitPromises.delete(attemptId);
         this.stoppingAttempts.delete(attemptId);
@@ -906,7 +883,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         if (!exited && this.exitPromises.has(attemptId)) {
           this.exitPromises.delete(attemptId);
           this.stoppingAttempts.delete(attemptId);
-          await this.supervisor.kill(pid, { processGroupOwned: attemptOwnsProcessGroup(attempt) });
+          await this.supervisor.kill(pid, processSignalOptions(attempt));
         }
 
         // If process exited after an operator stop, handleProcessExit already updated status — don't overwrite
@@ -922,7 +899,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
   async kill(runId: string, attemptId: string): Promise<BeastRunAttempt> {
     const attempt = this.requireAttempt(attemptId);
     if (attempt.pid !== undefined) {
-      await this.supervisor.kill(attempt.pid, { processGroupOwned: attemptOwnsProcessGroup(attempt) });
+      await this.supervisor.kill(attempt.pid, processSignalOptions(attempt));
     }
     return this.finishAttempt(runId, attempt, 'stopped', 'operator_kill');
   }

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn as defaultSpawn } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import type { BeastProcessSpec } from '../types.js';
 import { DEFAULT_BEAST_ENV_ALLOWLIST } from './sandbox-policy.js';
@@ -23,7 +23,12 @@ export interface ProcessSupervisorLike {
 
 export interface ProcessSignalOptions {
   readonly processGroupOwned?: boolean | undefined;
+  readonly expectedStartTimeTicks?: string | undefined;
 }
+
+export type ProcessIdentityReadResult =
+  | { readonly status: 'found'; readonly startTimeTicks: string }
+  | { readonly status: 'absent' | 'unreadable' | 'unsupported' };
 
 export interface ProcessSupervisorOptions {
   readonly projectRoot?: string | undefined;
@@ -37,6 +42,7 @@ export interface OrphanProcessSweeperOptions {
   readonly escalationDelayMs?: number | undefined;
   readonly platform?: NodeJS.Platform | undefined;
   readonly killProcess?: typeof process.kill | undefined;
+  readonly readProcessIdentity?: ((pid: number) => ProcessIdentityReadResult) | undefined;
 }
 
 export interface OrphanProcessSweepResult {
@@ -55,6 +61,28 @@ function allowlistedEnv(env: NodeJS.ProcessEnv): Record<string, string> {
     }
   }
   return cleaned;
+}
+
+function readLinuxProcessIdentity(pid: number): ProcessIdentityReadResult {
+  if (process.platform !== 'linux') {
+    return { status: 'unsupported' };
+  }
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const endOfCommand = stat.lastIndexOf(')');
+    if (endOfCommand < 0) {
+      return { status: 'unreadable' };
+    }
+    const fieldsFromState = stat.slice(endOfCommand + 2).trim().split(/\s+/);
+    const startTimeTicks = fieldsFromState[19];
+    return typeof startTimeTicks === 'string' && startTimeTicks.length > 0
+      ? { status: 'found', startTimeTicks }
+      : { status: 'unreadable' };
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+      ? { status: 'absent' }
+      : { status: 'unreadable' };
+  }
 }
 
 export function assertContainedCwd(projectRoot: string | undefined, cwd: string | undefined): void {
@@ -89,6 +117,45 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
   private killProcess(): typeof process.kill {
     return this.options.orphanSweeper?.killProcess ?? process.kill;
   }
+
+  private verifyUntrackedProcessIdentity(pid: number, options: ProcessSignalOptions): 'verified' | 'absent' {
+    const identity = (this.options.orphanSweeper?.readProcessIdentity ?? readLinuxProcessIdentity)(pid);
+    if (identity.status === 'absent') {
+      return 'absent';
+    }
+
+    const expectedStartTimeTicks = options.expectedStartTimeTicks;
+    if (typeof expectedStartTimeTicks !== 'string' || expectedStartTimeTicks.length === 0) {
+      throw new Error(
+        `Refusing to signal untracked PID ${pid}: no verified process identity is available; an operator must inspect the process and stop it manually.`,
+      );
+    }
+
+    if (identity.status !== 'found' || identity.startTimeTicks !== expectedStartTimeTicks) {
+      throw new Error(
+        `Refusing to signal untracked PID ${pid}: the current process identity could not be verified; an operator must inspect the process and stop it manually.`,
+      );
+    }
+    return 'verified';
+  }
+
+  private signalUntrackedProcess(pid: number, signal: NodeJS.Signals, options: ProcessSignalOptions): void {
+    if (this.verifyUntrackedProcessIdentity(pid, options) === 'absent') {
+      return;
+    }
+
+    if (options.processGroupOwned && this.sweepOrphanProcessGroup(pid, signal).swept) {
+      return;
+    }
+
+    // Revalidate after a failed group sweep so PID reuse during fallback cannot
+    // redirect the direct signal to a different process.
+    if (options.processGroupOwned && this.verifyUntrackedProcessIdentity(pid, options) === 'absent') {
+      return;
+    }
+    this.killProcess()(pid, signal);
+  }
+
   private shouldUseProcessGroup(): boolean {
     return this.orphanSweeperEnabled() && this.orphanSweeperPlatform() !== 'win32';
   }
@@ -343,13 +410,10 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       return;
     }
 
-    // Only process-group sweep recovered attempts that were persisted as
-    // process-group leaders. Legacy/stale attempts fall back to direct PID
-    // signaling so a reused PID cannot fan out to an unrelated group.
+    // Recovered attempts are signaled only after their persisted process
+    // identity is revalidated at the signal boundary.
     try {
-      if (!options.processGroupOwned || !this.sweepOrphanProcessGroup(pid, 'SIGTERM').swept) {
-        this.killProcess()(pid, 'SIGTERM');
-      }
+      this.signalUntrackedProcess(pid, 'SIGTERM', options);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code !== 'ESRCH') {
@@ -369,13 +433,10 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
       return;
     }
 
-    // Only process-group sweep recovered attempts that were persisted as
-    // process-group leaders. Legacy/stale attempts fall back to direct PID
-    // signaling so a reused PID cannot fan out to an unrelated group.
+    // Recovered attempts are signaled only after their persisted process
+    // identity is revalidated at the signal boundary.
     try {
-      if (!options.processGroupOwned || !this.sweepOrphanProcessGroup(pid, 'SIGKILL').swept) {
-        this.killProcess()(pid, 'SIGKILL');
-      }
+      this.signalUntrackedProcess(pid, 'SIGKILL', options);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code !== 'ESRCH') {

--- a/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-supervisor.ts
@@ -140,7 +140,14 @@ export class ProcessSupervisor implements ProcessSupervisorLike {
   }
 
   private signalUntrackedProcess(pid: number, signal: NodeJS.Signals, options: ProcessSignalOptions): void {
-    if (this.verifyUntrackedProcessIdentity(pid, options) === 'absent') {
+    const identityStatus = this.verifyUntrackedProcessIdentity(pid, options);
+    if (identityStatus === 'absent') {
+      // A recovered group can remain alive after its original leader exits. The
+      // absent leader PID cannot be targeted directly, but its persisted,
+      // owned process-group ID remains safe to sweep.
+      if (options.processGroupOwned) {
+        this.sweepOrphanProcessGroup(pid, signal);
+      }
       return;
     }
 

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -495,6 +495,24 @@ process.stdout.write('parent done\\n');`,
       expect(killProcess).not.toHaveBeenCalled();
     });
 
+    it('sweeps an owned recovered group when its leader PID is absent', async () => {
+      const killProcess = vi.fn(() => true as const);
+      supervisor = new ProcessSupervisor({
+        orphanSweeper: {
+          killProcess,
+          readProcessIdentity: () => ({ status: 'absent' }),
+        },
+      });
+
+      await supervisor.kill(12345, {
+        processGroupOwned: true,
+        expectedStartTimeTicks: 'original-start-time',
+      });
+
+      expect(killProcess).toHaveBeenCalledOnce();
+      expect(killProcess).toHaveBeenCalledWith(-12345, 'SIGKILL');
+    });
+
     it('signals an untracked PID only when its persisted identity still matches', async () => {
       const killProcess = vi.fn();
       supervisor = new ProcessSupervisor({

--- a/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/execution/process-supervisor.test.ts
@@ -420,30 +420,151 @@ process.stdout.write('parent done\\n');`,
       });
     });
 
-    it('uses direct PID signaling by default for unmarked recovered attempts', async () => {
+    it('refuses fallback signaling when an untracked PID has no verifiable identity', async () => {
       const killProcess = vi.fn();
       supervisor = new ProcessSupervisor({
-        orphanSweeper: { killProcess },
+        orphanSweeper: {
+          killProcess,
+          readProcessIdentity: () => ({
+            status: 'found',
+            startTimeTicks: 'untrusted-current-process',
+          }),
+        },
       });
 
-      await supervisor.stop(12345);
-      await supervisor.kill(23456);
+      await expect(supervisor.stop(12345)).rejects.toThrow(
+        /Refusing to signal untracked PID 12345.*identity.*operator/i,
+      );
+      await expect(supervisor.kill(23456)).rejects.toThrow(
+        /Refusing to signal untracked PID 23456.*identity.*operator/i,
+      );
 
-      expect(killProcess).toHaveBeenNthCalledWith(1, 12345, 'SIGTERM');
-      expect(killProcess).toHaveBeenNthCalledWith(2, 23456, 'SIGKILL');
+      expect(killProcess).not.toHaveBeenCalled();
+    });
+
+    it('refuses fallback signaling when an untracked PID identity has changed', async () => {
+      const killProcess = vi.fn();
+      supervisor = new ProcessSupervisor({
+        orphanSweeper: {
+          killProcess,
+          readProcessIdentity: () => ({
+            status: 'found',
+            startTimeTicks: 'reused-pid-start-time',
+          }),
+        },
+      });
+
+      await expect(supervisor.kill(12345, {
+        expectedStartTimeTicks: 'original-start-time',
+      })).rejects.toThrow(/current process identity could not be verified.*operator/i);
+
+      expect(killProcess).not.toHaveBeenCalled();
+    });
+
+    it.each(['unreadable', 'unsupported'] as const)(
+      'refuses fallback signaling when process identity is %s',
+      async (status) => {
+        const killProcess = vi.fn();
+        supervisor = new ProcessSupervisor({
+          orphanSweeper: {
+            killProcess,
+            readProcessIdentity: () => ({ status }),
+          },
+        });
+
+        await expect(supervisor.kill(12345, {
+          expectedStartTimeTicks: 'original-start-time',
+        })).rejects.toThrow(/current process identity could not be verified.*operator/i);
+        expect(killProcess).not.toHaveBeenCalled();
+      },
+    );
+
+    it('treats an absent untracked PID as an idempotent no-op', async () => {
+      const killProcess = vi.fn();
+      supervisor = new ProcessSupervisor({
+        orphanSweeper: {
+          killProcess,
+          readProcessIdentity: () => ({ status: 'absent' }),
+        },
+      });
+
+      await expect(supervisor.stop(12345, {
+        expectedStartTimeTicks: 'original-start-time',
+      })).resolves.toBeUndefined();
+
+      expect(killProcess).not.toHaveBeenCalled();
+    });
+
+    it('signals an untracked PID only when its persisted identity still matches', async () => {
+      const killProcess = vi.fn();
+      supervisor = new ProcessSupervisor({
+        orphanSweeper: {
+          killProcess,
+          readProcessIdentity: () => ({
+            status: 'found',
+            startTimeTicks: 'original-start-time',
+          }),
+        },
+      });
+
+      await supervisor.stop(12345, { expectedStartTimeTicks: 'original-start-time' });
+
+      expect(killProcess).toHaveBeenCalledOnce();
+      expect(killProcess).toHaveBeenCalledWith(12345, 'SIGTERM');
     });
 
     it('tries a process-group sweep before direct PID signaling for marked recovered attempts', async () => {
       const killProcess = vi.fn();
+      const readProcessIdentity = vi.fn(() => ({
+        status: 'found' as const,
+        startTimeTicks: 'known-start-time',
+      }));
       supervisor = new ProcessSupervisor({
-        orphanSweeper: { killProcess },
+        orphanSweeper: { killProcess, readProcessIdentity },
       });
 
-      await supervisor.stop(12345, { processGroupOwned: true });
-      await supervisor.kill(23456, { processGroupOwned: true });
+      await supervisor.stop(12345, {
+        processGroupOwned: true,
+        expectedStartTimeTicks: 'known-start-time',
+      });
+      await supervisor.kill(23456, {
+        processGroupOwned: true,
+        expectedStartTimeTicks: 'known-start-time',
+      });
 
       expect(killProcess).toHaveBeenNthCalledWith(1, -12345, 'SIGTERM');
       expect(killProcess).toHaveBeenNthCalledWith(2, -23456, 'SIGKILL');
+    });
+
+    it('revalidates identity before direct fallback when the process group is gone', async () => {
+      const noGroup = Object.assign(new Error('no process group'), { code: 'ESRCH' });
+      const killProcess = vi.fn((pid: number, _signal?: string | number) => {
+        if (pid < 0) {
+          throw noGroup;
+        }
+        return true as const;
+      });
+      const readProcessIdentity = vi.fn()
+        .mockReturnValueOnce({
+          status: 'found' as const,
+          startTimeTicks: 'known-start-time',
+        })
+        .mockReturnValueOnce({
+          status: 'found' as const,
+          startTimeTicks: 'reused-pid-start-time',
+        });
+      supervisor = new ProcessSupervisor({
+        orphanSweeper: { killProcess, readProcessIdentity },
+      });
+
+      await expect(supervisor.stop(34567, {
+        processGroupOwned: true,
+        expectedStartTimeTicks: 'known-start-time',
+      })).rejects.toThrow(/current process identity could not be verified.*operator/i);
+
+      expect(killProcess).toHaveBeenCalledOnce();
+      expect(killProcess).toHaveBeenCalledWith(-34567, 'SIGTERM');
+      expect(readProcessIdentity).toHaveBeenCalledTimes(2);
     });
 
     it('falls back to direct PID signaling when a marked recovered process group is gone', async () => {
@@ -454,14 +575,22 @@ process.stdout.write('parent done\\n');`,
         }
         return true as const;
       });
+      const readProcessIdentity = vi.fn(() => ({
+        status: 'found' as const,
+        startTimeTicks: 'known-start-time',
+      }));
       supervisor = new ProcessSupervisor({
-        orphanSweeper: { killProcess },
+        orphanSweeper: { killProcess, readProcessIdentity },
       });
 
-      await supervisor.stop(34567, { processGroupOwned: true });
+      await supervisor.stop(34567, {
+        processGroupOwned: true,
+        expectedStartTimeTicks: 'known-start-time',
+      });
 
       expect(killProcess).toHaveBeenCalledWith(-34567, 'SIGTERM');
       expect(killProcess).toHaveBeenCalledWith(34567, 'SIGTERM');
+      expect(readProcessIdentity).toHaveBeenCalledTimes(2);
     });
 
     it('strips CLAUDE env vars from spawned process environment', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -195,10 +195,13 @@ describe('ProcessBeastExecutor', () => {
 
     await executor.kill(run.id, attempt.id);
 
-    expect(supervisor.kill).toHaveBeenCalledWith(process.pid, { processGroupOwned: true });
+    expect(supervisor.kill).toHaveBeenCalledWith(process.pid, {
+      processGroupOwned: true,
+      expectedStartTimeTicks: processStartTimeTicks,
+    });
   });
 
-  it('fails closed to direct PID signaling when recovered process start time is unreadable or stale', async () => {
+  it('passes stale recovered identity metadata to the supervisor for fail-closed validation', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -217,10 +220,13 @@ describe('ProcessBeastExecutor', () => {
 
     await executor.kill(run.id, attempt.id);
 
-    expect(supervisor.kill).toHaveBeenCalledWith(4242, { processGroupOwned: false });
+    expect(supervisor.kill).toHaveBeenCalledWith(4242, {
+      processGroupOwned: true,
+      expectedStartTimeTicks: 'stale-start-time',
+    });
   });
 
-  it('fails closed when a recovered process-group leader start time is unreadable', async () => {
+  it('passes persisted identity metadata to the supervisor without pre-signaling probes', async () => {
     workDir = await createTempWorkDir();
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
     const logs = new BeastLogStore(join(workDir, 'logs'));
@@ -239,7 +245,10 @@ describe('ProcessBeastExecutor', () => {
 
     await executor.kill(run.id, attempt.id);
 
-    expect(supervisor.kill).toHaveBeenCalledWith(4242, { processGroupOwned: false });
+    expect(supervisor.kill).toHaveBeenCalledWith(4242, {
+      processGroupOwned: true,
+      expectedStartTimeTicks: 'known-original-start-time',
+    });
   });
 
   it('kills a spawned process when attempt creation fails', async () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-20 — Recovered PID signal-boundary identity checks
+- Carry the persisted process-start token into the supervisor and re-read identity immediately before every fallback signal; validating ownership in an upstream executor leaves a TOCTOU gap, especially when a failed process-group sweep falls back to direct PID signaling. If the token is missing, unreadable, unsupported, or mismatched while the PID exists, refuse the signal with operator guidance; an absent PID remains a safe no-op.
+
 ## 2026-07-20 — Incremental type-aware ESLint adoption
 - Enable type-aware rules in a dedicated TypeScript source override with `projectService: true` and an explicit `tsconfigRootDir`; source-adjacent tests excluded from package tsconfig files must be ignored by that override or ESLint fails before rule evaluation.
 - A targeted rule such as `@typescript-eslint/no-floating-promises` can establish type-aware coverage without enabling the entire strict preset at once. Treat surfaced promises as real call-site decisions: await work that must finish, use `void` only for intentional fire-and-forget, and add rejection handling for shutdown paths.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-20 — Recovered PID signal-boundary identity checks
-- Carry the persisted process-start token into the supervisor and re-read identity immediately before every fallback signal; validating ownership in an upstream executor leaves a TOCTOU gap, especially when a failed process-group sweep falls back to direct PID signaling. If the token is missing, unreadable, unsupported, or mismatched while the PID exists, refuse the signal with operator guidance; an absent PID remains a safe no-op.
+- Carry the persisted process-start token into the supervisor and re-read identity immediately before every fallback signal; validating ownership in an upstream executor leaves a TOCTOU gap, especially when a failed process-group sweep falls back to direct PID signaling. If the token is missing, unreadable, unsupported, or mismatched while the PID exists, refuse the signal with operator guidance. An absent PID is a safe no-op for direct signaling, but a persisted owned process group must still be swept because descendants can survive their group leader.
 
 ## 2026-07-20 — Incremental type-aware ESLint adoption
 - Enable type-aware rules in a dedicated TypeScript source override with `projectService: true` and an explicit `tsconfigRootDir`; source-adjacent tests excluded from package tsconfig files must be ignored by that override or ESLint fails before rule evaluation.


### PR DESCRIPTION
## Summary
- carry persisted Linux process start-time identity into recovered stop/kill operations
- fail closed before fallback signaling when identity is missing, unreadable, unsupported, or mismatched
- revalidate identity after a failed process-group sweep before direct PID fallback
- add focused regressions for matching, reused, absent, unreadable, and race-window identities

## Verification
- `npm exec vitest -- run tests/unit/beasts/execution/process-supervisor.test.ts tests/unit/beasts/process-beast-executor.test.ts tests/unit/beasts/execution/error-reporting.test.ts` (96 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `codex review --uncommitted` (no discrete regression identified)

Closes #2733