### PR TITLE
fix(planner): recover concurrent wave failures together

### DIFF
--- a/packages/franken-planner/src/core/types.ts
+++ b/packages/franken-planner/src/core/types.ts
@@ -62,6 +62,13 @@ export type PlanResult =
       failedTaskId: TaskId;
       error: Error;
       /**
+       * Failures from one execution wave that belong to the same recovery graph.
+       * Strategies may provide this so the Planner can inject every independent
+       * recovery before re-running the graph instead of recovering them one pass
+       * at a time. Omitted strategies retain single-failure recovery semantics.
+       */
+      recoveryFailures?: TaskResultFailure[];
+      /**
        * Graph that owns failedTaskId when it differs from the current top-level
        * graph, e.g. a recursive dynamic expansion sub-graph.
        */

--- a/packages/franken-planner/src/planner.ts
+++ b/packages/franken-planner/src/planner.ts
@@ -118,28 +118,42 @@ export class Planner {
 
       Planner.recordCompletedTasks(result.taskResults, completedTaskIds, completedTaskResults);
 
-      // result.status === 'failed' — attempt recovery
-      const failedTaskLineage = Planner.getRecoveryLineageRoot(result.failedTaskId);
-      const attempt = (recoveryAttemptsByTask.get(failedTaskLineage) ?? 0) + 1;
-      try {
-        const recoveryGraph = result.recoveryGraph ?? currentGraph;
-        currentGraph = await this.recovery.recover(
-          result.failedTaskId,
-          result.error,
-          recoveryGraph,
-          attempt
-        );
-        recoveryContinuationGraphs.unshift(...(result.recoveryContinuationGraphs ?? []));
-        recoveryAttemptsByTask.set(failedTaskLineage, attempt);
-      } catch (recoveryErr) {
-        if (
-          recoveryErr instanceof MaxRecoveryAttemptsError ||
-          recoveryErr instanceof UnknownErrorEscalatedError
-        ) {
-          return Planner.mergeCompletedIntoFailedResult(result, completedTaskResults);
+      // result.status === 'failed' — inject recovery for every independent
+      // failure reported from the same execution wave before retrying the graph.
+      // Strategies that omit recoveryFailures retain the historical single-
+      // failure behavior.
+      const recoveryFailures = result.recoveryFailures ?? [
+        { status: 'failure' as const, taskId: result.failedTaskId, error: result.error },
+      ];
+      let recoveredGraph = result.recoveryGraph ?? currentGraph;
+
+      for (const failure of recoveryFailures) {
+        const failedTaskLineage = Planner.getRecoveryLineageRoot(failure.taskId);
+        const attempt = (recoveryAttemptsByTask.get(failedTaskLineage) ?? 0) + 1;
+        try {
+          recoveredGraph = await this.recovery.recover(
+            failure.taskId,
+            failure.error,
+            recoveredGraph,
+            attempt
+          );
+          recoveryAttemptsByTask.set(failedTaskLineage, attempt);
+        } catch (recoveryErr) {
+          if (
+            recoveryErr instanceof MaxRecoveryAttemptsError ||
+            recoveryErr instanceof UnknownErrorEscalatedError
+          ) {
+            return Planner.mergeCompletedIntoFailedResult(
+              { ...result, failedTaskId: failure.taskId, error: failure.error },
+              completedTaskResults
+            );
+          }
+          throw recoveryErr;
         }
-        throw recoveryErr;
       }
+
+      currentGraph = recoveredGraph;
+      recoveryContinuationGraphs.unshift(...(result.recoveryContinuationGraphs ?? []));
     }
   }
 

--- a/packages/franken-planner/src/planners/parallel.ts
+++ b/packages/franken-planner/src/planners/parallel.ts
@@ -152,6 +152,7 @@ export class ParallelPlanner implements PlanningStrategy {
             taskResults: allResults,
             failedTaskId: first.taskId,
             error: first.error,
+            recoveryFailures: failures,
           };
         }
       }

--- a/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
+++ b/packages/franken-planner/tests/integration/planner-parallel.integration.test.ts
@@ -28,10 +28,10 @@ function stubGuardrails(): GuardrailsModule {
 function stubGraphBuilder(graph: PlanGraph): GraphBuilder {
   return { build: vi.fn().mockResolvedValue(graph) };
 }
-function stubMemory(): MemoryModule {
+function stubMemory(knownErrors: Awaited<ReturnType<MemoryModule['getKnownErrors']>> = []): MemoryModule {
   return {
     getADRs: vi.fn().mockResolvedValue([]),
-    getKnownErrors: vi.fn().mockResolvedValue([]),
+    getKnownErrors: vi.fn().mockResolvedValue(knownErrors),
     getProjectContext: vi.fn().mockResolvedValue({ projectName: 'test', adrs: [], rules: [] }),
   };
 }
@@ -39,9 +39,10 @@ function stubMemory(): MemoryModule {
 function buildParallelPlanner(
   graph: PlanGraph,
   executor: TaskExecutor,
-  selfCritique?: SelfCritiqueModule
+  selfCritique?: SelfCritiqueModule,
+  memory = stubMemory()
 ): Planner {
-  const recovery = new RecoveryController(stubMemory());
+  const recovery = new RecoveryController(memory);
   return new Planner(
     stubGuardrails(),
     stubGraphBuilder(graph),
@@ -134,6 +135,42 @@ describe('Integration — ParallelPlanner', () => {
     const result = await buildParallelPlanner(graph, executor).plan('...');
 
     expect(result.status).toBe('failed');
+  });
+
+  it('injects recovery tasks for every concurrent failure before retrying the wave', async () => {
+    const graph = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b'));
+    const knownError = {
+      pattern: 'transient failure',
+      description: 'recoverable test failure',
+      fixSuggestion: 'apply the task-specific fix',
+    };
+    const executedTaskIds: string[] = [];
+    const executor = vi.fn().mockImplementation((task: Task) => {
+      executedTaskIds.push(task.id);
+      if (
+        (task.id === createTaskId('a') || task.id === createTaskId('b')) &&
+        !executedTaskIds.includes(`fix-${task.id}-attempt-1`)
+      ) {
+        return Promise.resolve(fail(task.id, 'transient failure'));
+      }
+      return Promise.resolve(ok(task.id));
+    });
+
+    const result = await buildParallelPlanner(
+      graph,
+      executor,
+      undefined,
+      stubMemory([knownError])
+    ).plan('...');
+
+    expect(result.status).toBe('completed');
+    expect(executedTaskIds.slice(0, 2)).toEqual([createTaskId('a'), createTaskId('b')]);
+    expect(new Set(executedTaskIds.slice(2, 4))).toEqual(
+      new Set([createTaskId('fix-a-attempt-1'), createTaskId('fix-b-attempt-1')])
+    );
+    expect(executedTaskIds).toHaveLength(6);
   });
 
   it('returns rationale_rejected when CoT rejects a task rationale', async () => {


### PR DESCRIPTION
## Summary
- expose all same-wave ParallelPlanner failures as one recovery batch
- inject every independent recovery into the accumulated graph before retrying execution
- add an end-to-end regression proving both fix tasks run before either failed task is retried

## Test plan
- `npm run test --workspace @franken/planner`
- `npm run test:integration --workspace @franken/planner`
- `npm run typecheck --workspace @franken/planner`
- `npm run lint --workspace @franken/planner`
- `npm run build --workspace @franken/planner`

Closes #3342