### PR TITLE
fix(orchestrator): reuse network route supervisor

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/network-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/network-routes.ts
@@ -32,6 +32,8 @@ export interface NetworkRoutesDeps {
   frankenbeastDir: string;
   configFile: string;
   allowTrustedProviderCommandOverrides?: boolean | undefined;
+  /** Optional owner-provided factory; invoked once to establish the route lifetime. */
+  supervisorFactory?: () => NetworkSupervisor;
   getConfig(): OrchestratorConfig;
   setConfig(config: OrchestratorConfig): void;
 }
@@ -76,9 +78,9 @@ function assertKnownStopTarget(target: string): void {
 
 export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   const app = new Hono();
+  const supervisor = deps.supervisorFactory?.() ?? createSupervisor(deps.frankenbeastDir);
 
   app.get('/v1/network/status', async (c) => {
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     const status = await supervisor.status();
     const config = deps.getConfig();
     const services = resolveNetworkServices(config, {
@@ -101,7 +103,6 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   });
 
   app.post('/v1/network/up', async (c) => {
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     const config = deps.getConfig();
     const services = resolveNetworkServices(config, {
       repoRoot: deps.root,
@@ -118,14 +119,12 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   });
 
   app.post('/v1/network/down', async (c) => {
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     await supervisor.down();
     return c.json({ data: { ok: true } });
   });
 
   app.post('/v1/network/start', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     const config = deps.getConfig();
     const services = withValidTarget(
       resolveNetworkServices(config, {
@@ -146,7 +145,6 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
 
   app.post('/v1/network/stop', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     assertKnownStopTarget(body.target);
     await supervisor.stop(body.target);
     return c.json({ data: { ok: true } });
@@ -154,7 +152,6 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
 
   app.post('/v1/network/restart', async (c) => {
     const body = validateBody(TargetBody, await parseJsonBody(c));
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     const config = deps.getConfig();
     const services = withValidTarget(
       resolveNetworkServices(config, {
@@ -175,7 +172,6 @@ export function networkRoutes(deps: NetworkRoutesDeps): Hono {
   });
 
   app.get('/v1/network/logs/:service', async (c) => {
-    const supervisor = createSupervisor(deps.frankenbeastDir);
     const target = c.req.param('service');
     const logs = await supervisor.logs(target);
     return c.json({ data: { logs } });

--- a/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/network/network-routes.test.ts
@@ -3,7 +3,9 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createChatApp } from '../../../src/http/chat-app.js';
+import { networkRoutes } from '../../../src/http/routes/network-routes.js';
 import { defaultConfig } from '../../../src/config/orchestrator-config.js';
+import type { NetworkSupervisor } from '../../../src/network/network-supervisor.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const TMP = join(__dirname, '__fixtures__/network-routes');
@@ -11,6 +13,27 @@ const TMP = join(__dirname, '__fixtures__/network-routes');
 describe('network routes', () => {
   afterEach(() => {
     rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('reuses one supervisor across repeated status requests', async () => {
+    const status = vi.fn().mockResolvedValue({ services: [] });
+    const supervisorFactory = vi.fn(() => ({ status }) as unknown as NetworkSupervisor);
+    const app = networkRoutes({
+      root: TMP,
+      frankenbeastDir: TMP,
+      configFile: join(TMP, 'config.json'),
+      getConfig: () => defaultConfig(),
+      setConfig: () => {},
+      supervisorFactory,
+    });
+
+    const first = await app.request('/v1/network/status');
+    const second = await app.request('/v1/network/status');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(supervisorFactory).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenCalledTimes(2);
   });
 
   it('serves status and persists config updates', async () => {


### PR DESCRIPTION
## Summary
- create one network supervisor for the lifetime of the network route app
- reuse it across status, lifecycle, and log requests
- cover repeated status polling with a focused factory-lifecycle regression

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/integration/network/network-routes.test.ts`
- `npm run lint --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`

Closes #3206