### PR TITLE
fix(security): patch dependency audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3438,9 +3438,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
-      "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+      "integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "overrides": {
     "@anthropic-ai/sdk": "^0.110.0",
-    "@hono/node-server": "2.0.5",
+    "@hono/node-server": "2.0.10",
     "esbuild": "^0.28.1",
     "hono": "^4.12.27",
     "protobufjs": "^7.6.5",


### PR DESCRIPTION
## Summary
- upgrades transitive `fast-uri` from 3.1.3 to patched 3.1.4 for GHSA-v2hh-gcrm-f6hx
- advances the existing `@hono/node-server` security override from 2.0.5 to the smallest fixed release, 2.0.10, for GHSA-9mqv-5hh9-4cgg
- restores the required repository-wide dependency audit and vulnerability-SLA gates without modifying PR #3471

## Verification
- `npm ci` (found 0 vulnerabilities)
- `npm run audit:dependencies -- --json` (0 findings)
- `node scripts/dependency-vulnerability-sla.mjs --format human --fail-on-new-critical-high` (0 findings)
- `npx vitest run tests/unit/dependency-ci-guards.test.ts` (22 passed)
- `npm run build` (10/10 tasks)
- `npm run typecheck` (17/17 tasks)
- `npm run lint` (10/10 tasks; existing warnings only)
- `npm run test`: full green before the Hono override update; after the update, 8/10 workspace tasks and 4,298/4,299 orchestrator tests passed before an unrelated 20ms timing-budget test flaked, and that exact test passed immediately on targeted rerun (1 passed)

## Scope
Only `package.json` and `package-lock.json` dependency-security entries change. PR #3471 remains untouched.