### PR TITLE
fix(orchestrator): paginate Beast run listings

### DIFF
--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -204,6 +204,56 @@ export interface CorruptJsonRecoveryOptions {
   readonly recoverCorruptJson?: boolean;
 }
 
+export const DEFAULT_BEAST_RUN_PAGE_LIMIT = 50;
+export const MAX_BEAST_RUN_PAGE_LIMIT = 200;
+
+interface BeastRunPageCursor {
+  readonly version: 1;
+  readonly snapshotRowId: number;
+  readonly afterCreatedAt: string;
+  readonly afterId: string;
+}
+
+export interface BeastRunPageOptions extends CorruptJsonRecoveryOptions {
+  readonly limit: number;
+  readonly cursor?: string | undefined;
+}
+
+export interface BeastRunPage {
+  readonly runs: BeastRun[];
+  readonly nextCursor?: string | undefined;
+}
+
+export class InvalidBeastRunCursorError extends Error {
+  constructor() {
+    super('Invalid Beast run pagination cursor');
+    this.name = 'InvalidBeastRunCursorError';
+  }
+}
+
+function encodeBeastRunCursor(cursor: BeastRunPageCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeBeastRunCursor(value: string): BeastRunPageCursor {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<BeastRunPageCursor>;
+    if (parsed.version !== 1
+      || !Number.isSafeInteger(parsed.snapshotRowId)
+      || (parsed.snapshotRowId ?? -1) < 0
+      || typeof parsed.afterCreatedAt !== 'string'
+      || parsed.afterCreatedAt.length === 0
+      || typeof parsed.afterId !== 'string'
+      || parsed.afterId.length === 0) {
+      throw new InvalidBeastRunCursorError();
+    }
+    return parsed as BeastRunPageCursor;
+  } catch (error) {
+    if (error instanceof InvalidBeastRunCursorError) throw error;
+    throw new InvalidBeastRunCursorError();
+  }
+}
+
 export const DEFAULT_TRACKED_AGENT_PAGE_LIMIT = 50;
 export const MAX_TRACKED_AGENT_PAGE_LIMIT = 200;
 
@@ -349,6 +399,41 @@ export class SQLiteBeastRepository {
     return mapRowsRecoveringCorruptJson(rows, mapRun, options);
   }
 
