### PR TITLE
fix(brain): quarantine corrupt episodic details

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2839,7 +2839,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           for (const chunk of chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY)) {
             const events = collectRowsToEvents(
               (batchLimit, offset) => this.recallKeywordChunk(chunk, batchLimit, offset),
-              -1,
+              limit,
               this.encryption,
               reportCorruptDetails,
               (event) => recallEventScore(event, keywords) > 0,
@@ -2948,18 +2948,32 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     limit?: number,
     offset = 0,
   ): Array<EpisodicRow & { relevance_score: number }> {
+    const searchableDetails = `CASE
+      WHEN json_valid(details)
+        AND NOT (
+          json_type(details) = 'object'
+          AND (SELECT COUNT(*) FROM json_each(details)) = 1
+          AND json_type(details, '$.quarantine') = 'object'
+          AND (SELECT COUNT(*) FROM json_each(details, '$.quarantine')) = 3
+          AND json_extract(details, '$.quarantine.field') = 'details'
+          AND json_extract(details, '$.quarantine.reason') = 'invalid JSON'
+          AND json_extract(details, '$.quarantine.eventId') = id
+        )
+      THEN details
+      ELSE ''
+    END`;
     // Build scoring SQL: count keyword matches across summary + details
     const scoringCases = keywords
       .map(
         () =>
-          `(CASE WHEN LOWER(summary) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END + CASE WHEN LOWER(COALESCE(details, '')) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END)`,
+          `(CASE WHEN LOWER(summary) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END + CASE WHEN LOWER(${searchableDetails}) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END)`,
       )
       .join(' + ');
 
     const whereClauses = keywords
       .map(
         () =>
-          `(LOWER(summary) LIKE ? ESCAPE '\\' OR LOWER(COALESCE(details, '')) LIKE ? ESCAPE '\\')`,
+          `(LOWER(summary) LIKE ? ESCAPE '\\' OR LOWER(${searchableDetails}) LIKE ? ESCAPE '\\')`,
       )
       .join(' OR ');
 
@@ -6238,14 +6252,13 @@ export class SqliteBrain implements IBrain {
           ...(eventDetails === undefined ? {} : { details: eventDetails }),
         };
         if (isRightToForgetAuditEvent(candidateEvent)) return false;
-        if (isQuarantinedRightToForgetAuditEvent(candidateEvent)) {
+        if (isQuarantinedEpisodicDetails(candidateEvent)) {
           // Persisted quarantine envelopes contain synthetic diagnostics, not
           // the original corrupt payload, and must never become deletion input.
           // Fresh malformed rows may still be removed when their raw payload
-          // itself matches the selector.
-          if (!detailsWereMalformed || !episodicRowMatchesSelector('', '', details, selector)) {
-            return false;
-          }
+          // itself matches the selector, regardless of the event's domain type.
+          return detailsWereMalformed
+            && episodicRowMatchesSelector('', '', details, selector);
         }
         return episodicRowMatchesSelector(step, summary, details, selector);
       })

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2838,9 +2838,11 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         } else {
           const eventsById = new Map<number, EpisodicEvent>();
           const keywordChunks = chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY);
