### PR TITLE
docs: update dashboard chat provider troubleshooting

### DIFF
--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -45,7 +45,9 @@ For a persistent selection, update the config used by the server:
 }
 ```
 
-`providers.overrides.<provider>.extraArgs` changes that provider's CLI arguments. For dashboard chat, `providers.overrides.<selected-provider>.model` has the highest model precedence. When that field is absent, `chat.model` overrides the provider's built-in chat model. Remove a stale selected-provider model override (or set it to the same value) when changing `chat.model`. Keep provider credentials in the provider's normal environment or credential store, not in this JSON file.
+`providers.overrides.<provider>.extraArgs` changes that provider's CLI arguments for conversational replies. For those replies, `providers.overrides.<selected-provider>.model` has the highest model precedence. When that field is absent, optional `chat.model` overrides the provider's built-in chat model. Remove a stale selected-provider model override (or set it to the same value) when changing `chat.model`.
+
+Dashboard `/run` uses the selected provider's execution adapter, not the conversational adapter. Its spawned agent uses the provider's built-in/default model; `chat.model`, provider `model`, and provider `extraArgs` do not change `/run` execution. A trusted provider `command` override does apply to both paths. Keep provider credentials in the provider's normal environment or credential store, not in this JSON file.
 
 Command overrides are intentionally fail-closed. Do not add `command` when the provider's normal binary is sufficient. To use a wrapper or nonstandard binary, put the override in an explicit operator-owned config outside the repository, set `trustCommandOverride: true`, restrict an absolute wrapper path with `trustedCommandPaths`, and start the server with both `--config <operator-config.json>` and `--trust-provider-command-overrides`:
 
@@ -210,8 +212,8 @@ and marker-looking text nested there must not be treated as a real prompt bounda
 - verify the selected CLI provider works directly and is authenticated, then verify it with `frankenbeast chat`
 - pass `--provider <name>` explicitly to distinguish a bad `providers.default` from a provider runtime failure
 - if fallback selection is unexpected, pass `--providers <comma-separated-list>` explicitly and check `providers.fallbackChain`
-- if you use a config file, pass `--config <path>` and confirm that file contains `providers` and `chat.model` at the top level
-- if `chat.model` appears to be ignored, check `providers.overrides.<selected-provider>.model`, which takes precedence
+- if you use a config file, pass `--config <path>` and confirm provider settings are under top-level `providers`; when used, the optional conversation-model override belongs at `chat.model`
+- if `chat.model` appears to be ignored for a conversational reply, check `providers.overrides.<selected-provider>.model`, which takes precedence; neither model setting changes `/run` execution
 - if a command override is refused, do not weaken repository config; use the operator-owned config and explicit trust flow above
 
 `The UI loads but does not connect`

--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -15,7 +15,63 @@ This guide starts the Frankenbeast dashboard chat with the real CLI-chat-compati
 - `npm install` has already been run at the repo root
 - at least one supported CLI chat provider is configured locally
 
-If you normally run `frankenbeast chat`, use the same provider setup here. By default the server uses `claude`. You can override that with `--provider <name>` or `--config <path>`.
+If you normally run `frankenbeast chat`, use the same provider setup here. The server reads `.fbeast/config.json` by default. An explicit `--provider <name>` wins over `providers.default`; an explicit `--providers <comma-separated-list>` wins over `providers.fallbackChain`. Use `--config <path>` to load a different JSON config.
+
+### Provider and model overrides
+
+For a one-off provider switch, pass a registered CLI provider name (`claude`, `codex`, `gemini`, or `aider`):
+
+```bash
+npm --workspace @franken/orchestrator run chat-server -- --provider codex
+npm --workspace @franken/orchestrator run chat-server -- --provider claude --providers codex,gemini
+```
+
+For a persistent selection, update the config used by the server:
+
+```json
+{
+  "providers": {
+    "default": "claude",
+    "fallbackChain": ["claude", "codex"],
+    "overrides": {
+      "claude": {
+        "extraArgs": ["--verbose"]
+      }
+    }
+  },
+  "chat": {
+    "model": "claude-sonnet-4-6"
+  }
+}
+```
+
+`providers.overrides.<provider>.extraArgs` changes that provider's CLI arguments. For dashboard chat, set `chat.model` to override the conversational model; it takes precedence over a model in the selected provider override. Keep provider credentials in the provider's normal environment or credential store, not in this JSON file.
+
+Command overrides are intentionally fail-closed. Do not add `command` when the provider's normal binary is sufficient. To use a wrapper or nonstandard binary, put the override in an explicit operator-owned config outside the repository, set `trustCommandOverride: true`, restrict an absolute wrapper path with `trustedCommandPaths`, and start the server with both `--config <operator-config.json>` and `--trust-provider-command-overrides`:
+
+```json
+{
+  "providers": {
+    "default": "codex",
+    "fallbackChain": [],
+    "overrides": {
+      "codex": {
+        "command": "/opt/frankenbeast/bin/codex-wrapper",
+        "trustCommandOverride": true,
+        "trustedCommandPaths": ["/opt/frankenbeast/bin"]
+      }
+    }
+  }
+}
+```
+
+```bash
+npm --workspace @franken/orchestrator run chat-server -- \
+  --config "$HOME/.config/frankenbeast/dashboard-chat.json" \
+  --trust-provider-command-overrides
+```
+
+Repository-local config cannot approve its own command override: trust fields in `.fbeast/config.json` are stripped, and combining repo-local trust fields with the CLI approval flag is rejected. This prevents a checked-out project from selecting an executable merely because the server was started inside that project.
 
 ## 1. Start the chat server
 
@@ -151,9 +207,11 @@ and marker-looking text nested there must not be treated as a real prompt bounda
 
 `The server starts but chat replies fail`
 
-- verify your configured CLI provider works with `frankenbeast chat`
-- try passing `--provider <name>` explicitly
-- if you use a config file, pass `--config <path>`
+- verify the selected CLI provider works directly and is authenticated, then verify it with `frankenbeast chat`
+- pass `--provider <name>` explicitly to distinguish a bad `providers.default` from a provider runtime failure
+- if fallback selection is unexpected, pass `--providers <comma-separated-list>` explicitly and check `providers.fallbackChain`
+- if you use a config file, pass `--config <path>` and confirm that file contains `providers` and `chat.model` at the top level
+- if a command override is refused, do not weaken repository config; use the operator-owned config and explicit trust flow above
 
 `The UI loads but does not connect`
 

--- a/docs/guides/run-dashboard-chat.md
+++ b/docs/guides/run-dashboard-chat.md
@@ -45,7 +45,7 @@ For a persistent selection, update the config used by the server:
 }
 ```
 
