### PR TITLE
docs(readme): clarify current testing baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,9 +963,9 @@ Delivery-channel sensitivity defaults fail-closed: runtime replies marked with `
 | 11 | External Comms (Slack/Discord/Telegram/WhatsApp) | Complete |
 | 12 | GitHub Issues Pipeline | Complete |
 
-Run `npm test`, `npm run typecheck`, and `npm run build` for the current baseline. The workspace currently contains 10 package manifests under `packages/*`; avoid relying on stale static test-count claims in older docs.
+Run `npm test`, `npm run typecheck`, and `npm run build` for the current baseline. Use the [test command decision tree](docs/onboarding/test-command-decision-tree.md) to choose narrower checks for a specific change. The maintained root and workspace scripts are authoritative; avoid relying on stale static test-count claims in older docs.
 
-See [docs/PROGRESS.md](docs/PROGRESS.md) for the full PR-by-PR breakdown.
+For historical implementation chronology only, see the archived [PR-by-PR progress tracker](docs/PROGRESS.md); it does not define the current testing baseline.
 
 ### In Progress
 

--- a/tests/docs-issue-3472.test.ts
+++ b/tests/docs-issue-3472.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+describe('issue #3472 README testing baseline', () => {
+  it('points contributors to maintained commands instead of historical PR progress', () => {
+    const readme = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+    const projectStatus = readme.slice(
+      readme.indexOf('## Project Status'),
+      readme.indexOf('### In Progress'),
+    );
+
+    expect(projectStatus).toContain('`npm test`, `npm run typecheck`, and `npm run build`');
+    expect(projectStatus).toContain(
+      '[test command decision tree](docs/onboarding/test-command-decision-tree.md)',
+    );
+    expect(projectStatus).toContain('historical implementation chronology only');
+    expect(projectStatus).toContain('it does not define the current testing baseline');
+    expect(projectStatus).not.toContain('for the full PR-by-PR breakdown');
+  });
+});


### PR DESCRIPTION
## Summary
- point contributors to the maintained test command decision tree
- label the PR-by-PR progress tracker as historical context only
- add focused regression coverage for the README baseline wording

## Verification
- `npm run test:root -- tests/docs-issue-3472.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #3472