### PR TITLE
docs(readme): explain issue label filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ frankenbeast chat-server --port 3737
 frankenbeast issues --label bug --repo owner/repo
 ```
 
+Pass one label with `--label bug`, or multiple labels as a single comma-separated value like `--label critical,high`.
+
 ### Options
 
 ```

--- a/tests/unit/readme-issue-flags.test.ts
+++ b/tests/unit/readme-issue-flags.test.ts
@@ -25,6 +25,14 @@ function expectFlagToken(source: string, flag: string): void {
 }
 
 describe('README issue workflow flags', () => {
+  it('explains single and multiple issue-label filters in plain text', () => {
+    const subcommands = sectionBetween(README, '### Subcommands', '### Options');
+
+    expect(subcommands).toContain(
+      'Pass one label with `--label bug`, or multiple labels as a single comma-separated value like `--label critical,high`.',
+    );
+  });
+
   it('keeps the quick-reference aligned with the dedicated issue guide', () => {
     const readmeIssueFlags = sectionBetween(
       README,


### PR DESCRIPTION
## Summary
- explain the single-label `--label bug` example in plain language
- document the comma-separated multi-label form next to the issue command example
- add a focused README regression test

## Verification
- `npx vitest run tests/unit/readme-issue-flags.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #3431