### PR TITLE
fix(orchestrator): reject Slack sends without routing

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
@@ -34,9 +34,12 @@ export class SlackAdapter implements ChannelAdapter {
   }
 
   async send(sessionId: string, message: ChannelOutboundMessage): Promise<void> {
-    // In a real implementation, we would map sessionId back to Slack channel/thread
-    // For now, we assume metadata contains the routing info or we have a store
-    const channel = (message.metadata?.channelId as string) || 'unknown';
+    const channelId = message.metadata?.channelId;
+    if (typeof channelId !== 'string' || channelId.trim().length === 0) {
+      throw new Error('Slack routing error: missing channelId metadata');
+    }
+
+    const channel = channelId.trim();
     const thread_ts = message.metadata?.threadTs as string | undefined;
 
     const blocks = this.formatBlocks(message);

--- a/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
@@ -43,7 +43,7 @@ describe('SlackAdapter', () => {
     await adapter.send('session-123', {
       text: 'hello',
       status: 'reply',
-      metadata: { channelId: 'C1' },
+      metadata: { channelId: ' C1 ', threadTs: '1712345678.000100' },
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -53,7 +53,47 @@ describe('SlackAdapter', () => {
         body: expect.stringContaining('"text":"hello"'),
       })
     );
+    const body = JSON.parse(mockFetch.mock.calls[0]![1]!.body as string) as {
+      channel: string;
+      thread_ts: string;
+    };
+    expect(body.channel).toBe('C1');
+    expect(body.thread_ts).toBe('1712345678.000100');
   });
+
+  it.each([
+    { name: 'reply', message: { text: 'hello', status: 'reply' as const } },
+    {
+      name: 'approval',
+      message: {
+        text: 'approve?',
+        status: 'approval' as const,
+        actions: [{ id: 'approve', label: 'Approve' }],
+      },
+    },
+  ])('rejects $name messages without channelId before calling Slack', async ({ message }) => {
+    const mockFetch = vi.fn<typeof fetch>();
+    const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN, fetchImpl: mockFetch });
+
+    await expect(adapter.send('session-123', message)).rejects.toThrow(
+      'Slack routing error: missing channelId metadata',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null, 42, '', '   '])(
+    'rejects invalid channelId metadata value %j before calling Slack',
+    async (channelId) => {
+      const mockFetch = vi.fn<typeof fetch>();
+      const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN, fetchImpl: mockFetch });
+
+      await expect(adapter.send('session-123', {
+        text: 'hello',
+        metadata: { channelId },
+      })).rejects.toThrow('Slack routing error: missing channelId metadata');
+      expect(mockFetch).not.toHaveBeenCalled();
+    },
+  );
 
   it('formats buttons correctly in blocks', async () => {
     const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN });


### PR DESCRIPTION
## Summary
- reject Slack outbound messages when `metadata.channelId` is missing or invalid
- trim valid Slack channel IDs while preserving thread routing
- add regression coverage proving invalid routing never reaches Slack

## Test plan
- `npm test -- --run` (`@franken/orchestrator`: 4,245 tests passed)
- `npm run lint` (`@franken/orchestrator`: 0 errors; existing warnings only)
- `npm run build` (root Turbo build: 10/10 packages successful)
- `npm run typecheck` (`@franken/orchestrator`)

Closes #3148