+  listRunPage(options: BeastRunPageOptions): BeastRunPage {
+    if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > MAX_BEAST_RUN_PAGE_LIMIT) {
+      throw new RangeError(`Beast run page limit must be between 1 and ${MAX_BEAST_RUN_PAGE_LIMIT}`);
+    }
+    const cursor = options.cursor !== undefined ? decodeBeastRunCursor(options.cursor) : undefined;
+    const snapshotRowId = cursor?.snapshotRowId ?? (
+      this.db.prepare('SELECT COALESCE(MAX(rowid), 0) AS max_row_id FROM beast_runs')
+        .get() as { max_row_id: number }
+    ).max_row_id;
+    const rows = (cursor
+      ? this.db.prepare(
+        `SELECT * FROM beast_runs INDEXED BY idx_beast_runs_created_at_id WHERE rowid <= ?
+           AND (created_at < ? OR (created_at = ? AND id < ?))
+         ORDER BY created_at DESC, id DESC LIMIT ?`,
+      ).all(snapshotRowId, cursor.afterCreatedAt, cursor.afterCreatedAt, cursor.afterId, options.limit + 1)
+      : this.db.prepare(
+        `SELECT * FROM beast_runs INDEXED BY idx_beast_runs_created_at_id WHERE rowid <= ?
+         ORDER BY created_at DESC, id DESC LIMIT ?`,
+      ).all(snapshotRowId, options.limit + 1)) as BeastRunRow[];
+    const pageRows = rows.slice(0, options.limit);
+    const runs = mapRowsRecoveringCorruptJson(pageRows, mapRun, options);
+    const lastRow = pageRows.at(-1);
+    return {
+      runs,
+      ...(rows.length > options.limit && lastRow ? {
+        nextCursor: encodeBeastRunCursor({
+          version: 1,
+          snapshotRowId,
+          afterCreatedAt: lastRow.created_at,
+          afterId: lastRow.id,
+        }),
+      } : {}),
+    };
+  }
+
   listRunProcessReferences(): BeastRunProcessReference[] {
     const rows = this.db.prepare(
       'SELECT id, tracked_agent_id, status, current_attempt_id FROM beast_runs ORDER BY created_at DESC, id DESC',
@@ -376,9 +461,10 @@ export class SQLiteBeastRepository {
     return mapRowsRecoveringCorruptJson(rows, mapAttempt, options);
   }
 
-  getAttempt(attemptId: string): BeastRunAttempt | undefined {
+  getAttempt(attemptId: string, options: CorruptJsonRecoveryOptions = {}): BeastRunAttempt | undefined {
     const row = this.db.prepare('SELECT * FROM beast_run_attempts WHERE id = ?').get(attemptId) as BeastAttemptRow | undefined;
-    return row ? mapAttempt(row) : undefined;
+    if (!row) return undefined;
+    return mapRowsRecoveringCorruptJson([row], mapAttempt, options)[0];
   }
 
   updateRun(runId: string, patch: UpdateRunPatch): BeastRun {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -20,6 +20,8 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
     latest_exit_code INTEGER,
     FOREIGN KEY (tracked_agent_id) REFERENCES tracked_agents(id)
   )`,
+  `CREATE INDEX IF NOT EXISTS idx_beast_runs_created_at_id
+    ON beast_runs(created_at DESC, id DESC)`,
   `CREATE TABLE IF NOT EXISTS beast_run_attempts (
     id TEXT PRIMARY KEY,
     run_id TEXT NOT NULL,

--- a/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-run-service.ts
@@ -1,7 +1,11 @@
-import type { BeastDefinition, BeastRun, BeastRunEvent, ModuleConfig } from '../types.js';
+import type { BeastDefinition, BeastRun, BeastRunAttempt, BeastRunEvent, ModuleConfig } from '../types.js';
 import { BeastLogStore, type BeastLogPage, type BeastLogPageOptions } from '../events/beast-log-store.js';
 import type { BeastEventBus, BeastSseEvent } from '../events/beast-event-bus.js';
-import { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
+import {
+  SQLiteBeastRepository,
+  type BeastRunPage,
+  type BeastRunPageOptions,
+} from '../repository/sqlite-beast-repository.js';
 import type { BeastMetrics } from '../telemetry/beast-metrics.js';
 import { normalizeBeastRunConfig, type BeastExecutors } from './beast-dispatch-service.js';
 import { SAFE_DISPATCH_FAILURE_MESSAGE } from './dispatch-failure-message.js';
@@ -62,6 +66,20 @@ export class BeastRunService {
     return this.listRunsFromRepository(true);
   }
 
+  listRunPageForResponse(options: Omit<BeastRunPageOptions, 'recoverCorruptJson'>): BeastRunPage {
+    const page = this.repository.listRunPage({ ...options, recoverCorruptJson: true });
+    const pageAgentIds = page.runs.flatMap((run) => run.trackedAgentId ? [run.trackedAgentId] : []);
+    const redactedAgentIds = new Set(this.repository.listDispatchFailureHistoryAgentIds(pageAgentIds));
+    return {
+      ...page,
+      runs: page.runs.map((run) => (
+        run.trackedAgentId && redactedAgentIds.has(run.trackedAgentId)
+          ? { ...run, configSnapshot: {} }
+          : run
+      )),
+    };
+  }
+
   private listRunsFromRepository(recoverCorruptJson = false): BeastRun[] {
     const redactedAgentIds = new Set(this.repository.listDispatchFailureHistoryAgentIds());
     return this.repository.listRuns({ recoverCorruptJson }).map((run) => (
@@ -92,6 +110,15 @@ export class BeastRunService {
 
   listAttemptsForResponse(runId: string) {
     return this.listAttemptsFromRepository(runId, true);
+  }
+
+  getCurrentAttemptForResponse(run: BeastRun): BeastRunAttempt | undefined {
+    if (!run.currentAttemptId) return undefined;
+    const attempt = this.repository.getAttempt(run.currentAttemptId, { recoverCorruptJson: true });
+    if (!attempt) return undefined;
+    return this.hasDispatchFailureHistory(run)
+      ? { ...attempt, executorMetadata: undefined }
+      : attempt;
   }
 
   private listAttemptsFromRepository(runId: string, recoverCorruptJson = false) {

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -31,6 +31,11 @@ import {
 import { wallClockNow } from '@franken/types';
 import { TransportSecurityService } from '../security/transport-security.js';
 import type { BeastRun, BeastRunAttempt } from '../../beasts/types.js';
+import {
+  DEFAULT_BEAST_RUN_PAGE_LIMIT,
+  InvalidBeastRunCursorError,
+  MAX_BEAST_RUN_PAGE_LIMIT,
+} from '../../beasts/repository/sqlite-beast-repository.js';
 
 type BeastRunResponse = BeastRun & {
   readonly containerId?: unknown;
@@ -95,7 +100,8 @@ function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDep
   if (!run || run.executionMode !== 'container') {
     return [];
   }
-  return deps.runs.listAttemptsForResponse(run.id);
+  const currentAttempt = deps.runs.getCurrentAttemptForResponse(run);
+  return currentAttempt ? [currentAttempt] : [];
 }
 
 function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunResponse | undefined {
@@ -412,11 +418,38 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
   });
 
   app.get('/v1/beasts/runs', (c) => {
+    const rawLimit = c.req.query('limit');
+    const limit = rawLimit === undefined ? DEFAULT_BEAST_RUN_PAGE_LIMIT : Number(rawLimit);
+    if (rawLimit !== undefined
+      && (!/^\d+$/.test(rawLimit)
+        || !Number.isSafeInteger(limit)
+        || limit < 1
+        || limit > MAX_BEAST_RUN_PAGE_LIMIT)) {
+      throw new HttpError(
+        400,
+        'INVALID_BEAST_RUN_PAGE_LIMIT',
+        `Beast run page limit must be an integer between 1 and ${MAX_BEAST_RUN_PAGE_LIMIT}`,
+      );
+    }
+    let page;
+    try {
+      const cursor = c.req.query('cursor');
+      page = deps.runs.listRunPageForResponse({
+        limit,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+    } catch (error) {
+      if (error instanceof InvalidBeastRunCursorError) {
+        throw new HttpError(400, 'INVALID_BEAST_RUN_PAGE_CURSOR', error.message);
+      }
+      throw error;
+    }
     return c.json({
       data: {
-        runs: deps.runs.listRunsForResponse().map((run) => (
+        runs: page.runs.map((run) => (
           runWithContainerFields(run, attemptsForContainerRun(run, deps))
         )),
+        ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
       },
     });
   });

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -165,6 +165,51 @@ describe('beast routes', () => {
     ]);
   });
 
+  it('defaults Beast run pages to 50 and validates cursors and limits', async () => {
+    const { app, operatorToken, repository } = createBeastApp({ rateLimitMax: 100 });
+    const headers = { authorization: 'Bearer ' + operatorToken };
+    const createdIds = Array.from({ length: 51 }, (_, index) => repository.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'operator',
+      createdAt: new Date(Date.UTC(2026, 2, 10, 0, 0, index)).toISOString(),
+    }).id);
+
+    const firstResponse = await app.request('/v1/beasts/runs', { headers });
+    expect(firstResponse.status).toBe(200);
+    const first = await firstResponse.json() as { data: { runs: Array<{ id: string }>; nextCursor?: string } };
+    expect(first.data.runs).toHaveLength(50);
+    expect(first.data.nextCursor).toEqual(expect.any(String));
+
+    const secondResponse = await app.request(
+      `/v1/beasts/runs?cursor=${encodeURIComponent(first.data.nextCursor ?? '')}`,
+      { headers },
+    );
+    expect(secondResponse.status).toBe(200);
+    const second = await secondResponse.json() as { data: { runs: Array<{ id: string }>; nextCursor?: string } };
+    expect(second.data.runs).toHaveLength(1);
+    expect(second.data.nextCursor).toBeUndefined();
+    expect([...first.data.runs, ...second.data.runs].map(({ id }) => id).sort()).toEqual(createdIds.sort());
+
+    const limitedResponse = await app.request('/v1/beasts/runs?limit=1', { headers });
+    expect(limitedResponse.status).toBe(200);
+    const limited = await limitedResponse.json() as { data: { runs: Array<{ id: string }>; nextCursor?: string } };
+    expect(limited.data.runs).toHaveLength(1);
+    expect(limited.data.nextCursor).toEqual(expect.any(String));
+
+    for (const path of [
+      '/v1/beasts/runs?limit=201',
+      '/v1/beasts/runs?limit=1.5',
+      '/v1/beasts/runs?cursor=',
+      '/v1/beasts/runs?cursor=not-a-cursor',
+    ]) {
+      expect((await app.request(path, { headers })).status).toBe(400);
+    }
+  });
+
   it('creates a run, reads it back, and exposes events and logs', async () => {
     const { app, operatorToken } = createBeastApp();
     const headers = {

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -208,6 +208,69 @@ describe('SQLiteBeastRepository', () => {
     expect(repo.listRuns()).toEqual([run]);
   });
 
+  it('paginates Beast runs over a stable snapshot and enforces page limits', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    let sequence = 0;
+    const createRun = () => repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      createdAt: new Date(Date.UTC(2026, 2, 10, 0, 0, sequence++)).toISOString(),
+    });
+    const originalIds = [createRun().id, createRun().id, createRun().id];
+
+    const first = repo.listRunPage({ limit: 2 });
+    expect(first.runs).toHaveLength(2);
+    expect(first.nextCursor).toEqual(expect.any(String));
+
+    const insertedBetweenPages = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'dashboard',
+      dispatchedByUser: 'pfk',
+      // A row inserted after page one but sorted into the remaining window must
+      // still be excluded from the snapshot.
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const second = repo.listRunPage({ limit: 2, cursor: first.nextCursor });
+    expect(second.runs).toHaveLength(1);
+    expect(second.nextCursor).toBeUndefined();
+    expect([...first.runs, ...second.runs].map(({ id }) => id).sort()).toEqual(originalIds.sort());
+    expect([...first.runs, ...second.runs]).not.toContainEqual(expect.objectContaining({ id: insertedBetweenPages.id }));
+    expect(() => repo.listRunPage({ limit: 201 })).toThrow(RangeError);
+    expect(() => repo.listRunPage({ limit: 1, cursor: 'not-a-cursor' })).toThrow('Invalid Beast run pagination cursor');
+
+    const db = new Database(dbPath, { readonly: true });
+    const firstPlan = db.prepare(
+      `EXPLAIN QUERY PLAN SELECT * FROM beast_runs INDEXED BY idx_beast_runs_created_at_id
+        WHERE rowid <= ? ORDER BY created_at DESC, id DESC LIMIT ?`,
+    ).all(3, 3) as Array<{ detail: string }>;
+    const cursorPlan = db.prepare(
+      `EXPLAIN QUERY PLAN SELECT * FROM beast_runs INDEXED BY idx_beast_runs_created_at_id
+        WHERE rowid <= ?
+          AND (created_at < ? OR (created_at = ? AND id < ?))
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?`,
+    ).all(
+      3,
+      '2026-03-10T00:00:01.000Z',
+      '2026-03-10T00:00:01.000Z',
+      originalIds[1],
+      3,
+    ) as Array<{ detail: string }>;
+    const plan = [...firstPlan, ...cursorPlan].map(({ detail }) => detail).join('\n');
+    expect(plan).toContain('idx_beast_runs_created_at_id');
+    expect(plan).not.toContain('USE TEMP B-TREE');
+    db.close();
+  });
+
   it('creates attempts and keeps run state in sync', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-web/src/components/chat-shell.test.tsx
+++ b/packages/franken-web/src/components/chat-shell.test.tsx
@@ -76,7 +76,7 @@ vi.mock('../lib/beast-api', () => ({
     getContainerRuntimeStatus = vi.fn().mockResolvedValue(undefined);
     listCatalog = vi.fn().mockResolvedValue([]);
     listAgentPage = vi.fn().mockResolvedValue({ agents: [] });
-    listRuns = vi.fn().mockResolvedValue([]);
+    listRunPage = vi.fn().mockResolvedValue({ runs: [] });
     getContainerRuntime = vi.fn().mockResolvedValue(undefined);
     subscribe = vi.fn().mockResolvedValue(() => undefined);
     subscribeToEvents = vi.fn().mockResolvedValue(() => undefined);

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -365,13 +365,13 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
     async function refreshBeasts() {
       let catalog: Awaited<ReturnType<typeof client.getCatalog>>;
       let agentWindow: TrackedAgentWindow;
-      let runs: Awaited<ReturnType<typeof client.listRuns>>;
+      let runPage: Awaited<ReturnType<typeof client.listRunPage>>;
       let containerRuntime: Awaited<ReturnType<typeof client.getContainerRuntimeStatus>>;
       try {
-        [catalog, agentWindow, runs, containerRuntime] = await Promise.all([
+        [catalog, agentWindow, runPage, containerRuntime] = await Promise.all([
           client.getCatalog(),
           loadTrackedAgentWindow(client, beastAgentPagesLoadedRef.current, selectedBeastAgentIdRef.current),
-          client.listRuns(),
+          client.listRunPage(),
           client.getContainerRuntimeStatus().catch((error) => ({
             available: false,
             reason: error instanceof Error ? error.message : 'Container runtime status unavailable.',
@@ -400,7 +400,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
       setBeastAgentNextCursor(agentWindow.nextCursor);
       beastAgentPagesLoadedRef.current = agentWindow.pagesLoaded;
       setBeastAgentsLoadingMore(false);
-      setBeastRuns(runs);
+      setBeastRuns(runPage.runs);
       setBeastContainerRuntime(containerRuntime);
       const autoSelectedAgentId = agentWindow.agents.find((agent) => agent.status !== 'deleted')?.id ?? null;
       const currentAgentId = selectedBeastAgentIdRef.current ?? (shouldAutoSelectBeastAgentRef.current ? autoSelectedAgentId : null);

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -18,7 +18,7 @@ import {
   type TrackedAgentInitAction,
   type TrackedAgentSummary,
 } from '../lib/beast-api';
-import { loadTrackedAgentWindow, sortTrackedAgentsNewestFirst, type TrackedAgentWindow } from '../lib/tracked-agent-window';
+import { loadMissingAgentRuns, loadTrackedAgentWindow, mergeUniqueRuns, sortTrackedAgentsNewestFirst, type TrackedAgentWindow } from '../lib/tracked-agent-window';
 import { ChatApiClient, type ChatSessionSummary, type CorruptChatSessionFile } from '../lib/api';
 import { NetworkApiClient, type NetworkConfigResponse, type NetworkStatusResponse } from '../lib/network-api';
 import type { AgentLifecycleAction } from './beasts/agent-action-bar';
@@ -377,6 +377,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
             reason: error instanceof Error ? error.message : 'Container runtime status unavailable.',
           })),
         ]);
+        runPage = { ...runPage, runs: [...runPage.runs, ...await loadMissingAgentRuns(client, agentWindow.agents, runPage.runs)] };
         if (cancelled) {
           return;
         }
@@ -1056,6 +1057,7 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
               setBeastAgentsLoadingMore(true);
               try {
                 const page = await beastClient.listAgentPage({ cursor });
+                const linkedRuns = await loadMissingAgentRuns(beastClient, page.agents, beastRuns);
                 if (windowVersion !== beastAgentWindowVersionRef.current) return;
                 setBeastAgents((current) => {
                   const knownIds = new Set(current.map((agent) => agent.id));
@@ -1064,6 +1066,9 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 beastAgentNextCursorRef.current = page.nextCursor;
                 setBeastAgentNextCursor(page.nextCursor);
                 beastAgentPagesLoadedRef.current += 1;
+                if (linkedRuns.length > 0) {
+                  setBeastRuns((current) => mergeUniqueRuns(current, linkedRuns));
+                }
               } catch (error) {
                 if (windowVersion === beastAgentWindowVersionRef.current) {
                   setBeastError(error instanceof Error ? error.message : 'Unable to load more tracked agents.');

--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -91,9 +91,18 @@ export class BeastApiClient {
     return this.request<BeastContainerRuntimeStatus>('/v1/beasts/runtime/container', { method: 'GET' });
   }
 
-  async listRuns(): Promise<BeastRunSummary[]> {
-    const body = await this.request<{ runs: BeastRunSummary[] }>('/v1/beasts/runs', { method: 'GET' });
-    return body.runs;
+  async listRunPage(options: { limit?: number; cursor?: string } = {}): Promise<{
+    runs: BeastRunSummary[];
+    nextCursor?: string;
+  }> {
+    const search = new URLSearchParams();
+    if (options.limit !== undefined) search.set('limit', String(options.limit));
+    if (options.cursor) search.set('cursor', options.cursor);
+    const query = search.size > 0 ? `?${search.toString()}` : '';
+    return this.request<{ runs: BeastRunSummary[]; nextCursor?: string }>(
+      `/v1/beasts/runs${query}`,
+      { method: 'GET' },
+    );
   }
 
   async listAgentPage(options: { limit?: number; cursor?: string } = {}): Promise<{

--- a/packages/franken-web/src/lib/tracked-agent-window.ts
+++ b/packages/franken-web/src/lib/tracked-agent-window.ts
@@ -1,5 +1,5 @@
 import type { TrackedAgentSummary } from '@franken/types';
-import type { BeastApiClient } from './beast-api';
+import type { BeastApiClient, BeastRunSummary } from './beast-api';
 
 interface TrackedAgentPage {
   agents: TrackedAgentSummary[];
@@ -25,6 +25,26 @@ export function sortTrackedAgentsNewestFirst(agents: TrackedAgentSummary[]): Tra
     if (isTrackedAgentSortKeyNewer(b, a)) return 1;
     return 0;
   });
+}
+
+export function mergeUniqueRuns(current: BeastRunSummary[], additions: BeastRunSummary[]): BeastRunSummary[] {
+  const knownRunIds = new Set(current.map((run) => run.id));
+  return [...current, ...additions.filter((run) => !knownRunIds.has(run.id))];
+}
+
+export async function loadMissingAgentRuns(
+  client: BeastApiClient,
+  agents: TrackedAgentSummary[],
+  knownRuns: BeastRunSummary[],
+): Promise<BeastRunSummary[]> {
+  const knownRunIds = new Set(knownRuns.map((run) => run.id));
+  const missingRunIds = [...new Set(agents.flatMap((agent) => {
+    const runId = agent.dispatchRunId;
+    return typeof runId === 'string' && !knownRunIds.has(runId) ? [runId] : [];
+  }))];
+  if (missingRunIds.length === 0) return [];
+  const details = await Promise.all(missingRunIds.map((runId) => client.getRun(runId)));
+  return details.map((detail) => detail.run);
 }
 
 export async function loadTrackedAgentWindow(

--- a/packages/franken-web/src/lib/tracked-agent-window.ts
+++ b/packages/franken-web/src/lib/tracked-agent-window.ts
@@ -43,8 +43,8 @@ export async function loadMissingAgentRuns(
     return typeof runId === 'string' && !knownRunIds.has(runId) ? [runId] : [];
   }))];
   if (missingRunIds.length === 0) return [];
-  const details = await Promise.all(missingRunIds.map((runId) => client.getRun(runId)));
-  return details.map((detail) => detail.run);
+  const details = await Promise.all(missingRunIds.map((runId) => client.getRun(runId).catch(() => null)));
+  return details.flatMap((detail) => detail ? [detail.run] : []);
 }
 
 export async function loadTrackedAgentWindow(

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -1067,14 +1067,32 @@ describe('ChatShell', () => {
       createdByUser: 'operator',
       initAction: { kind: 'chunk-plan', command: '/plan', config: {} },
       initConfig: {},
+      dispatchRunId: 'run-page-1',
       createdAt: '2026-03-11T00:00:00.000Z',
       updatedAt: '2026-03-11T00:00:01.000Z',
     };
     const secondAgent = {
       ...firstAgent,
       id: 'agent-page-2',
+      dispatchRunId: 'run-page-2',
       createdAt: '2026-03-10T00:00:00.000Z',
     };
+    mockListRunPage.mockResolvedValue({
+      runs: [{
+        id: 'run-page-1', definitionId: 'chunk-plan', status: 'succeeded',
+        dispatchedBy: 'dashboard', dispatchedByUser: 'operator', executionMode: 'process',
+        createdAt: '2026-03-11T00:00:00.000Z', updatedAt: '2026-03-11T00:00:01.000Z',
+      }],
+    });
+    mockGetRun.mockResolvedValue({
+      run: {
+        id: 'run-page-2', definitionId: 'chunk-plan', status: 'succeeded',
+        dispatchedBy: 'dashboard', dispatchedByUser: 'operator', executionMode: 'container',
+        createdAt: '2026-03-10T00:00:00.000Z', updatedAt: '2026-03-10T00:00:01.000Z',
+      },
+      steps: [],
+      logs: [],
+    });
     mockListAgentPage
       .mockResolvedValueOnce({ agents: [firstAgent], nextCursor: 'cursor-page-2' })
       .mockResolvedValueOnce({ agents: [secondAgent] });
@@ -1091,6 +1109,8 @@ describe('ChatShell', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Load more agents' }, { timeout: 5000 }));
     await waitFor(() => expect(screen.getByText('agent-page-2')).toBeTruthy());
     expect(mockListAgentPage).toHaveBeenNthCalledWith(2, { cursor: 'cursor-page-2' });
+    expect(mockGetRun).toHaveBeenCalledWith('run-page-2');
+    expect(screen.getAllByText('container mode').length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: 'Load more agents' })).toBeNull();
 
     fireEvent.click(screen.getByText('agent-page-2'));

--- a/packages/franken-web/tests/components/chat-shell.test.tsx
+++ b/packages/franken-web/tests/components/chat-shell.test.tsx
@@ -67,8 +67,8 @@ const mockListAgentPage = vi.fn().mockImplementation(async () => ({
   agents: await mockListAgents(),
 }));
 
-const mockListRuns = vi.fn().mockResolvedValue([
-  {
+const mockListRunPage = vi.fn().mockResolvedValue({
+  runs: [{
     id: 'run-1',
     definitionId: 'chunk-plan',
     status: 'running',
@@ -78,8 +78,8 @@ const mockListRuns = vi.fn().mockResolvedValue([
     attemptCount: 1,
     executionMode: 'process',
     createdAt: '2026-03-11T00:00:02.000Z',
-  },
-]);
+  }],
+});
 const mockGetContainerRuntimeStatus = vi.fn().mockResolvedValue({ available: true });
 
 const mockGetAgent = vi.fn().mockResolvedValue({
@@ -288,7 +288,7 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     getCatalog: typeof mockGetCatalog;
     listAgentPage: typeof mockListAgentPage;
     listAgents: typeof mockListAgents;
-    listRuns: typeof mockListRuns;
+    listRunPage: typeof mockListRunPage;
     getContainerRuntimeStatus: typeof mockGetContainerRuntimeStatus;
     getAgent: typeof mockGetAgent;
     getRun: typeof mockGetRun;
@@ -310,7 +310,7 @@ vi.mock('../../src/lib/beast-api.js', () => ({
     this.getCatalog = mockGetCatalog;
     this.listAgentPage = mockListAgentPage;
     this.listAgents = mockListAgents;
-    this.listRuns = mockListRuns;
+    this.listRunPage = mockListRunPage;
     this.getContainerRuntimeStatus = mockGetContainerRuntimeStatus;
     this.getAgent = mockGetAgent;
     this.getRun = mockGetRun;
@@ -432,8 +432,8 @@ afterEach(() => {
   ]);
   mockListAgentPage.mockReset();
   mockListAgentPage.mockImplementation(async () => ({ agents: await mockListAgents() }));
-  mockListRuns.mockResolvedValue([
-    {
+  mockListRunPage.mockResolvedValue({
+    runs: [{
       id: 'run-1',
       definitionId: 'chunk-plan',
       status: 'running',
@@ -443,8 +443,8 @@ afterEach(() => {
       attemptCount: 1,
       executionMode: 'process',
       createdAt: '2026-03-11T00:00:02.000Z',
-    },
-  ]);
+    }],
+  });
   mockGetContainerRuntimeStatus.mockResolvedValue({ available: true });
   mockGetAgent.mockResolvedValue({
     agent: {

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -116,6 +116,22 @@ describe('BeastApiClient', () => {
     );
   });
 
+  it('requests encoded Beast run pages without eagerly following cursors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { runs: [{ id: 'run-1' }], nextCursor: 'next/page+=' } }),
+    });
+
+    await expect(client.listRunPage({ limit: 25, cursor: 'cursor/with+symbols=' })).resolves.toEqual({
+      runs: [{ id: 'run-1' }],
+      nextCursor: 'next/page+=',
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/v1/beasts/runs?limit=25&cursor=cursor%2Fwith%2Bsymbols%3D',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('rejects createAgent when the API reports an auto-dispatch failure', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/packages/franken-web/tests/lib/tracked-agent-window.test.ts
+++ b/packages/franken-web/tests/lib/tracked-agent-window.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { TrackedAgentSummary } from '@franken/types';
 import type { BeastApiClient } from '../../src/lib/beast-api';
-import { loadTrackedAgentWindow, sortTrackedAgentsNewestFirst } from '../../src/lib/tracked-agent-window';
+import { loadMissingAgentRuns, loadTrackedAgentWindow, sortTrackedAgentsNewestFirst } from '../../src/lib/tracked-agent-window';
 
 function agent(id: string, createdAt = '2026-03-11T00:00:00.000Z'): TrackedAgentSummary {
   return {
@@ -56,6 +56,20 @@ describe('loadTrackedAgentWindow', () => {
 
     expect(client.getAgent).toHaveBeenCalledWith(selected.id);
     expect(window.agents).toEqual([agent('first'), selected]);
+  });
+
+  it('keeps linked-run hydration best-effort when a historical run is unavailable', async () => {
+    const getRun = vi.fn()
+      .mockRejectedValueOnce(new Error('corrupt historical run'))
+      .mockResolvedValueOnce({ run: { id: 'run-ok' } });
+    const client = { getRun } as unknown as BeastApiClient;
+    const agents = [
+      { ...agent('first'), dispatchRunId: 'run-bad' },
+      { ...agent('second'), dispatchRunId: 'run-ok' },
+    ];
+
+    await expect(loadMissingAgentRuns(client, agents, [])).resolves.toEqual([{ id: 'run-ok' }]);
+    expect(getRun).toHaveBeenCalledTimes(2);
   });
 
   it('restores server keyset ordering when retained selections are merged with later pages', () => {


### PR DESCRIPTION
## Summary
- paginate `GET /v1/beasts/runs` with a stable row snapshot, opaque cursors, and validated limits
- bound redaction and container-attempt hydration to the returned page, backed by an indexed query plan
- expose explicit run-page loading in the web client and load only the bounded initial page in the dashboard

## Test plan
- `npm test --workspace @franken/orchestrator`
- `npm test --workspace @franken/web`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/web`
- `npm run lint --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/web`
- `npm run build --workspace @franken/orchestrator`
- `npm run build --workspace @franken/web`

Closes #3207