### PR TITLE
ci(release): fail closed during latest-tag repair

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,12 +66,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           # Root releases use bare version tags (v1.2.3).
           # Component releases are prefixed (franken-brain-v0.3.0).
           # GitHub auto-marks the most recently created release as "latest",
           # which could be any sub-package. Fix that.
-          latest_tag=$(gh release view --json tagName --jq '.tagName' 2>/dev/null || echo '')
-          if [ -z "$latest_tag" ]; then exit 0; fi
+          release_json=$(gh release list --limit 1000 --json tagName,isLatest)
+          latest_tag=$(jq -r '([.[] | select(.isLatest)][0].tagName // empty)' <<<"$release_json")
+          if [ -z "$latest_tag" ]; then
+            echo "No latest release found; nothing to repair"
+            exit 0
+          fi
 
           # If the current "latest" is already a root release, nothing to do
           if [[ "$latest_tag" =~ ^v[0-9] ]]; then
@@ -82,7 +88,7 @@ jobs:
           # Promote the most recent root release back to latest. If no root
           # release exists yet, keep the current latest marker in place rather
           # than demoting the component release and leaving no latest release.
-          root_tag=$(gh release list --limit 1000 --json tagName --jq '([.[] | select(.tagName | test("^v[0-9]"))][0].tagName // empty)' 2>/dev/null || echo '')
+          root_tag=$(jq -r '([.[] | select(.tagName | test("^v[0-9]"))][0].tagName // empty)' <<<"$release_json")
           if [ -z "$root_tag" ]; then
             echo "No root release found; leaving component latest unchanged: $latest_tag"
             exit 0
@@ -94,6 +100,12 @@ jobs:
 
           echo "Promoting root release: $root_tag"
           gh release edit "$root_tag" --latest
+
+          verified_tag=$(gh release view --json tagName --jq '.tagName')
+          if [ "$verified_tag" != "$root_tag" ]; then
+            echo "Latest release verification failed: expected $root_tag, got $verified_tag" >&2
+            exit 1
+          fi
 
   publish-npm:
     needs: release-please

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -554,6 +554,29 @@ jobs:
     );
   });
 
+  it('fails closed while repairing the latest release marker', () => {
+    const releaseLatestStep = expectSteps(releasePlease).find(
+      (step) => step.name === 'Ensure only root release is marked latest',
+    );
+    expect(releaseLatestStep).toBeTruthy();
+    const releaseLatestRun = String(releaseLatestStep?.run ?? '');
+    const firstCommand = releaseLatestRun
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !line.startsWith('#'));
+
+    expect(firstCommand).toBe('set -euo pipefail');
+    expect(releaseLatestRun).not.toContain("|| echo ''");
+    expect(releaseLatestRun).toContain('release_json=$(gh release list');
+    expect(releaseLatestRun).toContain('latest_tag=$(jq -r');
+
+    const promoteIndex = releaseLatestRun.indexOf('gh release edit "$root_tag" --latest');
+    const verifyIndex = releaseLatestRun.indexOf('verified_tag=$(gh release view');
+    expect(verifyIndex).toBeGreaterThan(promoteIndex);
+    expect(releaseLatestRun).toContain('if [ "$verified_tag" != "$root_tag" ]; then');
+    expect(releaseLatestRun).toContain('exit 1');
+  });
+
   it('does not demote component-only latest releases unless a root release exists to promote', () => {
     const releaseLatestStep = expectSteps(releasePlease).find(
       (step) => step.name === 'Ensure only root release is marked latest',
@@ -561,8 +584,8 @@ jobs:
     expect(releaseLatestStep).toBeTruthy();
     const releaseLatestRun = String(releaseLatestStep?.run ?? '');
 
-    const rootLookupIndex = releaseLatestRun.indexOf('root_tag=$(gh release list');
-    const emptyRootNormalizationIndex = releaseLatestRun.indexOf('.tagName // empty');
+    const rootLookupIndex = releaseLatestRun.indexOf('root_tag=$(jq -r');
+    const emptyRootNormalizationIndex = releaseLatestRun.indexOf('.tagName // empty', rootLookupIndex);
     const noRootGuardIndex = releaseLatestRun.indexOf(
       'No root release found; leaving component latest unchanged',
     );
@@ -570,7 +593,7 @@ jobs:
     const promoteIndex = releaseLatestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(releaseLatestRun).toContain('gh release list --limit 1000 --json tagName');
+    expect(releaseLatestRun).toContain('gh release list --limit 1000 --json tagName,isLatest');
     expect(emptyRootNormalizationIndex).toBeGreaterThan(rootLookupIndex);
     expect(noRootGuardIndex).toBeGreaterThan(emptyRootNormalizationIndex);
     expect(demoteIndex).toBeGreaterThan(noRootGuardIndex);
@@ -593,13 +616,13 @@ jobs:
     expect(latestStep).toBeTruthy();
 
     const latestRun = String(latestStep?.run ?? '');
-    const rootLookupIndex = latestRun.indexOf('root_tag=$(gh release list');
+    const rootLookupIndex = latestRun.indexOf('root_tag=$(jq -r');
     const missingRootGuardIndex = latestRun.indexOf('No root release found; leaving component latest unchanged');
     const demoteIndex = latestRun.indexOf('gh release edit "$latest_tag" --latest=false');
     const promoteIndex = latestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(latestRun).toContain('gh release list --limit 1000 --json tagName');
+    expect(latestRun).toContain('gh release list --limit 1000 --json tagName,isLatest');
     expect(missingRootGuardIndex).toBeGreaterThan(rootLookupIndex);
     expect(demoteIndex).toBeGreaterThan(missingRootGuardIndex);
     expect(promoteIndex).toBeGreaterThan(demoteIndex);


### PR DESCRIPTION
## Summary
- enable strict shell handling for the latest-release repair step
- query release metadata once and handle an empty release list explicitly
- verify the root release is actually marked latest after repair
- add workflow regression coverage for strict/error-visible behavior

## Test plan
- `npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/web-dev-server-dependency-policy.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `actionlint .github/workflows/release-please.yml`

Closes #3056