### PR TITLE
fix(planner): inspect error pattern code points

### DIFF
--- a/packages/franken-planner/src/recovery/error-ingester.ts
+++ b/packages/franken-planner/src/recovery/error-ingester.ts
@@ -64,14 +64,17 @@ function patternMatches(message: string, pattern: string): boolean {
     return false;
   }
   const escapedPattern = escapeRegex(normalizedPattern).replace(/\s+/g, String.raw`\s+`);
+  const patternCodePoints = Array.from(normalizedPattern);
   // Only guard an edge with a word boundary when the pattern actually starts/ends
-  // with a word character. Applying the lookarounds unconditionally would drop
-  // legitimate partial patterns ending (or starting) in punctuation — e.g.
-  // `failed:` or `Cannot find module '` — when adjacent error text is a word.
-  const leadingBoundary = WORD_CHAR_RE.test(normalizedPattern[0] ?? '')
+  // with a word character. Iterate by Unicode code point so astral letters and
+  // numbers are tested whole instead of as individual UTF-16 surrogate halves.
+  // Applying the lookarounds unconditionally would drop legitimate partial
+  // patterns ending (or starting) in punctuation — e.g. `failed:` or
+  // `Cannot find module '` — when adjacent error text is a word.
+  const leadingBoundary = WORD_CHAR_RE.test(patternCodePoints[0] ?? '')
     ? String.raw`(?<![${WORD_CHAR_CLASS}])`
     : '';
-  const trailingBoundary = WORD_CHAR_RE.test(normalizedPattern[normalizedPattern.length - 1] ?? '')
+  const trailingBoundary = WORD_CHAR_RE.test(patternCodePoints.at(-1) ?? '')
     ? String.raw`(?![${WORD_CHAR_CLASS}])`
     : '';
   const matcher = new RegExp(`${leadingBoundary}${escapedPattern}${trailingBoundary}`, 'iu');

--- a/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
+++ b/packages/franken-planner/tests/unit/recovery/error-ingester.test.ts
@@ -130,4 +130,16 @@ describe('ErrorIngester', () => {
     const result = new ErrorIngester().classify(new Error('operation timedout unexpectedly'), [ke]);
     expect(result.type).toBe('unknown');
   });
+
+  it('applies word boundaries to non-BMP letters at both pattern edges', () => {
+    const leading = new ErrorIngester().classify(new Error('x𐐀failure'), [
+      makeKnownError('𐐀failure'),
+    ]);
+    expect(leading.type).toBe('unknown');
+
+    const trailing = new ErrorIngester().classify(new Error('failure𐐀x'), [
+      makeKnownError('failure𐐀'),
+    ]);
+    expect(trailing.type).toBe('unknown');
+  });
 });


### PR DESCRIPTION
## Summary
- inspect ErrorIngester pattern edges by Unicode code point rather than UTF-16 code unit
- preserve punctuation behavior while applying word guards to astral letters and numbers
- cover non-BMP letters at both leading and trailing pattern edges

## Test plan
- `npm run test --workspace @franken/planner`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/planner`
- `npm run build --workspace @franken/planner`
- `npm run lint --workspace @franken/planner`

Closes #3043