### PR TITLE
test(config): derive path aliases from package metadata

### DIFF
--- a/tests/helpers/workspaces.ts
+++ b/tests/helpers/workspaces.ts
@@ -3,21 +3,21 @@ import { join, posix } from "node:path";
 
 export const ROOT = join(import.meta.dirname, "..", "..");
 
+export type PackageExportTarget =
+  | string
+  | {
+      import?: string;
+      types?: string;
+      default?: string;
+    };
+
 export type PackageJson = {
   name?: string;
   version?: string;
   workspaces?: string[];
   main?: string;
   types?: string;
-  exports?: Record<
-    string,
-    | string
-    | {
-        import?: string;
-        types?: string;
-        default?: string;
-      }
-  >;
+  exports?: PackageExportTarget | Record<string, PackageExportTarget>;
   scripts?: Record<string, string>;
   license?: string;
   description?: string;
@@ -117,34 +117,37 @@ const sourcePathFromPublishedEntry = (publishedEntry: string): string | null => 
 };
 
 const getPublishedEntry = (
-  target: NonNullable<PackageJson["exports"]>[string],
+  target: PackageExportTarget,
 ): string | undefined =>
   typeof target === "string"
     ? target
     : (target.types ?? target.import ?? target.default);
 
+export const getPackageExportEntries = (
+  packageJson: PackageJson,
+): Array<[string, PackageExportTarget]> => {
+  const packageExports = packageJson.exports;
+  if (typeof packageExports === "string") {
+    return [[".", packageExports]];
+  }
+  if (packageExports !== undefined) {
+    const exportNames = Object.keys(packageExports);
+    return exportNames.some((exportName) => exportName.startsWith("."))
+      ? Object.entries(packageExports)
+      : [[".", packageExports]];
+  }
+
+  const fallbackEntry = packageJson.types ?? packageJson.main;
+  return fallbackEntry === undefined ? [] : [[".", fallbackEntry]];
+};
+
 export const getWorkspaceSourceAliases = (): Record<string, string> => {
   const aliases: Array<[string, string]> = [];
 
   for (const workspacePackage of getWorkspacePackages()) {
-    const exportedEntries = Object.entries(
-      workspacePackage.packageJson.exports ?? {},
-    );
-    const entries: Array<
-      [string, NonNullable<PackageJson["exports"]>[string] | undefined]
-    > =
-      exportedEntries.length > 0
-        ? exportedEntries
-        : [
-            [
-              ".",
-              workspacePackage.packageJson.types ??
-                workspacePackage.packageJson.main,
-            ],
-          ];
+    const entries = getPackageExportEntries(workspacePackage.packageJson);
 
     for (const [exportName, target] of entries) {
-      if (exportName === undefined || target === undefined) continue;
       const publishedEntry = getPublishedEntry(target);
       if (publishedEntry === undefined) continue;
       const sourcePath = sourcePathFromPublishedEntry(publishedEntry);

--- a/tests/helpers/workspaces.ts
+++ b/tests/helpers/workspaces.ts
@@ -7,6 +7,17 @@ export type PackageJson = {
   name?: string;
   version?: string;
   workspaces?: string[];
+  main?: string;
+  types?: string;
+  exports?: Record<
+    string,
+    | string
+    | {
+        import?: string;
+        types?: string;
+        default?: string;
+      }
+  >;
   scripts?: Record<string, string>;
   license?: string;
   description?: string;
@@ -90,6 +101,76 @@ export const getWorkspacePackages = (): WorkspacePackage[] => {
       packageJson,
     };
   });
+};
+
+const sourcePathFromPublishedEntry = (publishedEntry: string): string | null => {
+  const normalizedEntry = publishedEntry.replace(/^\.\//u, "");
+  if (!normalizedEntry.startsWith("dist/")) return null;
+
+  if (normalizedEntry.endsWith(".d.ts")) {
+    return `src/${normalizedEntry.slice("dist/".length, -".d.ts".length)}.ts`;
+  }
+  if (normalizedEntry.endsWith(".js")) {
+    return `src/${normalizedEntry.slice("dist/".length, -".js".length)}.ts`;
+  }
+  return null;
+};
+
+const getPublishedEntry = (
+  target: NonNullable<PackageJson["exports"]>[string],
+): string | undefined =>
+  typeof target === "string"
+    ? target
+    : (target.types ?? target.import ?? target.default);
+
+export const getWorkspaceSourceAliases = (): Record<string, string> => {
+  const aliases: Array<[string, string]> = [];
+
+  for (const workspacePackage of getWorkspacePackages()) {
+    const exportedEntries = Object.entries(
+      workspacePackage.packageJson.exports ?? {},
+    );
+    const entries: Array<
+      [string, NonNullable<PackageJson["exports"]>[string] | undefined]
+    > =
+      exportedEntries.length > 0
+        ? exportedEntries
+        : [
+            [
+              ".",
+              workspacePackage.packageJson.types ??
+                workspacePackage.packageJson.main,
+            ],
+          ];
+
+    for (const [exportName, target] of entries) {
+      if (exportName === undefined || target === undefined) continue;
+      const publishedEntry = getPublishedEntry(target);
+      if (publishedEntry === undefined) continue;
+      const sourcePath = sourcePathFromPublishedEntry(publishedEntry);
+      if (sourcePath === null) {
+        throw new Error(
+          `${workspacePackage.name} export ${exportName} has unsupported entry ${publishedEntry}`,
+        );
+      }
+
+      const alias =
+        exportName === "."
+          ? workspacePackage.name
+          : `${workspacePackage.name}/${exportName.replace(/^\.\//u, "")}`;
+      const targetPath = `./${workspacePackage.dir}/${sourcePath}`;
+      if (!existsSync(join(ROOT, workspacePackage.dir, sourcePath))) {
+        throw new Error(
+          `${alias} maps from ${publishedEntry} to missing source entry ${targetPath}`,
+        );
+      }
+      aliases.push([alias, targetPath]);
+    }
+  }
+
+  return Object.fromEntries(
+    aliases.sort(([left], [right]) => left.localeCompare(right)),
+  );
 };
 
 export const getWorkspacePackageDirNames = (): string[] =>

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { ROOT, readJson, getWorkspacePackages } from "./helpers/workspaces.js";
+import {
+  ROOT,
+  readJson,
+  getWorkspacePackages,
+  getWorkspaceSourceAliases,
+} from "./helpers/workspaces.js";
 
 const hasTypeScriptSource = (relDir: string): boolean => {
   const absDir = join(ROOT, relDir);
@@ -33,22 +38,7 @@ const REQUIRED_STRICT_COMPILER_OPTIONS = [
   "noFallthroughCasesInSwitch",
 ] as const;
 
-const EXPECTED_ALIASES: Record<string, string> = {
-  "@franken/brain": "./packages/franken-brain/src/index.ts",
-  "@franken/planner": "./packages/franken-planner/src/index.ts",
-  "@franken/observer": "./packages/franken-observer/src/index.ts",
-  "@franken/critique": "./packages/franken-critique/src/index.ts",
-  "@franken/governor": "./packages/franken-governor/src/index.ts",
-  "@franken/types/path-containment":
-    "./packages/franken-types/src/path-containment.ts",
-  "@franken/types/json-pointer":
-    "./packages/franken-types/src/json-pointer.ts",
-  "@franken/types/utils": "./packages/franken-types/src/utils/index.ts",
-  "@franken/types": "./packages/franken-types/src/index.ts",
-  "@franken/orchestrator": "./packages/franken-orchestrator/src/index.ts",
-  "@franken/mcp-suite": "./packages/franken-mcp-suite/src/index.ts",
-  "@franken/live-bench": "./packages/live-bench/src/index.ts",
-};
+const EXPECTED_ALIASES = getWorkspaceSourceAliases();
 
 const ALIASED_WORKSPACE_PACKAGES = new Set(
   workspacePackages

--- a/tests/tsconfig-paths.test.ts
+++ b/tests/tsconfig-paths.test.ts
@@ -6,6 +6,7 @@ import {
   readJson,
   getWorkspacePackages,
   getWorkspaceSourceAliases,
+  getPackageExportEntries,
 } from "./helpers/workspaces.js";
 
 const hasTypeScriptSource = (relDir: string): boolean => {
@@ -63,6 +64,25 @@ const TSCONFIG_TEST_INCLUDE_ALLOWLIST: Record<string, string> = {
   "@franken/mcp-suite":
     "Uses a package-level tsconfig/vitest boundary for src and tests; the root tsconfig.test.json cannot model its CLI/server package settings.",
 };
+
+describe("workspace package exports", () => {
+  it("normalizes string-form exports as the root export", () => {
+    expect(
+      getPackageExportEntries({ exports: "./dist/index.js" }),
+    ).toEqual([[".", "./dist/index.js"]]);
+  });
+
+  it("normalizes root conditional exports as the root export", () => {
+    const rootExport = {
+      types: "./dist/index.d.ts",
+      import: "./dist/index.js",
+    };
+
+    expect(getPackageExportEntries({ exports: rootExport })).toEqual([
+      [".", rootExport],
+    ]);
+  });
+});
 
 describe("tsconfig.json path aliases", () => {
   const tsconfig = readJson("tsconfig.json");


### PR DESCRIPTION
## Summary
- derive expected TypeScript path aliases from workspace package publication metadata
- cover root and exported subpath entries without duplicating `tsconfig.json`
- fail with actionable errors when published entries cannot map to source files

## Test plan
- `npm run test:root -- tests/tsconfig-paths.test.ts`
- mutation checks: incorrect alias target and omitted workspace include both fail the targeted suite
- `npx vitest run --testTimeout 30000`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #3461