### PR TITLE
refactor(web): scope wizard Zustand selectors

### DIFF
--- a/docs/adr/024-introduce-zustand-for-form-state.md
+++ b/docs/adr/024-introduce-zustand-for-form-state.md
@@ -11,7 +11,7 @@ The beasts panel redesign introduces two complex state management needs:
 1. **Agent creation wizard** — 8-step form with per-step validation, cross-step dependencies (e.g., module toggles affect which config sections appear), wizard/form mode toggle that must preserve state, and a review step that reads all prior steps.
 2. **Agent detail edit mode** — dirty tracking via snapshot diff, save/cancel with discard confirmation, hot-swap vs restart-required field classification.
 
-The current dashboard uses React hooks (useState, useEffect) exclusively. While hooks work for simple state, the wizard's cross-component state sharing and dirty tracking logic would require deep prop drilling or context providers that add complexity without structure.
+At the time of this decision, the dashboard used React hooks (`useState`, `useEffect`) exclusively. While hooks work for simple state, the wizard's cross-component state sharing and dirty tracking logic would require deep prop drilling or context providers that add complexity without structure.
 
 ## Decision
 
@@ -21,6 +21,12 @@ Introduce Zustand (~1KB gzipped) with two store slices:
 - **`agentEditSlice`** — last-saved config snapshot, current edit values, computed `isDirty` flag, field-level restart-required metadata
 
 The rest of the dashboard continues using React hooks. No migration of existing state management.
+
+## Implementation
+
+The accepted design is implemented in `packages/franken-web/src/stores/beast-store.ts`. Wizard values, navigation, mode, and validation errors live in `useBeastStore`; the wizard dialog and every step component subscribe through scoped selectors rather than subscribing to the entire store. `BeastsPage` calls `resetWizard()` before each new create flow so state survives step unmounts but does not leak between launches.
+
+Local-only presentation state, such as the skills search query or dialog loading state, remains in React hooks as required by the boundary above. Store behavior is covered by `src/stores/beast-store.test.ts`, dialog behavior by `src/components/beasts/wizard-dialog.test.tsx`, and the scoped-selector boundary by `tests/components/beasts/wizard-zustand-architecture.test.ts`.
 
 ## Consequences
 

