### PR TITLE
chore(web): upgrade jest-dom to version 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,9 +1847,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1861,9 +1861,12 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=22",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -6724,7 +6727,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.2",
-        "@testing-library/jest-dom": "^6.0.0",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",

--- a/packages/franken-web/package.json
+++ b/packages/franken-web/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",
-    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/scripts/major-outdated-baseline.json
+++ b/scripts/major-outdated-baseline.json
@@ -10,16 +10,6 @@
     "reason": "Existing direct major-version gap present when the CI guard was introduced for issue #1414."
   },
   {
-    "name": "@testing-library/jest-dom",
-    "dependent": "@franken/web",
-    "location": "node_modules/@testing-library/jest-dom",
-    "currentMajor": 6,
-    "latestMajor": 7,
-    "current": "6.9.1",
-    "latest": "7.0.0",
-    "reason": "Major release appeared after the branch was synchronized and would otherwise make the repository-wide freshness gate fail independently of this PR."
-  },
-  {
     "name": "@types/node",
     "dependent": "@franken/brain",
     "location": "node_modules/@types/node",


### PR DESCRIPTION
## Summary
- upgrade `@testing-library/jest-dom` from 6.9.1 to 7.0.0
- remove the temporary major-version freshness baseline entry
- keep the repository-wide dependency freshness gate actionable

## Verification
- `npm run deps:outdated:major`
- `npm run test:root -- tests/unit/dependency-ci-guards.test.ts` (22 tests)
- `npm run test --workspace @franken/web` (690 tests)
- `npm run lint --workspace @franken/web`
- isolated web TypeScript check and Vite production build passed; canonical local build was obstructed by an unrelated empty `node_modules/@types/babel__traverse` directory in the parent checkout, so CI will validate the clean-checkout build

Closes #3475