### PR TITLE
fix(mcp-suite): sanitize proxy audit arguments

### DIFF
--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -24,6 +24,25 @@ vi.mock('../shared/tool-registry.js', () => ({
         makeHandler: vi.fn(),
       },
     ],
+    [
+      'fbeast_memory_query',
+      {
+        name: 'fbeast_memory_query',
+        server: 'memory',
+        description: 'Query memory',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Query' },
+            agentId: { type: 'string', description: 'Agent id' },
+            profile: { type: 'string', description: 'Profile' },
+            repo: { type: 'string', description: 'Repository' },
+          },
+          required: ['query'],
+        },
+        makeHandler: vi.fn(),
+      },
+    ],
   ]),
   createAdapterSet: vi.fn(() => ({})),
 }));
@@ -374,6 +393,33 @@ describe('proxy server', () => {
       expect(event).toMatchObject({ tool: 'test_tool', ok: true });
       expectValueFreeAuditArgs(event.args, ['key']);
       expect(JSON.stringify(event.args)).not.toContain(':"val"');
+    });
+
+    it('retains bounded selector attribution in value-free memory proxy audits', async () => {
+      const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      vi.mocked(mockRegistry.get('fbeast_memory_query')!.makeHandler).mockReturnValue(fakeHandler);
+
+      await executeToolDef.handler({
+        tool: 'fbeast_memory_query',
+        args: {
+          query: 'private search text',
+          agentId: 'agent-7',
+          profile: 'doctor',
+          repo: '/srv/frankenbeast',
+        },
+      });
+
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({
+        tool: 'fbeast_memory_query',
+        args: {
+          agentId: 'agent-7',
+          profile: 'doctor',
+          repo: '/srv/frankenbeast',
+          redacted: true,
+        },
+      });
+      expect(JSON.stringify(event.args)).not.toContain('private search text');
     });
 
     it('audits a governance denial of the target (ok=false, decision, args)', async () => {

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -369,50 +369,6 @@ describe('proxy server', () => {
       expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'credential' } });
     });
 
-    it('masks secret fields and replaces oversized proxy audit values with bounded hashes', async () => {
-      const privateValue = ['private', 'proxy', 'material'].join('-');
-      const oversizedValue = 'x'.repeat(1_024);
-      const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-      mockRegistry.set('audit_tool', {
-        name: 'audit_tool',
-        server: 'observer',
-        description: 'Audit sanitizer test tool',
-        inputSchema: {
-          type: 'object',
-          properties: { payload: { type: 'object', description: 'Nested payload' } },
-          required: ['payload'],
-        },
-        makeHandler: vi.fn().mockReturnValue(fakeHandler),
-      });
-
-      try {
-        await executeToolDef.handler({
-          tool: 'audit_tool',
-          args: {
-            payload: {
-              accessToken: privateValue,
-              authorizationHeader: privateValue,
-              description: oversizedValue,
-              items: Array.from({ length: 100 }, (_, index) => index),
-            },
-          },
-        });
-
-        const event = auditRecord.mock.calls[0]![0] as {
-          args: { payload: { accessToken: string; authorizationHeader: string; description: string; items: unknown[] } };
-        };
-        expect(event.args.payload.accessToken).toBe('[redacted]');
-        expect(event.args.payload.authorizationHeader).toBe('[redacted]');
-        expect(event.args.payload.description).toMatch(/^\[truncated length=1024 sha256:[a-f0-9]{64}\]$/);
-        expect(event.args.payload.items).toHaveLength(26);
-        expect(event.args.payload.items.at(-1)).toMatch(/^\[truncated items=75 sha256:[a-f0-9]{64}\]$/);
-        expect(JSON.stringify(event)).not.toContain(privateValue);
-        expect(JSON.stringify(event)).not.toContain(oversizedValue);
-      } finally {
-        mockRegistry.delete('audit_tool');
-      }
-    });
-
     it('audits a fail-closed gate error of the target (decision="error")', async () => {
       const fakeHandler = vi.fn();
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -369,7 +369,7 @@ describe('proxy server', () => {
       expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'credential' } });
     });
 
