### PR TITLE
fix(orchestrator): redact Beast host execution paths

### DIFF
--- a/packages/franken-orchestrator/src/http/beast-response-redaction.ts
+++ b/packages/franken-orchestrator/src/http/beast-response-redaction.ts
@@ -1,0 +1,46 @@
+const HOST_PATH_KEYS = new Set([
+  'projectRoot',
+  'workspaceHostPath',
+  'worktreePath',
+  'worktreeExecutionCwd',
+  'worktreeProjectRoot',
+  'command',
+  'args',
+  'dockerCommand',
+  'dockerArgs',
+]);
+
+function isAbsoluteHostPath(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/u.test(value) || value.startsWith('\\\\');
+}
+
+export function redactAbsoluteHostPathValues(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return isAbsoluteHostPath(value) ? '[REDACTED_HOST_PATH]' : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactAbsoluteHostPathValues);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => key !== 'projectRoot')
+      .map(([key, nested]) => [key, redactAbsoluteHostPathValues(nested)]),
+  );
+}
+
+export function redactHostExecutionData(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactHostExecutionData);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !HOST_PATH_KEYS.has(key))
+      .map(([key, nested]) => [key, redactHostExecutionData(nested)]),
+  );
+}

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -30,7 +30,7 @@ import {
 } from '../middleware.js';
 import { wallClockNow } from '@franken/types';
 import { TransportSecurityService } from '../security/transport-security.js';
-import type { BeastRun, BeastRunAttempt } from '../../beasts/types.js';
+import type { BeastRun, BeastRunAttempt, BeastRunEvent } from '../../beasts/types.js';
 import {
   DEFAULT_BEAST_RUN_PAGE_LIMIT,
   InvalidBeastRunCursorError,
@@ -70,6 +70,7 @@ function parseBeastEventPagination(query: Record<string, string>): { afterSequen
 }
 
 function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAttempt[]): BeastRunResponse | undefined {
+  run = redactRunHostPaths(run);
   if (!run || run.executionMode !== 'container') {
     return run;
   }
@@ -104,7 +105,30 @@ function redactHostExecutionPaths(attempt: BeastRunAttempt): BeastRunAttempt {
   delete executorMetadata.args;
   delete executorMetadata.dockerCommand;
   delete executorMetadata.dockerArgs;
+  delete executorMetadata.worktreePath;
+  delete executorMetadata.worktreeExecutionCwd;
+  delete executorMetadata.worktreeProjectRoot;
   return { ...attempt, executorMetadata };
+}
+
+function redactRunHostPaths(run: BeastRun | undefined): BeastRun | undefined {
+  if (!run) return run;
+  const configSnapshot = { ...run.configSnapshot };
+  delete configSnapshot.projectRoot;
+  return { ...run, configSnapshot };
+}
+
+function redactEventHostPaths(event: BeastRunEvent): BeastRunEvent {
+  const payload = { ...event.payload };
+  delete payload.command;
+  delete payload.args;
+  delete payload.dockerCommand;
+  delete payload.dockerArgs;
+  return { ...event, payload };
+}
+
+function redactEventPageHostPaths<T extends { readonly events: BeastRunEvent[] }>(page: T): T {
+  return { ...page, events: page.events.map(redactEventHostPaths) };
 }
 
 function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunAttempt[] {
@@ -476,7 +500,9 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
       data: {
         run: runWithContainerFields(deps.runs.sanitizeRunForResponse(run), attempts),
         attempts,
-        events: deps.runs.listEventPageForResponse(runId, 0, DEFAULT_BEAST_EVENT_PAGE_LIMIT).events,
+        events: redactEventPageHostPaths(
+          deps.runs.listEventPageForResponse(runId, 0, DEFAULT_BEAST_EVENT_PAGE_LIMIT),
+        ).events,
       },
     });
   });
