### PR TITLE
docs(readme): add architecture text alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The diagrams below use current package names or implementation-surface names, an
 
 Start with the [current workspace package inventory](#current-workspace-packages) for the package-name source of truth, then see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full interconnection diagram.
 
+Older copies of these diagrams used numbered MOD capability labels. Their current equivalents are: `MOD-01` → `@franken/orchestrator firewall`; `MOD-02` → `@franken/orchestrator skills`; `MOD-03` → `@franken/brain`; `MOD-04` → `@franken/planner`; `MOD-05` → `@franken/observer`; `MOD-06` → `@franken/critique`; `MOD-07` → `@franken/governor`; and `MOD-08` → `@franken/orchestrator heartbeat`.
+
+**Text alternative — Beast Loop overview:** User input enters ingestion, where the orchestrator firewall sanitizes it and the brain hydrates context. Planning builds and critiques a task graph. Execution resolves tools and requests human approval for high-stakes work. Closure records observability data and performs reflection before it returns the final BeastResult to the user. Circuit breakers can halt unsafe input, require approval when budgets are exceeded, or escalate planning spirals.
+
 ```mermaid
 flowchart TD
     User([User Input])
@@ -114,6 +118,8 @@ flowchart TD
 ```
 
 ### Beast Loop Sequence
+
+**Text alternative — Beast Loop sequence:** The user sends raw input to the orchestrator firewall, which scans for injection and masks PII while the brain supplies project context to the planner. The planner builds a task DAG and sends it through repeated deterministic and heuristic critique until it passes; a spiral instead escalates to the governor. For each approved task, orchestrator skills resolve a registry or MCP tool, the governor accepts or denies high-stakes actions, and the observer records spans and token usage. Finally, the observer produces trace and cost summaries, orchestrator heartbeat reflects and may feed improvement tasks back to planning, and the observer returns BeastResult to the user.
 
 ```mermaid
 sequenceDiagram
@@ -177,6 +183,8 @@ sequenceDiagram
 ```
 
 ### Module Interconnections
+
+**Text alternative — module interconnections:** The orchestrator's four-phase Beast Loop coordinates the current implementation surfaces: ingestion connects to the orchestrator firewall and brain; planning connects to planner and critique; execution connects to orchestrator skills, governor, and the MCP suite; and closure connects to observer and orchestrator heartbeat before returning a result. The firewall sends sanitized intent to planning and validates skill calls; planning discovers skills and loads memory; critique can enforce firewall rules or escalate to the governor; the governor consults observer circuit breakers; and heartbeat uses traces and memory to inject improvement tasks. External LLM providers connect through the firewall adapter, while external MCP servers connect through the MCP suite registry and client.
 
 ```mermaid
 graph TB

--- a/tests/docs-issue-2652.test.ts
+++ b/tests/docs-issue-2652.test.ts
@@ -27,7 +27,11 @@ describe('issue #2652 architecture labels', () => {
       '## Current workspace packages',
     );
 
-    expect(readmeArchitecture).not.toMatch(/MOD-\d{2}/);
+    const readmeDiagrams = [...readmeArchitecture.matchAll(/```mermaid\n[\s\S]*?\n```/g)]
+      .map((match) => match[0])
+      .join('\n');
+
+    expect(readmeDiagrams).not.toMatch(/MOD-\d{2}/);
     expect(readmeArchitecture).not.toContain('still use MOD labels');
     expect(readmeArchitecture).toContain('@franken/orchestrator');
     expect(readmeArchitecture).toContain('@franken/mcp-suite');

--- a/tests/docs-issue-3414.test.ts
+++ b/tests/docs-issue-3414.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const README = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+const ARCHITECTURE = README.slice(
+  README.indexOf('## Architecture'),
+  README.indexOf('## Current workspace packages'),
+);
+
+describe('issue #3414 accessible architecture diagrams', () => {
+  it('maps every legacy MOD label to its current implementation surface', () => {
+    const mappings = [
+      ['MOD-01', '@franken/orchestrator firewall'],
+      ['MOD-02', '@franken/orchestrator skills'],
+      ['MOD-03', '@franken/brain'],
+      ['MOD-04', '@franken/planner'],
+      ['MOD-05', '@franken/observer'],
+      ['MOD-06', '@franken/critique'],
+      ['MOD-07', '@franken/governor'],
+      ['MOD-08', '@franken/orchestrator heartbeat'],
+    ] as const;
+
+    for (const [legacyLabel, currentSurface] of mappings) {
+      expect(ARCHITECTURE).toContain(`\`${legacyLabel}\` → \`${currentSurface}\``);
+    }
+  });
+
+  it('provides a visible text alternative immediately before each Mermaid diagram', () => {
+    const mermaidDiagrams = [...ARCHITECTURE.matchAll(/```mermaid/g)];
+    const textAlternatives = [...ARCHITECTURE.matchAll(/\*\*Text alternative[^*]*:\*\*/g)];
+
+    expect(mermaidDiagrams).toHaveLength(3);
+    expect(textAlternatives).toHaveLength(3);
+
+    for (let index = 0; index < mermaidDiagrams.length; index += 1) {
+      const diagramStart = mermaidDiagrams[index]?.index ?? -1;
+      const alternativeStart = textAlternatives[index]?.index ?? -1;
+      const previousDiagramEnd = index === 0
+        ? 0
+        : (mermaidDiagrams[index - 1]?.index ?? 0) + '```mermaid'.length;
+
+      expect(alternativeStart).toBeGreaterThan(previousDiagramEnd);
+      expect(alternativeStart).toBeLessThan(diagramStart);
+    }
+  });
+
+  it('describes the complete non-visual flow and external connections', () => {
+    for (const requiredText of [
+      'User input enters ingestion',
+      'Planning builds and critiques a task graph',
+      'Execution resolves tools and requests human approval',
+      'Closure records observability data and performs reflection',
+      'returns the final BeastResult to the user',
+      'External LLM providers connect through the firewall adapter',
+      'external MCP servers connect through the MCP suite registry and client',
+    ]) {
+      expect(ARCHITECTURE).toContain(requiredText);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add visible prose alternatives for all three README architecture diagrams
- map legacy MOD-01 through MOD-08 labels to current packages and implementation surfaces
- add focused regression coverage and narrow the older diagram-label guard to Mermaid blocks

## Test plan
- `npm run test:root -- tests/docs-issue-3414.test.ts tests/docs-issue-2652.test.ts`
- `npm run test:root` (639 passed, 1 skipped)
- `npm run lint` (passes with pre-existing warnings)
- `git diff --check`

Closes #3414