-`providers.overrides.<provider>.extraArgs` changes that provider's CLI arguments. For dashboard chat, set `chat.model` to override the conversational model; it takes precedence over a model in the selected provider override. Keep provider credentials in the provider's normal environment or credential store, not in this JSON file.
+`providers.overrides.<provider>.extraArgs` changes that provider's CLI arguments. For dashboard chat, `providers.overrides.<selected-provider>.model` has the highest model precedence. When that field is absent, `chat.model` overrides the provider's built-in chat model. Remove a stale selected-provider model override (or set it to the same value) when changing `chat.model`. Keep provider credentials in the provider's normal environment or credential store, not in this JSON file.
 
 Command overrides are intentionally fail-closed. Do not add `command` when the provider's normal binary is sufficient. To use a wrapper or nonstandard binary, put the override in an explicit operator-owned config outside the repository, set `trustCommandOverride: true`, restrict an absolute wrapper path with `trustedCommandPaths`, and start the server with both `--config <operator-config.json>` and `--trust-provider-command-overrides`:
 
@@ -211,6 +211,7 @@ and marker-looking text nested there must not be treated as a real prompt bounda
 - pass `--provider <name>` explicitly to distinguish a bad `providers.default` from a provider runtime failure
 - if fallback selection is unexpected, pass `--providers <comma-separated-list>` explicitly and check `providers.fallbackChain`
 - if you use a config file, pass `--config <path>` and confirm that file contains `providers` and `chat.model` at the top level
+- if `chat.model` appears to be ignored, check `providers.overrides.<selected-provider>.model`, which takes precedence
 - if a command override is refused, do not weaken repository config; use the operator-owned config and explicit trust flow above
 
 `The UI loads but does not connect`

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-21 — Dashboard chat model precedence
+- For dashboard chat, the selected provider's `providers.overrides.<provider>.model` wins over `chat.model`; `chat.model` only replaces the provider's built-in chat model when no selected-provider model override exists. Trace both initial adapter construction and runtime provider override resolution before documenting model precedence.
+
 ## 2026-07-20 — Outbound request deadlines must include response consumption
 - JavaScript `fetch()` resolves when response headers arrive, not when the body has been consumed. A hard outbound-delivery deadline must wrap both the fetch and all body/error parsing under the same abort signal and timer; otherwise a provider can send headers and stall forever during `json()` or `text()`.
 - In fresh monorepo worktrees, run the root build before package-local TypeScript checks so internal workspace declaration outputs exist and unrelated module-resolution errors do not mask the feature result.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-21 — Dashboard chat model precedence
