### PR TITLE
fix(orchestrator): reject WhatsApp sends without recipient

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
@@ -37,8 +37,12 @@ export class WhatsAppAdapter implements ChannelAdapter {
   }
 
   async send(sessionId: string, message: ChannelOutboundMessage): Promise<void> {
-    const to = (message.metadata?.phoneNumber as string) || 'unknown';
-    const body = this.formatPayload(to, message);
+    const phoneNumber = message.metadata?.phoneNumber;
+    if (typeof phoneNumber !== 'string' || phoneNumber.trim().length === 0) {
+      throw new Error('WhatsApp routing error: missing recipient phoneNumber metadata');
+    }
+
+    const body = this.formatPayload(phoneNumber.trim(), message);
 
     const targetUrl = `https://graph.facebook.com/v21.0/${this.phoneNumberId}/messages`;
     const response = await this.fetchImpl(targetUrl, {

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
@@ -52,6 +52,33 @@ describe('WhatsAppAdapter', () => {
     expect(body.interactive.action.buttons[0].reply.title).toBe('Approve');
   });
 
+  it.each([
+    {
+      name: 'text',
+      message: { text: 'hello whatsapp', status: 'reply' as const },
+    },
+    {
+      name: 'interactive',
+      message: {
+        text: 'Approve?',
+        status: 'approval' as const,
+        actions: [{ id: 'approve', label: 'Approve' }],
+      },
+    },
+  ])('rejects $name messages without recipient metadata before calling WhatsApp', async ({ message }) => {
+    const mockFetch = vi.fn<typeof fetch>();
+    const adapter = new WhatsAppAdapter({
+      accessToken: 'token',
+      phoneNumberId: '123',
+      fetchImpl: mockFetch,
+    });
+
+    await expect(adapter.send('session-123', message)).rejects.toThrow(
+      'WhatsApp routing error: missing recipient phoneNumber metadata',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('includes endpoint and response body when WhatsApp returns HTTP errors', async () => {
     const adapter = new WhatsAppAdapter({
       accessToken: 'token',


### PR DESCRIPTION
## Summary
- reject outbound WhatsApp text and interactive messages when recipient phoneNumber metadata is missing
- validate and trim recipient metadata before formatting payloads or invoking the WhatsApp API
- add regression coverage proving invalid routing fails before fetch

## Verification
- npm test -- --run tests/unit/comms/whatsapp-adapter.test.ts (5 passed)
- npm test (4,237 passed)
- npm run lint (passes with existing warnings)
- npm run build (10 packages successful)
- npm run typecheck (passes after workspace dependencies are built)

Closes #3151