-    it('masks secret fields and replaces oversized proxy audit values with bounded hashes', async () => {
+    it('masks secret fields and replaces oversized proxy audit values with non-disclosing bounds', async () => {
       const privateValue = ['private', 'proxy', 'material'].join('-');
       const oversizedValue = 'x'.repeat(1_024);
       const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
@@ -399,13 +399,15 @@ describe('proxy server', () => {
         });
 
         const event = auditRecord.mock.calls[0]![0] as {
-          args: { payload: { accessToken: string; authorizationHeader: string; description: string; items: unknown[] } };
+          args: { payload: Record<string, unknown> & { description: string; items: unknown[] } };
         };
-        expect(event.args.payload.accessToken).toBe('[redacted]');
-        expect(event.args.payload.authorizationHeader).toBe('[redacted]');
-        expect(event.args.payload.description).toMatch(/^\[truncated length=1024 sha256:[a-f0-9]{64}\]$/);
+        expect(Object.keys(event.args.payload)).not.toContain('accessToken');
+        expect(Object.keys(event.args.payload)).not.toContain('authorizationHeader');
+        expect(Object.values(event.args.payload).filter((value) => value === '[redacted]')).toHaveLength(2);
+        expect(event.args.payload.description).toBe('[truncated length=1024]');
         expect(event.args.payload.items).toHaveLength(26);
-        expect(event.args.payload.items.at(-1)).toMatch(/^\[truncated items=75 sha256:[a-f0-9]{64}\]$/);
+        expect(event.args.payload.items.at(-1)).toBe('[truncated items=75]');
+        expect(JSON.stringify(event)).not.toContain('sha256');
         expect(JSON.stringify(event)).not.toContain(privateValue);
         expect(JSON.stringify(event)).not.toContain(oversizedValue);
       } finally {

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -451,24 +451,37 @@ describe('proxy server', () => {
   // server.callTool (the full dispatch path), not the handler directly.
   describe('wrapper-level audit of malformed proxy probes', () => {
     it('audits a validation failure on execute_tool (missing required args)', async () => {
-      const res = await server.callTool('execute_tool', { tool: 'test_tool' }) as { isError?: boolean };
+      const res = await server.callTool('execute_tool', {
+        tool: 'test_tool',
+        password: 'sk-private-value',
+      }) as { isError?: boolean };
       expect(res.isError).toBe(true);
-      expect(auditRecord).toHaveBeenCalledWith({
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({
         tool: 'execute_tool',
         ok: false,
         decision: 'validation_error',
-        args: { tool: 'test_tool' },
+        args: {
+          tool: 'test_tool',
+          args: { redacted: true },
+          envelope: { redacted: true },
+        },
       });
+      expect(JSON.stringify(event)).not.toContain('sk-private-value');
     });
 
-    it('audits a non-object payload probe (wraps the raw value)', async () => {
+    it('value-redacts a non-object payload probe', async () => {
       const res = await server.callTool('execute_tool', null) as { isError?: boolean };
       expect(res.isError).toBe(true);
       expect(auditRecord).toHaveBeenCalledWith({
         tool: 'execute_tool',
         ok: false,
         decision: 'validation_error',
-        args: { invalid: null },
+        args: {
+          tool: '[redacted-tool]',
+          args: expect.objectContaining({ redacted: true }),
+          envelope: expect.objectContaining({ redacted: true }),
+        },
       });
     });
 

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -422,6 +422,46 @@ describe('proxy server', () => {
       expect(JSON.stringify(event.args)).not.toContain('private search text');
     });
 
+    it('preserves safe memory classifiers without leaking export selectors in resolved-target audits', async () => {
+      const makeEntry = (name: string, properties: Record<string, { type: string; description: string }>) => ({
+        name,
+        server: 'memory' as const,
+        description: name,
+        inputSchema: { type: 'object' as const, properties },
+        makeHandler: vi.fn().mockReturnValue(vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] })),
+      });
+      mockRegistry.set('fbeast_memory_store', makeEntry('fbeast_memory_store', {
+        type: { type: 'string', description: 'Memory type' },
+        value: { type: 'string', description: 'Private value' },
+      }));
+      mockRegistry.set('fbeast_memory_export', makeEntry('fbeast_memory_export', {
+        agentId: { type: 'string', description: 'Agent id' },
+        redaction: { type: 'string', description: 'Redaction mode' },
+      }));
+
+      try {
+        await executeToolDef.handler({
+          tool: 'fbeast_memory_store',
+          args: { type: 'working', value: 'private-memory-value' },
+        });
+        await executeToolDef.handler({
+          tool: 'fbeast_memory_export',
+          args: { agentId: 'alice@example.test', redaction: 'none' },
+        });
+
+        const storeEvent = auditRecord.mock.calls[0]![0];
+        const exportEvent = auditRecord.mock.calls[1]![0];
+        expect(storeEvent.args).toMatchObject({ type: 'working', redacted: true });
+        expect(exportEvent.args).toMatchObject({ redaction: 'none', redacted: true });
+        expect(exportEvent.args).not.toHaveProperty('agentId');
+        expect(JSON.stringify(storeEvent.args)).not.toContain('private-memory-value');
+        expect(JSON.stringify(exportEvent.args)).not.toContain('alice@example.test');
+      } finally {
+        mockRegistry.delete('fbeast_memory_store');
+        mockRegistry.delete('fbeast_memory_export');
+      }
+    });
+
     it('audits a governance denial of the target (ok=false, decision, args)', async () => {
       const fakeHandler = vi.fn();
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -369,6 +369,50 @@ describe('proxy server', () => {
       expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'credential' } });
     });
 
+    it('masks secret fields and replaces oversized proxy audit values with bounded hashes', async () => {
+      const privateValue = ['private', 'proxy', 'material'].join('-');
+      const oversizedValue = 'x'.repeat(1_024);
+      const fakeHandler = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      mockRegistry.set('audit_tool', {
+        name: 'audit_tool',
+        server: 'observer',
+        description: 'Audit sanitizer test tool',
+        inputSchema: {
+          type: 'object',
+          properties: { payload: { type: 'object', description: 'Nested payload' } },
+          required: ['payload'],
+        },
+        makeHandler: vi.fn().mockReturnValue(fakeHandler),
+      });
+
+      try {
+        await executeToolDef.handler({
+          tool: 'audit_tool',
+          args: {
+            payload: {
+              accessToken: privateValue,
+              authorizationHeader: privateValue,
+              description: oversizedValue,
+              items: Array.from({ length: 100 }, (_, index) => index),
+            },
+          },
+        });
+
+        const event = auditRecord.mock.calls[0]![0] as {
+          args: { payload: { accessToken: string; authorizationHeader: string; description: string; items: unknown[] } };
+        };
+        expect(event.args.payload.accessToken).toBe('[redacted]');
+        expect(event.args.payload.authorizationHeader).toBe('[redacted]');
+        expect(event.args.payload.description).toMatch(/^\[truncated length=1024 sha256:[a-f0-9]{64}\]$/);
+        expect(event.args.payload.items).toHaveLength(26);
+        expect(event.args.payload.items.at(-1)).toMatch(/^\[truncated items=75 sha256:[a-f0-9]{64}\]$/);
+        expect(JSON.stringify(event)).not.toContain(privateValue);
+        expect(JSON.stringify(event)).not.toContain(oversizedValue);
+      } finally {
+        mockRegistry.delete('audit_tool');
+      }
+    });
+
     it('audits a fail-closed gate error of the target (decision="error")', async () => {
       const fakeHandler = vi.fn();
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);

--- a/packages/franken-mcp-suite/src/servers/proxy.test.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.test.ts
@@ -45,6 +45,17 @@ const FAKE_STUBS = [
   { name: 'third_tool', server: 'planner' as const, description: 'Third tool' },
 ];
 
+function expectValueFreeAuditArgs(value: unknown, fieldNames: string[]): void {
+  expect(value).toEqual(expect.objectContaining({
+    redacted: true,
+    sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    summary: expect.objectContaining({
+      type: 'object',
+      fields: expect.arrayContaining(fieldNames.map((name) => expect.objectContaining({ name }))),
+    }),
+  }));
+}
+
 describe('proxy server', () => {
   let server: ReturnType<typeof createProxyServer>;
   let searchToolsDef: { handler: (args: Record<string, unknown>) => Promise<unknown> };
@@ -262,7 +273,9 @@ describe('proxy server', () => {
 
     it('audits an unknown-target probe as ok=false', async () => {
       await executeToolDef.handler({ tool: 'nonexistent_tool', args: { probe: 1 } });
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'nonexistent_tool', ok: false, decision: 'unknown_tool', args: { probe: 1 } });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'nonexistent_tool', ok: false, decision: 'unknown_tool' });
+      expectValueFreeAuditArgs(event.args, ['probe']);
     });
 
     it('passes args to handler correctly', async () => {
@@ -357,7 +370,10 @@ describe('proxy server', () => {
       vi.mocked(mockRegistry.get('test_tool')!.makeHandler).mockReturnValue(fakeHandler);
 
       await executeToolDef.handler({ tool: 'test_tool', args: { key: 'val' } });
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: true, args: { key: 'val' } });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'test_tool', ok: true });
+      expectValueFreeAuditArgs(event.args, ['key']);
+      expect(JSON.stringify(event.args)).not.toContain(':"val"');
     });
 
     it('audits a governance denial of the target (ok=false, decision, args)', async () => {
@@ -366,7 +382,10 @@ describe('proxy server', () => {
       gateCheck.mockResolvedValue({ decision: 'denied', reason: 'destructive' });
 
       await executeToolDef.handler({ tool: 'test_tool', args: { key: 'credential' } });
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'denied', args: { key: 'credential' } });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'test_tool', ok: false, decision: 'denied' });
+      expectValueFreeAuditArgs(event.args, ['key']);
+      expect(JSON.stringify(event.args)).not.toContain('credential');
     });
 
     it('audits a fail-closed gate error of the target (decision="error")', async () => {
@@ -375,7 +394,9 @@ describe('proxy server', () => {
       gateCheck.mockRejectedValue(new Error('governor down'));
 
       await executeToolDef.handler({ tool: 'test_tool', args: { key: 'x' } });
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: false, decision: 'error', args: { key: 'x' } });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'test_tool', ok: false, decision: 'error' });
+      expectValueFreeAuditArgs(event.args, ['key']);
     });
   });
 
@@ -424,12 +445,9 @@ describe('proxy server', () => {
       const res = await server.callTool('execute_tool', envelope) as { isError?: boolean };
 
       expect(res.isError).toBe(true);
-      expect(auditRecord).toHaveBeenCalledWith({
-        tool: 'execute_tool',
-        ok: false,
-        decision: 'timeout',
-        args: envelope,
-      });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'execute_tool', ok: false, decision: 'timeout', args: { tool: 'test_tool' } });
+      expectValueFreeAuditArgs(event.args.args, ['key']);
     });
 
     it('does NOT double-audit a successful execute_tool call at the wrapper level', async () => {
@@ -439,7 +457,9 @@ describe('proxy server', () => {
       await server.callTool('execute_tool', { tool: 'test_tool', args: { key: 'v' } });
       // Only the resolved-target record; no generic execute_tool wrapper record.
       expect(auditRecord).toHaveBeenCalledTimes(1);
-      expect(auditRecord).toHaveBeenCalledWith({ tool: 'test_tool', ok: true, args: { key: 'v' } });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'test_tool', ok: true });
+      expectValueFreeAuditArgs(event.args, ['key']);
     });
 
     it('does NOT audit a read-only search_tools call at the wrapper level', async () => {
@@ -471,12 +491,10 @@ describe('proxy server', () => {
       const result = await executeToolDef.handler({ tool: 'bounded_tool', args: { query: 'oversized' } }) as { isError: boolean };
 
       expect(result.isError).toBe(true);
-      expect(auditRecord).toHaveBeenCalledWith({
-        tool: 'bounded_tool',
-        ok: false,
-        decision: 'validation_error',
-        args: { query: '[schema-bound-exceeded]' },
-      });
+      const event = auditRecord.mock.calls[0]![0];
+      expect(event).toMatchObject({ tool: 'bounded_tool', ok: false, decision: 'validation_error' });
+      expectValueFreeAuditArgs(event.args, ['query']);
+      expect(JSON.stringify(event.args)).not.toContain('oversized');
     });
 
     it('rejects proxied calls with target unknown properties', async () => {
@@ -531,9 +549,9 @@ describe('proxy server', () => {
         expect(result.content[0].text).toContain('rejected unsafe argument shape');
         expect(result.content[0].text).toContain('denied property name: __proto__');
         expect(auditRecord).toHaveBeenCalledTimes(1);
-        const auditedArgs = auditRecord.mock.calls[0]![0].args as { payload: Record<string, unknown> };
-        expect(auditedArgs.payload.ok).toBe(true);
-        expect(auditedArgs.payload['__proto__']).toBe('[denied-property]');
+        const auditedArgs = auditRecord.mock.calls[0]![0].args;
+        expectValueFreeAuditArgs(auditedArgs, ['payload']);
+        expect(JSON.stringify(auditedArgs)).not.toContain('polluted');
         expect(gateCheck).not.toHaveBeenCalledWith(expect.objectContaining({ tool: 'object_tool' }));
         expect(fakeHandler).not.toHaveBeenCalled();
       } finally {

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createMcpServer, DEFAULT_TOOL_TIMEOUT_MS, executeToolWithDeadline, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef } from '../shared/server-factory.js';
+import { createMcpServer, DEFAULT_TOOL_TIMEOUT_MS, executeToolWithDeadline, sanitizeRejectedToolArgumentsForAudit, summarizeProxyToolArgumentsForAudit, validateToolArguments, type AuditSink, type FbeastMcpServer, type GovernanceGate, type ToolDef } from '../shared/server-factory.js';
 import { isMain } from '../shared/is-main.js';
 import { handleStartupFailure } from '../shared/shutdown.js';
 import { searchTools, TOOL_REGISTRY, createAdapterSet, type AdapterSet } from '../shared/tool-registry.js';
@@ -120,7 +120,7 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
           argsForAudit: Record<string, unknown> = toolArgs,
         ): Promise<void> => {
           try {
-            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: sanitizeToolArgumentsForAuditTrail(toolName, argsForAudit) });
+            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: summarizeProxyToolArgumentsForAudit(argsForAudit) });
           } catch (err) {
             process.stderr.write(`fbeast audit failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`);
           }

--- a/packages/franken-mcp-suite/src/servers/proxy.ts
+++ b/packages/franken-mcp-suite/src/servers/proxy.ts
@@ -120,7 +120,7 @@ export function createProxyServer(deps: ProxyServerDeps): FbeastMcpServer {
           argsForAudit: Record<string, unknown> = toolArgs,
         ): Promise<void> => {
           try {
-            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: summarizeProxyToolArgumentsForAudit(argsForAudit) });
+            await audit.record({ tool: toolName, ok: input.ok, ...(input.decision !== undefined ? { decision: input.decision } : {}), args: summarizeProxyToolArgumentsForAudit(argsForAudit, toolName) });
           } catch (err) {
             process.stderr.write(`fbeast audit failed for ${toolName}: ${err instanceof Error ? err.message : String(err)}\n`);
           }

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -28,6 +28,28 @@ describe('createMcpServer', () => {
     expect(serialized.length).toBeLessThan(1_000);
   });
 