@@ -486,7 +512,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     const { afterSequence, limit } = parseBeastEventPagination(c.req.query());
     try {
       return c.json({
-        data: deps.runs.listEventPageForResponse(runId, afterSequence, limit),
+        data: redactEventPageHostPaths(deps.runs.listEventPageForResponse(runId, afterSequence, limit)),
       });
     } catch (error) {
       throwKnownRunError(runId, error);

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -46,7 +46,6 @@ type BeastRunResponse = BeastRun & {
   readonly containerNetwork?: unknown;
   readonly resourceSnapshot?: unknown;
   readonly resources?: unknown;
-  readonly workspaceHostPath?: unknown;
   readonly workspaceContainerPath?: unknown;
 };
 
@@ -91,9 +90,21 @@ function runWithContainerFields(run: BeastRun | undefined, attempts: BeastRunAtt
     ...(metadata.containerNetwork !== undefined ? { containerNetwork: metadata.containerNetwork } : {}),
     ...(metadata.resourceSnapshot !== undefined ? { resourceSnapshot: metadata.resourceSnapshot } : {}),
     ...(metadata.resources !== undefined ? { resources: metadata.resources } : {}),
-    ...(metadata.workspaceHostPath !== undefined ? { workspaceHostPath: metadata.workspaceHostPath } : {}),
     ...(metadata.workspaceContainerPath !== undefined ? { workspaceContainerPath: metadata.workspaceContainerPath } : {}),
   };
+}
+
+function redactHostExecutionPaths(attempt: BeastRunAttempt): BeastRunAttempt {
+  if (!attempt.executorMetadata) {
+    return attempt;
+  }
+  const executorMetadata = { ...attempt.executorMetadata };
+  delete executorMetadata.workspaceHostPath;
+  delete executorMetadata.command;
+  delete executorMetadata.args;
+  delete executorMetadata.dockerCommand;
+  delete executorMetadata.dockerArgs;
+  return { ...attempt, executorMetadata };
 }
 
 function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunAttempt[] {
@@ -101,7 +112,7 @@ function attemptsForContainerRun(run: BeastRun | undefined, deps: BeastRoutesDep
     return [];
   }
   const currentAttempt = deps.runs.getCurrentAttemptForResponse(run);
-  return currentAttempt ? [currentAttempt] : [];
+  return currentAttempt ? [redactHostExecutionPaths(currentAttempt)] : [];
 }
 
 function runResponse(run: BeastRun | undefined, deps: BeastRoutesDeps): BeastRunResponse | undefined {
@@ -460,7 +471,7 @@ export function beastRoutes(deps: BeastRoutesDeps): Hono {
     if (!run) {
       throw beastRunNotFound(runId);
     }
-    const attempts = deps.runs.listAttemptsForResponse(runId);
+    const attempts = deps.runs.listAttemptsForResponse(runId).map(redactHostExecutionPaths);
     return c.json({
       data: {
         run: runWithContainerFields(deps.runs.sanitizeRunForResponse(run), attempts),

--- a/packages/franken-orchestrator/src/http/routes/beast-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-routes.ts
@@ -36,6 +36,7 @@ import {
   InvalidBeastRunCursorError,
   MAX_BEAST_RUN_PAGE_LIMIT,
 } from '../../beasts/repository/sqlite-beast-repository.js';
+import { redactAbsoluteHostPathValues, redactHostExecutionData } from '../beast-response-redaction.js';
 
 type BeastRunResponse = BeastRun & {
   readonly containerId?: unknown;
@@ -113,17 +114,12 @@ function redactHostExecutionPaths(attempt: BeastRunAttempt): BeastRunAttempt {
 
 function redactRunHostPaths(run: BeastRun | undefined): BeastRun | undefined {
   if (!run) return run;
-  const configSnapshot = { ...run.configSnapshot };
-  delete configSnapshot.projectRoot;
+  const configSnapshot = redactAbsoluteHostPathValues(run.configSnapshot) as Readonly<Record<string, unknown>>;
   return { ...run, configSnapshot };
 }
 
 function redactEventHostPaths(event: BeastRunEvent): BeastRunEvent {
-  const payload = { ...event.payload };
-  delete payload.command;
-  delete payload.args;
-  delete payload.dockerCommand;
-  delete payload.dockerArgs;
+  const payload = redactHostExecutionData(event.payload) as Readonly<Record<string, unknown>>;
   return { ...event, payload };
 }
 

--- a/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/beast-sse-routes.ts
@@ -5,6 +5,7 @@ import { streamSSE } from 'hono/streaming';
 import type { BeastEventBus } from '../../beasts/events/beast-event-bus.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
 import { extractOperatorToken, extractOperatorTokenCookie, isCookieOperatorAuthAllowed } from '../operator-auth.js';
+import { redactHostExecutionData } from '../beast-response-redaction.js';
 
 const SSE_TICKET_COOKIE = 'frankenbeast_sse_ticket';
 const SSE_STREAM_PATH = '/v1/beasts/events/stream';
@@ -127,7 +128,7 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
           await stream.writeSSE({
             id: String(event.id),
             event: event.type,
-            data: JSON.stringify(event.data),
+            data: JSON.stringify(redactHostExecutionData(event.data)),
           });
         }
       }
@@ -137,7 +138,7 @@ export function createBeastSseRoutes(deps: BeastSseRouteDeps): Hono {
           await stream.writeSSE({
             id: String(event.id),
             event: event.type,
-            data: JSON.stringify(event.data),
+            data: JSON.stringify(redactHostExecutionData(event.data)),
           });
         } catch {
           unsub();

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -894,6 +894,60 @@ describe('beast routes', () => {
     expect(JSON.stringify(list)).not.toContain(TMP);
   });
 
+  it('redacts host paths from run snapshots, process attempts, and events', async () => {
+    const { app, operatorToken, repository } = createBeastApp();
+    const hostRoot = '/srv/private/frankenbeast';
+    const run = repository.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { objective: 'redact paths', projectRoot: hostRoot },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-21T00:00:00.000Z',
+    });
+    const attempt = repository.createAttempt(run.id, {
+      status: 'running',
+      executorMetadata: {
+        backend: 'process',
+        worktreeIsolation: true,
+        worktreePath: `${hostRoot}/.worktrees/agent-1`,
+        worktreeExecutionCwd: `${hostRoot}/.worktrees/agent-1/packages/app`,
+        worktreeProjectRoot: hostRoot,
+        worktreeBranch: 'beast/agent-1',
+      },
+    });
+    repository.updateRun(run.id, { currentAttemptId: attempt.id, attemptCount: 1 });
+    repository.appendEvent(run.id, {
+      attemptId: attempt.id,
+      type: 'attempt.started',
+      payload: { pid: 1234, command: `${hostRoot}/bin/frankenbeast` },
+      createdAt: '2026-07-21T00:01:00.000Z',
+    });
+    const headers = { authorization: 'Bearer ' + operatorToken };
+
+    const detail = await (await app.request(`/v1/beasts/runs/${run.id}`, { headers })).json() as {
+      data: {
+        run: { configSnapshot: Record<string, unknown> };
+        attempts: Array<{ executorMetadata?: Record<string, unknown> }>;
+        events: Array<{ payload: Record<string, unknown> }>;
+      };
+    };
+    expect(detail.data.run.configSnapshot).toEqual({ objective: 'redact paths' });
+    expect(detail.data.attempts[0]?.executorMetadata).toEqual({
+      backend: 'process',
+      worktreeIsolation: true,
+      worktreeBranch: 'beast/agent-1',
+    });
+    expect(detail.data.events[0]?.payload).toEqual({ pid: 1234 });
+    expect(JSON.stringify(detail)).not.toContain(hostRoot);
+
+    const events = await (await app.request(`/v1/beasts/runs/${run.id}/events`, { headers })).json();
+    const list = await (await app.request('/v1/beasts/runs', { headers })).json();
+    expect(JSON.stringify(events)).not.toContain(hostRoot);
+    expect(JSON.stringify(list)).not.toContain(hostRoot);
+  });
+
   it('does not expose stale container metadata when the current attempt metadata is corrupt', async () => {
     const { app, operatorToken, repository } = createBeastApp();
     const run = repository.createRun({

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -901,7 +901,11 @@ describe('beast routes', () => {
       definitionId: 'martin-loop',
       definitionVersion: 1,
       executionMode: 'process',
-      configSnapshot: { objective: 'redact paths', projectRoot: hostRoot },
+      configSnapshot: {
+        objective: 'redact paths',
+        projectRoot: hostRoot,
+        chunkDirectory: `${hostRoot}/docs/chunks`,
+      },
       dispatchedBy: 'api',
       dispatchedByUser: 'operator',
       createdAt: '2026-07-21T00:00:00.000Z',
@@ -933,7 +937,10 @@ describe('beast routes', () => {
         events: Array<{ payload: Record<string, unknown> }>;
       };
     };
-    expect(detail.data.run.configSnapshot).toEqual({ objective: 'redact paths' });
+    expect(detail.data.run.configSnapshot).toEqual({
+      objective: 'redact paths',
+      chunkDirectory: '[REDACTED_HOST_PATH]',
+    });
     expect(detail.data.attempts[0]?.executorMetadata).toEqual({
       backend: 'process',
       worktreeIsolation: true,

--- a/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/beast-routes.test.ts
@@ -799,7 +799,7 @@ describe('beast routes', () => {
     });
   });
 
-  it('dispatches a real container executor through the API and exposes container fields', async () => {
+  it('dispatches a real container executor through the API and exposes only safe container fields', async () => {
     const { app, operatorToken, fakeContainerSupervisor } = createBeastApp({ realContainer: true });
     const headers = {
       authorization: 'Bearer ' + operatorToken,
@@ -847,6 +847,8 @@ describe('beast routes', () => {
       resourceSnapshot: { memory: '512m', cpus: '1.0', pidsLimit: 256 },
       workspaceContainerPath: '/workspace',
     });
+    expect(created.data).not.toHaveProperty('workspaceHostPath');
+    expect(JSON.stringify(created)).not.toContain(TMP);
     expect(fakeContainerSupervisor.spawn).toHaveBeenCalledWith(
       expect.objectContaining({ command: 'docker' }),
       expect.any(Object),
@@ -874,8 +876,22 @@ describe('beast routes', () => {
       containerRuntime: 'docker',
       image: 'fbeast/sandbox:test',
       containerImage: 'fbeast/sandbox:test',
-      dockerCommand: 'docker',
     });
+    expect(detail.data.run).not.toHaveProperty('workspaceHostPath');
+    expect(detail.data.attempts[0]?.executorMetadata).not.toHaveProperty('workspaceHostPath');
+    expect(detail.data.attempts[0]?.executorMetadata).not.toHaveProperty('command');
+    expect(detail.data.attempts[0]?.executorMetadata).not.toHaveProperty('args');
+    expect(detail.data.attempts[0]?.executorMetadata).not.toHaveProperty('dockerCommand');
+    expect(detail.data.attempts[0]?.executorMetadata).not.toHaveProperty('dockerArgs');
+    expect(JSON.stringify(detail)).not.toContain(TMP);
+
+    const listResponse = await app.request('/v1/beasts/runs', {
+      headers: { authorization: authorizationHeader(operatorToken) },
+    });
+    expect(listResponse.status).toBe(200);
+    const list = await listResponse.json() as { data: { runs: Array<Record<string, unknown>> } };
+    expect(list.data.runs[0]).not.toHaveProperty('workspaceHostPath');
+    expect(JSON.stringify(list)).not.toContain(TMP);
   });
 
   it('does not expose stale container metadata when the current attempt metadata is corrupt', async () => {
@@ -936,7 +952,7 @@ describe('beast routes', () => {
     expect(body.data.runs.map((run) => run.id)).toContain(staleRun.id);
   });
 
-  it('exposes container fields in start and restart action responses', async () => {
+  it('exposes safe container fields in start and restart action responses', async () => {
     const { app, operatorToken } = createBeastApp({ realContainer: true });
     const headers = {
       authorization: 'Bearer ' + operatorToken,
@@ -973,6 +989,7 @@ describe('beast routes', () => {
       containerId: `fbeast-${startCandidate.data.id}-attempt-1`,
       containerRuntime: 'docker',
     });
+    expect(started.data).not.toHaveProperty('workspaceHostPath');
 
     const restartCandidate = await createRun();
     const restartResponse = await app.request(`/v1/beasts/runs/${restartCandidate.data.id}/restart`, {
@@ -985,6 +1002,7 @@ describe('beast routes', () => {
       containerId: `fbeast-${restartCandidate.data.id}-attempt-1`,
       containerRuntime: 'docker',
     });
+    expect(restarted.data).not.toHaveProperty('workspaceHostPath');
   });
 
   it.each(['start', 'stop', 'kill', 'restart'] as const)(

--- a/packages/franken-orchestrator/tests/unit/http/beast-response-redaction.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/beast-response-redaction.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  redactAbsoluteHostPathValues,
+  redactHostExecutionData,
+} from '../../../src/http/beast-response-redaction.js';
+
+describe('Beast response redaction', () => {
+  it('removes project roots and recursively redacts absolute config paths', () => {
+    expect(redactAbsoluteHostPathValues({
+      projectRoot: '/srv/private/project',
+      chunkDirectory: '/srv/private/project/docs/chunks',
+      nested: { outputPath: 'C:\\private\\report.md', relativePath: 'docs/report.md' },
+    })).toEqual({
+      chunkDirectory: '[REDACTED_HOST_PATH]',
+      nested: { outputPath: '[REDACTED_HOST_PATH]', relativePath: 'docs/report.md' },
+    });
+  });
+
+  it('recursively removes host execution fields from SSE event data', () => {
+    expect(redactHostExecutionData({
+      runId: 'run-1',
+      event: {
+        type: 'attempt.started',
+        payload: {
+          pid: 1234,
+          command: '/srv/private/project/bin/frankenbeast',
+          nested: { worktreePath: '/srv/private/project/.worktrees/agent-1', safe: true },
+        },
+      },
+    })).toEqual({
+      runId: 'run-1',
+      event: {
+        type: 'attempt.started',
+        payload: { pid: 1234, nested: { safe: true } },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- omit host workspace paths from Beast run response projections
- sanitize attempt metadata that can embed host paths in process and Docker command arguments
- cover create, detail, list, start, and restart response surfaces

## Verification
- `npm --workspace @franken/orchestrator test -- --run tests/integration/beasts/beast-routes.test.ts` (39 passed)
- `npm --workspace @franken/orchestrator test` (4,261 passed)
- `npm --workspace @franken/orchestrator run lint` (0 errors; existing warnings only)
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run build`

Closes #3211