### PR TITLE
fix(orchestrator): reject unroutable Telegram sends

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
@@ -57,7 +57,11 @@ export class TelegramAdapter implements ChannelAdapter {
   }
 
   async send(sessionId: string, message: ChannelOutboundMessage): Promise<void> {
-    const chatId = (message.metadata?.chatId as string) || 'unknown';
+    const chatId = message.metadata?.chatId;
+    if (typeof chatId !== 'string' || chatId.trim().length === 0) {
+      throw new Error('Telegram routing error: missing chatId metadata');
+    }
+
     const body = this.formatPayload(sessionId, chatId, message);
     const targetUrl = `https://api.telegram.org/bot${this.token}/sendMessage`;
 

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
@@ -29,6 +29,18 @@ describe('TelegramAdapter', () => {
     );
   });
 
+  it('rejects missing chat routing metadata without calling Telegram', async () => {
+    const adapter = new TelegramAdapter({ token: 'bot-token' });
+    const mockFetch = vi.mocked(fetch);
+
+    await expect(adapter.send('session-123', {
+      text: 'hello telegram',
+      status: 'reply',
+    })).rejects.toThrow('Telegram routing error: missing chatId metadata');
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('formats inline keyboards for approvals', async () => {
     const adapter = new TelegramAdapter({ token: 'bot-token' });
     const mockFetch = vi.mocked(fetch);


### PR DESCRIPTION
## Summary
- reject Telegram sends when `chatId` routing metadata is absent or blank
- fail locally before constructing or issuing a provider request
- cover valid and missing routing metadata paths

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/comms/telegram-adapter.test.ts`
- `npm run test --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build`

Closes #3150