### PR TITLE
fix(security): remediate fresh dependency advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,12 @@ jobs:
         run: npm run deps:outdated:major
 
       - name: Generate CycloneDX dependency SBOM
-        run: npm sbom --sbom-format cyclonedx > "${RUNNER_TEMP}/sbom.cyclonedx.json"
+        run: |
+          # npm's installed-package metadata retains the pre-override range, so
+          # reconcile it with the root override before npm validates the graph.
+          hono_node_server_override=$(npm pkg get 'overrides.@modelcontextprotocol/sdk.@hono/node-server' | jq -r .)
+          npm pkg set "dependencies.@hono/node-server=${hono_node_server_override}" --prefix node_modules/@modelcontextprotocol/sdk
+          npm sbom --sbom-format cyclonedx > "${RUNNER_TEMP}/sbom.cyclonedx.json"
 
       - name: Upload dependency SBOM
         uses: actions/upload-artifact@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,12 +587,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
   },
   "overrides": {
     "@anthropic-ai/sdk": "^0.110.0",
+    "@modelcontextprotocol/sdk": {
+      "@hono/node-server": "^2.0.5"
+    },
     "esbuild": "^0.28.1",
     "hono": "^4.12.27",
     "protobufjs": "^7.6.5",


### PR DESCRIPTION
## Summary
- override `@modelcontextprotocol/sdk` to use the patched `@hono/node-server` v2 line
- refresh the lockfile entry to `@hono/node-server` 2.0.11
- reconcile npm’s stale installed dependency metadata before SBOM validation so the resolved override graph is represented accurately
- preserve the existing dependency audit gate without bypasses

## Verification
- `npm ci --ignore-scripts` (then `npm rebuild better-sqlite3` for native test bindings)
- `npm run audit:dependencies -- --json` (0 vulnerabilities)
- exact CI SBOM command after override metadata reconciliation
- `npm run test` (10/10 workspace tasks passed; initial two unrelated flakes passed targeted rerun)
- `npm run lint`
- `npm run typecheck`
- `npm run build`

This is intentionally separate from PR #3425.