### PR TITLE
fix(governor): preserve out-of-order approval responses

### DIFF
--- a/packages/franken-governor/src/gateway/approval-waiter-registry.ts
+++ b/packages/franken-governor/src/gateway/approval-waiter-registry.ts
@@ -52,6 +52,10 @@ export class ApprovalWaiterRegistry {
   }
 
   has(requestId: string): boolean {
+    return this.pending.has(requestId);
+  }
+
+  hasKnownRequest(requestId: string): boolean {
     return this.pending.has(requestId) || this.resolvedBeforeWaiter.has(requestId);
   }
 

--- a/packages/franken-governor/src/gateway/approval-waiter-registry.ts
+++ b/packages/franken-governor/src/gateway/approval-waiter-registry.ts
@@ -34,6 +34,12 @@ export interface PendingApprovalSnapshot {
  */
 export class ApprovalWaiterRegistry {
   private readonly pending = new Map<string, PendingApproval>();
+  /**
+   * Responses accepted for placeholder-only registrations before the
+   * in-process channel attaches its real waiter. Entries are one-shot: the
+   * matching waiter consumes them, while cancellation removes them.
+   */
+  private readonly resolvedBeforeWaiter = new Map<string, ApprovalResponse>();
 
   get size(): number {
     return this.pending.size;
@@ -69,6 +75,11 @@ export class ApprovalWaiterRegistry {
    * `waitFor`), its resolver is preserved rather than overwritten.
    */
   register(requestId: string, taskId: string, summary: string, approvalAnomalyNotice?: string): void {
+    // A response can race ahead of a later placeholder refresh. Preserve the
+    // completed decision for the real waiter rather than making it pending
+    // again and hanging that waiter.
+    if (this.resolvedBeforeWaiter.has(requestId)) return;
+
     const existing = this.pending.get(requestId);
     const effectiveApprovalAnomalyNotice = approvalAnomalyNotice ?? existing?.approvalAnomalyNotice;
     this.pending.set(requestId, {
@@ -92,6 +103,12 @@ export class ApprovalWaiterRegistry {
     summary: string,
     approvalAnomalyNotice?: string,
   ): Promise<ApprovalResponse> {
+    const earlyResponse = this.resolvedBeforeWaiter.get(requestId);
+    if (earlyResponse) {
+      this.resolvedBeforeWaiter.delete(requestId);
+      return Promise.resolve(earlyResponse);
+    }
+
     const existing = this.pending.get(requestId);
     if (existing?.hasRealWaiter) {
       return Promise.reject(new Error(`Approval waiter already registered for requestId ${requestId}`));
@@ -120,11 +137,17 @@ export class ApprovalWaiterRegistry {
     const pending = this.pending.get(requestId);
     if (!pending) return false;
     this.pending.delete(requestId);
-    pending.resolve(response);
+    if (pending.hasRealWaiter) {
+      pending.resolve(response);
+    } else {
+      this.resolvedBeforeWaiter.set(requestId, response);
+    }
     return true;
   }
 
   delete(requestId: string): boolean {
-    return this.pending.delete(requestId);
+    const deletedPending = this.pending.delete(requestId);
+    const deletedEarlyResponse = this.resolvedBeforeWaiter.delete(requestId);
+    return deletedPending || deletedEarlyResponse;
   }
 }

--- a/packages/franken-governor/src/gateway/approval-waiter-registry.ts
+++ b/packages/franken-governor/src/gateway/approval-waiter-registry.ts
@@ -8,6 +8,11 @@ interface PendingApproval {
   resolve: (response: ApprovalResponse) => void;
 }
 
+interface EarlyApprovalResponse {
+  readonly response: ApprovalResponse;
+  readonly expiry: ReturnType<typeof setTimeout>;
+}
+
 export interface PendingApprovalSnapshot {
   readonly requestId: string;
   readonly taskId: string;
@@ -33,13 +38,14 @@ export interface PendingApprovalSnapshot {
  * in-process waiter (see issue #411).
  */
 export class ApprovalWaiterRegistry {
+  private static readonly EARLY_RESPONSE_TTL_MS = 30_000;
   private readonly pending = new Map<string, PendingApproval>();
   /**
    * Responses accepted for placeholder-only registrations before the
    * in-process channel attaches its real waiter. Entries are one-shot: the
    * matching waiter consumes them, while cancellation removes them.
    */
-  private readonly resolvedBeforeWaiter = new Map<string, ApprovalResponse>();
+  private readonly resolvedBeforeWaiter = new Map<string, EarlyApprovalResponse>();
 
   get size(): number {
     return this.pending.size;
@@ -106,7 +112,8 @@ export class ApprovalWaiterRegistry {
     const earlyResponse = this.resolvedBeforeWaiter.get(requestId);
     if (earlyResponse) {
       this.resolvedBeforeWaiter.delete(requestId);
-      return Promise.resolve(earlyResponse);
+      clearTimeout(earlyResponse.expiry);
+      return Promise.resolve(earlyResponse.response);
     }
 
     const existing = this.pending.get(requestId);
@@ -140,14 +147,23 @@ export class ApprovalWaiterRegistry {
     if (pending.hasRealWaiter) {
       pending.resolve(response);
     } else {
-      this.resolvedBeforeWaiter.set(requestId, response);
+      const expiry = setTimeout(() => {
+        const cached = this.resolvedBeforeWaiter.get(requestId);
+        if (cached?.expiry === expiry) {
+          this.resolvedBeforeWaiter.delete(requestId);
+        }
+      }, ApprovalWaiterRegistry.EARLY_RESPONSE_TTL_MS);
+      expiry.unref?.();
+      this.resolvedBeforeWaiter.set(requestId, { response, expiry });
     }
     return true;
   }
 
   delete(requestId: string): boolean {
     const deletedPending = this.pending.delete(requestId);
+    const earlyResponse = this.resolvedBeforeWaiter.get(requestId);
     const deletedEarlyResponse = this.resolvedBeforeWaiter.delete(requestId);
+    if (earlyResponse) clearTimeout(earlyResponse.expiry);
     return deletedPending || deletedEarlyResponse;
   }
 }

--- a/packages/franken-governor/src/gateway/approval-waiter-registry.ts
+++ b/packages/franken-governor/src/gateway/approval-waiter-registry.ts
@@ -38,7 +38,7 @@ export interface PendingApprovalSnapshot {
  * in-process waiter (see issue #411).
  */
 export class ApprovalWaiterRegistry {
-  private static readonly EARLY_RESPONSE_TTL_MS = 30_000;
+  private static readonly EARLY_RESPONSE_TTL_MS = 300_000;
   private readonly pending = new Map<string, PendingApproval>();
   /**
    * Responses accepted for placeholder-only registrations before the
@@ -52,7 +52,7 @@ export class ApprovalWaiterRegistry {
   }
 
   has(requestId: string): boolean {
-    return this.pending.has(requestId);
+    return this.pending.has(requestId) || this.resolvedBeforeWaiter.has(requestId);
   }
 
   get(requestId: string): { taskId: string; summary: string; approvalAnomalyNotice?: string } | undefined {
@@ -113,7 +113,22 @@ export class ApprovalWaiterRegistry {
     if (earlyResponse) {
       this.resolvedBeforeWaiter.delete(requestId);
       clearTimeout(earlyResponse.expiry);
-      return Promise.resolve(earlyResponse.response);
+      return new Promise<ApprovalResponse>((resolvePromise) => {
+        this.pending.set(requestId, {
+          taskId,
+          summary,
+          ...(approvalAnomalyNotice !== undefined ? { approvalAnomalyNotice } : {}),
+          hasRealWaiter: true,
+          resolve: resolvePromise,
+        });
+        queueMicrotask(() => {
+          const pending = this.pending.get(requestId);
+          if (pending?.resolve === resolvePromise) {
+            this.pending.delete(requestId);
+            resolvePromise(earlyResponse.response);
+          }
+        });
+      });
     }
 
     const existing = this.pending.get(requestId);

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -346,7 +346,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
 
     if (
       approvalQueueBackpressure
-      && !registry.has(body.requestId)
+      && !registry.hasKnownRequest(body.requestId)
       && registry.size >= approvalQueueBackpressure.maxPendingApprovals
     ) {
       if (approvalQueueBackpressure.retryAfterSeconds) {

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -229,6 +229,32 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
     await expect(waiter).resolves.toBe(response);
   });
 
+  it('delivers an HTTP response that arrives after placeholder registration but before the real waiter', async () => {
+    const registry = new ApprovalWaiterRegistry();
+    const app = createGovernorApp({ registry, allowUnsignedApprovalsForTests: true });
+
+    registry.register('req-out-of-order-1', 'task-1', 'Deploy');
+    const response = await app.request('/v1/approval/respond', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestId: 'req-out-of-order-1', decision: 'APPROVE' }),
+    });
+    expect(response.status).toBe(200);
+    expect(registry.size).toBe(0);
+
+    // A retry of the request metadata must not overwrite the already accepted
+    // decision before the in-process channel attaches its waiter.
+    registry.register('req-out-of-order-1', 'task-1', 'Deploy retry');
+    await expect(
+      registry.waitFor('req-out-of-order-1', 'task-1', 'Deploy'),
+    ).resolves.toMatchObject({
+      requestId: 'req-out-of-order-1',
+      decision: 'APPROVE',
+      respondedBy: 'http-operator',
+    });
+    expect(registry.size).toBe(0);
+  });
+
   /**
    * Regression coverage for a Codex review follow-up on PR #452:
    * `ApprovalGateway`'s own timeout fired without telling the channel, so

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createGovernorApp } from '../../../src/server/app.js';
 import { ApprovalGateway } from '../../../src/gateway/approval-gateway.js';
@@ -253,6 +253,29 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
       respondedBy: 'http-operator',
     });
     expect(registry.size).toBe(0);
+  });
+
+  it('expires an early response when no real waiter ever attaches', () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new ApprovalWaiterRegistry();
+      const response = {
+        requestId: 'req-http-only-1',
+        decision: 'APPROVE' as const,
+        respondedBy: 'operator',
+        respondedAt: new Date('2026-01-01T00:00:00Z'),
+      };
+
+      registry.register('req-http-only-1', 'task-1', 'HTTP-only approval');
+      expect(registry.resolve('req-http-only-1', response)).toBe(true);
+      vi.advanceTimersByTime(30_000);
+
+      expect(registry.delete('req-http-only-1')).toBe(false);
+      registry.register('req-http-only-1', 'task-2', 'Reused request ID');
+      expect(registry.has('req-http-only-1')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /**

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -241,7 +241,15 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
     });
     expect(response.status).toBe(200);
     expect(registry.size).toBe(0);
-    expect(registry.has('req-out-of-order-1')).toBe(true);
+    expect(registry.has('req-out-of-order-1')).toBe(false);
+    expect(registry.hasKnownRequest('req-out-of-order-1')).toBe(true);
+
+    const duplicateResponse = await app.request('/v1/approval/respond', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestId: 'req-out-of-order-1', decision: 'ABORT' }),
+    });
+    expect(duplicateResponse.status).toBe(404);
 
     // A retry of the request metadata must not overwrite the already accepted
     // decision before the in-process channel attaches its waiter.

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -241,6 +241,7 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
     });
     expect(response.status).toBe(200);
     expect(registry.size).toBe(0);
+    expect(registry.has('req-out-of-order-1')).toBe(true);
 
     // A retry of the request metadata must not overwrite the already accepted
     // decision before the in-process channel attaches its waiter.
@@ -253,6 +254,58 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
       respondedBy: 'http-operator',
     });
     expect(registry.size).toBe(0);
+  });
+
+  it('accepts metadata retries for cached early responses even when pending approval backpressure is full', async () => {
+    const registry = new ApprovalWaiterRegistry();
+    const app = createGovernorApp({
+      registry,
+      allowUnsignedApprovalsForTests: true,
+      approvalQueueBackpressure: { maxPendingApprovals: 1 },
+    });
+    const response = {
+      requestId: 'req-early-backpressure-1',
+      decision: 'APPROVE' as const,
+      respondedBy: 'operator',
+      respondedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+
+    registry.register('req-early-backpressure-1', 'task-1', 'Deploy');
+    expect(registry.resolve('req-early-backpressure-1', response)).toBe(true);
+    registry.register('req-at-capacity-1', 'task-2', 'Other approval');
+
+    const retry = await app.request('/v1/approval/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requestId: 'req-early-backpressure-1',
+        taskId: 'task-1',
+        summary: 'Deploy retry',
+      }),
+    });
+    expect(retry.status).toBe(201);
+    await expect(
+      registry.waitFor('req-early-backpressure-1', 'task-1', 'Deploy'),
+    ).resolves.toBe(response);
+  });
+
+  it('rejects a duplicate waiter while delivering a cached early response', async () => {
+    const registry = new ApprovalWaiterRegistry();
+    const response = {
+      requestId: 'req-early-duplicate-1',
+      decision: 'APPROVE' as const,
+      respondedBy: 'operator',
+      respondedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+
+    registry.register('req-early-duplicate-1', 'task-1', 'Deploy');
+    expect(registry.resolve('req-early-duplicate-1', response)).toBe(true);
+
+    const firstWaiter = registry.waitFor('req-early-duplicate-1', 'task-1', 'Deploy');
+    await expect(
+      registry.waitFor('req-early-duplicate-1', 'task-2', 'Duplicate deploy'),
+    ).rejects.toThrow('Approval waiter already registered for requestId req-early-duplicate-1');
+    await expect(firstWaiter).resolves.toBe(response);
   });
 
   it('expires an early response when no real waiter ever attaches', () => {
@@ -268,7 +321,7 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
 
       registry.register('req-http-only-1', 'task-1', 'HTTP-only approval');
       expect(registry.resolve('req-http-only-1', response)).toBe(true);
-      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(300_000);
 
       expect(registry.delete('req-http-only-1')).toBe(false);
       registry.register('req-http-only-1', 'task-2', 'Reused request ID');


### PR DESCRIPTION
## Summary
- retain responses that arrive after placeholder registration but before a real waiter
- consume retained responses immediately when the waiter attaches
- preserve accepted decisions across request metadata retries and cancellation cleanup

## Test plan
- `npm run test --workspace @franken/governor`
- `npm run lint --workspace @franken/governor`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/governor`
- `npm run build --workspace @franken/governor`

Closes #3344