-          const candidateLimit = keywordChunks.length === 1
-            ? limit
-            : MAX_CROSS_CHUNK_RECALL_CANDIDATES;
+          const candidateLimit = limit < 0
+            ? -1
+            : keywordChunks.length === 1
+              ? limit
+              : MAX_CROSS_CHUNK_RECALL_CANDIDATES;
           for (const chunk of keywordChunks) {
             const events = collectRowsToEvents(
               (batchLimit, offset) => this.recallKeywordChunk(chunk, batchLimit, offset),
@@ -2955,7 +2957,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
   ): Array<EpisodicRow & { relevance_score: number }> {
     const searchableDetails = `CASE
       WHEN json_valid(details)
-        AND NOT (
+        AND NOT COALESCE((
           json_type(details) = 'object'
           AND (SELECT COUNT(*) FROM json_each(details)) = 1
           AND json_type(details, '$.quarantine') = 'object'
@@ -2963,7 +2965,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           AND json_extract(details, '$.quarantine.field') = 'details'
           AND json_extract(details, '$.quarantine.reason') = 'invalid JSON'
           AND json_extract(details, '$.quarantine.eventId') = id
-        )
+        ), 0)
       THEN details
       ELSE ''
     END`;

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2594,6 +2594,8 @@ interface EpisodicRow {
   created_at: string;
 }
 
+type CorruptEpisodicDetailsReporter = (eventId: number) => void;
+
 class SqliteEpisodicMemory implements IEpisodicMemory {
   constructor(
     private db: Database.Database,
@@ -2813,9 +2815,13 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
   recall(query: string, limit = 10): EpisodicEvent[] {
     try {
+      const quarantinedEventIds = new Set<number>();
+      const reportCorruptDetails: CorruptEpisodicDetailsReporter = (eventId) => {
+        quarantinedEventIds.add(eventId);
+      };
       let result: EpisodicEvent[];
       if (this.encryption) {
-        result = this.recallEncrypted(query, limit);
+        result = this.recallEncrypted(query, limit, reportCorruptDetails);
       } else {
         const keywords = query
           .toLowerCase()
@@ -2824,13 +2830,14 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           .filter((w) => !STOPWORDS.has(w));
 
         if (keywords.length === 0) {
-          result = this.recent(limit);
+          result = this.recent(limit, reportCorruptDetails);
         } else if (keywords.length <= MAX_RECALL_KEYWORDS_PER_QUERY) {
           result = collectRowsToEvents(
             (batchLimit, offset) =>
               this.recallKeywordChunk(keywords, batchLimit, offset),
             limit,
             this.encryption,
+            reportCorruptDetails,
           );
         } else {
           const rowsById = new Map<
@@ -2855,7 +2862,12 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
               b.id - a.id,
           );
 
-          result = rowsToEvents(sortedRows, limit, this.encryption);
+          result = rowsToEvents(
+            sortedRows,
+            limit,
+            this.encryption,
+            reportCorruptDetails,
+          );
         }
       }
       this.audit?.({
@@ -2863,7 +2875,13 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         store: 'episodic',
         query,
         outcome: 'success',
-        details: { limit, count: result.length },
+        details: {
+          limit,
+          count: result.length,
+          ...(quarantinedEventIds.size > 0
+            ? { quarantinedEventIds: [...quarantinedEventIds] }
+            : {}),
+        },
       });
       return result;
     } catch (error) {
@@ -2881,7 +2899,11 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
   }
 
-  private recallEncrypted(query: string, limit = 10): EpisodicEvent[] {
+  private recallEncrypted(
+    query: string,
+    limit = 10,
+    reportCorruptDetails?: CorruptEpisodicDetailsReporter,
+  ): EpisodicEvent[] {
     if (limit === 0) return [];
     const keywords = query
       .toLowerCase()
@@ -2889,12 +2911,17 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       .filter((w) => w.length > 2)
       .filter((w) => !STOPWORDS.has(w));
     if (keywords.length === 0) {
-      return this.recent(limit);
+      return this.recent(limit, reportCorruptDetails);
     }
     const rows = this.db
       .prepare(`SELECT * FROM episodic_events ORDER BY created_at DESC`)
       .all() as EpisodicRow[];
-    const scored = rowsToEvents(rows, -1, this.encryption)
+    const scored = rowsToEvents(
+      rows,
+      -1,
+      this.encryption,
+      reportCorruptDetails,
+    )
       .map((event) => {
         const summary = event.summary.toLowerCase();
         const details = event.details
@@ -2968,6 +2995,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
   recentFailures(n = 10): EpisodicEvent[] {
     try {
+      const quarantinedEventIds = new Set<number>();
       const stmt = this.db.prepare(
         `SELECT * FROM episodic_events WHERE type = 'failure'
          ORDER BY created_at DESC LIMIT ? OFFSET ?`,
@@ -2976,12 +3004,19 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
         n,
         this.encryption,
+        (eventId) => quarantinedEventIds.add(eventId),
       );
       this.audit?.({
         operation: 'episodic.recentFailures',
         store: 'episodic',
         outcome: 'success',
-        details: { limit: n, count: result.length },
+        details: {
+          limit: n,
+          count: result.length,
+          ...(quarantinedEventIds.size > 0
+            ? { quarantinedEventIds: [...quarantinedEventIds] }
+            : {}),
+        },
       });
       return result;
     } catch (error) {
@@ -2998,8 +3033,12 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
   }
 
-  recent(n = 10): EpisodicEvent[] {
+  recent(
+    n = 10,
+    reportCorruptDetails?: CorruptEpisodicDetailsReporter,
+  ): EpisodicEvent[] {
     try {
+      const quarantinedEventIds = new Set<number>();
       const stmt = this.db.prepare(
         `SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT ? OFFSET ?`,
       );
@@ -3007,12 +3046,22 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
         n,
         this.encryption,
+        (eventId) => {
+          quarantinedEventIds.add(eventId);
+          reportCorruptDetails?.(eventId);
+        },
       );
       this.audit?.({
         operation: 'episodic.recent',
         store: 'episodic',
         outcome: 'success',
-        details: { limit: n, count: result.length },
+        details: {
+          limit: n,
+          count: result.length,
+          ...(quarantinedEventIds.size > 0
+            ? { quarantinedEventIds: [...quarantinedEventIds] }
+            : {}),
+        },
       });
       return result;
     } catch (error) {
@@ -8137,6 +8186,7 @@ function rowsToEvents(
   rows: EpisodicRow[],
   limit: number,
   encryption?: MemoryCipher,
+  reportCorruptDetails?: CorruptEpisodicDetailsReporter,
 ): EpisodicEvent[] {
   if (limit === 0) {
     return [];
@@ -8144,7 +8194,7 @@ function rowsToEvents(
 
   const events: EpisodicEvent[] = [];
   for (const row of rows) {
-    const event = rowToEvent(row, encryption);
+    const event = rowToEvent(row, encryption, reportCorruptDetails);
     if (event) {
       events.push(event);
       if (limit >= 0 && events.length >= limit) {
@@ -8159,6 +8209,7 @@ function collectRowsToEvents(
   fetchRows: (limit: number, offset: number) => EpisodicRow[],
   limit: number,
   encryption?: MemoryCipher,
+  reportCorruptDetails?: CorruptEpisodicDetailsReporter,
 ): EpisodicEvent[] {
   if (limit === 0) {
     return [];
@@ -8174,7 +8225,7 @@ function collectRowsToEvents(
   for (let offset = 0; events.length < target; offset += batchSize) {
     const rows = fetchRows(batchSize, offset);
     for (const row of rows) {
-      const event = rowToEvent(row, encryption);
+      const event = rowToEvent(row, encryption, reportCorruptDetails);
       if (event) {
         events.push(event);
         if (events.length >= target) {
@@ -8206,7 +8257,8 @@ function parseCheckpointState(
 function rowToEvent(
   row: EpisodicRow,
   encryption?: MemoryCipher,
-): EpisodicEvent | null {
+  reportCorruptDetails?: CorruptEpisodicDetailsReporter,
+): EpisodicEvent {
   const event: EpisodicEvent = {
     id: row.id,
     type: row.type as EpisodicEventType,
@@ -8214,13 +8266,20 @@ function rowToEvent(
     createdAt: row.created_at,
   };
   if (row.step) event.step = row.step;
-  if (row.details) {
+  if (row.details !== null) {
     try {
       event.details = JSON.parse(
         encryption?.decrypt(row.details) ?? row.details,
       ) as Record<string, unknown>;
     } catch {
-      return null;
+      reportCorruptDetails?.(row.id);
+      event.details = {
+        quarantine: {
+          field: 'details',
+          eventId: row.id,
+          reason: 'invalid JSON',
+        },
+      };
     }
   }
   return event;

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2584,6 +2584,7 @@ const MAX_RECALL_KEYWORDS_PER_QUERY = Math.floor(
   (SQLITE_VARIABLE_LIMIT - RECALL_LIMIT_VARIABLES) /
     RECALL_VARIABLES_PER_KEYWORD,
 );
+const MAX_CROSS_CHUNK_RECALL_CANDIDATES = 10_000;
 
 interface EpisodicRow {
   id: number;
@@ -2836,10 +2837,14 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           result = this.recent(limit, reportCorruptDetails);
         } else {
           const eventsById = new Map<number, EpisodicEvent>();
-          for (const chunk of chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY)) {
+          const keywordChunks = chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY);
+          const candidateLimit = keywordChunks.length === 1
+            ? limit
+            : MAX_CROSS_CHUNK_RECALL_CANDIDATES;
+          for (const chunk of keywordChunks) {
             const events = collectRowsToEvents(
               (batchLimit, offset) => this.recallKeywordChunk(chunk, batchLimit, offset),
-              limit,
+              candidateLimit,
               this.encryption,
               reportCorruptDetails,
               (event) => recallEventScore(event, keywords) > 0,
@@ -6254,11 +6259,19 @@ export class SqliteBrain implements IBrain {
         if (isRightToForgetAuditEvent(candidateEvent)) return false;
         if (isQuarantinedEpisodicDetails(candidateEvent)) {
           // Persisted quarantine envelopes contain synthetic diagnostics, not
-          // the original corrupt payload, and must never become deletion input.
-          // Fresh malformed rows may still be removed when their raw payload
-          // itself matches the selector, regardless of the event's domain type.
-          return detailsWereMalformed
-            && episodicRowMatchesSelector('', '', details, selector);
+          // the original corrupt payload. Keep audit-envelope summary/step
+          // protected, but preserve matching on readable domain fields for
+          // ordinary corrupt events.
+          if (isQuarantinedRightToForgetAuditEvent(candidateEvent)) {
+            return detailsWereMalformed
+              && episodicRowMatchesSelector('', '', details, selector);
+          }
+          return episodicRowMatchesSelector(
+            step,
+            summary,
+            detailsWereMalformed ? details : null,
+            selector,
+          );
         }
         return episodicRowMatchesSelector(step, summary, details, selector);
       })

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2836,13 +2836,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           result = this.recent(limit, reportCorruptDetails);
         } else {
           const eventsById = new Map<number, EpisodicEvent>();
-          const candidateLimit = limit < 0
-            ? -1
-            : Math.max(CORRUPT_JSON_SCAN_BATCH_SIZE, limit * 2);
           for (const chunk of chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY)) {
             const events = collectRowsToEvents(
               (batchLimit, offset) => this.recallKeywordChunk(chunk, batchLimit, offset),
-              candidateLimit,
+              -1,
               this.encryption,
               reportCorruptDetails,
               (event) => recallEventScore(event, keywords) > 0,
@@ -6214,6 +6211,7 @@ export class SqliteBrain implements IBrain {
         const summary = this.encryption?.decrypt(row.summary) ?? row.summary;
         const details = row.details ? (this.encryption?.decrypt(row.details) ?? row.details) : null;
         let eventDetails: Record<string, unknown> | undefined;
+        let detailsWereMalformed = false;
         if (details !== null) {
           try {
             const parsedDetails = JSON.parse(details) as unknown;
@@ -6221,6 +6219,7 @@ export class SqliteBrain implements IBrain {
               eventDetails = parsedDetails as Record<string, unknown>;
             }
           } catch {
+            detailsWereMalformed = true;
             eventDetails = {
               quarantine: {
                 field: 'details',
@@ -6239,10 +6238,15 @@ export class SqliteBrain implements IBrain {
           ...(eventDetails === undefined ? {} : { details: eventDetails }),
         };
         if (isRightToForgetAuditEvent(candidateEvent)) return false;
-        if (
-          isQuarantinedRightToForgetAuditEvent(candidateEvent)
-          && !episodicRowMatchesSelector('', '', details, selector)
-        ) return false;
+        if (isQuarantinedRightToForgetAuditEvent(candidateEvent)) {
+          // Persisted quarantine envelopes contain synthetic diagnostics, not
+          // the original corrupt payload, and must never become deletion input.
+          // Fresh malformed rows may still be removed when their raw payload
+          // itself matches the selector.
+          if (!detailsWereMalformed || !episodicRowMatchesSelector('', '', details, selector)) {
+            return false;
+          }
+        }
         return episodicRowMatchesSelector(step, summary, details, selector);
       })
       .map(row => row.id);

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2924,9 +2924,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     )
       .map((event) => {
         const summary = event.summary.toLowerCase();
-        const details = event.details
-          ? JSON.stringify(event.details).toLowerCase()
-          : '';
+        const details =
+          event.details && !isQuarantinedEpisodicDetails(event)
+            ? JSON.stringify(event.details).toLowerCase()
+            : '';
         const score = keywords.reduce(
           (sum, keyword) =>
             sum +
@@ -2993,7 +2994,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     >;
   }
 
-  recentFailures(n = 10): EpisodicEvent[] {
+  recentFailures(n = 10, includeQuarantined = true): EpisodicEvent[] {
     try {
       const quarantinedEventIds = new Set<number>();
       const stmt = this.db.prepare(
@@ -3005,6 +3006,9 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         n,
         this.encryption,
         (eventId) => quarantinedEventIds.add(eventId),
+        includeQuarantined
+          ? undefined
+          : (event) => !isQuarantinedEpisodicDetails(event),
       );
       this.audit?.({
         operation: 'episodic.recentFailures',
@@ -5566,7 +5570,7 @@ export class SqliteBrain implements IBrain {
         evidencePointers: Set<string>;
       }>();
 
-      for (const event of this.episodic.recentFailures(lookback)) {
+      for (const event of this.episodic.recentFailures(lookback, false)) {
         const signal = skillEvolutionSignalFromEvent(event);
         if (!signal) continue;
         const groupKey = `${normalizeLearningKey(signal.skillName)}:${signal.failureSignatureHash}`;
@@ -5928,7 +5932,10 @@ export class SqliteBrain implements IBrain {
 
     for (const event of this.episodic.recent(-1)) {
       const key = String(event.id ?? event.summary);
-      const className = isRightToForgetAuditEvent(event)
+      const className = (
+        isRightToForgetAuditEvent(event)
+        || isQuarantinedRightToForgetAuditEvent(event)
+      )
         ? 'audit_record'
         : classifyMemoryEntry({
           store: 'episodic',
@@ -7617,6 +7624,24 @@ function workingEntryMatchesSelector(key: string, value: unknown, selector: Norm
   return false;
 }
 
+function isQuarantinedEpisodicDetails(event: EpisodicEvent): boolean {
+  const details = event.details;
+  if (details === null || typeof details !== 'object' || Array.isArray(details)) return false;
+  const quarantine = (details as Record<string, unknown>).quarantine;
+  if (quarantine === null || typeof quarantine !== 'object' || Array.isArray(quarantine)) return false;
+  const record = quarantine as Record<string, unknown>;
+  return record.field === 'details'
+    && record.eventId === event.id
+    && record.reason === 'invalid JSON';
+}
+
+function isQuarantinedRightToForgetAuditEvent(event: EpisodicEvent): boolean {
+  return event.type === 'observation'
+    && event.step === 'right-to-forget'
+    && event.summary === 'Right-to-forget deletion completed'
+    && isQuarantinedEpisodicDetails(event);
+}
+
 function isRightToForgetAuditEvent(event: EpisodicEvent): boolean {
   if (event.type !== 'observation' || event.step !== 'right-to-forget') return false;
   if (event.summary !== 'Right-to-forget deletion completed') return false;
@@ -8210,6 +8235,7 @@ function collectRowsToEvents(
   limit: number,
   encryption?: MemoryCipher,
   reportCorruptDetails?: CorruptEpisodicDetailsReporter,
+  includeEvent?: (event: EpisodicEvent) => boolean,
 ): EpisodicEvent[] {
   if (limit === 0) {
     return [];
@@ -8226,7 +8252,7 @@ function collectRowsToEvents(
     const rows = fetchRows(batchSize, offset);
     for (const row of rows) {
       const event = rowToEvent(row, encryption, reportCorruptDetails);
-      if (event) {
+      if (includeEvent?.(event) ?? true) {
         events.push(event);
         if (events.length >= target) {
           break;

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2835,21 +2835,25 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         if (keywords.length === 0) {
           result = this.recent(limit, reportCorruptDetails);
         } else {
-          const rowsById = new Map<number, EpisodicRow>();
+          const eventsById = new Map<number, EpisodicEvent>();
+          const candidateLimit = limit < 0
+            ? -1
+            : Math.max(CORRUPT_JSON_SCAN_BATCH_SIZE, limit * 2);
           for (const chunk of chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY)) {
-            for (const row of this.recallKeywordChunk(chunk)) {
-              rowsById.set(row.id, row);
+            const events = collectRowsToEvents(
+              (batchLimit, offset) => this.recallKeywordChunk(chunk, batchLimit, offset),
+              candidateLimit,
+              this.encryption,
+              reportCorruptDetails,
+              (event) => recallEventScore(event, keywords) > 0,
+            );
+            for (const event of events) {
+              eventsById.set(event.id!, event);
             }
           }
 
-          const scoredEvents = rowsToEvents(
-            [...rowsById.values()],
-            -1,
-            this.encryption,
-            reportCorruptDetails,
-          )
+          const scoredEvents = [...eventsById.values()]
             .map((event) => ({ event, score: recallEventScore(event, keywords) }))
-            .filter(({ score }) => score > 0)
             .sort(
               (a, b) =>
                 b.score - a.score ||
@@ -6234,9 +6238,10 @@ export class SqliteBrain implements IBrain {
           createdAt: '',
           ...(eventDetails === undefined ? {} : { details: eventDetails }),
         };
+        if (isRightToForgetAuditEvent(candidateEvent)) return false;
         if (
-          isRightToForgetAuditEvent(candidateEvent)
-          || isQuarantinedRightToForgetAuditEvent(candidateEvent)
+          isQuarantinedRightToForgetAuditEvent(candidateEvent)
+          && !episodicRowMatchesSelector('', '', details, selector)
         ) return false;
         return episodicRowMatchesSelector(step, summary, details, selector);
       })
@@ -8227,7 +8232,9 @@ function recallEventScore(
   keywords: string[],
 ): number {
   const summary = event.summary.toLowerCase();
-  const details = event.details === undefined ? '' : JSON.stringify(event.details).toLowerCase();
+  const details = event.details === undefined || isQuarantinedEpisodicDetails(event)
+    ? ''
+    : JSON.stringify(event.details).toLowerCase();
   return keywords.reduce(
     (score, keyword) => score + Number(summary.includes(keyword)) + Number(details.includes(keyword)),
     0,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -7639,10 +7639,13 @@ function workingEntryMatchesSelector(key: string, value: unknown, selector: Norm
 function isQuarantinedEpisodicDetails(event: EpisodicEvent): boolean {
   const details = event.details;
   if (details === null || typeof details !== 'object' || Array.isArray(details)) return false;
-  const quarantine = (details as Record<string, unknown>).quarantine;
+  const detailsRecord = details as Record<string, unknown>;
+  if (Object.keys(detailsRecord).join(',') !== 'quarantine') return false;
+  const quarantine = detailsRecord.quarantine;
   if (quarantine === null || typeof quarantine !== 'object' || Array.isArray(quarantine)) return false;
   const record = quarantine as Record<string, unknown>;
-  return record.field === 'details'
+  return Object.keys(record).sort().join(',') === 'eventId,field,reason'
+    && record.field === 'details'
     && record.eventId === event.id
     && record.reason === 'invalid JSON';
 }
@@ -8321,6 +8324,9 @@ function rowToEvent(
       event.details = JSON.parse(
         encryption?.decrypt(row.details) ?? row.details,
       ) as Record<string, unknown>;
+      if (isQuarantinedEpisodicDetails(event)) {
+        reportCorruptDetails?.(row.id);
+      }
     } catch {
       reportCorruptDetails?.(row.id);
       event.details = {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2838,6 +2838,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
             limit,
             this.encryption,
             reportCorruptDetails,
+            (event) => recallEventMatchesKeywords(event, keywords),
           );
         } else {
           const rowsById = new Map<
@@ -2862,12 +2863,13 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
               b.id - a.id,
           );
 
-          result = rowsToEvents(
+          const matchingEvents = rowsToEvents(
             sortedRows,
-            limit,
+            -1,
             this.encryption,
             reportCorruptDetails,
-          );
+          ).filter((event) => recallEventMatchesKeywords(event, keywords));
+          result = limit < 0 ? matchingEvents : matchingEvents.slice(0, limit);
         }
       }
       this.audit?.({
@@ -6449,7 +6451,10 @@ export class SqliteBrain implements IBrain {
           brain.working.flushToDb() ?? undefined;
 
         for (const event of snapshot.episodic) {
-          if (!isRightToForgetAuditEvent(event)) {
+          if (
+            !isRightToForgetAuditEvent(event)
+            && !isQuarantinedRightToForgetAuditEvent(event)
+          ) {
             assertEpisodicNotDeletionGuarded(brain.db, event, brain.encryption);
           }
           insertEvent.run(
@@ -8205,6 +8210,15 @@ function parseHydratedWorkingMemoryValue(key: string, value: string): unknown {
     }
     return value;
   }
+}
+
+function recallEventMatchesKeywords(
+  event: EpisodicEvent,
+  keywords: string[],
+): boolean {
+  if (!isQuarantinedEpisodicDetails(event)) return true;
+  const summary = event.summary.toLowerCase();
+  return keywords.some((keyword) => summary.includes(keyword));
 }
 
 function rowsToEvents(

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -132,7 +132,7 @@ export interface MemoryRetentionPolicy {
 export interface MemoryRetentionEntryReport {
   store: 'working' | 'episodic';
   key: string;
-  agentId?: string;
+  agentId?: string | null;
   class: MemoryRetentionClass;
   action: MemoryRetentionAction;
   policy: MemoryRetentionPolicy;
@@ -2815,6 +2815,9 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
   recall(query: string, limit = 10): EpisodicEvent[] {
     try {
+      if (!Number.isSafeInteger(limit)) {
+        throw new RangeError('Episodic recall limit must be a safe integer');
+      }
       const quarantinedEventIds = new Set<number>();
       const reportCorruptDetails: CorruptEpisodicDetailsReporter = (eventId) => {
         quarantinedEventIds.add(eventId);
@@ -2831,45 +2834,30 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
 
         if (keywords.length === 0) {
           result = this.recent(limit, reportCorruptDetails);
-        } else if (keywords.length <= MAX_RECALL_KEYWORDS_PER_QUERY) {
-          result = collectRowsToEvents(
-            (batchLimit, offset) =>
-              this.recallKeywordChunk(keywords, batchLimit, offset),
-            limit,
-            this.encryption,
-            reportCorruptDetails,
-            (event) => recallEventMatchesKeywords(event, keywords),
-          );
         } else {
-          const rowsById = new Map<
-            number,
-            EpisodicRow & { relevance_score: number }
-          >();
+          const rowsById = new Map<number, EpisodicRow>();
           for (const chunk of chunkArray(keywords, MAX_RECALL_KEYWORDS_PER_QUERY)) {
             for (const row of this.recallKeywordChunk(chunk)) {
-              const existing = rowsById.get(row.id);
-              if (existing) {
-                existing.relevance_score += row.relevance_score;
-              } else {
-                rowsById.set(row.id, { ...row });
-              }
+              rowsById.set(row.id, row);
             }
           }
 
-          const sortedRows = [...rowsById.values()].sort(
-            (a, b) =>
-              b.relevance_score - a.relevance_score ||
-              b.created_at.localeCompare(a.created_at) ||
-              b.id - a.id,
-          );
-
-          const matchingEvents = rowsToEvents(
-            sortedRows,
+          const scoredEvents = rowsToEvents(
+            [...rowsById.values()],
             -1,
             this.encryption,
             reportCorruptDetails,
-          ).filter((event) => recallEventMatchesKeywords(event, keywords));
-          result = limit < 0 ? matchingEvents : matchingEvents.slice(0, limit);
+          )
+            .map((event) => ({ event, score: recallEventScore(event, keywords) }))
+            .filter(({ score }) => score > 0)
+            .sort(
+              (a, b) =>
+                b.score - a.score ||
+                b.event.createdAt.localeCompare(a.event.createdAt) ||
+                Number(b.event.id ?? 0) - Number(a.event.id ?? 0),
+            )
+            .map(({ event }) => event);
+          result = limit < 0 ? scoredEvents : scoredEvents.slice(0, limit);
         }
       }
       this.audit?.({
@@ -5955,7 +5943,9 @@ export class SqliteBrain implements IBrain {
         nowMs,
         expiryHorizonMs,
       });
-      const agentId = parseAgentScopedEpisodicDetails(event.details);
+      const agentId = isQuarantinedEpisodicDetails(event)
+        ? null
+        : parseAgentScopedEpisodicDetails(event.details);
       entries.push({
         store: 'episodic',
         key,
@@ -6207,8 +6197,9 @@ export class SqliteBrain implements IBrain {
   }
 
   private matchingEpisodicIds(selector: NormalizedRightToForgetSelector): number[] {
-    const rows = this.db.prepare(`SELECT id, step, summary, details FROM episodic_events`).all() as Array<{
+    const rows = this.db.prepare(`SELECT id, type, step, summary, details FROM episodic_events`).all() as Array<{
       id: number;
+      type: EpisodicEventType;
       step: string | null;
       summary: string;
       details: string | null;
@@ -6218,19 +6209,35 @@ export class SqliteBrain implements IBrain {
         const step = row.step ?? '';
         const summary = this.encryption?.decrypt(row.summary) ?? row.summary;
         const details = row.details ? (this.encryption?.decrypt(row.details) ?? row.details) : null;
-        const parsedDetails = details === null ? null : safeJsonParse(details);
-        const eventDetails = parsedDetails !== null && typeof parsedDetails === 'object' && !Array.isArray(parsedDetails)
-          ? parsedDetails as Record<string, unknown>
-          : undefined;
+        let eventDetails: Record<string, unknown> | undefined;
+        if (details !== null) {
+          try {
+            const parsedDetails = JSON.parse(details) as unknown;
+            if (parsedDetails !== null && typeof parsedDetails === 'object' && !Array.isArray(parsedDetails)) {
+              eventDetails = parsedDetails as Record<string, unknown>;
+            }
+          } catch {
+            eventDetails = {
+              quarantine: {
+                field: 'details',
+                eventId: row.id,
+                reason: 'invalid JSON',
+              },
+            };
+          }
+        }
         const candidateEvent: EpisodicEvent = {
           id: row.id,
-          type: 'observation',
+          type: row.type,
           step,
           summary,
           createdAt: '',
           ...(eventDetails === undefined ? {} : { details: eventDetails }),
         };
-        if (isRightToForgetAuditEvent(candidateEvent)) return false;
+        if (
+          isRightToForgetAuditEvent(candidateEvent)
+          || isQuarantinedRightToForgetAuditEvent(candidateEvent)
+        ) return false;
         return episodicRowMatchesSelector(step, summary, details, selector);
       })
       .map(row => row.id);
@@ -8212,13 +8219,16 @@ function parseHydratedWorkingMemoryValue(key: string, value: string): unknown {
   }
 }
 
-function recallEventMatchesKeywords(
+function recallEventScore(
   event: EpisodicEvent,
   keywords: string[],
-): boolean {
-  if (!isQuarantinedEpisodicDetails(event)) return true;
+): number {
   const summary = event.summary.toLowerCase();
-  return keywords.some((keyword) => summary.includes(keyword));
+  const details = event.details === undefined ? '' : JSON.stringify(event.details).toLowerCase();
+  return keywords.reduce(
+    (score, keyword) => score + Number(summary.includes(keyword)) + Number(details.includes(keyword)),
+    0,
+  );
 }
 
 function rowsToEvents(

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6188,6 +6188,41 @@ describe('SqliteBrain', () => {
       ]);
     });
 
+    it('preserves unbounded recall across keyword chunks', () => {
+      const episodic = brain.episodic as unknown as {
+        recall: (query: string, limit: number) => EpisodicEvent[];
+        recallKeywordChunk: (
+          keywords: string[],
+          limit?: number,
+          offset?: number,
+        ) => Array<Record<string, unknown>>;
+      };
+      const recallKeywordChunk = vi
+        .spyOn(episodic, 'recallKeywordChunk')
+        .mockImplementation((keywords, batchLimit = 100, offset = 0) => {
+          if (offset >= 10_001) return [];
+          return Array.from(
+            { length: Math.min(batchLimit, 10_001 - offset) },
+            (_, index) => ({
+              id: offset + index + 1,
+              type: 'observation',
+              step: null,
+              summary: `${keywords[0]} cross-chunk match`,
+              details: null,
+              created_at: '2026-07-10T00:00:00.000Z',
+              relevance_score: 1,
+            }),
+          );
+        });
+      const query = Array.from(
+        { length: 1200 },
+        (_, i) => `kw${String(i).padStart(4, '0')}`,
+      ).join(' ');
+
+      expect(episodic.recall(query, -1)).toHaveLength(10_001);
+      expect(recallKeywordChunk.mock.calls.some(([, , offset]) => offset === 10_000)).toBe(true);
+    });
+
     it('quarantines corrupt persisted details while keeping recent and failure rows available', () => {
       brain.episodic.record(
         makeEvent({
@@ -6361,6 +6396,27 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recall('alpha invalid json', 1).map((event) => event.summary)).toEqual([
         'alpha invalid healthy candidate',
       ]);
+    });
+
+    it('keeps nonmatching quarantine metadata with null fields searchable', () => {
+      brain.episodic.record(makeEvent({
+        summary: 'ordinary metadata candidate',
+        details: { marker: 'before-update' },
+      }));
+      const eventId = brain.episodic.recent(1)[0]!.id;
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run(
+        JSON.stringify({
+          quarantine: {
+            field: null,
+            eventId,
+            reason: 'invalid JSON',
+          },
+        }),
+        eventId,
+      );
+
+      expect(brain.episodic.recall('invalid JSON', 1).map((event) => event.id)).toEqual([eventId]);
     });
 
     it('uses finite batches for bounded plaintext recall', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6221,7 +6221,7 @@ describe('SqliteBrain', () => {
 
       expect(episodic.recall(query, -1)).toHaveLength(10_001);
       expect(recallKeywordChunk.mock.calls.some(([, , offset]) => offset === 10_000)).toBe(true);
-    });
+    }, 20_000);
 
     it('quarantines corrupt persisted details while keeping recent and failure rows available', () => {
       brain.episodic.record(

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -885,6 +885,23 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(auditEventId);
     });
 
+    it('deletes quarantined audit rows when their malformed details contain the selector', () => {
+      brain.working.set('task', 'delete project note');
+      const first = brain.rightToForget({ query: 'delete project' });
+      const auditEventId = first.auditEventId;
+      expect(auditEventId).toBeDefined();
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run(
+        '{"residual":"alice@example.test"',
+        auditEventId,
+      );
+
+      const report = brain.rightToForget({ query: 'alice@example.test' });
+
+      expect(report.deleted.episodic).toBe(1);
+      expect(brain.episodic.recent(-1).map((event) => event.id)).not.toContain(auditEventId);
+    });
+
     it('supports dry-run counts without deleting or auditing', () => {
       brain.working.set('pii:phone', { value: '+15555550123', category: 'pii' });
       brain.episodic.record({
@@ -6230,6 +6247,45 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recall('alpha beta', 1).map((event) => event.summary)).toEqual([
         'alpha healthy candidate',
       ]);
+    });
+
+    it('does not score synthetic quarantine metadata during plaintext recall', () => {
+      brain.episodic.record(
+        makeEvent({
+          summary: 'alpha quarantined candidate',
+          createdAt: '2026-07-20T00:00:00.000Z',
+          details: { marker: 'before-corruption' },
+        }),
+      );
+      brain.episodic.record(
+        makeEvent({
+          summary: 'alpha invalid healthy candidate',
+          createdAt: '2026-07-21T00:00:00.000Z',
+          details: { marker: 'healthy' },
+        }),
+      );
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary = ?`).run(
+        '{"marker":"before-corruption"',
+        'alpha quarantined candidate',
+      );
+
+      expect(brain.episodic.recall('alpha invalid json', 1).map((event) => event.summary)).toEqual([
+        'alpha invalid healthy candidate',
+      ]);
+    });
+
+    it('uses finite batches for bounded plaintext recall', () => {
+      const episodic = brain.episodic as unknown as {
+        recall: (query: string, limit: number) => EpisodicEvent[];
+        recallKeywordChunk: (keywords: string[], limit?: number, offset?: number) => unknown[];
+      };
+      const recallKeywordChunk = vi.spyOn(episodic, 'recallKeywordChunk');
+      brain.episodic.record(makeEvent({ summary: 'bounded recall candidate' }));
+
+      expect(episodic.recall('bounded', 1)).toHaveLength(1);
+      expect(recallKeywordChunk).toHaveBeenCalledWith(['bounded'], expect.any(Number), 0);
+      expect(recallKeywordChunk.mock.calls.every(([, batchLimit]) => batchLimit !== undefined)).toBe(true);
     });
 
     it('audits quarantined details rows with their event ids', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -5945,7 +5945,7 @@ describe('SqliteBrain', () => {
       ).toEqual(['late match kw1199', 'early match kw0000']);
     });
 
-    it('skips corrupt persisted details while keeping healthy recent and failure rows available', () => {
+    it('quarantines corrupt persisted details while keeping recent and failure rows available', () => {
       brain.episodic.record(
         makeEvent({
           type: 'failure',
@@ -5983,18 +5983,35 @@ describe('SqliteBrain', () => {
       ).run('{', 'newer corrupt failure');
 
       expect(() => brain.episodic.recent(2)).not.toThrow();
-      expect(brain.episodic.recent(2).map((event) => event.summary)).toEqual([
+      const recent = brain.episodic.recent(2);
+      expect(recent.map((event) => event.summary)).toEqual([
         'newest healthy success',
-        'older healthy failure',
+        'newer corrupt failure',
       ]);
+      expect(recent[0]!.details).toEqual({ marker: 'healthy' });
+      expect(recent[1]!.details).toEqual({
+        quarantine: {
+          field: 'details',
+          eventId: recent[1]!.id,
+          reason: 'invalid JSON',
+        },
+      });
 
       expect(() => brain.episodic.recentFailures(1)).not.toThrow();
-      expect(
-        brain.episodic.recentFailures(1).map((event) => event.summary),
-      ).toEqual(['older healthy failure']);
+      const failures = brain.episodic.recentFailures(1);
+      expect(failures.map((event) => event.summary)).toEqual([
+        'newer corrupt failure',
+      ]);
+      expect(failures[0]!.details).toEqual({
+        quarantine: {
+          field: 'details',
+          eventId: failures[0]!.id,
+          reason: 'invalid JSON',
+        },
+      });
     });
 
-    it('skips corrupt persisted details during recall', () => {
+    it('quarantines corrupt persisted details during recall', () => {
       brain.episodic.record(
         makeEvent({
           summary: 'healthy searchable event',
@@ -6022,12 +6039,68 @@ describe('SqliteBrain', () => {
       ).run('{', 'corrupt searchable event');
 
       expect(() => brain.episodic.recall('searchable', 10)).not.toThrow();
-      expect(
-        brain.episodic.recall('searchable', 10).map((event) => event.summary),
-      ).toEqual(['healthy searchable event']);
+      const recalled = brain.episodic.recall('searchable', 10);
+      expect(recalled.map((event) => event.summary)).toEqual([
+        'healthy searchable event',
+        'corrupt searchable event',
+      ]);
+      expect(recalled[0]!.details).toEqual({ marker: 'searchable' });
+      expect(recalled[1]!.details).toEqual({
+        quarantine: {
+          field: 'details',
+          eventId: recalled[1]!.id,
+          reason: 'invalid JSON',
+        },
+      });
       expect(brain.episodic.recall('searchable', 0)).toEqual([]);
       expect(brain.episodic.recent(0)).toEqual([]);
       expect(brain.episodic.recentFailures(0)).toEqual([]);
+    });
+
+    it('audits quarantined details rows with their event ids', () => {
+      brain.episodic.record(
+        makeEvent({
+          summary: 'diagnostic searchable event',
+          details: { marker: 'valid-before-corruption' },
+        }),
+      );
+      const eventId = brain.episodic.recent(1)[0]!.id;
+      const db = (
+        brain as unknown as {
+          db: {
+            prepare: (sql: string) => { run: (...args: unknown[]) => void };
+          };
+        }
+      ).db;
+      db.prepare(
+        `UPDATE episodic_events SET details = ? WHERE id = ?`,
+      ).run('{', eventId);
+
+      const recent = brain.episodic.recent(1);
+      expect(recent).toHaveLength(1);
+      expect(recent[0]).toMatchObject({
+        id: eventId,
+        summary: 'diagnostic searchable event',
+        details: {
+          quarantine: {
+            field: 'details',
+            eventId,
+            reason: 'invalid JSON',
+          },
+        },
+      });
+      expect(brain.accessAudit.list({ operation: 'episodic.recent' })[0]).toMatchObject({
+        outcome: 'success',
+        details: { quarantinedEventIds: [eventId] },
+      });
+
+      const recalled = brain.episodic.recall('diagnostic', 1);
+      expect(recalled).toHaveLength(1);
+      expect(recalled[0]).toMatchObject({ id: eventId });
+      expect(brain.accessAudit.list({ operation: 'episodic.recall' })[0]).toMatchObject({
+        outcome: 'success',
+        details: { quarantinedEventIds: [eventId] },
+      });
     });
   });
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6277,6 +6277,44 @@ describe('SqliteBrain', () => {
         details: { quarantinedEventIds: [eventId] },
       });
     });
+
+    it('audits imported quarantine envelopes with their event ids', () => {
+      brain.episodic.record(
+        makeEvent({
+          summary: 'imported diagnostic event',
+          details: { marker: 'valid-before-import' },
+        }),
+      );
+      const eventId = brain.episodic.recent(1)[0]!.id;
+      const db = (
+        brain as unknown as {
+          db: {
+            prepare: (sql: string) => { run: (...args: unknown[]) => void };
+          };
+        }
+      ).db;
+      db.prepare(
+        `UPDATE episodic_events SET details = ? WHERE id = ?`,
+      ).run(JSON.stringify({
+        quarantine: {
+          field: 'details',
+          eventId,
+          reason: 'invalid JSON',
+        },
+      }), eventId);
+
+      expect(brain.episodic.recent(1)).toHaveLength(1);
+      expect(brain.accessAudit.list({ operation: 'episodic.recent' })[0]).toMatchObject({
+        outcome: 'success',
+        details: { quarantinedEventIds: [eventId] },
+      });
+
+      expect(brain.episodic.recall('imported diagnostic', 1)).toHaveLength(1);
+      expect(brain.accessAudit.list({ operation: 'episodic.recall' })[0]).toMatchObject({
+        outcome: 'success',
+        details: { quarantinedEventIds: [eventId] },
+      });
+    });
   });
 
   describe('recovery memory', () => {
@@ -6657,6 +6695,28 @@ describe('SqliteBrain', () => {
         details: { quarantine: { field: 'details', reason: 'invalid JSON' } },
       });
       hydrated.close();
+      source.close();
+    });
+
+    it('hydrate() rejects quarantined audit envelopes with extra guarded details', () => {
+      const source = new SqliteBrain(':memory:');
+      source.working.set('task', 'alice@example.test');
+      source.rightToForget({ query: 'alice@example.test' });
+      const snapshot = source.serialize();
+      const auditEvent = snapshot.episodic.find(
+        (event) => event.step === 'right-to-forget',
+      );
+      expect(auditEvent).toBeDefined();
+      auditEvent!.details = {
+        quarantine: {
+          field: 'details',
+          eventId: auditEvent!.id,
+          reason: 'invalid JSON',
+        },
+        note: 'alice@example.test',
+      };
+
+      expect(() => SqliteBrain.hydrate(snapshot)).toThrow(/right-to-forget/);
       source.close();
     });
 

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -327,6 +327,28 @@ describe('SqliteBrain', () => {
       );
     });
 
+    it('marks quarantined episodic retention rows as unreadable by scoped reports', () => {
+      brain.episodic.record({
+        type: 'observation',
+        summary: 'private scoped retention entry',
+        details: {
+          __fbeastMemoryScope: 'fbeast:agent-memory',
+          agentId: 'private-agent',
+        },
+        createdAt: '2026-07-20T00:00:00.000Z',
+      });
+      const eventId = brain.episodic.recent(1)[0]!.id;
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run('{', eventId);
+
+      const report = brain.memoryRetentionReport({ now: '2026-07-21T00:00:00.000Z' });
+
+      expect(report.entries.find((entry) => entry.key === String(eventId))).toMatchObject({
+        store: 'episodic',
+        agentId: null,
+      });
+    });
+
     it('treats explicit audit class aliases as protected audit records', () => {
       brain.episodic.record({
         type: 'observation',
@@ -848,6 +870,19 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recall('alice@example.test', 5)).toEqual([]);
       expect(brain.episodic.recall('Safe project note', 5)).toHaveLength(1);
       expect(brain.episodic.recent(5).some(event => event.step === 'right-to-forget')).toBe(true);
+    });
+
+    it('preserves quarantined right-to-forget audit envelopes during later forgets', () => {
+      brain.working.set('task', 'delete project note');
+      const first = brain.rightToForget({ query: 'delete project' });
+      const auditEventId = first.auditEventId;
+      expect(auditEventId).toBeDefined();
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run('{', auditEventId);
+
+      brain.rightToForget({ query: 'right-to-forget' });
+
+      expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(auditEventId);
     });
 
     it('supports dry-run counts without deleting or auditing', () => {
@@ -6169,6 +6204,32 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recall('searchable', 0)).toEqual([]);
       expect(brain.episodic.recent(0)).toEqual([]);
       expect(brain.episodic.recentFailures(0)).toEqual([]);
+    });
+
+    it('re-scores quarantined plaintext recall rows from readable fields before limiting', () => {
+      brain.episodic.record(
+        makeEvent({
+          summary: 'alpha quarantined candidate',
+          createdAt: '2026-07-20T00:00:00.000Z',
+          details: { marker: 'beta' },
+        }),
+      );
+      brain.episodic.record(
+        makeEvent({
+          summary: 'alpha healthy candidate',
+          createdAt: '2026-07-21T00:00:00.000Z',
+          details: { marker: 'healthy' },
+        }),
+      );
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary = ?`).run(
+        '{"marker":"beta"',
+        'alpha quarantined candidate',
+      );
+
+      expect(brain.episodic.recall('alpha beta', 1).map((event) => event.summary)).toEqual([
+        'alpha healthy candidate',
+      ]);
     });
 
     it('audits quarantined details rows with their event ids', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6129,6 +6129,13 @@ describe('SqliteBrain', () => {
           details: { marker: 'searchable' },
         }),
       );
+      brain.episodic.record(
+        makeEvent({
+          summary: 'corrupt details-only event',
+          createdAt: '2026-07-10T00:02:00.000Z',
+          details: { marker: 'details-only-token' },
+        }),
+      );
 
       const db = (
         brain as unknown as {
@@ -6140,6 +6147,9 @@ describe('SqliteBrain', () => {
       db.prepare(
         `UPDATE episodic_events SET details = ? WHERE summary = ?`,
       ).run('{', 'corrupt searchable event');
+      db.prepare(
+        `UPDATE episodic_events SET details = ? WHERE summary = ?`,
+      ).run('{"details-only-token"', 'corrupt details-only event');
 
       expect(() => brain.episodic.recall('searchable', 10)).not.toThrow();
       const recalled = brain.episodic.recall('searchable', 10);
@@ -6155,6 +6165,7 @@ describe('SqliteBrain', () => {
           reason: 'invalid JSON',
         },
       });
+      expect(brain.episodic.recall('details-only-token', 10)).toEqual([]);
       expect(brain.episodic.recall('searchable', 0)).toEqual([]);
       expect(brain.episodic.recent(0)).toEqual([]);
       expect(brain.episodic.recentFailures(0)).toEqual([]);
@@ -6557,6 +6568,33 @@ describe('SqliteBrain', () => {
       const hydrated = SqliteBrain.hydrate(snapshot);
 
       expect(hydrated.episodic.recent(1)[0]?.step).toBe('right-to-forget');
+      hydrated.close();
+      source.close();
+    });
+
+    it('hydrate() preserves quarantined right-to-forget audit envelopes', () => {
+      const source = new SqliteBrain(':memory:');
+      source.working.set('task', 'delete project note');
+      source.rightToForget({ query: 'delete project' });
+      const snapshot = source.serialize();
+      const auditEvent = snapshot.episodic.find(
+        (event) => event.step === 'right-to-forget',
+      );
+      expect(auditEvent).toBeDefined();
+      auditEvent!.details = {
+        quarantine: {
+          field: 'details',
+          eventId: auditEvent!.id,
+          reason: 'invalid JSON',
+        },
+      };
+
+      const hydrated = SqliteBrain.hydrate(snapshot);
+
+      expect(hydrated.episodic.recent(1)[0]).toMatchObject({
+        step: 'right-to-forget',
+        details: { quarantine: { field: 'details', reason: 'invalid JSON' } },
+      });
       hydrated.close();
       source.close();
     });

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -931,6 +931,25 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(ordinaryEventId);
     });
 
+    it('matches readable summary fields on ordinary corrupt events', () => {
+      brain.episodic.record({
+        type: 'success',
+        summary: 'delete corrupt summary',
+        details: { marker: 'will-corrupt' },
+        createdAt: '2026-07-20T00:00:00.000Z',
+      });
+      const ordinaryEventId = brain.episodic.recent(1)[0]!.id;
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run(
+        '{"marker":"broken"',
+        ordinaryEventId,
+      );
+
+      brain.rightToForget({ query: 'corrupt summary' });
+
+      expect(brain.episodic.recent(-1).map((event) => event.id)).not.toContain(ordinaryEventId);
+    });
+
     it('deletes quarantined audit rows when their malformed details contain the selector', () => {
       brain.working.set('task', 'delete project note');
       const first = brain.rightToForget({ query: 'delete project' });
@@ -6144,6 +6163,29 @@ describe('SqliteBrain', () => {
       expect(
         brain.episodic.recall(query, 10).map((event) => event.summary),
       ).toEqual(['late match kw1199', 'early match kw0000']);
+    });
+
+    it('preserves global ranking across recall keyword chunks', () => {
+      brain.episodic.record(makeEvent({
+        summary: 'older combined kw0000 kw1199 match',
+        createdAt: '2026-07-10T00:00:00.000Z',
+      }));
+      brain.episodic.record(makeEvent({
+        summary: 'newer first-chunk kw0000 match',
+        createdAt: '2026-07-10T00:02:00.000Z',
+      }));
+      brain.episodic.record(makeEvent({
+        summary: 'newer last-chunk kw1199 match',
+        createdAt: '2026-07-10T00:01:00.000Z',
+      }));
+      const query = Array.from(
+        { length: 1200 },
+        (_, i) => `kw${String(i).padStart(4, '0')}`,
+      ).join(' ');
+
+      expect(brain.episodic.recall(query, 1).map((event) => event.summary)).toEqual([
+        'older combined kw0000 kw1199 match',
+      ]);
     });
 
     it('quarantines corrupt persisted details while keeping recent and failure rows available', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -907,6 +907,30 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(auditEventId);
     });
 
+    it('does not match persisted quarantine diagnostics on ordinary events', () => {
+      brain.episodic.record({
+        type: 'success',
+        summary: 'ordinary quarantined row',
+        createdAt: '2026-07-20T00:00:00.000Z',
+      });
+      const ordinaryEventId = brain.episodic.recent(1)[0]!.id;
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run(
+        JSON.stringify({
+          quarantine: {
+            field: 'details',
+            eventId: ordinaryEventId,
+            reason: 'invalid JSON',
+          },
+        }),
+        ordinaryEventId,
+      );
+
+      brain.rightToForget({ query: 'invalid JSON' });
+
+      expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(ordinaryEventId);
+    });
+
     it('deletes quarantined audit rows when their malformed details contain the selector', () => {
       brain.working.set('task', 'delete project note');
       const first = brain.rightToForget({ query: 'delete project' });

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -296,6 +296,37 @@ describe('SqliteBrain', () => {
       expect(report.compactionCandidates.map((entry) => entry.class)).not.toContain('audit_record');
     });
 
+    it('protects quarantined right-to-forget audit envelopes from retention compaction', () => {
+      brain.episodic.record({
+        type: 'observation',
+        step: 'right-to-forget',
+        summary: 'Right-to-forget deletion completed',
+        details: {
+          selectorHash: 'a'.repeat(64),
+          deleted: { working: 1, episodic: 0, derived: 1 },
+        },
+        createdAt: '2020-01-01T00:00:00.000Z',
+      });
+      const eventId = brain.episodic.recent(1)[0]!.id;
+      const db = (
+        brain as unknown as {
+          db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+        }
+      ).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run('{', eventId);
+
+      const report = brain.memoryRetentionReport({ now: '2027-01-01T00:00:00.000Z' });
+
+      expect(report.entries.find((entry) => entry.key === String(eventId))).toMatchObject({
+        class: 'audit_record',
+        action: 'protect',
+        protected: true,
+      });
+      expect(report.compactionCandidates).not.toContainEqual(
+        expect.objectContaining({ key: String(eventId) }),
+      );
+    });
+
     it('treats explicit audit class aliases as protected audit records', () => {
       brain.episodic.record({
         type: 'observation',
@@ -508,6 +539,39 @@ describe('SqliteBrain', () => {
       }));
       expect(JSON.stringify(item)).not.toContain('stack trace');
       expect(brain.createSkillEvolutionReviewGate({ threshold: 3 })).toEqual([]);
+    });
+
+    it('does not let quarantined failures consume the skill-evolution lookback', () => {
+      for (const evidenceId of ['task-1', 'task-2', 'task-3']) {
+        brain.episodic.recordSkillFailure({
+          skillName: 'resolve-issues',
+          failureSignature: 'same bounded failure',
+          evidenceId,
+          createdAt: '2026-07-16T10:00:00.000Z',
+        });
+      }
+      brain.episodic.record({
+        type: 'failure',
+        summary: 'newer corrupt failure',
+        details: { marker: 'valid-before-corruption' },
+        createdAt: '2026-07-16T10:01:00.000Z',
+      });
+      const db = (
+        brain as unknown as {
+          db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+        }
+      ).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary = ?`).run(
+        '{',
+        'newer corrupt failure',
+      );
+
+      const [item] = brain.createSkillEvolutionReviewGate({ threshold: 3, lookback: 3 });
+
+      expect(item?.value).toMatchObject({
+        kind: 'skill-evolution-review',
+        failureCount: 3,
+      });
     });
 
     it('does not create a review item for unrelated one-off failures', () => {
@@ -5461,6 +5525,45 @@ describe('SqliteBrain', () => {
         expect(
           encrypted.episodic.recall('alpha', 2).map((event) => event.createdAt),
         ).toEqual(['2026-07-13T00:00:00.000Z', '2026-07-13T00:01:00.000Z']);
+        encrypted.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not score synthetic quarantine metadata during encrypted recall', () => {
+      const dir = mkdtempSync(
+        join(tmpdir(), 'sqlite-brain-encryption-quarantine-recall-'),
+      );
+      const dbPath = join(dir, 'brain.db');
+
+      try {
+        const encrypted = new SqliteBrain(dbPath, undefined, { encryption });
+        encrypted.episodic.record({
+          type: 'observation',
+          summary: 'corrupt payload event',
+          details: { note: 'valid before corruption' },
+          createdAt: '2026-07-13T00:00:00.000Z',
+        });
+        const encodedMalformedJson = (
+          encrypted.episodic as unknown as { encode: (value: string) => string }
+        ).encode('{');
+        const db = (
+          encrypted as unknown as {
+            db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+          }
+        ).db;
+        db.prepare(`UPDATE episodic_events SET details = ?`).run(encodedMalformedJson);
+
+        expect(encrypted.episodic.recall('invalid', 10)).toEqual([]);
+        expect(encrypted.episodic.recall('corrupt', 10)[0]).toMatchObject({
+          details: {
+            quarantine: {
+              field: 'details',
+              reason: 'invalid JSON',
+            },
+          },
+        });
         encrypted.close();
       } finally {
         rmSync(dir, { recursive: true, force: true });

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -885,6 +885,28 @@ describe('SqliteBrain', () => {
       expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(auditEventId);
     });
 
+    it('does not match persisted quarantine diagnostics when deleting audit rows', () => {
+      brain.working.set('task', 'delete project note');
+      const first = brain.rightToForget({ query: 'delete project' });
+      const auditEventId = first.auditEventId;
+      expect(auditEventId).toBeDefined();
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE id = ?`).run(
+        JSON.stringify({
+          quarantine: {
+            field: 'details',
+            eventId: auditEventId,
+            reason: 'invalid JSON',
+          },
+        }),
+        auditEventId,
+      );
+
+      brain.rightToForget({ query: 'invalid JSON' });
+
+      expect(brain.episodic.recent(-1).map((event) => event.id)).toContain(auditEventId);
+    });
+
     it('deletes quarantined audit rows when their malformed details contain the selector', () => {
       brain.working.set('task', 'delete project note');
       const first = brain.rightToForget({ query: 'delete project' });
@@ -6286,6 +6308,27 @@ describe('SqliteBrain', () => {
       expect(episodic.recall('bounded', 1)).toHaveLength(1);
       expect(recallKeywordChunk).toHaveBeenCalledWith(['bounded'], expect.any(Number), 0);
       expect(recallKeywordChunk.mock.calls.every(([, batchLimit]) => batchLimit !== undefined)).toBe(true);
+    });
+
+    it('scans past corrupt SQL-ranked pages before applying final recall ranking', () => {
+      brain.episodic.record(makeEvent({
+        summary: 'alpha beta healthy best match',
+        createdAt: '2026-07-19T00:00:00.000Z',
+      }));
+      for (let index = 0; index < 101; index += 1) {
+        brain.episodic.record(makeEvent({
+          summary: `alpha corrupt candidate ${index}`,
+          details: { marker: 'beta' },
+          createdAt: '2026-07-20T00:00:00.000Z',
+        }));
+      }
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.prepare(`UPDATE episodic_events SET details = ? WHERE summary LIKE 'alpha corrupt candidate %'`)
+        .run('{"marker":"beta"');
+
+      expect(brain.episodic.recall('alpha beta', 1).map((event) => event.summary)).toEqual([
+        'alpha beta healthy best match',
+      ]);
     });
 
     it('audits quarantined details rows with their event ids', () => {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -954,7 +954,7 @@ describe("createBrainAdapter", () => {
     const brain = createBrainAdapter("/tmp/quarantined-scope.db");
     const mockBrain = brainInstances[0]!;
     const quarantinedEvent = {
-      id: "evt-quarantined",
+      id: 17,
       type: "success",
       summary: "private quarantined episode",
       details: {
@@ -987,6 +987,74 @@ describe("createBrainAdapter", () => {
       limit: 10,
     });
     expect(exported.episodic).toEqual([]);
+  });
+
+  it("backfills all-scope episodic reads after quarantined events are hidden", async () => {
+    const brain = createBrainAdapter("/tmp/quarantined-backfill.db");
+    const mockBrain = brainInstances[0]!;
+    const quarantinedEvents = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      type: "success",
+      summary: `quarantined event ${index + 1}`,
+      details: {
+        quarantine: {
+          field: "details",
+          eventId: index + 1,
+          reason: "invalid JSON",
+        },
+      },
+      createdAt: `2026-07-20T00:${String(index % 60).padStart(2, "0")}:00.000Z`,
+    }));
+    const readableEvent = {
+      id: 101,
+      type: "success",
+      summary: "readable backfill event",
+      createdAt: "2026-07-19T00:00:00.000Z",
+    };
+    const events = [...quarantinedEvents, readableEvent];
+    const bounded = (limit: number) => limit < 0 ? events : events.slice(0, limit);
+    mockBrain.episodic.recall.mockImplementation((_query: string, limit: number) => bounded(limit));
+    mockBrain.episodic.recent.mockImplementation((limit: number) => bounded(limit));
+
+    await expect(brain.query({
+      query: "event",
+      type: "episodic",
+      readScope: "all",
+      limit: 1,
+    })).resolves.toEqual([
+      expect.objectContaining({ key: "101", value: "readable backfill event" }),
+    ]);
+    const frontload = await brain.frontload({ readScope: "all" });
+    expect(frontload.flatMap((section) => section.entries)).toContain("101: readable backfill event");
+    const exported = await brain.exportProjectMemory({ readScope: "all", limit: 1 });
+    expect(exported.episodic).toEqual([
+      expect.objectContaining({ id: 101, summary: "readable backfill event" }),
+    ]);
+    expect(mockBrain.episodic.recall).toHaveBeenCalledWith("event", -1);
+    expect(mockBrain.episodic.recent).toHaveBeenCalledWith(-1);
+  });
+
+  it("does not hide ordinary episodic metadata with an incomplete quarantine marker", async () => {
+    const brain = createBrainAdapter("/tmp/ordinary-quarantine-metadata.db");
+    const mockBrain = brainInstances[0]!;
+    const event = {
+      id: 42,
+      type: "success",
+      summary: "ordinary domain quarantine metadata",
+      details: { quarantine: { field: "details", reason: "business review", eventId: 42 } },
+      createdAt: "2026-07-20T00:00:00.000Z",
+    };
+    mockBrain.episodic.recall.mockReturnValue([event]);
+    mockBrain.episodic.recent.mockReturnValue([event]);
+
+    await expect(brain.query({
+      query: "ordinary",
+      type: "episodic",
+      readScope: "all",
+      limit: 1,
+    })).resolves.toEqual([
+      expect.objectContaining({ key: "42", value: "ordinary domain quarantine metadata" }),
+    ]);
   });
 
   it("exports scoped project memory with safe redaction by default", async () => {
@@ -1098,6 +1166,31 @@ describe("createBrainAdapter", () => {
       total: 2,
       compactionCandidates: 1,
     });
+  });
+
+  it("hides quarantined episodic rows from scoped retention reports", async () => {
+    const brain = createBrainAdapter("/tmp/quarantined-retention.db");
+    brainInstances[0].memoryRetentionReport.mockReturnValueOnce({
+      generatedAt: "2026-07-21T00:00:00.000Z",
+      policies: [],
+      counts: { total: 1, protected: 0, expired: 0, nearingExpiry: 0, compactionCandidates: 0 },
+      entries: [{
+        store: "episodic",
+        key: "17",
+        agentId: null,
+        class: "transient_observation",
+        action: "retain",
+        policy: { class: "transient_observation", retentionDays: 30, compactPriority: 1, protected: false, description: "test" },
+        protected: false,
+        reason: "test",
+      }],
+      compactionCandidates: [],
+    });
+
+    const report = await brain.memoryRetentionReport({ readScope: "shared" });
+
+    expect(report.entries).toEqual([]);
+    expect(report.counts.total).toBe(0);
   });
 
   it("counts existing scoped compaction candidates before applying retention budgets", async () => {
@@ -1233,7 +1326,7 @@ describe("createBrainAdapter", () => {
     );
   });
 
-  it("keeps all-scope episodic reads bounded while scoped reads can backfill visible rows", async () => {
+  it("backfills visible rows for both all-scope and scoped episodic reads", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
     const mockBrain = brainInstances[0];
 
@@ -1250,9 +1343,9 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.episodic.recall).toHaveBeenNthCalledWith(
       1,
       "episode",
-      7,
+      -1,
     );
-    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(1, 100);
+    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(1, -1);
     expect(mockBrain.episodic.recall).toHaveBeenNthCalledWith(
       2,
       "episode",

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -946,8 +946,8 @@ describe("createBrainAdapter", () => {
     expect(text).not.toContain("beta episode");
 
     const mockBrain = brainInstances[0];
-    expect(mockBrain.episodic.recall).toHaveBeenCalledWith("entry", -1);
-    expect(mockBrain.episodic.recent).toHaveBeenCalledWith(-1);
+    expect(mockBrain.episodic.recall).not.toHaveBeenCalledWith("entry", -1);
+    expect(mockBrain.episodic.recent).not.toHaveBeenCalledWith(-1);
   });
 
   it("fails closed for episodic events whose details scope was quarantined", async () => {
@@ -1030,8 +1030,10 @@ describe("createBrainAdapter", () => {
     expect(exported.episodic).toEqual([
       expect.objectContaining({ id: 101, summary: "readable backfill event" }),
     ]);
-    expect(mockBrain.episodic.recall).toHaveBeenCalledWith("event", -1);
-    expect(mockBrain.episodic.recent).toHaveBeenCalledWith(-1);
+    expect(mockBrain.episodic.recall).not.toHaveBeenCalledWith("event", -1);
+    expect(mockBrain.episodic.recent).not.toHaveBeenCalledWith(-1);
+    expect(mockBrain.episodic.recall.mock.calls.every(([, scanLimit]) => scanLimit > 0)).toBe(true);
+    expect(mockBrain.episodic.recent.mock.calls.every(([scanLimit]) => scanLimit > 0)).toBe(true);
   });
 
   it("does not hide ordinary episodic metadata with an incomplete quarantine marker", async () => {
@@ -1343,15 +1345,15 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.episodic.recall).toHaveBeenNthCalledWith(
       1,
       "episode",
-      -1,
+      100,
     );
-    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(1, -1);
+    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(1, 200);
     expect(mockBrain.episodic.recall).toHaveBeenNthCalledWith(
       2,
       "episode",
-      -1,
+      100,
     );
-    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(2, -1);
+    expect(mockBrain.episodic.recent).toHaveBeenNthCalledWith(2, 200);
   });
 
   it("translates right-to-forget exact keys for agent-scoped working memory", async () => {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -1036,6 +1036,36 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.episodic.recent.mock.calls.every(([scanLimit]) => scanLimit > 0)).toBe(true);
   });
 
+  it("caps visibility backfill scans when every episodic row is hidden", async () => {
+    const brain = createBrainAdapter("/tmp/quarantined-backfill-cap.db");
+    const mockBrain = brainInstances[0]!;
+    mockBrain.episodic.recall.mockImplementation((_query: string, limit: number) =>
+      Array.from({ length: limit }, (_, index) => ({
+        id: index + 1,
+        type: "success",
+        summary: `quarantined event ${index + 1}`,
+        details: {
+          quarantine: {
+            field: "details",
+            eventId: index + 1,
+            reason: "invalid JSON",
+          },
+        },
+        createdAt: "2026-07-20T00:00:00.000Z",
+      })),
+    );
+
+    await expect(brain.query({
+      query: "event",
+      type: "episodic",
+      readScope: "all",
+      limit: 1,
+    })).resolves.toEqual([]);
+
+    expect(mockBrain.episodic.recall.mock.calls.at(-1)?.[1]).toBe(10_000);
+    expect(mockBrain.episodic.recall).toHaveBeenCalledTimes(8);
+  });
+
   it("does not hide ordinary episodic metadata with an incomplete quarantine marker", async () => {
     const brain = createBrainAdapter("/tmp/ordinary-quarantine-metadata.db");
     const mockBrain = brainInstances[0]!;

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -1291,6 +1291,19 @@ describe("createBrainAdapter", () => {
     expect(report.compactionCandidates).toEqual([]);
   });
 
+  it("rejects invalid all-scope retention budgets before post-filtering", async () => {
+    const brain = createBrainAdapter("/tmp/invalid-all-retention.db");
+
+    for (const maxEntries of [0, -1, 1.5, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+      await expect(brain.memoryRetentionReport({
+        readScope: "all",
+        maxEntries,
+      })).rejects.toThrow("maxEntries must be a positive safe integer");
+    }
+
+    expect(brainInstances[0].memoryRetentionReport).not.toHaveBeenCalled();
+  });
+
   it("counts existing scoped compaction candidates before applying retention budgets", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
     brainInstances[0].memoryRetentionReport.mockReturnValueOnce({

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -950,6 +950,45 @@ describe("createBrainAdapter", () => {
     expect(mockBrain.episodic.recent).toHaveBeenCalledWith(-1);
   });
 
+  it("fails closed for episodic events whose details scope was quarantined", async () => {
+    const brain = createBrainAdapter("/tmp/quarantined-scope.db");
+    const mockBrain = brainInstances[0]!;
+    const quarantinedEvent = {
+      id: "evt-quarantined",
+      type: "success",
+      summary: "private quarantined episode",
+      details: {
+        quarantine: {
+          field: "details",
+          eventId: 17,
+          reason: "invalid JSON",
+        },
+      },
+      createdAt: "2026-07-20T00:00:00.000Z",
+    };
+    mockBrain.episodic.recall.mockReturnValue([quarantinedEvent]);
+    mockBrain.episodic.recent.mockReturnValue([quarantinedEvent]);
+
+    await expect(brain.query({
+      query: "private",
+      type: "episodic",
+      readScope: "all",
+      limit: 10,
+    })).resolves.toEqual([]);
+    const sharedFrontload = await brain.frontload({ readScope: "shared" });
+    expect(sharedFrontload.find((section) => section.type === "episodic")).toBeUndefined();
+    const agentFrontload = await brain.frontload({
+      readScope: "agent",
+      agentId: "another-agent",
+    });
+    expect(agentFrontload.find((section) => section.type === "episodic")).toBeUndefined();
+    const exported = await brain.exportProjectMemory({
+      readScope: "all",
+      limit: 10,
+    });
+    expect(exported.episodic).toEqual([]);
+  });
+
   it("exports scoped project memory with safe redaction by default", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -1059,6 +1059,31 @@ describe("createBrainAdapter", () => {
     ]);
   });
 
+  it("does not hide ordinary episodic metadata that only contains a quarantine child", async () => {
+    const brain = createBrainAdapter("/tmp/ordinary-quarantine-child.db");
+    const mockBrain = brainInstances[0]!;
+    const event = {
+      id: 43,
+      type: "success",
+      summary: "ordinary event with diagnostic-looking metadata",
+      details: {
+        quarantine: { field: "details", reason: "invalid JSON", eventId: 43 },
+        note: "ordinary domain metadata",
+      },
+      createdAt: "2026-07-20T00:00:00.000Z",
+    };
+    mockBrain.episodic.recall.mockReturnValue([event]);
+
+    await expect(brain.query({
+      query: "ordinary",
+      type: "episodic",
+      readScope: "all",
+      limit: 1,
+    })).resolves.toEqual([
+      expect.objectContaining({ key: "43", value: "ordinary event with diagnostic-looking metadata" }),
+    ]);
+  });
+
   it("exports scoped project memory with safe redaction by default", async () => {
     const brain = createBrainAdapter("/tmp/beast.db");
 
@@ -1193,6 +1218,47 @@ describe("createBrainAdapter", () => {
 
     expect(report.entries).toEqual([]);
     expect(report.counts.total).toBe(0);
+  });
+
+  it("applies all-scope retention budgets after hiding quarantined rows", async () => {
+    const brain = createBrainAdapter("/tmp/quarantined-all-retention.db");
+    brainInstances[0].memoryRetentionReport.mockReturnValueOnce({
+      generatedAt: "2026-07-21T00:00:00.000Z",
+      policies: [],
+      counts: { total: 2, protected: 0, expired: 0, nearingExpiry: 0, compactionCandidates: 0 },
+      entries: [
+        {
+          store: "episodic",
+          key: "17",
+          agentId: null,
+          class: "transient_observation",
+          action: "retain",
+          policy: { class: "transient_observation", retentionDays: 30, compactPriority: 1, protected: false, description: "test" },
+          protected: false,
+          reason: "test",
+        },
+        {
+          store: "working",
+          key: "shared.visible",
+          class: "environment_fact",
+          action: "retain",
+          policy: { class: "environment_fact", retentionDays: 180, compactPriority: 30, protected: false, description: "env" },
+          protected: false,
+          reason: "retain",
+        },
+      ],
+      compactionCandidates: [],
+    });
+
+    const report = await brain.memoryRetentionReport({ readScope: "all", maxEntries: 1 });
+
+    expect(brainInstances[0].memoryRetentionReport).toHaveBeenCalledWith({
+      maxEntries: Number.MAX_SAFE_INTEGER,
+    });
+    expect(report.entries).toEqual([
+      expect.objectContaining({ key: "shared.visible", action: "retain" }),
+    ]);
+    expect(report.compactionCandidates).toEqual([]);
   });
 
   it("counts existing scoped compaction candidates before applying retention budgets", async () => {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -186,6 +186,7 @@ const SUPPORTED_MEMORY_TYPES = ["working", "episodic"] as const;
 const DEFAULT_QUERY_LIMIT = 20;
 const DEFAULT_ATTRIBUTION_LIMIT = 50;
 const MAX_QUERY_LIMIT = 1000;
+const MAX_EPISODIC_VISIBILITY_SCAN = 10_000;
 const MEMORY_ACCESS_AUDIT_SCAN_MULTIPLIER = 50;
 const MAX_MEMORY_ACCESS_AUDIT_SCAN_LIMIT = 10_000;
 const AGENT_WORKING_KEY_PREFIX = "__fbeast_agent_memory__/";
@@ -470,14 +471,19 @@ function collectVisibleEntries<T>(
   canRead: (entry: T) => boolean,
 ): T[] {
   if (limit <= 0) return [];
-  const batchSize = Math.max(100, limit * 2);
+  let scanLimit = Math.min(MAX_EPISODIC_VISIBILITY_SCAN, Math.max(100, limit * 2));
 
-  for (let scanLimit = batchSize; ; scanLimit += batchSize) {
+  for (;;) {
     const entries = fetchEntries(scanLimit);
     const visible = takeVisibleEntries(entries, limit, canRead);
-    if (visible.length >= limit || entries.length < scanLimit) {
+    if (
+      visible.length >= limit
+      || entries.length < scanLimit
+      || scanLimit >= MAX_EPISODIC_VISIBILITY_SCAN
+    ) {
       return visible;
     }
+    scanLimit = Math.min(MAX_EPISODIC_VISIBILITY_SCAN, scanLimit * 2);
   }
 }
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -391,6 +391,7 @@ function formatWorkingEntryValue(entry: { value: string; expiresAt?: string }): 
 
 function parseAgentFromEpisodicDetails(
   details: Record<string, unknown> | undefined,
+  eventId?: unknown,
 ): string | null | undefined {
   if (!details) return undefined;
   const quarantine = details["quarantine"];
@@ -398,7 +399,9 @@ function parseAgentFromEpisodicDetails(
     quarantine !== null &&
     typeof quarantine === "object" &&
     !Array.isArray(quarantine) &&
-    (quarantine as Record<string, unknown>)["field"] === "details"
+    (quarantine as Record<string, unknown>)["field"] === "details" &&
+    (quarantine as Record<string, unknown>)["reason"] === "invalid JSON" &&
+    (quarantine as Record<string, unknown>)["eventId"] === eventId
   ) {
     return null;
   }
@@ -1175,13 +1178,12 @@ export function createBrainAdapter(
 
       // Search episodic memory
       if (!memoryType || memoryType === "episodic") {
-        const episodicLimit = readScope.readScope === "all" ? limit : -1;
         const events = takeVisibleEntries(
-          brain.episodic.recall(input.query, episodicLimit) as EpisodicEvent[],
+          brain.episodic.recall(input.query, -1) as EpisodicEvent[],
           limit,
           (event) =>
             canReadMemoryEntry(
-              parseAgentFromEpisodicDetails(event.details),
+              parseAgentFromEpisodicDetails(event.details, event.id),
               readScope,
             ),
         );
@@ -1259,13 +1261,12 @@ export function createBrainAdapter(
       }
 
       // Recent episodic events
-      const episodicLimit = readScope.readScope === "all" ? 100 : -1;
       const events = takeVisibleEntries(
-        brain.episodic.recent(episodicLimit) as EpisodicEvent[],
+        brain.episodic.recent(-1) as EpisodicEvent[],
         100,
         (event) =>
           canReadMemoryEntry(
-            parseAgentFromEpisodicDetails(event.details),
+            parseAgentFromEpisodicDetails(event.details, event.id),
             readScope,
           ),
       );
@@ -1307,17 +1308,16 @@ export function createBrainAdapter(
           return exported;
         });
 
-      const episodicLimit = readScope.readScope === "all" ? limit : -1;
       const episodic = takeVisibleEntries(
-        brain.episodic.recent(episodicLimit) as EpisodicEvent[],
+        brain.episodic.recent(-1) as EpisodicEvent[],
         limit,
         (event) =>
           canReadMemoryEntry(
-            parseAgentFromEpisodicDetails(event.details),
+            parseAgentFromEpisodicDetails(event.details, event.id),
             readScope,
           ),
       ).map((event) => {
-        const entryAgentId = parseAgentFromEpisodicDetails(event.details);
+        const entryAgentId = parseAgentFromEpisodicDetails(event.details, event.id);
         const exported: MemoryExportEpisodicEntry = {
           ...(event.id === undefined ? {} : { id: event.id }),
           eventType: event.type,

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1547,6 +1547,12 @@ export function createBrainAdapter(
 
     async memoryRetentionReport(input = {}) {
       const readScope = resolveMemoryReadScope(input);
+      if (
+        input.maxEntries !== undefined
+        && (!Number.isSafeInteger(input.maxEntries) || input.maxEntries < 1)
+      ) {
+        throw new Error("maxEntries must be a positive safe integer");
+      }
       const reportOptions: MemoryRetentionReportOptions = {
         ...(input.now === undefined ? {} : { now: input.now }),
         ...(input.expiryHorizonMs === undefined ? {} : { expiryHorizonMs: input.expiryHorizonMs }),

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -391,8 +391,17 @@ function formatWorkingEntryValue(entry: { value: string; expiresAt?: string }): 
 
 function parseAgentFromEpisodicDetails(
   details: Record<string, unknown> | undefined,
-): string | undefined {
+): string | null | undefined {
   if (!details) return undefined;
+  const quarantine = details["quarantine"];
+  if (
+    quarantine !== null &&
+    typeof quarantine === "object" &&
+    !Array.isArray(quarantine) &&
+    (quarantine as Record<string, unknown>)["field"] === "details"
+  ) {
+    return null;
+  }
   return details["__fbeastMemoryScope"] === AGENT_MEMORY_SCOPE_MARKER &&
     typeof details["agentId"] === "string"
     ? details["agentId"]
@@ -429,9 +438,12 @@ function resolveMemoryReadScope(input: MemoryScopeInput): {
 }
 
 function canReadMemoryEntry(
-  entryAgentId: string | undefined,
+  entryAgentId: string | null | undefined,
   scope: { readScope: MemoryReadScope; agentId?: string },
 ): boolean {
+  // Corrupt episodic details can no longer prove whether an event was shared or
+  // agent-scoped, so quarantine envelopes are hidden from every memory scope.
+  if (entryAgentId === null) return false;
   if (scope.readScope === "all") return true;
   if (scope.readScope === "shared") return entryAgentId === undefined;
   return entryAgentId === undefined || entryAgentId === scope.agentId;
@@ -1316,7 +1328,7 @@ export function createBrainAdapter(
           ...(event.details === undefined
             ? {}
             : { details: redactExportField(event.details, redaction, "details") }),
-          ...(entryAgentId === undefined
+          ...(entryAgentId == null
             ? {}
             : {
                 agentId: redactExportField(

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -460,6 +460,23 @@ function takeVisibleEntries<T>(
   return entries.filter(canRead).slice(0, limit);
 }
 
+function collectVisibleEntries<T>(
+  fetchEntries: (limit: number) => T[],
+  limit: number,
+  canRead: (entry: T) => boolean,
+): T[] {
+  if (limit <= 0) return [];
+  const batchSize = Math.max(100, limit * 2);
+
+  for (let scanLimit = batchSize; ; scanLimit += batchSize) {
+    const entries = fetchEntries(scanLimit);
+    const visible = takeVisibleEntries(entries, limit, canRead);
+    if (visible.length >= limit || entries.length < scanLimit) {
+      return visible;
+    }
+  }
+}
+
 function scopedReportEntry(entry: MemoryRetentionEntryReport): MemoryRetentionEntryReport {
   if (entry.store !== "working") return entry;
   const scoped = parseScopedWorkingExportEntry(entry.key, undefined);
@@ -1178,8 +1195,8 @@ export function createBrainAdapter(
 
       // Search episodic memory
       if (!memoryType || memoryType === "episodic") {
-        const events = takeVisibleEntries(
-          brain.episodic.recall(input.query, -1) as EpisodicEvent[],
+        const events = collectVisibleEntries(
+          (scanLimit) => brain.episodic.recall(input.query, scanLimit) as EpisodicEvent[],
           limit,
           (event) =>
             canReadMemoryEntry(
@@ -1261,8 +1278,8 @@ export function createBrainAdapter(
       }
 
       // Recent episodic events
-      const events = takeVisibleEntries(
-        brain.episodic.recent(-1) as EpisodicEvent[],
+      const events = collectVisibleEntries(
+        (scanLimit) => brain.episodic.recent(scanLimit) as EpisodicEvent[],
         100,
         (event) =>
           canReadMemoryEntry(
@@ -1308,8 +1325,8 @@ export function createBrainAdapter(
           return exported;
         });
 
-      const episodic = takeVisibleEntries(
-        brain.episodic.recent(-1) as EpisodicEvent[],
+      const episodic = collectVisibleEntries(
+        (scanLimit) => brain.episodic.recent(scanLimit) as EpisodicEvent[],
         limit,
         (event) =>
           canReadMemoryEntry(

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -394,11 +394,15 @@ function parseAgentFromEpisodicDetails(
   eventId?: unknown,
 ): string | null | undefined {
   if (!details) return undefined;
+  const detailKeys = Object.keys(details);
   const quarantine = details["quarantine"];
   if (
+    detailKeys.length === 1 &&
+    detailKeys[0] === "quarantine" &&
     quarantine !== null &&
     typeof quarantine === "object" &&
     !Array.isArray(quarantine) &&
+    Object.keys(quarantine as Record<string, unknown>).sort().join(",") === "eventId,field,reason" &&
     (quarantine as Record<string, unknown>)["field"] === "details" &&
     (quarantine as Record<string, unknown>)["reason"] === "invalid JSON" &&
     (quarantine as Record<string, unknown>)["eventId"] === eventId
@@ -1540,17 +1544,14 @@ export function createBrainAdapter(
       const reportOptions: MemoryRetentionReportOptions = {
         ...(input.now === undefined ? {} : { now: input.now }),
         ...(input.expiryHorizonMs === undefined ? {} : { expiryHorizonMs: input.expiryHorizonMs }),
-        ...(readScope.readScope === "all" && input.maxEntries !== undefined
-          ? { maxEntries: input.maxEntries }
-          : {}),
-        ...(readScope.readScope !== "all" && input.maxEntries !== undefined
+        ...(input.maxEntries !== undefined
           ? { maxEntries: Number.MAX_SAFE_INTEGER }
           : {}),
       };
       return filterRetentionReportByScope(
         brain.memoryRetentionReport(reportOptions),
         readScope,
-        readScope.readScope === "all" ? undefined : input.maxEntries,
+        input.maxEntries,
       );    },
 
     async forget(key, input = {}) {

--- a/tasks/pr-3471-codex-remediation-progress.md
+++ b/tasks/pr-3471-codex-remediation-progress.md
@@ -1,0 +1,15 @@
+# PR #3471 Codex remediation progress
+
+- [x] Verify isolated workspace, GitHub authentication, and exact live PR head.
+- [x] Inspect the five current-head Codex findings.
+- [x] Trace affected adapter and SQLite implementations and existing tests.
+- [x] Add focused failing regression(s) for adapter all-scope backfill and strict quarantine envelope detection.
+- [x] Implement minimal adapter fixes and pass focused tests (72/72).
+- [x] Add focused failing regression(s) for plaintext recall re-scoring, scoped retention fail-closed behavior, and quarantined audit preservation.
+- [x] Implement minimal SQLite fixes and pass focused tests (270/270).
+- [x] Run full relevant tests (brain 325/325; MCP suite 605/605), lint, typecheck, and build. Root test sweep has one unrelated orchestrator cleanup-test timeout at `dep-factory-providers.test.ts:258`.
+- [ ] Commit only scoped code/test changes.
+- [ ] Update the existing PR branch with lease safety.
+- [ ] Reply to and resolve Codex threads 3624887842, 3624887846, 3624887851, 3624887854, and 3624887856.
+- [ ] Verify exact remote head and zero unresolved target Codex threads.
+- [ ] Record structured review handoff and block for reviewer approval.

--- a/tasks/pr-3471-codex-remediation-progress.md
+++ b/tasks/pr-3471-codex-remediation-progress.md
@@ -15,6 +15,22 @@
 - [ ] Record review handoff evidence on the kanban card.
 - [ ] Block the task for required human review.
 
+## Fresh current-head review round (`ac77da5c8`)
+
+- [x] Add regressions proving plaintext recall ignores quarantine metadata while retaining bounded backfill.
+- [x] Add a regression proving malformed audit details are scanned before the quarantine-audit exemption.
+- [x] Add a regression proving bounded frontload backfills in batches instead of reading the whole episodic table.
+- [x] Implement the minimal fixes and run affected package checks.
+- [ ] Publish with lease safety, reply to and resolve threads 3626006123, 3626006126, 3626006130, and 3626006134.
+- [ ] Record exact-head CI/Codex evidence and finish the Kanban handoff.
+
+Verification for this round:
+
+- `@franken/brain`: 330/330 tests passed; lint and typecheck passed.
+- `@franken/mcp-suite`: 605/605 tests passed; lint and typecheck passed (pre-existing warnings only).
+- Repository typecheck, build, and lint passed.
+- Repository test sweep reached 7/10 successful package tasks; three unrelated orchestrator timing failures all passed together in isolation (122/122).
+
 ## Review handoff notes
 
 - Current implementation commit: `e7915c8e2f60b25abe299380b0b3dce563567c65`.

--- a/tasks/pr-3471-codex-remediation-progress.md
+++ b/tasks/pr-3471-codex-remediation-progress.md
@@ -8,8 +8,16 @@
 - [x] Add focused failing regression(s) for plaintext recall re-scoring, scoped retention fail-closed behavior, and quarantined audit preservation.
 - [x] Implement minimal SQLite fixes and pass focused tests (270/270).
 - [x] Run full relevant tests (brain 325/325; MCP suite 605/605), lint, typecheck, and build. Root test sweep has one unrelated orchestrator cleanup-test timeout at `dep-factory-providers.test.ts:258`.
-- [ ] Commit only scoped code/test changes.
-- [ ] Update the existing PR branch with lease safety.
-- [ ] Reply to and resolve Codex threads 3624887842, 3624887846, 3624887851, 3624887854, and 3624887856.
-- [ ] Verify exact remote head and zero unresolved target Codex threads.
-- [ ] Record structured review handoff and block for reviewer approval.
+- [x] Commit only scoped code/test changes.
+- [x] Fast-forward the existing PR branch after exact-head verification.
+- [x] Reply to and resolve Codex threads 3624887842, 3624887846, 3624887851, 3624887854, and 3624887856.
+- [x] Confirm zero target Codex threads remain unresolved.
+- [ ] Record review handoff evidence on the kanban card.
+- [ ] Block the task for required human review.
+
+## Review handoff notes
+
+- Current implementation commit: `e7915c8e2f60b25abe299380b0b3dce563567c65`.
+- Root `npm run test` reached 8/10 successful package tasks and was blocked only by an unrelated existing 5-second timeout in `packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts:258`; the same test timed out in isolation.
+- CI `build-test-lint (1337)` is blocked at the dependency vulnerability audit; local lint, typecheck, build, and both affected package suites pass.
+- A delayed Codex review produced three new current-head threads after the scoped five were fixed. The invocation count already exceeds the review-loop cap, so no further trigger was sent; the reviewer must triage threads `PRRT_kwDORezACM6SsqCC`, `PRRT_kwDORezACM6SsqCE`, and `PRRT_kwDORezACM6SsqCJ`.

--- a/tasks/pr-3471-codex-remediation-progress.md
+++ b/tasks/pr-3471-codex-remediation-progress.md
@@ -21,8 +21,8 @@
 - [x] Add a regression proving malformed audit details are scanned before the quarantine-audit exemption.
 - [x] Add a regression proving bounded frontload backfills in batches instead of reading the whole episodic table.
 - [x] Implement the minimal fixes and run affected package checks.
-- [ ] Publish with lease safety, reply to and resolve threads 3626006123, 3626006126, 3626006130, and 3626006134.
-- [ ] Record exact-head CI/Codex evidence and finish the Kanban handoff.
+- [x] Publish with lease safety, reply to and resolve threads 3626006123, 3626006126, 3626006130, and 3626006134.
+- [x] Record implementation-head CI/Codex evidence and finish the Kanban handoff.
 
 Verification for this round:
 
@@ -30,6 +30,9 @@ Verification for this round:
 - `@franken/mcp-suite`: 605/605 tests passed; lint and typecheck passed (pre-existing warnings only).
 - Repository typecheck, build, and lint passed.
 - Repository test sweep reached 7/10 successful package tasks; three unrelated orchestrator timing failures all passed together in isolation (122/122).
+- Implementation commit `ce78ca08288d48e34b62ecf2c4999a542b99d0cf` passed all four CI checks, including `build-test-lint (1337)`.
+- All four target threads were answered and resolved; zero Codex-authored review threads remain unresolved.
+- A fresh Codex trigger was not sent because the PR already has 13 `@codex review` invocations, above the five-invocation safety cap.
 
 ## Review handoff notes
 

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -6,6 +6,9 @@
 ## 2026-07-21 — Dashboard chat model precedence
 - For conversational dashboard replies, the selected provider's `providers.overrides.<provider>.model` wins over `chat.model`; `chat.model` only replaces the provider's built-in chat model when no selected-provider model override exists. Dashboard `/run` uses a separate execution adapter that ignores both model settings and provider `extraArgs`, although it does apply trusted command overrides. Trace both adapter construction paths and runtime provider override resolution before documenting dashboard behavior.
 
+## 2026-07-20 — Episodic JSON quarantine reads
+- When an optional persisted JSON payload is corrupt, preserve the valid row envelope and replace only that payload with explicit quarantine metadata; thread the row id into read-audit diagnostics across every query path, including nested empty-query and encrypted scans, so operators can repair the exact record without losing timeline evidence.
+
 ## 2026-07-20 — Outbound request deadlines must include response consumption
 - JavaScript `fetch()` resolves when response headers arrive, not when the body has been consumed. A hard outbound-delivery deadline must wrap both the fetch and all body/error parsing under the same abort signal and timer; otherwise a provider can send headers and stall forever during `json()` or `text()`.
 - In fresh monorepo worktrees, run the root build before package-local TypeScript checks so internal workspace declaration outputs exist and unrelated module-resolution errors do not mask the feature result.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -9,6 +9,8 @@
 ## 2026-07-20 — Episodic JSON quarantine reads
 - When an optional persisted JSON payload is corrupt, preserve the valid row envelope and replace only that payload with explicit quarantine metadata; thread the row id into read-audit diagnostics across every query path, including nested empty-query and encrypted scans, so operators can repair the exact record without losing timeline evidence.
 - Treat quarantine metadata as diagnostics, not domain content: exclude it from encrypted recall scoring, let consumers that count meaningful failure windows backfill past quarantined rows, and preserve protected retention classification only in the retention path rather than weakening strict audit validation globally.
+- Any consumer whose authorization scope lives inside the quarantined payload must fail closed for every read scope, including privileged `all`; otherwise corrupt private rows are silently reclassified as shared. Plaintext SQL recall must also re-check quarantined rows against their surviving summary so a keyword that exists only in corrupt details cannot produce a false match.
+- Snapshot replay should recognize quarantined right-to-forget audit envelopes from their fixed summary plus strict quarantine shape before applying deletion-guard assertions; keep that exception narrow so ordinary quarantined events cannot bypass replay guards.
 
 ## 2026-07-20 — Outbound request deadlines must include response consumption
 - JavaScript `fetch()` resolves when response headers arrive, not when the body has been consumed. A hard outbound-delivery deadline must wrap both the fetch and all body/error parsing under the same abort signal and timer; otherwise a provider can send headers and stall forever during `json()` or `text()`.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -486,3 +486,6 @@
 
 ## 2026-07-20 — Terminal input ownership
 - Interactive CLI processes must have one long-lived stdin/readline owner. Inject that owner's question and cancellation functions into approval/governance channels rather than creating a second readline interface; create the owner lazily so startup work cannot consume early keystrokes, and abort expired questions without closing the shared interface. Preserve the existing non-TTY fail-closed path and verify chat-to-approval input routing with a real scripted PTY.
+
+## 2026-07-21 — Quarantine-envelope import hardening
+- Treat synthetic quarantine metadata as a strict, exact envelope at trust boundaries: validate the outer and inner key sets plus field, reason, and matching event ID before granting audit exemptions. Report both newly detected malformed rows and already-serialized quarantine envelopes through read audit diagnostics so handoff/import does not erase repair visibility.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -8,6 +8,7 @@
 
 ## 2026-07-20 — Episodic JSON quarantine reads
 - When an optional persisted JSON payload is corrupt, preserve the valid row envelope and replace only that payload with explicit quarantine metadata; thread the row id into read-audit diagnostics across every query path, including nested empty-query and encrypted scans, so operators can repair the exact record without losing timeline evidence.
+- Treat quarantine metadata as diagnostics, not domain content: exclude it from encrypted recall scoring, let consumers that count meaningful failure windows backfill past quarantined rows, and preserve protected retention classification only in the retention path rather than weakening strict audit validation globally.
 
 ## 2026-07-20 — Outbound request deadlines must include response consumption
 - JavaScript `fetch()` resolves when response headers arrive, not when the body has been consumed. A hard outbound-delivery deadline must wrap both the fetch and all body/error parsing under the same abort signal and timer; otherwise a provider can send headers and stall forever during `json()` or `text()`.


### PR DESCRIPTION
## Summary
- preserve episodic rows whose persisted `details` payload is malformed by returning a quarantine marker instead of dropping the event
- report quarantined event IDs through episodic read access-audit entries for repair workflows
- cover `recent`, `recentFailures`, and `recall` behavior with malformed persisted JSON

## Test Plan
- `npx vitest run --root packages/franken-brain --config vitest.config.ts`
- `npm run typecheck --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm run build --workspace @franken/brain`
- `git diff --check`

Closes #3137