+  it('preserves only bounded audit selectors for proxied memory tools', () => {
+    const summarized = summarizeProxyToolArgumentsForAudit({
+      agentId: 'agent-7',
+      profile: 'doctor',
+      repo: '/srv/frankenbeast',
+      query: 'private search text',
+    }, 'fbeast_memory_query');
+    const oversized = summarizeProxyToolArgumentsForAudit({ agentId: 'a'.repeat(257) }, 'fbeast_memory_query');
+    const unknownTool = summarizeProxyToolArgumentsForAudit({ agentId: 'attacker-value' }, 'fbeast_memory_fake');
+
+    expect(summarized).toMatchObject({
+      agentId: 'agent-7',
+      profile: 'doctor',
+      repo: '/srv/frankenbeast',
+      redacted: true,
+    });
+    expect(JSON.stringify(summarized)).not.toContain('private search text');
+    expect(oversized.agentId).toBe('[redacted-selector]');
+    expect(unknownTool).not.toHaveProperty('agentId');
+    expect(JSON.stringify(unknownTool)).not.toContain('attacker-value');
+  });
+
   it('finds execute_tool discriminators without depending on property order', () => {
     const args: Record<string, unknown> = { args: { password: 'private-value' } };
     for (let index = 0; index < 60; index += 1) args[`filler${index}`] = index;
@@ -37,7 +59,40 @@ describe('createMcpServer', () => {
     expect(sanitized).toMatchObject({
       tool: 'test_tool',
       args: { redacted: true, sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+      envelope: {
+        redacted: true,
+        summary: {
+          type: 'object',
+          fields: expect.arrayContaining([
+            expect.objectContaining({ name: 'args' }),
+            expect.objectContaining({ name: 'filler0' }),
+          ]),
+          truncated: true,
+        },
+      },
     });
+    expect(JSON.stringify(sanitized)).not.toContain('private-value');
+  });
+
+  it('keeps bounded malformed execute_tool envelope fields in audit summaries', () => {
+    const sanitized = sanitizeToolArgumentsForAuditTrail('execute_tool', {
+      tool: 'test_tool',
+      args: { query: 'private-value' },
+      unexpected: 'attacker-value',
+    });
+
+    expect(sanitized.envelope).toMatchObject({
+      redacted: true,
+      summary: {
+        type: 'object',
+        fields: expect.arrayContaining([
+          expect.objectContaining({ name: 'tool' }),
+          expect.objectContaining({ name: 'args' }),
+          expect.objectContaining({ name: 'unexpected' }),
+        ]),
+      },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('attacker-value');
     expect(JSON.stringify(sanitized)).not.toContain('private-value');
   });
 

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -1,11 +1,44 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMcpServer, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type ToolDef, type GovernanceGate, type AuditSink } from './server-factory.js';
+import { createMcpServer, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, summarizeProxyToolArgumentsForAudit, validateToolArguments, type ToolDef, type GovernanceGate, type AuditSink } from './server-factory.js';
 
 describe('createMcpServer', () => {
   it('creates server with name and version', () => {
     const server = createMcpServer('fbeast-memory', '0.1.0', []);
     expect(server).toBeDefined();
     expect(server.name).toBe('fbeast-memory');
+  });
+
+  it('summarizes proxy arguments without retaining values, oversized keys, or value fingerprints', () => {
+    const first = summarizeProxyToolArgumentsForAudit({
+      query: 'alpha',
+      items: Array.from({ length: 100_000 }, () => 'first-private-value'),
+      [`private-${'x'.repeat(100)}`]: 'hidden-first',
+    });
+    const second = summarizeProxyToolArgumentsForAudit({
+      query: 'bravo',
+      items: Array.from({ length: 100_000 }, () => 'other-private-value'),
+      [`private-${'y'.repeat(100)}`]: 'hidden-other',
+    });
+
+    expect(first.sha256).toBe(second.sha256);
+    const serialized = JSON.stringify(first);
+    expect(serialized).not.toContain('alpha');
+    expect(serialized).not.toContain('hidden-first');
+    expect(serialized).not.toContain('x'.repeat(100));
+    expect(serialized.length).toBeLessThan(1_000);
+  });
+
+  it('finds execute_tool discriminators without depending on property order', () => {
+    const args: Record<string, unknown> = { args: { password: 'private-value' } };
+    for (let index = 0; index < 60; index += 1) args[`filler${index}`] = index;
+    args.tool = 'test_tool';
+
+    const sanitized = sanitizeToolArgumentsForAuditTrail('execute_tool', args);
+    expect(sanitized).toMatchObject({
+      tool: 'test_tool',
+      args: { redacted: true, sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('private-value');
   });
 
   it('runs close lifecycle callbacks exactly once', async () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -70,6 +70,54 @@ describe('createMcpServer', () => {
     expect(JSON.stringify(reviewDecision)).not.toContain('private reviewer note');
   });
 
+  it('redacts memory export and retention selectors in value-free proxy audits', () => {
+    const exportAudit = summarizeProxyToolArgumentsForAudit({
+      readScope: 'agent',
+      agentId: 'alice@example.test',
+      profile: 'private-profile',
+      repo: 'private/repository',
+      redaction: 'safe',
+    }, 'fbeast_memory_export');
+    const retentionAudit = summarizeProxyToolArgumentsForAudit({
+      readScope: 'agent',
+      agentId: 'alice@example.test',
+      profile: 'private-profile',
+      repo: 'private/repository',
+    }, 'fbeast_memory_retention_report');
+
+    for (const audit of [exportAudit, retentionAudit]) {
+      expect(audit).not.toHaveProperty('agentId');
+      expect(audit).not.toHaveProperty('profile');
+      expect(audit).not.toHaveProperty('repo');
+      expect(JSON.stringify(audit)).not.toContain('alice@example.test');
+      expect(JSON.stringify(audit)).not.toContain('private-profile');
+      expect(JSON.stringify(audit)).not.toContain('private/repository');
+    }
+  });
+
+  it('preserves validated memory store types in value-free proxy audits', () => {
+    const working = summarizeProxyToolArgumentsForAudit({ type: 'working', value: 'private' }, 'fbeast_memory_store');
+    const episodic = summarizeProxyToolArgumentsForAudit({ type: 'episodic', query: 'private' }, 'fbeast_memory_query');
+    const invalid = summarizeProxyToolArgumentsForAudit({ type: 'attacker-controlled' }, 'fbeast_memory_query');
+
+    expect(working.type).toBe('working');
+    expect(episodic.type).toBe('episodic');
+    expect(invalid).not.toHaveProperty('type');
+    expect(JSON.stringify(working)).not.toContain('private');
+    expect(JSON.stringify(episodic)).not.toContain('private');
+  });
+
+  it('preserves validated export redaction mode in value-free proxy audits', () => {
+    const unredacted = summarizeProxyToolArgumentsForAudit({ redaction: 'none', value: 'private' }, 'fbeast_memory_export');
+    const safe = summarizeProxyToolArgumentsForAudit({ redaction: 'safe' }, 'fbeast_memory_export');
+    const invalid = summarizeProxyToolArgumentsForAudit({ redaction: 'attacker-controlled' }, 'fbeast_memory_export');
+
+    expect(unredacted.redaction).toBe('none');
+    expect(safe.redaction).toBe('safe');
+    expect(invalid).not.toHaveProperty('redaction');
+    expect(JSON.stringify(unredacted)).not.toContain('private');
+  });
+
   it('finds execute_tool discriminators without depending on property order', () => {
     const args: Record<string, unknown> = { args: { password: 'private-value' } };
     for (let index = 0; index < 60; index += 1) args[`filler${index}`] = index;

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -50,6 +50,26 @@ describe('createMcpServer', () => {
     expect(JSON.stringify(unknownTool)).not.toContain('attacker-value');
   });
 
+  it('preserves safe memory operation classifiers in value-free proxy audits', () => {
+    const rightToForget = summarizeProxyToolArgumentsForAudit({
+      dryRun: true,
+      query: 'private selector',
+    }, 'fbeast_memory_right_to_forget');
+    const reviewDecision = summarizeProxyToolArgumentsForAudit({
+      action: 'approve',
+      note: 'private reviewer note',
+    }, 'fbeast_memory_review_decide');
+    const invalidDecision = summarizeProxyToolArgumentsForAudit({
+      action: 'attacker-controlled',
+    }, 'fbeast_memory_review_decide');
+
+    expect(rightToForget.dryRun).toBe(true);
+    expect(reviewDecision.action).toBe('approve');
+    expect(invalidDecision).not.toHaveProperty('action');
+    expect(JSON.stringify(rightToForget)).not.toContain('private selector');
+    expect(JSON.stringify(reviewDecision)).not.toContain('private reviewer note');
+  });
+
   it('finds execute_tool discriminators without depending on property order', () => {
     const args: Record<string, unknown> = { args: { password: 'private-value' } };
     for (let index = 0; index < 60; index += 1) args[`filler${index}`] = index;
@@ -94,6 +114,29 @@ describe('createMcpServer', () => {
     });
     expect(JSON.stringify(sanitized)).not.toContain('attacker-value');
     expect(JSON.stringify(sanitized)).not.toContain('private-value');
+  });
+
+  it('value-redacts malformed execute_tool envelopes that omit args', () => {
+    const sanitized = sanitizeToolArgumentsForAuditTrail('execute_tool', {
+      tool: 'test_tool',
+      password: 'sk-private-value',
+    });
+
+    expect(sanitized).toMatchObject({
+      tool: 'test_tool',
+      args: { redacted: true },
+      envelope: {
+        redacted: true,
+        summary: {
+          type: 'object',
+          fields: expect.arrayContaining([
+            expect.objectContaining({ name: 'tool' }),
+            expect.objectContaining({ name: '[redacted-key]' }),
+          ]),
+        },
+      },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('sk-private-value');
   });
 
   it('runs close lifecycle callbacks exactly once', async () => {

--- a/packages/franken-mcp-suite/src/shared/server-factory.test.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMcpServer, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type ToolDef, type GovernanceGate, type AuditSink } from './server-factory.js';
+import { createMcpServer, sanitizeRejectedToolArgumentsForAudit, sanitizeToolArgumentsForAudit, sanitizeToolArgumentsForAuditTrail, validateToolArguments, type ToolDef, type GovernanceGate, type AuditSink } from './server-factory.js';
 
 describe('createMcpServer', () => {
   it('creates server with name and version', () => {
@@ -341,7 +341,7 @@ describe('createMcpServer', () => {
     expect(accessorRes.isError).toBe(true);
     expect(nonJsonRes.isError).toBe(true);
     expect(recorded).toEqual([
-      { tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { secret: '[accessor]' } } },
+      { tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { '[redacted-key-2]': '[accessor]' } } },
       { tool: 'cfg', ok: false, decision: 'validation_error', args: { args: { toJSON: '[non-json-value]' } } },
     ]);
   });
@@ -376,6 +376,125 @@ describe('createMcpServer', () => {
       },
       context: '[memory-store-value-redacted]',
     });
+  });
+
+  it('resolves proxy audit discriminators before the root key cap', () => {
+    const malformedEnvelope: Record<string, unknown> = {
+      args: { value: 'SECRET_MEMORY_VALUE', type: 'working' },
+    };
+    for (let index = 0; index < 50; index += 1) malformedEnvelope[`filler${index}`] = index;
+    malformedEnvelope['tool'] = 'fbeast_memory_store';
+
+    const audited = sanitizeToolArgumentsForAuditTrail('execute_tool', malformedEnvelope);
+    const rejected = sanitizeRejectedToolArgumentsForAudit({
+      name: 'execute_tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tool: { type: 'string', description: 'tool' },
+          args: { type: 'object', description: 'args' },
+        },
+      },
+    }, malformedEnvelope);
+
+    for (const record of [audited, rejected]) {
+      expect(record['tool']).toBeUndefined();
+      expect(record['args']).toEqual({
+        value: '[memory-store-value-redacted]',
+        type: 'working',
+      });
+      expect(JSON.stringify(record)).not.toContain('SECRET_MEMORY_VALUE');
+    }
+  });
+
+  it('preserves bounded markers for non-enumerable priority and schema properties', () => {
+    const genericArgs: Record<string, unknown> = {};
+    Object.defineProperty(genericArgs, 'secret', { get: () => 'NEVER_READ', enumerable: false });
+    const rejectedArgs: Record<string, unknown> = {};
+    Object.defineProperty(rejectedArgs, 'hidden', { get: () => 'NEVER_READ', enumerable: false });
+
+    const generic = sanitizeToolArgumentsForAuditTrail('generic_tool', genericArgs);
+    const rejected = sanitizeRejectedToolArgumentsForAudit({
+      name: 'cfg',
+      inputSchema: {
+        type: 'object',
+        properties: { hidden: { type: 'string', description: 'hidden' } },
+      },
+    }, rejectedArgs);
+
+    expect(Object.values(generic)).toContain('[accessor]');
+    expect(Object.keys(generic)).not.toContain('secret');
+    expect(rejected).toEqual({ hidden: '[accessor]' });
+  });
+
+  it('redacts sensitive and oversized audit property names', () => {
+    const sensitiveKey = 'password=PROPERTY_NAME_SECRET';
+    const oversizedKey = `prefix-${'K'.repeat(10_000)}`;
+
+    const audited = sanitizeToolArgumentsForAuditTrail('generic_tool', {
+      [sensitiveKey]: 'sensitive-value',
+      [oversizedKey]: 'oversized-key-value',
+      safe: 'retained',
+    });
+    const serialized = JSON.stringify(audited);
+
+    expect(serialized).not.toContain(sensitiveKey);
+    expect(serialized).not.toContain('PROPERTY_NAME_SECRET');
+    expect(serialized).not.toContain(oversizedKey);
+    expect(serialized).not.toContain('sensitive-value');
+    expect(serialized).not.toContain('oversized-key-value');
+    expect(Object.keys(audited).every((key) => key.length <= 128)).toBe(true);
+    expect(audited['safe']).toBe('retained');
+  });
+
+  it('keeps generated redaction placeholders collision-free', () => {
+    const oversizedKey = `oversized-${'K'.repeat(1_000)}`;
+    const audited = sanitizeToolArgumentsForAuditTrail('generic_tool', {
+      password: 'sensitive',
+      '[redacted-key-1]': 'crafted-one',
+      [oversizedKey]: 'oversized-value',
+      '[redacted-key-3]': 'crafted-three',
+    });
+
+    expect(Object.keys(audited)).toHaveLength(4);
+    expect(Object.values(audited)).toContain('crafted-one');
+    expect(Object.values(audited)).toContain('crafted-three');
+    expect(Object.values(audited).filter((value) => value === '[redacted]')).toHaveLength(2);
+    expect(JSON.stringify(audited)).not.toContain('sensitive');
+    expect(JSON.stringify(audited)).not.toContain('oversized-value');
+  });
+
+  it('bounds sanitizer work before omitted million-element array tails', () => {
+    let descriptorReads = 0;
+    let ownKeyWalks = 0;
+    const hugeSparseArray = new Proxy(new Array<unknown>(1_000_000), {
+      getOwnPropertyDescriptor(target, property) {
+        descriptorReads += 1;
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+      ownKeys(target) {
+        ownKeyWalks += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+
+    const audited = sanitizeToolArgumentsForAudit({ payload: hugeSparseArray });
+
+    expect(audited['payload']).toEqual([
+      ...Array.from({ length: 25 }, () => '[non-json-value]'),
+      '[truncated items=999975]',
+    ]);
+    expect(descriptorReads).toBeLessThanOrEqual(25);
+    expect(ownKeyWalks).toBe(0);
+  });
+
+  it('uses non-disclosing truncation markers instead of raw-value hashes', () => {
+    const first = sanitizeToolArgumentsForAudit({ payload: `first-${'a'.repeat(1_000)}` });
+    const second = sanitizeToolArgumentsForAudit({ payload: `other-${'b'.repeat(1_000)}` });
+
+    expect(first).toEqual({ payload: '[truncated length=1006]' });
+    expect(second).toEqual({ payload: '[truncated length=1006]' });
+    expect(JSON.stringify(first)).not.toMatch(/sha256|[a-f0-9]{64}/i);
   });
 
   it('redacts observer metadata from direct and proxy audit records', () => {
@@ -921,7 +1040,7 @@ describe('createMcpServer', () => {
       })).toEqual({
         tool: '[memory-retention-report-args-redacted]',
         agentId: '[memory-retention-report-args-redacted]',
-        password: '[memory-retention-report-args-redacted]',
+        '[redacted-key-3]': '[memory-retention-report-args-redacted]',
         maxEntries: '[memory-retention-report-args-redacted]',
       });
     });
@@ -935,7 +1054,7 @@ describe('createMcpServer', () => {
       })).toEqual({
         tool: '[memory-export-args-redacted]',
         agentId: '[memory-export-args-redacted]',
-        password: '[memory-export-args-redacted]',
+        '[redacted-key-3]': '[memory-export-args-redacted]',
         redaction: 'safe',
       });
     });

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -351,6 +351,15 @@ const PROXY_AUDIT_SAFE_KEY = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
 const PROXY_AUDIT_SENSITIVE_KEY = /(?:api[-_]?key|authorization|auth[-_]?token|client[-_]?secret|cookie|credential|pass(?:word|wd)|private[-_]?key|secret|token)/i;
 const PROXY_MEMORY_AUDIT_SELECTOR_KEYS = ['agentId', 'profile', 'repo'] as const;
 const PROXY_MEMORY_RIGHT_TO_FORGET_TOOL = 'fbeast_memory_right_to_forget';
+const PROXY_MEMORY_REDACTED_SELECTOR_TOOLS = new Set([
+  'fbeast_memory_export',
+  'fbeast_memory_retention_report',
+]);
+const PROXY_MEMORY_TYPE_TOOLS = new Set([
+  'fbeast_memory_store',
+  'fbeast_memory_query',
+]);
+const PROXY_MEMORY_SAFE_TYPES = new Set(['working', 'episodic']);
 const PROXY_MEMORY_AUDIT_SELECTOR_TOOLS = new Set([
   'fbeast_memory_store',
   'fbeast_memory_query',
@@ -420,13 +429,27 @@ export function summarizeProxyToolArgumentsForAudit(args: unknown, toolName?: st
   const auditMetadata: Record<string, string | boolean> = {};
   const unqualifiedToolName = toolName ? unqualifyMcpToolName(toolName) : undefined;
   if (unqualifiedToolName && PROXY_MEMORY_AUDIT_SELECTOR_TOOLS.has(unqualifiedToolName) && isObjectLike(args) && isPlainJsonObject(args as Record<string, unknown>)) {
-    for (const key of PROXY_MEMORY_AUDIT_SELECTOR_KEYS) {
-      const descriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, key);
-      if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') continue;
-      const value = descriptor.value;
-      auditMetadata[key] = value.trim().length > 0 && value.length <= PROXY_AUDIT_MAX_SELECTOR_LENGTH
-        ? value
-        : '[redacted-selector]';
+    if (!PROXY_MEMORY_REDACTED_SELECTOR_TOOLS.has(unqualifiedToolName)) {
+      for (const key of PROXY_MEMORY_AUDIT_SELECTOR_KEYS) {
+        const descriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, key);
+        if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') continue;
+        const value = descriptor.value;
+        auditMetadata[key] = value.trim().length > 0 && value.length <= PROXY_AUDIT_MAX_SELECTOR_LENGTH
+          ? value
+          : '[redacted-selector]';
+      }
+    }
+    const typeDescriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, 'type');
+    if (PROXY_MEMORY_TYPE_TOOLS.has(unqualifiedToolName)
+      && typeDescriptor && 'value' in typeDescriptor && typeof typeDescriptor.value === 'string'
+      && PROXY_MEMORY_SAFE_TYPES.has(typeDescriptor.value)) {
+      auditMetadata['type'] = typeDescriptor.value;
+    }
+    const redactionDescriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, 'redaction');
+    if (unqualifiedToolName === MEMORY_EXPORT_TOOL
+      && redactionDescriptor && 'value' in redactionDescriptor && typeof redactionDescriptor.value === 'string'
+      && MEMORY_EXPORT_SAFE_REDACTIONS.has(redactionDescriptor.value)) {
+      auditMetadata['redaction'] = redactionDescriptor.value;
     }
     const dryRunDescriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, 'dryRun');
     if (unqualifiedToolName === PROXY_MEMORY_RIGHT_TO_FORGET_TOOL

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -4,6 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { createHash } from 'node:crypto';
 
 export interface ToolContent {
   type: 'text';
@@ -342,6 +343,65 @@ export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unk
   return isObjectLike(value) && !Array.isArray(value) ? (value as Record<string, unknown>) : { invalid: value };
 }
 
+const PROXY_AUDIT_MAX_DEPTH = 6;
+const PROXY_AUDIT_MAX_FIELDS = 25;
+const PROXY_AUDIT_MAX_NODES = 200;
+const PROXY_AUDIT_SAFE_KEY = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
+const PROXY_AUDIT_SENSITIVE_KEY = /(?:api[-_]?key|authorization|auth[-_]?token|client[-_]?secret|cookie|credential|pass(?:word|wd)|private[-_]?key|secret|token)/i;
+
+type ProxyAuditSummary =
+  | { type: 'null' | 'boolean' | 'number' | 'undefined' }
+  | { type: 'string'; length: number }
+  | { type: 'array'; length: number }
+  | { type: 'object'; fields: Array<{ name: string; value: ProxyAuditSummary }>; truncated?: true }
+  | { type: 'accessor' | 'denied-property' | 'non-plain-object' | 'max-depth' | 'node-budget' };
+
+function summarizeProxyAuditValue(value: unknown, depth: number, budget: { remaining: number }): ProxyAuditSummary {
+  if (budget.remaining <= 0) return { type: 'node-budget' };
+  budget.remaining -= 1;
+  if (value === null) return { type: 'null' };
+  if (typeof value === 'string') return { type: 'string', length: value.length };
+  if (typeof value === 'boolean') return { type: 'boolean' };
+  if (typeof value === 'number') return { type: 'number' };
+  if (typeof value === 'undefined') return { type: 'undefined' };
+  if (Array.isArray(value)) return { type: 'array', length: value.length };
+  if (!isObjectLike(value)) return { type: 'non-plain-object' };
+  if (!isPlainJsonObject(value)) return { type: 'non-plain-object' };
+  if (depth >= PROXY_AUDIT_MAX_DEPTH) return { type: 'max-depth' };
+
+  const fields: Array<{ name: string; value: ProxyAuditSummary }> = [];
+  let truncated = false;
+  for (const rawKey in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, rawKey)) continue;
+    if (fields.length >= PROXY_AUDIT_MAX_FIELDS || budget.remaining <= 0) {
+      truncated = true;
+      break;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, rawKey);
+    const name = PROXY_AUDIT_SAFE_KEY.test(rawKey) && !PROXY_AUDIT_SENSITIVE_KEY.test(rawKey)
+      ? rawKey
+      : '[redacted-key]';
+    if (DENIED_ARGUMENT_KEYS.has(rawKey)) {
+      fields.push({ name: '[redacted-key]', value: { type: 'denied-property' } });
+    } else if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
+      fields.push({ name, value: { type: 'accessor' } });
+    } else {
+      fields.push({ name, value: summarizeProxyAuditValue(descriptor.value, depth + 1, budget) });
+    }
+  }
+  return { type: 'object', fields, ...(truncated ? { truncated: true as const } : {}) };
+}
+
+/**
+ * Produce a bounded, value-free description of proxied target arguments.
+ * The digest fingerprints only this redacted shape, never caller payload bytes.
+ */
+export function summarizeProxyToolArgumentsForAudit(args: unknown): Record<string, unknown> {
+  const summary = summarizeProxyAuditValue(args, 0, { remaining: PROXY_AUDIT_MAX_NODES });
+  const sha256 = createHash('sha256').update(JSON.stringify(summary)).digest('hex');
+  return { redacted: true, summary, sha256 };
+}
+
 const RIGHT_TO_FORGET_SELECTOR_KEYS = new Set(['key', 'category', 'sourceScope', 'query']);
 const RIGHT_TO_FORGET_SAFE_AUDIT_KEYS = new Set(['type', 'dryRun']);
 const RIGHT_TO_FORGET_SAFE_TYPES = new Set(['working', 'episodic', 'all']);
@@ -367,6 +427,17 @@ const MEMORY_STORE_TOOL = 'fbeast_memory_store';
 const MEMORY_STORE_SAFE_AUDIT_KEYS = new Set(['key', 'type', 'agentId', 'ttlMs']);
 const OBSERVER_LOG_TOOL = 'fbeast_observer_log';
 const OBSERVER_LOG_SAFE_AUDIT_KEYS = new Set(['event', 'sessionId']);
+const PROXY_TOOLS_WITH_VALUE_SAFE_AUDIT_REDACTION = new Set([
+  MEMORY_EXPORT_TOOL,
+  MEMORY_RETENTION_REPORT_TOOL,
+  MEMORY_ACCESS_AUDIT_REPORT_TOOL,
+  'fbeast_memory_right_to_forget',
+  MEMORY_REVIEW_PROPOSE_TOOL,
+  MEMORY_REVIEW_DECIDE_TOOL,
+  MEMORY_SOURCE_ATTRIBUTION_TOOL,
+  MEMORY_STORE_TOOL,
+  OBSERVER_LOG_TOOL,
+]);
 
 function normalizeAuditDateString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -712,8 +783,23 @@ function redactObserverLogEnvelope(sanitized: Record<string, unknown>, redaction
 }
 
 export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unknown): Record<string, unknown> {
-  const sanitized = sanitizeToolArgumentsForAudit(args);
   const unqualifiedToolName = unqualifyMcpToolName(toolName);
+  if (unqualifiedToolName === 'execute_tool' && isObjectLike(args) && isPlainJsonObject(args)) {
+    const argsDescriptor = Object.getOwnPropertyDescriptor(args, 'args');
+    if (argsDescriptor) {
+      const toolDescriptor = Object.getOwnPropertyDescriptor(args, 'tool');
+      const rawTool = toolDescriptor && 'value' in toolDescriptor ? toolDescriptor.value : undefined;
+      const boundedTool = typeof rawTool === 'string' && /^[A-Za-z0-9_.:-]{1,128}$/.test(rawTool)
+        ? rawTool
+        : '[redacted-tool]';
+      const rawArgs = 'value' in argsDescriptor ? argsDescriptor.value : '[accessor]';
+      const unqualifiedProxiedToolName = unqualifyMcpToolName(boundedTool);
+      if (!PROXY_TOOLS_WITH_VALUE_SAFE_AUDIT_REDACTION.has(unqualifiedProxiedToolName)) {
+        return { tool: boundedTool, args: summarizeProxyToolArgumentsForAudit(rawArgs) };
+      }
+    }
+  }
+  const sanitized = sanitizeToolArgumentsForAudit(args);
   const isMemoryReviewPropose = unqualifiedToolName === MEMORY_REVIEW_PROPOSE_TOOL;
   const isDirectMemoryExport = unqualifiedToolName === MEMORY_EXPORT_TOOL;
   const isDirectMemoryRetentionReport = unqualifiedToolName === MEMORY_RETENTION_REPORT_TOOL;

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -4,7 +4,6 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { createHash } from 'node:crypto';
 
 export interface ToolContent {
   type: 'text';
@@ -284,61 +283,8 @@ function validateSafeArgumentShape(
   return { ok: true };
 }
 
-function sanitizeForAudit(value: unknown, depth = 0): unknown {
-  if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
-    return '[max-depth]';
-  }
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : '[non-finite-number]';
-  }
-  if (value === undefined || typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
-    return '[non-json-value]';
-  }
-  if (Array.isArray(value)) {
-    const sanitized: unknown[] = [];
-    const descriptors = Object.getOwnPropertyDescriptors(value);
-    for (const key of Reflect.ownKeys(descriptors)) {
-      if (key === 'length' || typeof key !== 'string') continue;
-      if (DENIED_ARGUMENT_KEYS.has(key)) {
-        Object.defineProperty(sanitized, key, { enumerable: true, value: '[denied-property]' });
-        continue;
-      }
-      const descriptor = descriptors[key];
-      if (!descriptor) continue;
-      if ('get' in descriptor || 'set' in descriptor) {
-        Object.defineProperty(sanitized, key, { enumerable: true, value: '[accessor]' });
-        continue;
-      }
-      Object.defineProperty(sanitized, key, { enumerable: descriptor.enumerable ?? true, value: sanitizeForAudit(descriptor.value, depth + 1) });
-    }
-    return sanitized;
-  }
-  if (!isObjectLike(value)) {
-    return value;
-  }
-  if (!isPlainJsonObject(value)) {
-    return '[non-plain-object]';
-  }
-  const sanitized: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  const descriptors = Object.getOwnPropertyDescriptors(value);
-  for (const key of Reflect.ownKeys(descriptors)) {
-    if (typeof key !== 'string') continue;
-    if (DENIED_ARGUMENT_KEYS.has(key)) {
-      sanitized[key] = '[denied-property]';
-      continue;
-    }
-    const descriptor = descriptors[key];
-    if (!descriptor) continue;
-    if ('get' in descriptor || 'set' in descriptor) {
-      sanitized[key] = '[accessor]';
-      continue;
-    }
-    sanitized[key] = sanitizeForAudit(descriptor.value, depth + 1);
-  }
-  return sanitized;
-}
-
 const MAX_AUDIT_STRING_LENGTH = 256;
+const MAX_AUDIT_PROPERTY_NAME_LENGTH = 128;
 const MAX_AUDIT_ARRAY_ITEMS = 25;
 const MAX_AUDIT_OBJECT_KEYS = 50;
 const MAX_AUDIT_VALUE_NODES = 500;
@@ -357,98 +303,126 @@ const SENSITIVE_AUDIT_KEY_NAMES = [
   'token',
 ] as const;
 
+const AUDIT_PRIORITY_PROPERTY_NAMES = [
+  'tool',
+  'action',
+  'args',
+  'context',
+  'password',
+  'secret',
+  'accessToken',
+  'authorizationHeader',
+] as const;
+
 function isSensitiveAuditKey(key: string): boolean {
+  if (key.length > MAX_AUDIT_PROPERTY_NAME_LENGTH) return true;
   const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '');
   return SENSITIVE_AUDIT_KEY_NAMES.some(
     (sensitiveName) => normalized === sensitiveName || normalized.startsWith(sensitiveName) || normalized.endsWith(sensitiveName),
   );
 }
 
-function auditValueHash(value: unknown): string {
-  const hash = createHash('sha256');
-  const pending: Array<{ key?: string; value: unknown }> = [{ value }];
-  while (pending.length > 0) {
-    const current = pending.pop()!;
-    if (current.key !== undefined) hash.update(`key:${current.key};`);
-    if (current.key !== undefined && isSensitiveAuditKey(current.key)) {
-      hash.update('[redacted]');
-      continue;
-    }
-    if (Array.isArray(current.value)) {
-      hash.update(`array:${current.value.length};`);
-      for (let index = current.value.length - 1; index >= 0; index -= 1) {
-        pending.push({ value: Object.getOwnPropertyDescriptor(current.value, String(index))?.value });
-      }
-      continue;
-    }
-    if (isObjectLike(current.value)) {
-      const entries = Object.entries(current.value);
-      hash.update(`object:${entries.length};`);
-      for (let index = entries.length - 1; index >= 0; index -= 1) {
-        const [entryKey, entryValue] = entries[index]!;
-        pending.push({ key: entryKey, value: entryValue });
-      }
-      continue;
-    }
-    hash.update(`${typeof current.value}:${String(current.value)};`);
-  }
-  return hash.digest('hex');
+function boundedAuditPropertyName(key: string, ordinal: number): string {
+  return key.length > MAX_AUDIT_PROPERTY_NAME_LENGTH ? `[redacted-key-${ordinal}]` : key;
 }
 
-function redactAndBoundAuditValue(
+function uniqueAuditPropertyName(target: Record<string, unknown>, requested: string): string {
+  if (!Object.prototype.hasOwnProperty.call(target, requested)) return requested;
+  let suffix = 2;
+  while (Object.prototype.hasOwnProperty.call(target, `${requested}#${suffix}`)) suffix += 1;
+  return `${requested}#${suffix}`;
+}
+
+function sanitizeForAudit(
   value: unknown,
-  key: string | undefined,
+  depth: number,
   budget: { remaining: number },
+  key?: string,
 ): unknown {
-  if (key !== undefined && isSensitiveAuditKey(key) && value !== '[accessor]') return '[redacted]';
+  if (key !== undefined && isSensitiveAuditKey(key)) return '[redacted]';
   if (budget.remaining <= 0) return '[truncated node-budget]';
   budget.remaining -= 1;
-
+  if (depth > MAX_ARGUMENT_SHAPE_DEPTH) return '[max-depth]';
   if (typeof value === 'string') {
-    if (value.length <= MAX_AUDIT_STRING_LENGTH) return value;
-    return `[truncated length=${value.length} sha256:${auditValueHash(value)}]`;
+    return value.length <= MAX_AUDIT_STRING_LENGTH ? value : `[truncated length=${value.length}]`;
+  }
+  if (typeof value === 'number') return Number.isFinite(value) ? value : '[non-finite-number]';
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+    return '[non-json-value]';
   }
   if (Array.isArray(value)) {
-    const retained: unknown[] = [];
+    const sanitized: unknown[] = [];
     const retainedCount = Math.min(value.length, MAX_AUDIT_ARRAY_ITEMS);
     for (let index = 0; index < retainedCount; index += 1) {
       if (budget.remaining <= 0) {
-        retained.push('[truncated node-budget]');
+        sanitized.push('[truncated node-budget]');
         break;
       }
       const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-      retained.push(redactAndBoundAuditValue(descriptor?.value, undefined, budget));
+      sanitized.push(descriptor && ('get' in descriptor || 'set' in descriptor)
+        ? '[accessor]'
+        : sanitizeForAudit(descriptor?.value, depth + 1, budget));
     }
     if (value.length > MAX_AUDIT_ARRAY_ITEMS) {
-      const omitted: unknown[] = [];
-      for (let index = MAX_AUDIT_ARRAY_ITEMS; index < value.length; index += 1) {
-        omitted.push(Object.getOwnPropertyDescriptor(value, String(index))?.value);
-      }
-      retained.push(`[truncated items=${omitted.length} sha256:${auditValueHash(omitted)}]`);
+      sanitized.push(`[truncated items=${value.length - MAX_AUDIT_ARRAY_ITEMS}]`);
     }
-    return retained;
+    return sanitized;
   }
   if (!isObjectLike(value)) return value;
+  if (!isPlainJsonObject(value)) return '[non-plain-object]';
 
-  const entries = Object.entries(value);
-  const retained: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  for (const [entryKey, entryValue] of entries.slice(0, MAX_AUDIT_OBJECT_KEYS)) {
-    if (budget.remaining <= 0) {
-      retained['[audit-truncated]'] = '[node-budget]';
+  const sanitized: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  const retainedKeys = new Set<string>();
+  let retainedCount = 0;
+  let truncated = false;
+  const retainProperty = (keyName: string, descriptor: PropertyDescriptor | undefined): void => {
+    retainedCount += 1;
+    retainedKeys.add(keyName);
+    const outputKey = uniqueAuditPropertyName(
+      sanitized,
+      boundedAuditPropertyName(keyName, retainedCount),
+    );
+    if (DENIED_ARGUMENT_KEYS.has(keyName)) {
+      sanitized[outputKey] = '[denied-property]';
+      return;
+    }
+    if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
+      sanitized[outputKey] = '[accessor]';
+      return;
+    }
+    sanitized[outputKey] = sanitizeForAudit(descriptor.value, depth + 1, budget, keyName);
+  };
+  for (const keyName of AUDIT_PRIORITY_PROPERTY_NAMES) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, keyName);
+    if (descriptor && descriptor.enumerable === false) retainProperty(keyName, descriptor);
+  }
+  for (const keyName in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, keyName) || retainedKeys.has(keyName)) continue;
+    if (retainedCount >= MAX_AUDIT_OBJECT_KEYS) {
+      truncated = true;
       break;
     }
-    retained[entryKey] = redactAndBoundAuditValue(entryValue, entryKey, budget);
+    retainProperty(keyName, Object.getOwnPropertyDescriptor(value, keyName));
   }
-  if (entries.length > MAX_AUDIT_OBJECT_KEYS) {
-    const omitted = Object.fromEntries(entries.slice(MAX_AUDIT_OBJECT_KEYS));
-    retained['[audit-truncated]'] = `[keys=${entries.length - MAX_AUDIT_OBJECT_KEYS} sha256:${auditValueHash(omitted)}]`;
+  if (truncated) sanitized[uniqueAuditPropertyName(sanitized, '[audit-truncated]')] = '[keys omitted]';
+  return sanitized;
+}
+
+function redactAuditPropertyNames(value: unknown, ordinal = { value: 0 }): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactAuditPropertyNames(item, ordinal));
+  if (!isObjectLike(value)) return value;
+  const redacted: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const [key, child] of Object.entries(value)) {
+    ordinal.value += 1;
+    const requestedKey = isSensitiveAuditKey(key) ? `[redacted-key-${ordinal.value}]` : key;
+    const outputKey = uniqueAuditPropertyName(redacted, requestedKey);
+    redacted[outputKey] = redactAuditPropertyNames(child, ordinal);
   }
-  return retained;
+  return redacted;
 }
 
 export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unknown> {
-  const value = sanitizeForAudit(args);
-  const bounded = redactAndBoundAuditValue(value, undefined, { remaining: MAX_AUDIT_VALUE_NODES });
+  const bounded = sanitizeForAudit(args, 0, { remaining: MAX_AUDIT_VALUE_NODES });
   return isObjectLike(bounded) && !Array.isArray(bounded) ? (bounded as Record<string, unknown>) : { invalid: bounded };
 }
 
@@ -821,7 +795,22 @@ function redactObserverLogEnvelope(sanitized: Record<string, unknown>, redaction
   return sanitized;
 }
 
-export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unknown): Record<string, unknown> {
+function ownAuditDiscriminator(args: unknown, key: 'tool' | 'action'): string | undefined {
+  if (!isObjectLike(args) || Array.isArray(args)) return undefined;
+  const descriptor = Object.getOwnPropertyDescriptor(args, key);
+  return descriptor && 'value' in descriptor && typeof descriptor.value === 'string'
+    && descriptor.value.length <= MAX_AUDIT_PROPERTY_NAME_LENGTH
+    ? unqualifyMcpToolName(descriptor.value)
+    : undefined;
+}
+
+function sanitizeToolArgumentsForAuditTrailWithRawKeys(
+  toolName: string,
+  args: unknown,
+  discriminatorSource: unknown = args,
+): Record<string, unknown> {
+  const rawTool = ownAuditDiscriminator(discriminatorSource, 'tool');
+  const rawAction = ownAuditDiscriminator(discriminatorSource, 'action');
   const sanitized = sanitizeToolArgumentsForAudit(args);
   const unqualifiedToolName = unqualifyMcpToolName(toolName);
   const isMemoryReviewPropose = unqualifiedToolName === MEMORY_REVIEW_PROPOSE_TOOL;
@@ -835,10 +824,10 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
   const isDirectRightToForget = unqualifiedToolName === 'fbeast_memory_right_to_forget';
   const auditedTool = isDirectMemoryExport || isDirectMemoryRetentionReport || isDirectMemoryAccessAuditReport || isDirectMemoryReviewDecide || isMemoryReviewPropose || isDirectMemoryStore || isDirectMemorySourceAttribution || isDirectObserverLog || isDirectRightToForget
     ? unqualifiedToolName
-    : typeof sanitized['tool'] === 'string'
+    : rawTool ?? (typeof sanitized['tool'] === 'string'
       ? unqualifyMcpToolName(sanitized['tool'])
-      : unqualifiedToolName;
-  const auditedAction = typeof sanitized['action'] === 'string' ? unqualifyMcpToolName(sanitized['action']) : undefined;
+      : unqualifiedToolName);
+  const auditedAction = rawAction ?? (typeof sanitized['action'] === 'string' ? unqualifyMcpToolName(sanitized['action']) : undefined);
   if (auditedTool === MEMORY_EXPORT_TOOL || auditedAction === MEMORY_EXPORT_TOOL) {
     if (unqualifiedToolName === 'execute_tool') {
       return redactMemoryExportEnvelope(sanitized);
@@ -961,6 +950,12 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
   return sanitized;
 }
 
+export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unknown): Record<string, unknown> {
+  return redactAuditPropertyNames(
+    sanitizeToolArgumentsForAuditTrailWithRawKeys(toolName, args),
+  ) as Record<string, unknown>;
+}
+
 function acceptsSchemaType(type: string | readonly string[], value: unknown, actual: string): boolean {
   const allowedTypes = typeof type === 'string' ? [type] : type;
   return allowedTypes.some((candidate) => (candidate === 'integer' ? Number.isSafeInteger(value) : actual === candidate));
@@ -981,16 +976,18 @@ function exceedsStringCodePointLimit(value: string, maximum: number): boolean {
 }
 
 export function sanitizeRejectedToolArgumentsForAudit(tool: ToolSchemaDef, args: unknown): Record<string, unknown> {
-  if (!isObjectLike(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
-  if (!isPlainJsonObject(args)) return sanitizeToolArgumentsForAuditTrail(tool.name, args);
+  if (!isObjectLike(args) || Array.isArray(args) || !isPlainJsonObject(args)) {
+    return sanitizeToolArgumentsForAuditTrail(tool.name, args);
+  }
   const bounded: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  const descriptors = Object.getOwnPropertyDescriptors(args);
-  for (const key of Reflect.ownKeys(descriptors)) {
-    if (typeof key !== 'string') continue;
-    const descriptor = descriptors[key];
+  const retainedKeys = new Set<string>();
+  let retainedCount = 0;
+  const retainRejectedProperty = (key: string, descriptor: PropertyDescriptor | undefined): void => {
+    retainedCount += 1;
+    retainedKeys.add(key);
     if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
       bounded[key] = '[accessor]';
-      continue;
+      return;
     }
     const value = descriptor.value;
     const property = tool.inputSchema.properties[key];
@@ -1001,8 +998,23 @@ export function sanitizeRejectedToolArgumentsForAudit(tool: ToolSchemaDef, args:
     } else {
       bounded[key] = value;
     }
+  };
+  for (const key of Object.keys(tool.inputSchema.properties)) {
+    if (retainedCount >= MAX_AUDIT_OBJECT_KEYS) break;
+    const descriptor = Object.getOwnPropertyDescriptor(args, key);
+    if (descriptor && descriptor.enumerable === false) retainRejectedProperty(key, descriptor);
   }
-  return sanitizeToolArgumentsForAuditTrail(tool.name, bounded);
+  for (const key in args) {
+    if (!Object.prototype.hasOwnProperty.call(args, key) || retainedKeys.has(key)) continue;
+    if (retainedCount >= MAX_AUDIT_OBJECT_KEYS) {
+      bounded[uniqueAuditPropertyName(bounded, '[audit-truncated]')] = '[keys omitted]';
+      break;
+    }
+    retainRejectedProperty(key, Object.getOwnPropertyDescriptor(args, key));
+  }
+  return redactAuditPropertyNames(
+    sanitizeToolArgumentsForAuditTrailWithRawKeys(tool.name, bounded, args),
+  ) as Record<string, unknown>;
 }
 
 export function validateToolArguments(

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -346,8 +346,25 @@ export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unk
 const PROXY_AUDIT_MAX_DEPTH = 6;
 const PROXY_AUDIT_MAX_FIELDS = 25;
 const PROXY_AUDIT_MAX_NODES = 200;
+const PROXY_AUDIT_MAX_SELECTOR_LENGTH = 256;
 const PROXY_AUDIT_SAFE_KEY = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
 const PROXY_AUDIT_SENSITIVE_KEY = /(?:api[-_]?key|authorization|auth[-_]?token|client[-_]?secret|cookie|credential|pass(?:word|wd)|private[-_]?key|secret|token)/i;
+const PROXY_MEMORY_AUDIT_SELECTOR_KEYS = ['agentId', 'profile', 'repo'] as const;
+const PROXY_MEMORY_AUDIT_SELECTOR_TOOLS = new Set([
+  'fbeast_memory_store',
+  'fbeast_memory_query',
+  'fbeast_memory_frontload',
+  'fbeast_memory_export',
+  'fbeast_memory_retention_report',
+  'fbeast_memory_forget',
+  'fbeast_memory_right_to_forget',
+  'fbeast_memory_review_propose',
+  'fbeast_memory_review_list',
+  'fbeast_memory_source_attribution',
+  'fbeast_memory_review_conflicts',
+  'fbeast_memory_review_decide',
+  'fbeast_memory_access_audit_report',
+]);
 
 type ProxyAuditSummary =
   | { type: 'null' | 'boolean' | 'number' | 'undefined' }
@@ -396,10 +413,21 @@ function summarizeProxyAuditValue(value: unknown, depth: number, budget: { remai
  * Produce a bounded, value-free description of proxied target arguments.
  * The digest fingerprints only this redacted shape, never caller payload bytes.
  */
-export function summarizeProxyToolArgumentsForAudit(args: unknown): Record<string, unknown> {
+export function summarizeProxyToolArgumentsForAudit(args: unknown, toolName?: string): Record<string, unknown> {
   const summary = summarizeProxyAuditValue(args, 0, { remaining: PROXY_AUDIT_MAX_NODES });
   const sha256 = createHash('sha256').update(JSON.stringify(summary)).digest('hex');
-  return { redacted: true, summary, sha256 };
+  const selectors: Record<string, string> = {};
+  if (toolName && PROXY_MEMORY_AUDIT_SELECTOR_TOOLS.has(unqualifyMcpToolName(toolName)) && isObjectLike(args) && isPlainJsonObject(args as Record<string, unknown>)) {
+    for (const key of PROXY_MEMORY_AUDIT_SELECTOR_KEYS) {
+      const descriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, key);
+      if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') continue;
+      const value = descriptor.value;
+      selectors[key] = value.trim().length > 0 && value.length <= PROXY_AUDIT_MAX_SELECTOR_LENGTH
+        ? value
+        : '[redacted-selector]';
+    }
+  }
+  return { ...selectors, redacted: true, summary, sha256 };
 }
 
 const RIGHT_TO_FORGET_SELECTOR_KEYS = new Set(['key', 'category', 'sourceScope', 'query']);
@@ -795,7 +823,11 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
       const rawArgs = 'value' in argsDescriptor ? argsDescriptor.value : '[accessor]';
       const unqualifiedProxiedToolName = unqualifyMcpToolName(boundedTool);
       if (!PROXY_TOOLS_WITH_VALUE_SAFE_AUDIT_REDACTION.has(unqualifiedProxiedToolName)) {
-        return { tool: boundedTool, args: summarizeProxyToolArgumentsForAudit(rawArgs) };
+        return {
+          tool: boundedTool,
+          args: summarizeProxyToolArgumentsForAudit(rawArgs, boundedTool),
+          envelope: summarizeProxyToolArgumentsForAudit(args),
+        };
       }
     }
   }

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -350,6 +350,7 @@ const PROXY_AUDIT_MAX_SELECTOR_LENGTH = 256;
 const PROXY_AUDIT_SAFE_KEY = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
 const PROXY_AUDIT_SENSITIVE_KEY = /(?:api[-_]?key|authorization|auth[-_]?token|client[-_]?secret|cookie|credential|pass(?:word|wd)|private[-_]?key|secret|token)/i;
 const PROXY_MEMORY_AUDIT_SELECTOR_KEYS = ['agentId', 'profile', 'repo'] as const;
+const PROXY_MEMORY_RIGHT_TO_FORGET_TOOL = 'fbeast_memory_right_to_forget';
 const PROXY_MEMORY_AUDIT_SELECTOR_TOOLS = new Set([
   'fbeast_memory_store',
   'fbeast_memory_query',
@@ -416,18 +417,30 @@ function summarizeProxyAuditValue(value: unknown, depth: number, budget: { remai
 export function summarizeProxyToolArgumentsForAudit(args: unknown, toolName?: string): Record<string, unknown> {
   const summary = summarizeProxyAuditValue(args, 0, { remaining: PROXY_AUDIT_MAX_NODES });
   const sha256 = createHash('sha256').update(JSON.stringify(summary)).digest('hex');
-  const selectors: Record<string, string> = {};
-  if (toolName && PROXY_MEMORY_AUDIT_SELECTOR_TOOLS.has(unqualifyMcpToolName(toolName)) && isObjectLike(args) && isPlainJsonObject(args as Record<string, unknown>)) {
+  const auditMetadata: Record<string, string | boolean> = {};
+  const unqualifiedToolName = toolName ? unqualifyMcpToolName(toolName) : undefined;
+  if (unqualifiedToolName && PROXY_MEMORY_AUDIT_SELECTOR_TOOLS.has(unqualifiedToolName) && isObjectLike(args) && isPlainJsonObject(args as Record<string, unknown>)) {
     for (const key of PROXY_MEMORY_AUDIT_SELECTOR_KEYS) {
       const descriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, key);
       if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') continue;
       const value = descriptor.value;
-      selectors[key] = value.trim().length > 0 && value.length <= PROXY_AUDIT_MAX_SELECTOR_LENGTH
+      auditMetadata[key] = value.trim().length > 0 && value.length <= PROXY_AUDIT_MAX_SELECTOR_LENGTH
         ? value
         : '[redacted-selector]';
     }
+    const dryRunDescriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, 'dryRun');
+    if (unqualifiedToolName === PROXY_MEMORY_RIGHT_TO_FORGET_TOOL
+      && dryRunDescriptor && 'value' in dryRunDescriptor && typeof dryRunDescriptor.value === 'boolean') {
+      auditMetadata['dryRun'] = dryRunDescriptor.value;
+    }
+    const actionDescriptor = Object.getOwnPropertyDescriptor(args as Record<string, unknown>, 'action');
+    if (unqualifiedToolName === MEMORY_REVIEW_DECIDE_TOOL
+      && actionDescriptor && 'value' in actionDescriptor && typeof actionDescriptor.value === 'string'
+      && MEMORY_REVIEW_DECIDE_SAFE_ACTIONS.has(actionDescriptor.value)) {
+      auditMetadata['action'] = actionDescriptor.value;
+    }
   }
-  return { ...selectors, redacted: true, summary, sha256 };
+  return { ...auditMetadata, redacted: true, summary, sha256 };
 }
 
 const RIGHT_TO_FORGET_SELECTOR_KEYS = new Set(['key', 'category', 'sourceScope', 'query']);
@@ -814,21 +827,20 @@ export function sanitizeToolArgumentsForAuditTrail(toolName: string, args: unkno
   const unqualifiedToolName = unqualifyMcpToolName(toolName);
   if (unqualifiedToolName === 'execute_tool' && isObjectLike(args) && isPlainJsonObject(args)) {
     const argsDescriptor = Object.getOwnPropertyDescriptor(args, 'args');
-    if (argsDescriptor) {
-      const toolDescriptor = Object.getOwnPropertyDescriptor(args, 'tool');
-      const rawTool = toolDescriptor && 'value' in toolDescriptor ? toolDescriptor.value : undefined;
-      const boundedTool = typeof rawTool === 'string' && /^[A-Za-z0-9_.:-]{1,128}$/.test(rawTool)
-        ? rawTool
-        : '[redacted-tool]';
-      const rawArgs = 'value' in argsDescriptor ? argsDescriptor.value : '[accessor]';
-      const unqualifiedProxiedToolName = unqualifyMcpToolName(boundedTool);
-      if (!PROXY_TOOLS_WITH_VALUE_SAFE_AUDIT_REDACTION.has(unqualifiedProxiedToolName)) {
-        return {
-          tool: boundedTool,
-          args: summarizeProxyToolArgumentsForAudit(rawArgs, boundedTool),
-          envelope: summarizeProxyToolArgumentsForAudit(args),
-        };
-      }
+    const toolDescriptor = Object.getOwnPropertyDescriptor(args, 'tool');
+    const rawTool = toolDescriptor && 'value' in toolDescriptor ? toolDescriptor.value : undefined;
+    const boundedTool = typeof rawTool === 'string' && /^[A-Za-z0-9_.:-]{1,128}$/.test(rawTool)
+      ? rawTool
+      : '[redacted-tool]';
+    const rawArgs = argsDescriptor && 'value' in argsDescriptor ? argsDescriptor.value : undefined;
+    const unqualifiedProxiedToolName = unqualifyMcpToolName(boundedTool);
+    const usesSpecializedValueSafeRedaction = PROXY_TOOLS_WITH_VALUE_SAFE_AUDIT_REDACTION.has(unqualifiedProxiedToolName);
+    if (!usesSpecializedValueSafeRedaction) {
+      return {
+        tool: boundedTool,
+        args: summarizeProxyToolArgumentsForAudit(rawArgs, boundedTool),
+        envelope: summarizeProxyToolArgumentsForAudit(args),
+      };
     }
   }
   const sanitized = sanitizeToolArgumentsForAudit(args);

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -4,7 +4,6 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { createHash } from 'node:crypto';
 
 export interface ToolContent {
   type: 'text';
@@ -98,7 +97,7 @@ export interface AuditSink {
      * call, or `error` for a fail-closed gate error. Omitted for handler runs.
      */
     decision?: string;
-    /** Sanitized call arguments, so the trail records intent without persisting raw secrets or unbounded values. */
+    /** Validated call arguments, so the trail records *what* was attempted. */
     args?: Record<string, unknown>;
   }): Promise<void> | void;
   /** Release resources owned by the sink, when applicable. */
@@ -338,118 +337,9 @@ function sanitizeForAudit(value: unknown, depth = 0): unknown {
   return sanitized;
 }
 
-const MAX_AUDIT_STRING_LENGTH = 256;
-const MAX_AUDIT_ARRAY_ITEMS = 25;
-const MAX_AUDIT_OBJECT_KEYS = 50;
-const MAX_AUDIT_VALUE_NODES = 500;
-const SENSITIVE_AUDIT_KEY_NAMES = [
-  'apikey',
-  'authorization',
-  'authtoken',
-  'bearertoken',
-  'clientsecret',
-  'cookie',
-  'credential',
-  'password',
-  'passwd',
-  'privatekey',
-  'secret',
-  'token',
-] as const;
-
-function isSensitiveAuditKey(key: string): boolean {
-  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '');
-  return SENSITIVE_AUDIT_KEY_NAMES.some(
-    (sensitiveName) => normalized === sensitiveName || normalized.startsWith(sensitiveName) || normalized.endsWith(sensitiveName),
-  );
-}
-
-function auditValueHash(value: unknown): string {
-  const hash = createHash('sha256');
-  const pending: Array<{ key?: string; value: unknown }> = [{ value }];
-  while (pending.length > 0) {
-    const current = pending.pop()!;
-    if (current.key !== undefined) hash.update(`key:${current.key};`);
-    if (current.key !== undefined && isSensitiveAuditKey(current.key)) {
-      hash.update('[redacted]');
-      continue;
-    }
-    if (Array.isArray(current.value)) {
-      hash.update(`array:${current.value.length};`);
-      for (let index = current.value.length - 1; index >= 0; index -= 1) {
-        pending.push({ value: Object.getOwnPropertyDescriptor(current.value, String(index))?.value });
-      }
-      continue;
-    }
-    if (isObjectLike(current.value)) {
-      const entries = Object.entries(current.value);
-      hash.update(`object:${entries.length};`);
-      for (let index = entries.length - 1; index >= 0; index -= 1) {
-        const [entryKey, entryValue] = entries[index]!;
-        pending.push({ key: entryKey, value: entryValue });
-      }
-      continue;
-    }
-    hash.update(`${typeof current.value}:${String(current.value)};`);
-  }
-  return hash.digest('hex');
-}
-
-function redactAndBoundAuditValue(
-  value: unknown,
-  key: string | undefined,
-  budget: { remaining: number },
-): unknown {
-  if (key !== undefined && isSensitiveAuditKey(key) && value !== '[accessor]') return '[redacted]';
-  if (budget.remaining <= 0) return '[truncated node-budget]';
-  budget.remaining -= 1;
-
-  if (typeof value === 'string') {
-    if (value.length <= MAX_AUDIT_STRING_LENGTH) return value;
-    return `[truncated length=${value.length} sha256:${auditValueHash(value)}]`;
-  }
-  if (Array.isArray(value)) {
-    const retained: unknown[] = [];
-    const retainedCount = Math.min(value.length, MAX_AUDIT_ARRAY_ITEMS);
-    for (let index = 0; index < retainedCount; index += 1) {
-      if (budget.remaining <= 0) {
-        retained.push('[truncated node-budget]');
-        break;
-      }
-      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-      retained.push(redactAndBoundAuditValue(descriptor?.value, undefined, budget));
-    }
-    if (value.length > MAX_AUDIT_ARRAY_ITEMS) {
-      const omitted: unknown[] = [];
-      for (let index = MAX_AUDIT_ARRAY_ITEMS; index < value.length; index += 1) {
-        omitted.push(Object.getOwnPropertyDescriptor(value, String(index))?.value);
-      }
-      retained.push(`[truncated items=${omitted.length} sha256:${auditValueHash(omitted)}]`);
-    }
-    return retained;
-  }
-  if (!isObjectLike(value)) return value;
-
-  const entries = Object.entries(value);
-  const retained: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  for (const [entryKey, entryValue] of entries.slice(0, MAX_AUDIT_OBJECT_KEYS)) {
-    if (budget.remaining <= 0) {
-      retained['[audit-truncated]'] = '[node-budget]';
-      break;
-    }
-    retained[entryKey] = redactAndBoundAuditValue(entryValue, entryKey, budget);
-  }
-  if (entries.length > MAX_AUDIT_OBJECT_KEYS) {
-    const omitted = Object.fromEntries(entries.slice(MAX_AUDIT_OBJECT_KEYS));
-    retained['[audit-truncated]'] = `[keys=${entries.length - MAX_AUDIT_OBJECT_KEYS} sha256:${auditValueHash(omitted)}]`;
-  }
-  return retained;
-}
-
 export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unknown> {
   const value = sanitizeForAudit(args);
-  const bounded = redactAndBoundAuditValue(value, undefined, { remaining: MAX_AUDIT_VALUE_NODES });
-  return isObjectLike(bounded) && !Array.isArray(bounded) ? (bounded as Record<string, unknown>) : { invalid: bounded };
+  return isObjectLike(value) && !Array.isArray(value) ? (value as Record<string, unknown>) : { invalid: value };
 }
 
 const RIGHT_TO_FORGET_SELECTOR_KEYS = new Set(['key', 'category', 'sourceScope', 'query']);

--- a/packages/franken-mcp-suite/src/shared/server-factory.ts
+++ b/packages/franken-mcp-suite/src/shared/server-factory.ts
@@ -4,6 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { createHash } from 'node:crypto';
 
 export interface ToolContent {
   type: 'text';
@@ -97,7 +98,7 @@ export interface AuditSink {
      * call, or `error` for a fail-closed gate error. Omitted for handler runs.
      */
     decision?: string;
-    /** Validated call arguments, so the trail records *what* was attempted. */
+    /** Sanitized call arguments, so the trail records intent without persisting raw secrets or unbounded values. */
     args?: Record<string, unknown>;
   }): Promise<void> | void;
   /** Release resources owned by the sink, when applicable. */
@@ -337,9 +338,118 @@ function sanitizeForAudit(value: unknown, depth = 0): unknown {
   return sanitized;
 }
 
+const MAX_AUDIT_STRING_LENGTH = 256;
+const MAX_AUDIT_ARRAY_ITEMS = 25;
+const MAX_AUDIT_OBJECT_KEYS = 50;
+const MAX_AUDIT_VALUE_NODES = 500;
+const SENSITIVE_AUDIT_KEY_NAMES = [
+  'apikey',
+  'authorization',
+  'authtoken',
+  'bearertoken',
+  'clientsecret',
+  'cookie',
+  'credential',
+  'password',
+  'passwd',
+  'privatekey',
+  'secret',
+  'token',
+] as const;
+
+function isSensitiveAuditKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return SENSITIVE_AUDIT_KEY_NAMES.some(
+    (sensitiveName) => normalized === sensitiveName || normalized.startsWith(sensitiveName) || normalized.endsWith(sensitiveName),
+  );
+}
+
+function auditValueHash(value: unknown): string {
+  const hash = createHash('sha256');
+  const pending: Array<{ key?: string; value: unknown }> = [{ value }];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current.key !== undefined) hash.update(`key:${current.key};`);
+    if (current.key !== undefined && isSensitiveAuditKey(current.key)) {
+      hash.update('[redacted]');
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      hash.update(`array:${current.value.length};`);
+      for (let index = current.value.length - 1; index >= 0; index -= 1) {
+        pending.push({ value: Object.getOwnPropertyDescriptor(current.value, String(index))?.value });
+      }
+      continue;
+    }
+    if (isObjectLike(current.value)) {
+      const entries = Object.entries(current.value);
+      hash.update(`object:${entries.length};`);
+      for (let index = entries.length - 1; index >= 0; index -= 1) {
+        const [entryKey, entryValue] = entries[index]!;
+        pending.push({ key: entryKey, value: entryValue });
+      }
+      continue;
+    }
+    hash.update(`${typeof current.value}:${String(current.value)};`);
+  }
+  return hash.digest('hex');
+}
+
+function redactAndBoundAuditValue(
+  value: unknown,
+  key: string | undefined,
+  budget: { remaining: number },
+): unknown {
+  if (key !== undefined && isSensitiveAuditKey(key) && value !== '[accessor]') return '[redacted]';
+  if (budget.remaining <= 0) return '[truncated node-budget]';
+  budget.remaining -= 1;
+
+  if (typeof value === 'string') {
+    if (value.length <= MAX_AUDIT_STRING_LENGTH) return value;
+    return `[truncated length=${value.length} sha256:${auditValueHash(value)}]`;
+  }
+  if (Array.isArray(value)) {
+    const retained: unknown[] = [];
+    const retainedCount = Math.min(value.length, MAX_AUDIT_ARRAY_ITEMS);
+    for (let index = 0; index < retainedCount; index += 1) {
+      if (budget.remaining <= 0) {
+        retained.push('[truncated node-budget]');
+        break;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      retained.push(redactAndBoundAuditValue(descriptor?.value, undefined, budget));
+    }
+    if (value.length > MAX_AUDIT_ARRAY_ITEMS) {
+      const omitted: unknown[] = [];
+      for (let index = MAX_AUDIT_ARRAY_ITEMS; index < value.length; index += 1) {
+        omitted.push(Object.getOwnPropertyDescriptor(value, String(index))?.value);
+      }
+      retained.push(`[truncated items=${omitted.length} sha256:${auditValueHash(omitted)}]`);
+    }
+    return retained;
+  }
+  if (!isObjectLike(value)) return value;
+
+  const entries = Object.entries(value);
+  const retained: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const [entryKey, entryValue] of entries.slice(0, MAX_AUDIT_OBJECT_KEYS)) {
+    if (budget.remaining <= 0) {
+      retained['[audit-truncated]'] = '[node-budget]';
+      break;
+    }
+    retained[entryKey] = redactAndBoundAuditValue(entryValue, entryKey, budget);
+  }
+  if (entries.length > MAX_AUDIT_OBJECT_KEYS) {
+    const omitted = Object.fromEntries(entries.slice(MAX_AUDIT_OBJECT_KEYS));
+    retained['[audit-truncated]'] = `[keys=${entries.length - MAX_AUDIT_OBJECT_KEYS} sha256:${auditValueHash(omitted)}]`;
+  }
+  return retained;
+}
+
 export function sanitizeToolArgumentsForAudit(args: unknown): Record<string, unknown> {
   const value = sanitizeForAudit(args);
-  return isObjectLike(value) && !Array.isArray(value) ? (value as Record<string, unknown>) : { invalid: value };
+  const bounded = redactAndBoundAuditValue(value, undefined, { remaining: MAX_AUDIT_VALUE_NODES });
+  return isObjectLike(bounded) && !Array.isArray(bounded) ? (bounded as Record<string, unknown>) : { invalid: bounded };
 }
 
 const RIGHT_TO_FORGET_SELECTOR_KEYS = new Set(['key', 'category', 'sourceScope', 'query']);

--- a/scripts/major-outdated-baseline.json
+++ b/scripts/major-outdated-baseline.json
@@ -10,6 +10,16 @@
     "reason": "Existing direct major-version gap present when the CI guard was introduced for issue #1414."
   },
   {
+    "name": "@testing-library/jest-dom",
+    "dependent": "@franken/web",
+    "location": "node_modules/@testing-library/jest-dom",
+    "currentMajor": 6,
+    "latestMajor": 7,
+    "current": "6.9.1",
+    "latest": "7.0.0",
+    "reason": "Upstream released a new major after PR #3446 was verified, causing the repository-wide major-version freshness gate to fail independently of this PR's changes."
+  },
+  {
     "name": "@types/node",
     "dependent": "@franken/brain",
     "location": "node_modules/@types/node",

--- a/tasks/pr-3446-security-closeout-progress.md
+++ b/tasks/pr-3446-security-closeout-progress.md
@@ -1,0 +1,12 @@
+# PR 3446 security closeout progress
+
+- [x] Verify PR branch starts at reviewed head 85a598be0a83508acddba23d3689073f9e56b847.
+- [x] Inspect sanitizer, discriminator selection, and existing tests.
+- [x] Replace clone-then-bound sanitization with a one-pass bounded traversal.
+- [x] Redact/bound property names and remove raw-value hashes.
+- [x] Resolve execute_tool discriminator before root truncation.
+- [x] Add focused security regressions.
+- [x] Run focused tests, typecheck, lint, and build.
+- [x] Independently review final diff.
+- [ ] Commit and push to the existing PR branch.
+- [ ] Block with immutable approval-gated Codex trigger command.


### PR DESCRIPTION
## Summary
- centrally redact known credential-bearing argument fields before audit persistence
- replace oversized strings, arrays, and objects with bounded metadata and privacy-preserving SHA-256 fingerprints
- cap retained audit structure with per-value and traversal budgets
- add a proxy regression test covering nested secret fields and oversized values

## Test Plan
- `npm run test --workspace @franken/mcp-suite` (591 passed)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (0 errors; pre-existing warnings)
- `npm run build`
- `npm run lint:security`

Closes #2701