### PR TITLE
fix(observer): cap model attribution cardinality

### DIFF
--- a/packages/franken-observer/src/cost/ModelAttribution.test.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.test.ts
@@ -22,6 +22,27 @@ describe('ModelAttribution', () => {
       expect(row.failedCalls).toBe(1)
     })
 
+    it('rejects a new model after reaching the configured cardinality limit', () => {
+      const attr = new ModelAttribution(DEFAULT_PRICING, { maxModels: 2 })
+      attr.record({ model: 'gpt-4o', promptTokens: 10, completionTokens: 5, success: true })
+      attr.record({ model: 'claude-opus-4-6', promptTokens: 20, completionTokens: 10, success: false })
+
+      expect(() =>
+        attr.record({ model: 'model-c', promptTokens: 30, completionTokens: 15, success: true }),
+      ).toThrow('model cardinality limit of 2 reached')
+      expect(attr.report().map(row => row.model)).toEqual(['gpt-4o', 'claude-opus-4-6'])
+    })
+
+    it('continues updating an existing model at the cardinality limit', () => {
+      const attr = new ModelAttribution(DEFAULT_PRICING, { maxModels: 1 })
+      attr.record({ model: 'gpt-4o', promptTokens: 10, completionTokens: 5, success: true })
+
+      expect(() =>
+        attr.record({ model: 'gpt-4o', promptTokens: 20, completionTokens: 10, success: false }),
+      ).not.toThrow()
+      expect(attr.report()[0]).toMatchObject({ model: 'gpt-4o', totalCalls: 2 })
+    })
+
     it.each([
       ['negative prompt tokens', { promptTokens: -1, completionTokens: 0 }],
       ['negative completion tokens', { promptTokens: 0, completionTokens: -1 }],

--- a/packages/franken-observer/src/cost/ModelAttribution.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.ts
@@ -24,14 +24,29 @@ interface ModelState {
   completionTokens: number
 }
 
+export interface ModelAttributionOptions {
+  /** Maximum number of distinct model labels retained by this attribution report. */
+  maxModels?: number
+}
+
+const DEFAULT_MAX_MODELS = 1_000
+
 export class ModelAttribution {
   private readonly calc: CostCalculator
   private readonly state = new Map<string, ModelState>()
+  private readonly maxModels: number
   private totalPromptTokens = 0
   private totalCompletionTokens = 0
 
-  constructor(pricing: PricingTable) {
+  constructor(pricing: PricingTable, options: ModelAttributionOptions = {}) {
+    const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
+    if (!Number.isSafeInteger(maxModels) || maxModels <= 0) {
+      throw new RangeError(
+        `ModelAttribution: maxModels must be a positive safe integer, received ${maxModels}`,
+      )
+    }
     this.calc = new CostCalculator(pricing)
+    this.maxModels = maxModels
   }
 
   /** A token delta must be a non-negative safe integer. */
@@ -57,6 +72,11 @@ export class ModelAttribution {
   record(entry: AttributionEntry): void {
     ModelAttribution.assertValidDelta(entry.promptTokens, 'promptTokens')
     ModelAttribution.assertValidDelta(entry.completionTokens, 'completionTokens')
+    if (!this.state.has(entry.model) && this.state.size >= this.maxModels) {
+      throw new RangeError(
+        `ModelAttribution: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
+      )
+    }
 
     const existing = this.state.get(entry.model) ?? {
       totalCalls: 0,

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -32,6 +32,36 @@ describe('TokenCounter', () => {
       expect(counter.totalsFor('claude-opus-4-6').totalTokens).toBe(150)
       expect(counter.totalsFor('gpt-4o').totalTokens).toBe(280)
     })
+
+    it('rejects a new model after reaching the configured cardinality limit', () => {
+      const boundedCounter = new TokenCounter({ maxModels: 2 })
+      boundedCounter.record({ model: 'model-a', promptTokens: 10, completionTokens: 5 })
+      boundedCounter.record({ model: 'model-b', promptTokens: 20, completionTokens: 10 })
+
+      expect(() =>
+        boundedCounter.record({ model: 'model-c', promptTokens: 30, completionTokens: 15 }),
+      ).toThrow('model cardinality limit of 2 reached')
+      expect(boundedCounter.allModels()).toEqual(['model-a', 'model-b'])
+      expect(boundedCounter.grandTotal()).toEqual({
+        promptTokens: 30,
+        completionTokens: 15,
+        totalTokens: 45,
+      })
+    })
+
+    it('continues updating an existing model at the cardinality limit', () => {
+      const boundedCounter = new TokenCounter({ maxModels: 1 })
+      boundedCounter.record({ model: 'model-a', promptTokens: 10, completionTokens: 5 })
+
+      expect(() =>
+        boundedCounter.record({ model: 'model-a', promptTokens: 20, completionTokens: 10 }),
+      ).not.toThrow()
+      expect(boundedCounter.totalsFor('model-a')).toEqual({
+        promptTokens: 30,
+        completionTokens: 15,
+        totalTokens: 45,
+      })
+    })
   })
 
   describe('totalsFor()', () => {

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -10,10 +10,28 @@ export interface TokenTotals {
   totalTokens: number
 }
 
+export interface TokenCounterOptions {
+  /** Maximum number of distinct model labels retained by this counter. */
+  maxModels?: number
+}
+
+const DEFAULT_MAX_MODELS = 1_000
+
 export class TokenCounter {
   private readonly counts = new Map<string, { prompt: number; completion: number }>()
+  private readonly maxModels: number
   private totalPromptTokens = 0
   private totalCompletionTokens = 0
+
+  constructor(options: TokenCounterOptions = {}) {
+    const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
+    if (!Number.isSafeInteger(maxModels) || maxModels <= 0) {
+      throw new RangeError(
+        `TokenCounter: maxModels must be a positive safe integer, received ${maxModels}`,
+      )
+    }
+    this.maxModels = maxModels
+  }
 
   /** A token delta must be a non-negative safe integer. */
   private static assertValidDelta(value: number, label: string): void {
@@ -38,6 +56,11 @@ export class TokenCounter {
   record(entry: TokenRecord): void {
     TokenCounter.assertValidDelta(entry.promptTokens, 'promptTokens')
     TokenCounter.assertValidDelta(entry.completionTokens, 'completionTokens')
+    if (!this.counts.has(entry.model) && this.counts.size >= this.maxModels) {
+      throw new RangeError(
+        `TokenCounter: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
+      )
+    }
     const existing = this.counts.get(entry.model) ?? { prompt: 0, completion: 0 }
     const prompt = TokenCounter.safeAdd(existing.prompt, entry.promptTokens)
     const completion = TokenCounter.safeAdd(existing.completion, entry.completionTokens)

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -120,10 +120,14 @@ export type {
   TraceValidationResult,
 } from './core/types.js'
 export type { TokenUsage } from './core/SpanLifecycle.js'
-export type { TokenRecord, TokenTotals } from './cost/TokenCounter.js'
+export type { TokenRecord, TokenTotals, TokenCounterOptions } from './cost/TokenCounter.js'
 export type { CostCalculatorOptions } from './cost/CostCalculator.js'
 export type { CircuitBreakerOptions, CircuitBreakerResult } from './cost/CircuitBreaker.js'
-export type { AttributionEntry, AttributionRow } from './cost/ModelAttribution.js'
+export type {
+  AttributionEntry,
+  AttributionRow,
+  ModelAttributionOptions,
+} from './cost/ModelAttribution.js'
 export type {
   AgentDecisionRecord,
   AgentDecisionRecordInput,


### PR DESCRIPTION
## Summary
- cap retained model labels in TokenCounter and ModelAttribution at 1,000 by default
- allow operators to configure a lower positive maxModels limit
- reject new labels atomically at the limit while continuing to update known models
- export the new option types from the observer package

## Verification
- `npm test` (observer: 842 passed)
- `npm run lint` (0 errors; 6 pre-existing warnings)
- `npm run typecheck`
- `npm run build`

Closes #3045