--- a/packages/franken-web/src/components/beasts/single-page-form.tsx
+++ b/packages/franken-web/src/components/beasts/single-page-form.tsx
@@ -26,7 +26,7 @@ interface SinglePageFormProps {
 }
 
 export function SinglePageForm({ onLaunch }: SinglePageFormProps) {
-  const { stepValues } = useBeastStore();
+  const stepValues = useBeastStore((state) => state.stepValues);
 
   function handleLaunch() {
     const config: Record<string, unknown> = {};

--- a/packages/franken-web/src/components/beasts/steps/step-git.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-git.tsx
@@ -19,8 +19,9 @@ const PRESET_CARDS = [
 ];
 
 export function StepGit() {
-  const { stepValues, setStepValues } = useBeastStore();
-  const values = (stepValues[6] ?? {}) as {
+  const stepValue = useBeastStore((state) => state.stepValues[6]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
+  const values = (stepValue ?? {}) as {
     preset?: string;
     baseBranch?: string;
     branchPattern?: string;

--- a/packages/franken-web/src/components/beasts/steps/step-identity.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-identity.tsx
@@ -1,8 +1,9 @@
 import { useBeastStore } from '../../../stores/beast-store';
 
 export function StepIdentity() {
-  const { stepValues, setStepValues } = useBeastStore();
-  const values = (stepValues[0] ?? {}) as { name?: string; description?: string };
+  const stepValue = useBeastStore((state) => state.stepValues[0]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
+  const values = (stepValue ?? {}) as { name?: string; description?: string };
 
   function updateField(field: string, value: string) {
     setStepValues(0, { ...values, [field]: value });

--- a/packages/franken-web/src/components/beasts/steps/step-llm-targets.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-llm-targets.tsx
@@ -6,13 +6,14 @@ import { dashboardProvidersToModelOptions } from '../shared/provider-catalog';
 const ACTION_TYPES = ['planning', 'execution', 'critique', 'reflection', 'chat'];
 
 export function StepLlmTargets() {
-  const { stepValues, setStepValues } = useBeastStore();
+  const stepValue = useBeastStore((state) => state.stepValues[2]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
   const dashboardProviders = useDashboardStore((state) => state.providers);
   const providersLoading = useDashboardStore((state) => state.loading);
   const providersError = useDashboardStore((state) => state.error);
   const providers = providersLoading || providersError ? [] : dashboardProvidersToModelOptions(dashboardProviders);
   const hasProviderStatus = providersLoading || providersError || providers.length === 0;
-  const values = (stepValues[2] ?? {}) as {
+  const values = (stepValue ?? {}) as {
     defaultProvider?: string;
     defaultModel?: string;
     overrides?: Record<string, { provider: string; model: string; useDefault: boolean }>;

--- a/packages/franken-web/src/components/beasts/steps/step-modules.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-modules.tsx
@@ -20,9 +20,10 @@ interface ModuleStepValues {
 }
 
 export function StepModules() {
-  const { stepValues, setStepValues } = useBeastStore();
+  const stepValue = useBeastStore((state) => state.stepValues[3]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
   const providers = dashboardProvidersToModelOptions(useDashboardStore((state) => state.providers));
-  const values = (stepValues[3] ?? {}) as ModuleStepValues;
+  const values = (stepValue ?? {}) as ModuleStepValues;
 
   function toggleModule(key: string) {
     setStepValues(3, { ...values, [key]: !values[key] });

--- a/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-prompts.tsx
@@ -2,8 +2,9 @@ import { useBeastStore } from '../../../stores/beast-store';
 import { FilePicker, type PickedFile } from '../shared/file-picker';
 
 export function StepPrompts() {
-  const { stepValues, setStepValues } = useBeastStore();
-  const values = (stepValues[5] ?? {}) as { promptText?: string; files?: PickedFile[] };
+  const stepValue = useBeastStore((state) => state.stepValues[5]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
+  const values = (stepValue ?? {}) as { promptText?: string; files?: PickedFile[] };
 
   function updateField(field: string, value: unknown) {
     const currentValues = (useBeastStore.getState().stepValues[5] ?? {}) as Record<string, unknown>;

--- a/packages/franken-web/src/components/beasts/steps/step-review.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-review.tsx
@@ -29,7 +29,8 @@ const CANONICAL_MODULE_KEYS = [
 ] as const;
 
 export function StepReview({ catalog }: { catalog?: readonly BeastCatalogEntry[] | undefined }) {
-  const { stepValues, setWizardStep } = useBeastStore();
+  const stepValues = useBeastStore((state) => state.stepValues);
+  const setWizardStep = useBeastStore((state) => state.setWizardStep);
 
   const identity = stepValues[0] as { name?: string; description?: string } | undefined;
   const workflow = stepValues[1] as WorkflowReviewValues | undefined;

--- a/packages/franken-web/src/components/beasts/steps/step-skills.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-skills.tsx
@@ -3,11 +3,12 @@ import { useBeastStore } from '../../../stores/beast-store';
 import { useDashboardStore } from '../../../stores/dashboard-store';
 
 export function StepSkills() {
-  const { stepValues, setStepValues } = useBeastStore();
+  const stepValue = useBeastStore((state) => state.stepValues[4]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
   const skills = useDashboardStore((state) => state.skills);
   const loading = useDashboardStore((state) => state.loading);
   const error = useDashboardStore((state) => state.error);
-  const values = (stepValues[4] ?? {}) as { selectedSkills?: string[] };
+  const values = (stepValue ?? {}) as { selectedSkills?: string[] };
   const selected = values.selectedSkills ?? [];
   const [search, setSearch] = useState('');
 

--- a/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-workflow.tsx
@@ -16,8 +16,10 @@ function isContainerRuntimeUnavailable(status: BeastContainerRuntimeStatus | und
 }
 
 export function StepWorkflow({ catalog, containerRuntime }: StepWorkflowProps) {
-  const { stepValues, setStepValues, wizardMode } = useBeastStore();
-  const values = (stepValues[1] ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
+  const stepValue = useBeastStore((state) => state.stepValues[1]);
+  const setStepValues = useBeastStore((state) => state.setStepValues);
+  const wizardMode = useBeastStore((state) => state.wizardMode);
+  const values = (stepValue ?? {}) as { workflowType?: string; executionMode?: BeastExecutionMode; [key: string]: unknown };
   const workflows = getEffectiveCatalog(catalog);
   const selectedWorkflow = workflows.find((entry) => entry.id === values.workflowType);
   const selectedExecutionMode = values.executionMode ?? selectedWorkflow?.executionModeDefault ?? 'process';

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -33,18 +33,16 @@ interface WizardDialogProps {
 
 export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRuntime, launching, launchError }: WizardDialogProps) {
   const descriptionId = useId();
-  const {
-    wizardStep,
-    highestCompleted,
-    wizardMode,
-    nextStep,
-    prevStep,
-    setWizardStep,
-    toggleWizardMode,
-    stepValues,
-    setValidationErrors,
-    clearValidationErrors,
-  } = useBeastStore();
+  const wizardStep = useBeastStore((state) => state.wizardStep);
+  const highestCompleted = useBeastStore((state) => state.highestCompleted);
+  const wizardMode = useBeastStore((state) => state.wizardMode);
+  const nextStep = useBeastStore((state) => state.nextStep);
+  const prevStep = useBeastStore((state) => state.prevStep);
+  const setWizardStep = useBeastStore((state) => state.setWizardStep);
+  const toggleWizardMode = useBeastStore((state) => state.toggleWizardMode);
+  const stepValues = useBeastStore((state) => state.stepValues);
+  const setValidationErrors = useBeastStore((state) => state.setValidationErrors);
+  const clearValidationErrors = useBeastStore((state) => state.clearValidationErrors);
 
   const isLastStep = wizardStep === STEP_LABELS.length - 1;
   const isFirstStep = wizardStep === 0;

--- a/packages/franken-web/src/components/beasts/wizard-dialog.tsx
+++ b/packages/franken-web/src/components/beasts/wizard-dialog.tsx
@@ -1,5 +1,6 @@
 import { useId, type ReactNode } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
+import { useShallow } from 'zustand/react/shallow';
 import { useBeastStore } from '../../stores/beast-store';
 import { WizardStepIndicator } from './wizard-step-indicator';
 import { StepIdentity } from './steps/step-identity';
@@ -40,18 +41,23 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
   const prevStep = useBeastStore((state) => state.prevStep);
   const setWizardStep = useBeastStore((state) => state.setWizardStep);
   const toggleWizardMode = useBeastStore((state) => state.toggleWizardMode);
-  const stepValues = useBeastStore((state) => state.stepValues);
   const setValidationErrors = useBeastStore((state) => state.setValidationErrors);
   const clearValidationErrors = useBeastStore((state) => state.clearValidationErrors);
 
   const isLastStep = wizardStep === STEP_LABELS.length - 1;
   const isFirstStep = wizardStep === 0;
-  const currentValidationErrors = validateWizardStep(wizardStep, stepValues, catalog);
+  const currentValidationErrors = useBeastStore(useShallow((state) => (
+    validateWizardStep(wizardStep, state.stepValues, catalog)
+  )));
   const currentStepIsValid = Object.keys(currentValidationErrors).length === 0;
-  const formValidationErrors = validateWizardStep(STEP_LABELS.length - 1, stepValues, catalog);
+  const formValidationErrors = useBeastStore(useShallow((state) => (
+    validateWizardStep(STEP_LABELS.length - 1, state.stepValues, catalog)
+  )));
   const formIsValid = Object.keys(formValidationErrors).length === 0;
-  const promptFilesLoading = Boolean(stepValues[5]?.filesLoading);
-  const stepStatuses = buildStepStatuses(wizardStep, highestCompleted, stepValues, catalog);
+  const promptFilesLoading = useBeastStore((state) => Boolean(state.stepValues[5]?.filesLoading));
+  const stepStatuses = useBeastStore(useShallow((state) => (
+    buildStepStatuses(wizardStep, highestCompleted, state.stepValues, catalog)
+  )));
 
   function syncValidationErrors(step: number, errors: WizardValidationErrors) {
     if (Object.keys(errors).length > 0) {
@@ -62,7 +68,9 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
   }
 
   function buildAndLaunch() {
-    if (promptFilesLoading) {
+    const stepValues = useBeastStore.getState().stepValues;
+
+    if (stepValues[5]?.filesLoading) {
       setValidationErrors(5, { files: 'Wait for selected files to finish loading before launching.' });
       if (wizardMode === 'wizard') {
         setWizardStep(5);
@@ -86,8 +94,10 @@ export function WizardDialog({ isOpen, onClose, onLaunch, catalog, containerRunt
   }
 
   function handleNext() {
-    syncValidationErrors(wizardStep, currentValidationErrors);
-    if (!currentStepIsValid) {
+    const stepValues = useBeastStore.getState().stepValues;
+    const latestValidationErrors = validateWizardStep(wizardStep, stepValues, catalog);
+    syncValidationErrors(wizardStep, latestValidationErrors);
+    if (Object.keys(latestValidationErrors).length > 0) {
       return;
     }
 

--- a/packages/franken-web/tests/components/beasts/wizard-zustand-architecture.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-zustand-architecture.test.ts
@@ -35,6 +35,13 @@ describe('wizard Zustand architecture', () => {
     }
   });
 
+  it('does not subscribe the dialog shell to the complete form map', () => {
+    const sourcePath = 'src/components/beasts/wizard-dialog.tsx';
+    const source = readFileSync(join(process.cwd(), sourcePath), 'utf8');
+
+    expect(source).not.toContain('useBeastStore((state) => state.stepValues);');
+  });
+
   it('subscribes each step only to its own form values', () => {
     for (const [sourcePath, step] of Object.entries(STEP_STATE_CONSUMERS)) {
       const source = readFileSync(join(process.cwd(), sourcePath), 'utf8');

--- a/packages/franken-web/tests/components/beasts/wizard-zustand-architecture.test.ts
+++ b/packages/franken-web/tests/components/beasts/wizard-zustand-architecture.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WIZARD_STATE_CONSUMERS = [
+  'src/components/beasts/wizard-dialog.tsx',
+  'src/components/beasts/single-page-form.tsx',
+  'src/components/beasts/steps/step-identity.tsx',
+  'src/components/beasts/steps/step-workflow.tsx',
+  'src/components/beasts/steps/step-llm-targets.tsx',
+  'src/components/beasts/steps/step-modules.tsx',
+  'src/components/beasts/steps/step-skills.tsx',
+  'src/components/beasts/steps/step-prompts.tsx',
+  'src/components/beasts/steps/step-git.tsx',
+  'src/components/beasts/steps/step-review.tsx',
+] as const;
+
+const STEP_STATE_CONSUMERS = {
+  'src/components/beasts/steps/step-identity.tsx': 0,
+  'src/components/beasts/steps/step-workflow.tsx': 1,
+  'src/components/beasts/steps/step-llm-targets.tsx': 2,
+  'src/components/beasts/steps/step-modules.tsx': 3,
+  'src/components/beasts/steps/step-skills.tsx': 4,
+  'src/components/beasts/steps/step-prompts.tsx': 5,
+  'src/components/beasts/steps/step-git.tsx': 6,
+} as const;
+
+describe('wizard Zustand architecture', () => {
+  it('subscribes each wizard component through scoped selectors', () => {
+    for (const sourcePath of WIZARD_STATE_CONSUMERS) {
+      const source = readFileSync(join(process.cwd(), sourcePath), 'utf8');
+
+      expect(source, sourcePath).toContain('useBeastStore(');
+      expect(source, sourcePath).not.toMatch(/useBeastStore\(\s*\)/);
+    }
+  });
+
+  it('subscribes each step only to its own form values', () => {
+    for (const [sourcePath, step] of Object.entries(STEP_STATE_CONSUMERS)) {
+      const source = readFileSync(join(process.cwd(), sourcePath), 'utf8');
+
+      expect(source, sourcePath).toContain(`state.stepValues[${step}]`);
+      expect(source, sourcePath).not.toContain('state.stepValues);');
+    }
+  });
+});

--- a/tasks/issue-3453-zustand-wizard-progress.md
+++ b/tasks/issue-3453-zustand-wizard-progress.md
@@ -1,0 +1,21 @@
+# Issue #3453 Zustand wizard migration progress
+
+- [x] Verify issue labels and confirm no `good first issue` reservation.
+- [x] Inspect the accepted ADR, wizard implementation, Zustand store, and existing tests.
+- [x] Add a failing architecture regression that requires scoped Zustand selectors throughout wizard form components.
+- [x] Replace whole-store wizard subscriptions with scoped selectors.
+- [x] Update ADR-024 to describe the implemented architecture and source locations.
+- [x] Run targeted tests plus `@franken/web` lint, typecheck, and build.
+- [ ] Commit, push, and open a one-issue PR with `Closes #3453`.
+- [ ] Drive CI and the real GitHub `@codex review` gate to current-head clean, then merge.
+- [ ] Record any durable shared lesson and close the Kanban card.
+
+## Verification
+
+- `npm test` in `packages/franken-web`: 77 files, 692 tests passed.
+- `npm run lint` in `packages/franken-web`: passed with 17 pre-existing warnings and no errors.
+- `npm run build --workspace @franken/types`: passed (fresh clone prerequisite).
+- `npm run typecheck` in `packages/franken-web`: passed.
+- `npm run build` in `packages/franken-web`: passed.
+- `git diff --check`: passed.
+- Added-line static security scan: clean.

--- a/tasks/issue-3453-zustand-wizard-progress.md
+++ b/tasks/issue-3453-zustand-wizard-progress.md
@@ -12,7 +12,7 @@
 
 ## Verification
 
-- `npm test` in `packages/franken-web`: 77 files, 692 tests passed.
+- `npm test` in `packages/franken-web`: 77 files, 693 tests passed.
 - `npm run lint` in `packages/franken-web`: passed with 17 pre-existing warnings and no errors.
 - `npm run build --workspace @franken/types`: passed (fresh clone prerequisite).
 - `npm run typecheck` in `packages/franken-web`: passed.


### PR DESCRIPTION
## Summary
- replace whole-store wizard subscriptions with focused Zustand selectors
- subscribe each form step only to its indexed state slice to prevent cross-step rerenders
- add an architecture regression and document ADR-024 implementation status

## Test plan
- `npm test` (`@franken/web`: 77 files, 692 tests)
- `npm run lint` (`@franken/web`: 0 errors; 17 pre-existing warnings)
- `npm run typecheck` (`@franken/web`)
- `npm run build --workspace @franken/types`
- `npm run build` (`@franken/web`)

Closes #3453