### PR TITLE
fix(orchestrator): reject unroutable Discord sends

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
@@ -14,6 +14,13 @@ export interface DiscordAdapterOptions {
   token: string;
 }
 
+export class DiscordRoutingError extends Error {
+  constructor() {
+    super('Discord routing error: missing channelId or threadId metadata');
+    this.name = 'DiscordRoutingError';
+  }
+}
+
 export class DiscordAdapter implements ChannelAdapter {
   readonly type: ChannelType = 'discord';
   readonly capabilities: ChannelCapabilities = {
@@ -40,14 +47,22 @@ export class DiscordAdapter implements ChannelAdapter {
     // but for general proactive messages or delayed execution results, 
     // we use the channel message API.
     
-    const channelId = (message.metadata?.channelId as string) || 'unknown';
-    const threadId = message.metadata?.threadId as string | undefined;
+    const rawChannelId = message.metadata?.channelId;
+    const rawThreadId = message.metadata?.threadId;
+    const channelId = typeof rawChannelId === 'string' && rawChannelId.trim().length > 0
+      ? rawChannelId.trim()
+      : undefined;
+    const threadId = typeof rawThreadId === 'string' && rawThreadId.trim().length > 0
+      ? rawThreadId.trim()
+      : undefined;
+
+    if (!channelId && !threadId) {
+      throw new DiscordRoutingError();
+    }
 
     const body = this.formatPayload(message);
 
-    const targetUrl = threadId 
-      ? `https://discord.com/api/v10/channels/${threadId}/messages`
-      : `https://discord.com/api/v10/channels/${channelId}/messages`;
+    const targetUrl = `https://discord.com/api/v10/channels/${threadId ?? channelId}/messages`;
 
     const response = await this.fetchImpl(targetUrl, {
       method: 'POST',

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { DiscordAdapter } from '../../../src/comms/channels/discord/discord-adapter.js';
+import {
+  DiscordAdapter,
+  DiscordRoutingError,
+} from '../../../src/comms/channels/discord/discord-adapter.js';
 
 describe('DiscordAdapter', () => {
   beforeEach(() => {
@@ -30,6 +33,47 @@ describe('DiscordAdapter', () => {
         body: expect.stringContaining('"content":"hello from discord"'),
       })
     );
+  });
+
+  it('sends thread replies to the thread channel', async () => {
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue({ ok: true } as Response);
+    const adapter = new DiscordAdapter({ token: 'bot-token', fetchImpl: mockFetch });
+
+    await adapter.send('session-123', {
+      text: 'hello thread',
+      status: 'reply',
+      metadata: { threadId: 'T1' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://discord.com/api/v10/channels/T1/messages',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it.each([
+    { name: 'missing metadata', metadata: undefined },
+    { name: 'missing route fields', metadata: {} },
+    { name: 'non-string channelId', metadata: { channelId: 123 } },
+    { name: 'empty channelId', metadata: { channelId: '' } },
+    { name: 'whitespace channelId', metadata: { channelId: '   ' } },
+    { name: 'non-string threadId', metadata: { threadId: 123 } },
+    { name: 'empty threadId', metadata: { threadId: '' } },
+    { name: 'whitespace threadId', metadata: { threadId: '   ' } },
+  ])('rejects $name before calling Discord', async ({ metadata }) => {
+    const mockFetch = vi.fn<typeof fetch>();
+    const adapter = new DiscordAdapter({ token: 'bot-token', fetchImpl: mockFetch });
+
+    await expect(adapter.send('session-123', {
+      text: 'hello from discord',
+      status: 'reply',
+      metadata,
+    })).rejects.toMatchObject({
+      name: 'DiscordRoutingError',
+      message: 'Discord routing error: missing channelId or threadId metadata',
+    } satisfies Partial<DiscordRoutingError>);
+
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('formats buttons and embeds for approval', async () => {


### PR DESCRIPTION
## Summary
- validate Discord channel/thread routing metadata before formatting or sending
- throw a typed `DiscordRoutingError` instead of targeting an `unknown` channel
- preserve valid channel and thread sends while trimming route identifiers
- add regression coverage proving invalid routes never call `fetch`

## Verification
- `npm test -- --run tests/unit/comms/discord-adapter.test.ts` (15 passed)
- `npm run typecheck`
- `npm run build`
- `npx eslint src/comms/channels/discord/discord-adapter.ts tests/unit/comms/discord-adapter.test.ts`
- package suite: 4,246 passed; one unrelated cleanup test timed out under concurrent verification, then passed in isolation
- root `npm run build` (10/10 packages)

Closes #3149