### PR TITLE
fix(live-bench): bound corpus traversal

### DIFF
--- a/packages/live-bench/README.md
+++ b/packages/live-bench/README.md
@@ -31,6 +31,7 @@ Key exports:
 | --- | --- |
 | `loadCorpus`, `loadTaskFile` | Strictly load benchmark task definitions from a corpus root. |
 | `loadCorpusWithDiagnostics` | Load valid tasks while quarantining malformed candidate-tier files in a structured diagnostics result. Core and stress task errors remain fatal. |
+| `CorpusLoadOptions` | Override corpus traversal limits passed as the third loader argument (`maxDepth`, default 32; `maxFiles`, default 10,000). |
 | `BenchmarkTaskSchema` | Validate benchmark task JSON with Zod. |
 | `ToolCallEvidenceSchema` | Validate a single tool-call evidence record. |
 | `ToolCallEvidenceManifestSchema`, `serializeToolCallEvidence` | Validate and serialize the full tool-call evidence artifact array. |

--- a/packages/live-bench/src/corpus/loader.ts
+++ b/packages/live-bench/src/corpus/loader.ts
@@ -14,6 +14,20 @@ export interface CorpusLoadDiagnostics {
   quarantined: QuarantinedCorpusTask[];
 }
 
+export interface CorpusLoadOptions {
+  maxDepth?: number;
+  maxFiles?: number;
+}
+
+const DEFAULT_MAX_CORPUS_DEPTH = 32;
+const DEFAULT_MAX_CORPUS_FILES = 10_000;
+
+interface CorpusTraversalState {
+  fileCount: number;
+  maxDepth: number;
+  maxFiles: number;
+}
+
 export function loadTaskFile(path: string): BenchmarkTask {
   try {
     const parsed = readTaskJson(path);
@@ -24,9 +38,13 @@ export function loadTaskFile(path: string): BenchmarkTask {
   }
 }
 
-export function loadCorpus(root: string, tiers?: readonly CorpusTier[]): BenchmarkTask[] {
+export function loadCorpus(
+  root: string,
+  tiers?: readonly CorpusTier[],
+  options: CorpusLoadOptions = {},
+): BenchmarkTask[] {
   const allowed = tiers ? new Set<CorpusTier>(tiers) : undefined;
-  const tasks = taskFiles(root)
+  const tasks = taskFiles(root, options)
     .filter((path) => !allowed || allowed.has(readValidatedTaskTier(path)))
     .map((path) => loadTaskFile(path))
     .filter((task) => !allowed || allowed.has(task.tier));
@@ -35,12 +53,16 @@ export function loadCorpus(root: string, tiers?: readonly CorpusTier[]): Benchma
   return tasks.sort((a, b) => a.taskId.localeCompare(b.taskId));
 }
 
-export function loadCorpusWithDiagnostics(root: string, tiers?: readonly CorpusTier[]): CorpusLoadDiagnostics {
+export function loadCorpusWithDiagnostics(
+  root: string,
+  tiers?: readonly CorpusTier[],
+  options: CorpusLoadOptions = {},
+): CorpusLoadDiagnostics {
   const allowed = tiers ? new Set<CorpusTier>(tiers) : undefined;
   const tasks: BenchmarkTask[] = [];
   const quarantined: QuarantinedCorpusTask[] = [];
 
-  for (const path of taskFiles(root).sort((a, b) => a.localeCompare(b))) {
+  for (const path of taskFiles(root, options).sort((a, b) => a.localeCompare(b))) {
     let parsed: unknown;
     try {
       parsed = readTaskJson(path);
@@ -131,17 +153,46 @@ function invalidTaskError(path: string, error: unknown): Error {
   return new Error(`Invalid benchmark task ${path}: ${detail}`);
 }
 
-function taskFiles(dir: string): string[] {
+function taskFiles(
+  dir: string,
+  options: CorpusLoadOptions,
+  depth = 0,
+  existingState?: CorpusTraversalState,
+): string[] {
+  const state = existingState ?? {
+    fileCount: 0,
+    maxDepth: corpusLoadLimit('maxDepth', options.maxDepth, DEFAULT_MAX_CORPUS_DEPTH),
+    maxFiles: corpusLoadLimit('maxFiles', options.maxFiles, DEFAULT_MAX_CORPUS_FILES),
+  };
+  if (depth > state.maxDepth) {
+    throw new Error(`Corpus directory depth limit of ${state.maxDepth} exceeded at ${dir}`);
+  }
+
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) {
-      out.push(...taskFiles(path));
+      out.push(...taskFiles(path, options, depth + 1, state));
       continue;
     }
-    if (entry.isFile() && entry.name.endsWith('.task.json') && statSync(path).isFile()) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    state.fileCount += 1;
+    if (state.fileCount > state.maxFiles) {
+      throw new Error(`Corpus file count limit of ${state.maxFiles} exceeded at ${path}`);
+    }
+    if (entry.name.endsWith('.task.json') && statSync(path).isFile()) {
       out.push(path);
     }
   }
   return out;
+}
+
+function corpusLoadLimit(name: keyof CorpusLoadOptions, value: number | undefined, fallback: number): number {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new Error(`Corpus load option ${name} must be a non-negative safe integer`);
+  }
+  return limit;
 }

--- a/packages/live-bench/src/index.ts
+++ b/packages/live-bench/src/index.ts
@@ -23,6 +23,7 @@ export {
   loadCorpusWithDiagnostics,
   loadTaskFile,
   type CorpusLoadDiagnostics,
+  type CorpusLoadOptions,
   type QuarantinedCorpusTask,
 } from './corpus/loader.js';
 export {

--- a/packages/live-bench/tests/corpus-loader.test.ts
+++ b/packages/live-bench/tests/corpus-loader.test.ts
@@ -79,6 +79,38 @@ describe('corpus loader', () => {
     expect(() => loadCorpus(root)).toThrow(/Invalid benchmark task/);
   });
 
+  it('rejects corpus directories deeper than the configured limit', () => {
+    const root = tempCorpus();
+    const taskPath = writeTask(root, 'core/one/two/deep.task.json', validTask);
+
+    expect(() => loadCorpus(root, undefined, { maxDepth: 2 })).toThrow(
+      `Corpus directory depth limit of 2 exceeded at ${join(taskPath, '..')}`,
+    );
+  });
+
+  it('rejects corpora with more files than the configured limit', () => {
+    const root = tempCorpus();
+    writeTask(root, 'core/a.task.json', { ...validTask, taskId: 'a-task' });
+    writeTask(root, 'core/b.task.json', { ...validTask, taskId: 'b-task' });
+    writeTask(root, 'core/c.task.json', { ...validTask, taskId: 'c-task' });
+
+    expect(() => loadCorpusWithDiagnostics(root, undefined, { maxFiles: 2 })).toThrow(
+      /Corpus file count limit of 2 exceeded/,
+    );
+  });
+
+  it.each([
+    ['maxDepth', -1],
+    ['maxFiles', Number.NaN],
+  ] as const)('rejects invalid corpus traversal option %s=%s', (name, value) => {
+    const root = tempCorpus();
+    writeTask(root, 'core/a.task.json', validTask);
+
+    expect(() => loadCorpus(root, undefined, { [name]: value })).toThrow(
+      `Corpus load option ${name} must be a non-negative safe integer`,
+    );
+  });
+
   it('loads matching tiers sorted by task id without validating unselected tiers', () => {
     const root = tempCorpus();
     writeTask(root, 'candidate/z.task.json', { ...validTask, taskId: 'z-task', tier: 'candidate' });


### PR DESCRIPTION
## Summary
- bound corpus directory traversal to 32 levels by default
- cap regular files scanned at 10,000 by default and validate operator overrides
- export/document traversal options and cover depth, file-count, and invalid-limit failures

## Test plan
- `npm test -- --run tests/corpus-loader.test.ts` (27 passed)
- `npm test` (127 passed, 1 skipped live test)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `codex review --uncommitted` (no actionable findings)

Closes #3068