-- For dashboard chat, the selected provider's `providers.overrides.<provider>.model` wins over `chat.model`; `chat.model` only replaces the provider's built-in chat model when no selected-provider model override exists. Trace both initial adapter construction and runtime provider override resolution before documenting model precedence.
+- For conversational dashboard replies, the selected provider's `providers.overrides.<provider>.model` wins over `chat.model`; `chat.model` only replaces the provider's built-in chat model when no selected-provider model override exists. Dashboard `/run` uses a separate execution adapter that ignores both model settings and provider `extraArgs`, although it does apply trusted command overrides. Trace both adapter construction paths and runtime provider override resolution before documenting dashboard behavior.
 
 ## 2026-07-20 — Outbound request deadlines must include response consumption
 - JavaScript `fetch()` resolves when response headers arrive, not when the body has been consumed. A hard outbound-delivery deadline must wrap both the fetch and all body/error parsing under the same abort signal and timer; otherwise a provider can send headers and stall forever during `json()` or `text()`.

--- a/tests/docs-issue-3507.test.ts
+++ b/tests/docs-issue-3507.test.ts
@@ -11,7 +11,8 @@ describe('issue #3507 dashboard chat provider override guidance', () => {
     expect(guide).toContain('`.fbeast/config.json` by default');
     expect(guide).toContain('`--provider <name>` wins over `providers.default`');
     expect(guide).toContain('`--providers <comma-separated-list>` wins over `providers.fallbackChain`');
-    expect(guide).toContain('set `chat.model` to override the conversational model');
+    expect(guide).toContain('`providers.overrides.<selected-provider>.model` has the highest model precedence');
+    expect(guide).toContain('`chat.model` overrides the provider\'s built-in chat model');
     expect(guide).toContain('`--trust-provider-command-overrides`');
     expect(guide).toContain('explicit operator-owned config outside the repository');
     expect(guide).toContain('trust fields in `.fbeast/config.json` are stripped');

--- a/tests/docs-issue-3507.test.ts
+++ b/tests/docs-issue-3507.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const guide = readFileSync(resolve(ROOT, 'docs/guides/run-dashboard-chat.md'), 'utf8');
+
+describe('issue #3507 dashboard chat provider override guidance', () => {
+  it('documents current provider selection, model, and command trust behavior', () => {
+    expect(guide).toContain('`.fbeast/config.json` by default');
+    expect(guide).toContain('`--provider <name>` wins over `providers.default`');
+    expect(guide).toContain('`--providers <comma-separated-list>` wins over `providers.fallbackChain`');
+    expect(guide).toContain('set `chat.model` to override the conversational model');
+    expect(guide).toContain('`--trust-provider-command-overrides`');
+    expect(guide).toContain('explicit operator-owned config outside the repository');
+    expect(guide).toContain('trust fields in `.fbeast/config.json` are stripped');
+  });
+
+  it('keeps copyable examples aligned with the current config schema', () => {
+    expect(guide).toContain('"extraArgs": ["--verbose"]');
+    expect(guide).toContain('"trustCommandOverride": true');
+    expect(guide).toContain('"trustedCommandPaths": ["/opt/frankenbeast/bin"]');
+    expect(guide).toContain('--config "$HOME/.config/frankenbeast/dashboard-chat.json"');
+  });
+});

--- a/tests/docs-issue-3507.test.ts
+++ b/tests/docs-issue-3507.test.ts
@@ -12,7 +12,9 @@ describe('issue #3507 dashboard chat provider override guidance', () => {
     expect(guide).toContain('`--provider <name>` wins over `providers.default`');
     expect(guide).toContain('`--providers <comma-separated-list>` wins over `providers.fallbackChain`');
     expect(guide).toContain('`providers.overrides.<selected-provider>.model` has the highest model precedence');
-    expect(guide).toContain('`chat.model` overrides the provider\'s built-in chat model');
+    expect(guide).toContain('optional `chat.model` overrides the provider\'s built-in chat model');
+    expect(guide).toContain('`chat.model`, provider `model`, and provider `extraArgs` do not change `/run` execution');
+    expect(guide).toContain('the optional conversation-model override belongs at `chat.model`');
     expect(guide).toContain('`--trust-provider-command-overrides`');
     expect(guide).toContain('explicit operator-owned config outside the repository');
     expect(guide).toContain('trust fields in `.fbeast/config.json` are stripped');


### PR DESCRIPTION
## Summary
- document dashboard chat provider and fallback override precedence
- add current model and trusted command override examples
- expand provider failure troubleshooting and add a regression test for the guide

## Verification
- `npm run test:root -- tests/docs-issue-3507.test.ts`
- `npm run test:root -- tests/docs-issue-1094.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #3507