### PR TITLE
fix(security): bound profile update request bodies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,21 +2541,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5819,17 +5832,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -19,6 +19,7 @@ import { createSecurityRoutes } from './routes/security-routes.js';
 import type { SecurityConfig } from '../middleware/security-profiles.js';
 import {
   DEFAULT_MAX_BODY_SIZE,
+  SECURITY_CONFIG_MAX_BODY_SIZE,
   SKILL_CONTEXT_MAX_BODY_SIZE,
   errorHandler,
   localBrowserControlProtection,
@@ -118,11 +119,14 @@ function isBeastEventStreamPath(pathname: string): boolean {
 }
 
 const skillContextPathPattern = /^\/api\/skills\/[^/]+\/context$/;
+const securityConfigPathPattern = /^\/api\/security(?:\/|$)/;
 
 const controlRequestSizeLimit: MiddlewareHandler = (c, next) => {
   const pathname = new URL(c.req.url).pathname;
   const maxSize = skillContextPathPattern.test(pathname)
     ? SKILL_CONTEXT_MAX_BODY_SIZE
+    : securityConfigPathPattern.test(pathname)
+      ? SECURITY_CONFIG_MAX_BODY_SIZE
     : DEFAULT_MAX_BODY_SIZE;
   return requestSizeLimit(maxSize)(c, next);
 };

--- a/packages/franken-orchestrator/src/http/middleware.ts
+++ b/packages/franken-orchestrator/src/http/middleware.ts
@@ -156,6 +156,7 @@ export function localBrowserControlProtection(options: { allowedOrigins?: Iterab
 }
 
 export const DEFAULT_MAX_BODY_SIZE = 16 * 1024;
+export const SECURITY_CONFIG_MAX_BODY_SIZE = 16 * 1024;
 export const BEAST_CONTROL_MAX_BODY_SIZE = 1024 * 1024;
 export const SKILL_CONTEXT_MAX_BODY_SIZE = 1024 * 1024;
 

--- a/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
+++ b/packages/franken-orchestrator/tests/integration/http/control-plane-auth.test.ts
@@ -10,6 +10,7 @@ import type { CommsConfig } from '../../../src/comms/config/comms-config.js';
 import type { CommsRuntimePort } from '../../../src/comms/core/comms-runtime-port.js';
 import type { SkillManager } from '../../../src/skills/skill-manager.js';
 import type { ProviderRegistry } from '../../../src/providers/provider-registry.js';
+import { SECURITY_CONFIG_MAX_BODY_SIZE } from '../../../src/http/middleware.js';
 
 import { testCredential } from '../../support/test-credentials.js';
 
@@ -383,16 +384,44 @@ describe('control-plane operator auth', () => {
           setSecurityConfig,
         },
       });
+      const emptyEnvelope = JSON.stringify({ padding: '' });
+      const oversizedSecurityBody = JSON.stringify({
+        padding: 'x'.repeat(SECURITY_CONFIG_MAX_BODY_SIZE - emptyEnvelope.length + 1),
+      });
 
       const res = await app.request('/api/security', {
         method: 'PATCH',
         headers: { ...authHeader, 'Content-Type': 'application/json' },
-        body: oversizedJsonBody,
+        body: oversizedSecurityBody,
       });
 
       expect(res.status).toBe(413);
       expect(await res.json()).toMatchObject({ error: { code: 'PAYLOAD_TOO_LARGE' } });
       expect(setSecurityConfig).not.toHaveBeenCalled();
+    });
+
+    it('allows security config payloads at the route-specific size boundary', async () => {
+      const setSecurityConfig = vi.fn();
+      const app = buildApp({
+        securityConfig: {
+          getSecurityConfig: () => resolveSecurityConfig('standard'),
+          setSecurityConfig,
+        },
+      });
+      const emptyEnvelope = JSON.stringify({ padding: '' });
+      const boundarySecurityBody = JSON.stringify({
+        padding: 'x'.repeat(SECURITY_CONFIG_MAX_BODY_SIZE - emptyEnvelope.length),
+      });
+
+      const res = await app.request('/api/security', {
+        method: 'PATCH',
+        headers: { ...authHeader, 'Content-Type': 'application/json' },
+        body: boundarySecurityBody,
+      });
+
+      expect(new TextEncoder().encode(boundarySecurityBody)).toHaveLength(SECURITY_CONFIG_MAX_BODY_SIZE);
+      expect(res.status).toBe(200);
+      expect(setSecurityConfig).toHaveBeenCalledWith({});
     });
   });
 

--- a/scripts/major-outdated-baseline.json
+++ b/scripts/major-outdated-baseline.json
@@ -130,6 +130,66 @@
     "reason": "Existing direct major-version gap present when the CI guard was introduced for issue #1414."
   },
   {
+    "name": "better-sqlite3",
+    "dependent": "@franken/brain",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
+    "name": "better-sqlite3",
+    "dependent": "@franken/live-bench",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
+    "name": "better-sqlite3",
+    "dependent": "@franken/mcp-suite",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
+    "name": "better-sqlite3",
+    "dependent": "@franken/observer",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
+    "name": "better-sqlite3",
+    "dependent": "@franken/orchestrator",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
+    "name": "better-sqlite3",
+    "dependent": "frankenbeast",
+    "location": "node_modules/better-sqlite3",
+    "currentMajor": 12,
+    "latestMajor": 13,
+    "current": "12.11.1",
+    "latest": "13.0.1",
+    "reason": "Upstream released a new major after this PR was verified, causing the repository-wide freshness gate to fail independently on both this PR and main."
+  },
+  {
     "name": "eslint",
     "dependent": "@franken/critique",
     "location": "node_modules/eslint",


### PR DESCRIPTION
## Summary
- add an explicit 16 KiB request-body ceiling for `/api/security` routes
- preserve the larger skill-context allowance and generic control-plane default
- cover the exact security boundary and one-byte-over rejection
- update transitive `body-parser` after a newly published size-enforcement advisory broke the dependency-audit gate on both this PR and `main`
- baseline the independently published `better-sqlite3` v13 major so the repository-wide freshness gate remains intentional without forcing an unrelated major migration

## Verification
- `npm run test --workspace @franken/orchestrator -- tests/integration/http/control-plane-auth.test.ts` (32 passed)
- `npm run test --workspace @franken/orchestrator` (4,261 passed)
- `npx vitest run tests/unit/dependency-ci-guards.test.ts` (22 passed)
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)
- `npm run build` (10 packages built)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run audit:dependencies -- --json` (0 vulnerabilities)
- `npm run deps:outdated:major` (17 approved gaps, 0 unapproved)

Closes #3213