### PR TITLE
fix(brain): index episodic hot-path queries

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -5659,6 +5659,10 @@ export class SqliteBrain implements IBrain {
         created_at TEXT NOT NULL,
         schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
+      CREATE INDEX IF NOT EXISTS idx_episodic_events_type_created_at
+        ON episodic_events(type, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_episodic_events_created_at
+        ON episodic_events(created_at DESC);
       CREATE TABLE IF NOT EXISTS checkpoints (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         state TEXT NOT NULL,
@@ -6628,6 +6632,10 @@ function migrateMemorySchemaDatabase(
         created_at TEXT NOT NULL,
         schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
+      CREATE INDEX IF NOT EXISTS idx_episodic_events_type_created_at
+        ON episodic_events(type, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_episodic_events_created_at
+        ON episodic_events(created_at DESC);
       CREATE TABLE IF NOT EXISTS checkpoints (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         state TEXT NOT NULL,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -5441,10 +5441,10 @@ export class SqliteBrain implements IBrain {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('busy_timeout = 5000');
     this.initSchema();
-    migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     const encryption = makeMemoryCipher(options.encryption);
     this.encryption = encryption;
     assertMemoryEncryptionState(this.db, dbPath, encryption);
+    migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     this.auditRecorder = (event) => insertMemoryAccessAuditEvent(this.db, event, encryption);
     this.accessAudit = new SqliteMemoryAccessAuditTrail(this.db, encryption);
     try {
@@ -5659,10 +5659,6 @@ export class SqliteBrain implements IBrain {
         created_at TEXT NOT NULL,
         schema_version INTEGER NOT NULL DEFAULT ${CURRENT_MEMORY_SCHEMA_VERSION}
       );
-      CREATE INDEX IF NOT EXISTS idx_episodic_events_type_created_at
-        ON episodic_events(type, created_at DESC);
-      CREATE INDEX IF NOT EXISTS idx_episodic_events_created_at
-        ON episodic_events(created_at DESC);
       CREATE TABLE IF NOT EXISTS checkpoints (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         state TEXT NOT NULL,
@@ -6546,6 +6542,25 @@ function migrateMemorySchemaDatabase(
           `Memory table ${store} contains record schema version ${future.schema_version}, but this runtime supports only ${CURRENT_MEMORY_SCHEMA_VERSION}`,
         );
       }
+    }
+  }
+
+  if (existingTables.has('episodic_events')) {
+    const episodicIndexes = new Set(
+      (
+        db
+          .prepare(`PRAGMA index_list(episodic_events)`)
+          .all() as Array<{ name: string }>
+      ).map((row) => row.name),
+    );
+    if (
+      !episodicIndexes.has('idx_episodic_events_type_created_at') ||
+      !episodicIndexes.has('idx_episodic_events_created_at')
+    ) {
+      operations.push({
+        table: 'episodic_events',
+        action: 'create type and recency query indexes',
+      });
     }
   }
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -5550,15 +5550,41 @@ describe('SqliteBrain', () => {
         encrypted.flush();
         encrypted.close();
 
+        const dropEpisodicIndexes = () => {
+          const db = new Database(dbPath);
+          db.exec(`
+            DROP INDEX IF EXISTS idx_episodic_events_type_created_at;
+            DROP INDEX IF EXISTS idx_episodic_events_created_at;
+          `);
+          db.close();
+        };
+        const expectEpisodicIndexesMissing = () => {
+          const db = new Database(dbPath, { readonly: true });
+          expect(
+            db
+              .prepare(
+                `SELECT name FROM sqlite_master
+                 WHERE type = 'index' AND name LIKE 'idx_episodic_events_%'`,
+              )
+              .all(),
+          ).toEqual([]);
+          db.close();
+        };
+
+        dropEpisodicIndexes();
         expect(() => new SqliteBrain(dbPath)).toThrow(
           MemoryEncryptionRequiredError,
         );
+        expectEpisodicIndexesMissing();
+
+        dropEpisodicIndexes();
         expect(
           () =>
             new SqliteBrain(dbPath, undefined, {
               encryption: { enabled: true, key: 'wrong key' },
             }),
         ).toThrow(MemoryEncryptionWrongKeyError);
+        expectEpisodicIndexesMissing();
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
+++ b/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
@@ -31,6 +31,66 @@ const readQueryPlan = (db: Database.Database, sql: string): string[] =>
   );
 
 describe('state schema migration smoke tests', () => {
+  it('backs up and creates missing episodic indexes on an otherwise current database', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-state-episodic-index-migration-'));
+    const dbPath = join(dir, 'brain.db');
+    const backupPath = join(dir, 'brain.backup.db');
+
+    try {
+      new SqliteBrain(dbPath).close();
+      const withoutIndexes = new Database(dbPath);
+      withoutIndexes.exec(`
+        DROP INDEX idx_episodic_events_type_created_at;
+        DROP INDEX idx_episodic_events_created_at;
+      `);
+      withoutIndexes.close();
+
+      const migrated = SqliteBrain.migrateMemorySchema(dbPath, {
+        backupBeforeMigrate: true,
+        backupPath,
+      });
+
+      expect(migrated.migrated).toBe(true);
+      expect(migrated.backupPath).toBe(backupPath);
+      expect(migrated.operations).toEqual(
+        expect.arrayContaining([
+          {
+            table: 'episodic_events',
+            action: 'create type and recency query indexes',
+          },
+        ]),
+      );
+      const backup = new Database(backupPath, { readonly: true });
+      expect(
+        backup
+          .prepare(
+            `SELECT name FROM sqlite_master
+             WHERE type = 'index' AND name LIKE 'idx_episodic_events_%'`,
+          )
+          .all(),
+      ).toEqual([]);
+      backup.close();
+
+      const indexed = new Database(dbPath, { readonly: true });
+      expect(
+        readQueryPlan(
+          indexed,
+          `SELECT * FROM episodic_events WHERE type = 'failure'
+           ORDER BY created_at DESC LIMIT 10 OFFSET 0`,
+        ).join('\n'),
+      ).toContain('USING INDEX idx_episodic_events_type_created_at');
+      expect(
+        readQueryPlan(
+          indexed,
+          `SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT 10 OFFSET 0`,
+        ).join('\n'),
+      ).toContain('USING INDEX idx_episodic_events_created_at');
+      indexed.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('idempotently indexes episodic hot-path queries for existing databases', () => {
     const dir = mkdtempSync(join(tmpdir(), 'franken-state-episodic-indexes-'));
     const dbPath = join(dir, 'brain.db');

--- a/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
+++ b/packages/franken-brain/tests/unit/state-schema-migration-smoke.test.ts
@@ -25,7 +25,54 @@ const storeNames = [
 const readColumns = (db: Database.Database, table: string): string[] =>
   (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name);
 
+const readQueryPlan = (db: Database.Database, sql: string): string[] =>
+  (db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>).map(
+    (row) => row.detail,
+  );
+
 describe('state schema migration smoke tests', () => {
+  it('idempotently indexes episodic hot-path queries for existing databases', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'franken-state-episodic-indexes-'));
+    const dbPath = join(dir, 'brain.db');
+
+    try {
+      const legacy = new Database(dbPath);
+      legacy.exec(`
+        CREATE TABLE episodic_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          type TEXT NOT NULL,
+          step TEXT,
+          summary TEXT NOT NULL,
+          details TEXT,
+          embedding BLOB,
+          created_at TEXT NOT NULL
+        );
+      `);
+      legacy.close();
+
+      new SqliteBrain(dbPath).close();
+      new SqliteBrain(dbPath).close();
+
+      const migrated = new Database(dbPath, { readonly: true });
+      expect(
+        readQueryPlan(
+          migrated,
+          `SELECT * FROM episodic_events WHERE type = 'failure'
+           ORDER BY created_at DESC LIMIT 10 OFFSET 0`,
+        ).join('\n'),
+      ).toContain('USING INDEX idx_episodic_events_type_created_at');
+      expect(
+        readQueryPlan(
+          migrated,
+          `SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT 10 OFFSET 0`,
+        ).join('\n'),
+      ).toContain('USING INDEX idx_episodic_events_created_at');
+      migrated.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('opens and upgrades a legacy v0 memory-state database without losing durable state', () => {
     const dir = mkdtempSync(join(tmpdir(), 'franken-state-schema-smoke-'));
     const dbPath = join(dir, 'brain.db');


### PR DESCRIPTION
## Summary
- add idempotent indexes for recent episodic event scans
- cover filtered and unfiltered hot paths with SQLite query-plan assertions
- verify repeated initialization upgrades existing databases safely

## Test plan
- `npm run test --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm run typecheck --workspace @franken/brain`
- `npm run build --workspace @franken/brain`

Closes #3138