### PR TITLE
fix(beasts): describe design document file prompt

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/chunk-plan-definition.ts
@@ -76,6 +76,7 @@ export const chunkPlanDefinition: BeastDefinition = {
     {
       key: 'designDocPath',
       prompt: 'Which design document should be chunked?',
+      description: 'Enter a repo-relative path to the Markdown design document (.md, .mdx, or .markdown) that will be split into implementation chunks.',
       kind: 'file',
       required: true,
     },

--- a/packages/franken-orchestrator/src/beasts/types.ts
+++ b/packages/franken-orchestrator/src/beasts/types.ts
@@ -24,6 +24,7 @@ export type BeastRunStatus =
 export interface BeastInterviewPrompt {
   readonly key: string;
   readonly prompt: string;
+  readonly description?: string | undefined;
   readonly kind: 'string' | 'boolean' | 'file' | 'directory';
   readonly required?: boolean | undefined;
   readonly options?: readonly string[] | undefined;

--- a/packages/franken-orchestrator/src/cli/beast-prompts.ts
+++ b/packages/franken-orchestrator/src/cli/beast-prompts.ts
@@ -9,6 +9,9 @@ export async function collectBeastConfig(
   const answers: Record<string, unknown> = {};
 
   for (const prompt of definition.interviewPrompts) {
+    if (prompt.description) {
+      io.display(prompt.description);
+    }
     const answer = await io.ask(prompt.prompt);
     answers[prompt.key] = coerceInterviewAnswer(prompt, answer);
   }

--- a/packages/franken-orchestrator/tests/unit/beasts/catalog-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/catalog-service.test.ts
@@ -41,6 +41,7 @@ describe('BeastCatalogService', () => {
       expect.objectContaining({
         key: 'designDocPath',
         kind: 'file',
+        description: 'Enter a repo-relative path to the Markdown design document (.md, .mdx, or .markdown) that will be split into implementation chunks.',
       }),
     ]));
 

--- a/packages/franken-orchestrator/tests/unit/cli/beast-prompts.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/beast-prompts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { collectBeastConfig } from '../../../src/cli/beast-prompts.js';
 import { martinLoopDefinition } from '../../../src/beasts/definitions/martin-loop-definition.js';
+import { chunkPlanDefinition } from '../../../src/beasts/definitions/chunk-plan-definition.js';
 
 describe('collectBeastConfig', () => {
   it('asks prompts in definition order and returns config answers', async () => {
@@ -34,4 +35,19 @@ describe('collectBeastConfig', () => {
     expect(io.ask).toHaveBeenCalledTimes(1);
   });
 
+  it('displays accessible file guidance before asking for a design document path', async () => {
+    const io = {
+      ask: vi.fn()
+        .mockResolvedValueOnce('docs/design.md')
+        .mockResolvedValueOnce('tasks/chunks'),
+      display: vi.fn(),
+    };
+
+    await collectBeastConfig(io, chunkPlanDefinition);
+
+    expect(io.display).toHaveBeenCalledWith(
+      'Enter a repo-relative path to the Markdown design document (.md, .mdx, or .markdown) that will be split into implementation chunks.',
+    );
+    expect(io.display.mock.invocationCallOrder[0]).toBeLessThan(io.ask.mock.invocationCallOrder[0]);
+  });
 });

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -126,6 +126,7 @@ export type ApprovalReadinessResult = z.infer<typeof ApprovalReadinessResultSche
 export interface BeastInterviewPrompt {
   key: string;
   prompt: string;
+  description?: string;
   kind: 'string' | 'boolean' | 'file' | 'directory';
   required?: boolean;
   options?: readonly string[];

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -194,6 +194,7 @@ function CatalogPromptField({
 }) {
   const label = getPromptLabel(prompt);
   const id = `wf-${prompt.key}`;
+  const descriptionId = prompt.description ? `${id}-description` : undefined;
 
   if (prompt.kind === 'boolean') {
     return (
@@ -216,6 +217,7 @@ function CatalogPromptField({
         <label htmlFor={id} className="block text-sm font-medium text-beast-text mb-1.5">{label}{prompt.required ? ' *' : ''}</label>
         <select
           id={id}
+          aria-describedby={descriptionId}
           value={typeof value === 'string' ? value : ''}
           onChange={(event) => onChange(event.target.value)}
           className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
@@ -223,6 +225,9 @@ function CatalogPromptField({
           <option value="">Select...</option>
           {prompt.options.map((option) => <option key={option} value={option}>{option}</option>)}
         </select>
+        {prompt.description && (
+          <p id={descriptionId} className="mt-1 text-xs text-beast-muted">{prompt.description}</p>
+        )}
       </div>
     );
   }
@@ -237,6 +242,7 @@ function CatalogPromptField({
       {rows ? (
         <textarea
           id={id}
+          aria-describedby={descriptionId}
           value={typeof value === 'string' ? value : ''}
           onChange={(event) => onChange(event.target.value)}
           placeholder={placeholder}
@@ -246,6 +252,7 @@ function CatalogPromptField({
       ) : (
         <input
           id={id}
+          aria-describedby={descriptionId}
           type={inputType ?? 'text'}
           value={typeof value === 'string' ? value : ''}
           onChange={(event) => onChange(event.target.value)}
@@ -253,10 +260,13 @@ function CatalogPromptField({
           className="w-full bg-beast-control border border-beast-border rounded-lg px-4 py-2.5 text-beast-text placeholder:text-beast-subtle text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
         />
       )}
-      {prompt.kind === 'file' && (
+      {prompt.description && (
+        <p id={descriptionId} className="mt-1 text-xs text-beast-muted">{prompt.description}</p>
+      )}
+      {!prompt.description && prompt.kind === 'file' && (
         <p className="mt-1 text-xs text-beast-muted">Use a repo-relative Markdown path when required by the selected Beast.</p>
       )}
-      {prompt.kind === 'directory' && (
+      {!prompt.description && prompt.kind === 'directory' && (
         <p className="mt-1 text-xs text-beast-muted">
           Browser directory pickers cannot provide server paths. Enter a repo-relative directory path manually.
         </p>

--- a/packages/franken-web/src/components/beasts/wizard-catalog.ts
+++ b/packages/franken-web/src/components/beasts/wizard-catalog.ts
@@ -19,7 +19,13 @@ export const FALLBACK_BEAST_CATALOG: readonly BeastCatalogEntry[] = [
     description: 'Turn a design document into chunked implementation artifacts through the tracked init workflow.',
     executionModeDefault: 'process',
     interviewPrompts: [
-      { key: 'designDocPath', prompt: 'Which design document should be chunked?', kind: 'file', required: true },
+      {
+        key: 'designDocPath',
+        prompt: 'Which design document should be chunked?',
+        description: 'Enter a repo-relative path to the Markdown design document (.md, .mdx, or .markdown) that will be split into implementation chunks.',
+        kind: 'file',
+        required: true,
+      },
       { key: 'outputDir', prompt: 'Where should the chunk plan be written?', kind: 'string', required: true },
     ],
   },

--- a/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-workflow.test.tsx
@@ -130,6 +130,17 @@ describe('StepWorkflow', () => {
     });
   });
 
+  it('associates the chunk-plan file description with its input', () => {
+    useBeastStore.getState().setStepValues(1, { workflowType: 'chunk-plan' });
+    render(<StepWorkflow />);
+
+    const input = screen.getByLabelText(/design document should be chunked/i);
+    const description = screen.getByText(/repo-relative path to the Markdown design document/i);
+
+    expect(input.getAttribute('aria-describedby')).toBe(description.id);
+    expect(description.textContent).toContain('split into implementation chunks');
+  });
+
   it('collects backend martin-loop fields', () => {
     useBeastStore.getState().setStepValues(1, { workflowType: 'martin-loop' });
     render(<StepWorkflow />);


### PR DESCRIPTION
## Summary
- add a reusable description field to Beast interview prompt contracts
- describe the chunk-plan design document path in both CLI and web workflows
- associate web helper text with its form control using `aria-describedby`

## Test plan
- `npm run build`
- `npm run lint --workspace @franken/types`
- `npm run lint --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/web`
- `npm test --workspace @franken/types` (123 tests)
- `npm test --workspace @franken/orchestrator` (4,239 tests)
- `npm test --workspace @franken/web` (690 tests)

Closes #3466