### PR TITLE
feat(web): adopt Radix provider selectors

### DIFF
--- a/docs/adr/022-adopt-radix-ui-primitives.md
+++ b/docs/adr/022-adopt-radix-ui-primitives.md
@@ -21,6 +21,14 @@ Adopt Radix UI primitives (`@radix-ui/react-*`) as the component foundation for 
 - **Slide-in detail panel** — Radix Dialog with `modal={false}` provides dialog semantics, open/close focus management, focus return, and Escape handling without trapping focus or making the rest of the dashboard inert.
 - **Wizard step indicator** — custom component (Tabs allows free navigation, incompatible with validation-gated step progression)
 
+### Implementation status
+
+The dashboard imports Radix primitives directly in its thin interactive components:
+- Beast creation and detail surfaces use Dialog, Alert Dialog, Accordion, Tooltip, Scroll Area, and Toggle Group primitives.
+- The non-modal detail drawer uses `Dialog.Root modal={false}` through `SlideInPanel`.
+- The shared provider/model cascade uses Radix Select triggers/listboxes, while its “Use default” control uses Radix Toggle.
+- Native form controls remain appropriate for ordinary text entry and standalone browser-native fields; new composite controls should prefer the adopted primitives above.
+
 ## Consequences
 
 ### Positive

--- a/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
+++ b/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
@@ -27,9 +27,15 @@ interface SelectFieldProps {
   describedBy?: string | undefined;
 }
 
+const UNSET_OPTION_VALUE = '__frankenbeast_unset__';
+
 function SelectField({ label, value, placeholder, options, onValueChange, disabled, describedBy }: SelectFieldProps) {
   return (
-    <Select.Root value={value} onValueChange={onValueChange} disabled={disabled ?? false}>
+    <Select.Root
+      value={value}
+      onValueChange={(nextValue) => onValueChange(nextValue === UNSET_OPTION_VALUE ? '' : nextValue)}
+      disabled={disabled ?? false}
+    >
       <Select.Trigger
         aria-label={label}
         aria-describedby={describedBy}
@@ -45,6 +51,12 @@ function SelectField({ label, value, placeholder, options, onValueChange, disabl
           className="z-[90] min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-beast-border bg-beast-panel text-beast-text shadow-xl"
         >
           <Select.Viewport className="p-1">
+            <Select.Item
+              value={UNSET_OPTION_VALUE}
+              className="relative flex cursor-default select-none items-center rounded-md px-3 py-2 text-sm outline-none data-[highlighted]:bg-beast-accent-soft data-[highlighted]:text-beast-accent"
+            >
+              <Select.ItemText>{placeholder}</Select.ItemText>
+            </Select.Item>
             {options.map((option) => (
               <Select.Item
                 key={option.id}

--- a/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
+++ b/packages/franken-web/src/components/beasts/shared/provider-model-select.tsx
@@ -1,4 +1,6 @@
 import { useId } from 'react';
+import * as Select from '@radix-ui/react-select';
+import * as Toggle from '@radix-ui/react-toggle';
 
 export interface ProviderOption {
   id: string;
@@ -15,66 +17,99 @@ interface ProviderModelSelectProps {
   onUseDefaultChange?: (useDefault: boolean) => void;
 }
 
+interface SelectFieldProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  options: { id: string; name: string }[];
+  onValueChange: (value: string) => void;
+  disabled?: boolean | undefined;
+  describedBy?: string | undefined;
+}
+
+function SelectField({ label, value, placeholder, options, onValueChange, disabled, describedBy }: SelectFieldProps) {
+  return (
+    <Select.Root value={value} onValueChange={onValueChange} disabled={disabled ?? false}>
+      <Select.Trigger
+        aria-label={label}
+        aria-describedby={describedBy}
+        className="flex flex-1 items-center justify-between gap-2 bg-beast-control border border-beast-border rounded-lg px-3 py-2 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent disabled:opacity-50"
+      >
+        <Select.Value placeholder={placeholder} />
+        <Select.Icon aria-hidden="true" className="text-beast-subtle">▾</Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          position="popper"
+          sideOffset={4}
+          className="z-[90] min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-beast-border bg-beast-panel text-beast-text shadow-xl"
+        >
+          <Select.Viewport className="p-1">
+            {options.map((option) => (
+              <Select.Item
+                key={option.id}
+                value={option.id}
+                className="relative flex cursor-default select-none items-center rounded-md px-3 py-2 text-sm outline-none data-[highlighted]:bg-beast-accent-soft data-[highlighted]:text-beast-accent"
+              >
+                <Select.ItemText>{option.name}</Select.ItemText>
+                <Select.ItemIndicator aria-hidden="true" className="absolute right-2">✓</Select.ItemIndicator>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+function UseDefaultToggle({ pressed, onPressedChange }: { pressed: boolean; onPressedChange: ((pressed: boolean) => void) | undefined }) {
+  return (
+    <Toggle.Root
+      pressed={pressed}
+      onPressedChange={onPressedChange ?? (() => undefined)}
+      aria-label="Use default"
+      className="group flex items-center gap-2 text-sm text-beast-muted"
+    >
+      <span aria-hidden="true" className="h-5 w-9 rounded-full border border-beast-border bg-beast-control p-0.5 transition-colors group-data-[state=on]:bg-beast-accent-soft group-data-[state=on]:border-beast-accent">
+        <span className="block h-3.5 w-3.5 rounded-full bg-beast-muted transition-transform group-data-[state=on]:translate-x-4" />
+      </span>
+      <span>Use default</span>
+    </Toggle.Root>
+  );
+}
+
 export function ProviderModelSelect({ providers, value, onChange, showUseDefault, useDefault, onUseDefaultChange }: ProviderModelSelectProps) {
   const modelGuidanceId = useId();
-  const selectedProvider = providers.find((p) => p.id === value.provider);
+  const selectedProvider = providers.find((provider) => provider.id === value.provider);
   const hasProviders = providers.length > 0;
 
   if (showUseDefault && useDefault) {
-    return (
-      <label className="flex items-center gap-2 text-sm text-beast-muted">
-        <input
-          type="checkbox"
-          checked={useDefault}
-          onChange={(e) => onUseDefaultChange?.(e.target.checked)}
-          aria-label="Use default"
-          className="accent-beast-accent"
-        />
-        Use default
-      </label>
-    );
+    return <UseDefaultToggle pressed={true} onPressedChange={onUseDefaultChange} />;
   }
 
   return (
     <div className="space-y-2">
       {showUseDefault && (
-        <label className="flex items-center gap-2 text-sm text-beast-muted">
-          <input
-            type="checkbox"
-            checked={useDefault ?? false}
-            onChange={(e) => onUseDefaultChange?.(e.target.checked)}
-            aria-label="Use default"
-            className="accent-beast-accent"
-          />
-          Use default
-        </label>
+        <UseDefaultToggle pressed={useDefault ?? false} onPressedChange={onUseDefaultChange} />
       )}
       <div className="flex gap-2">
-        <select
+        <SelectField
+          label="Provider"
           value={value.provider}
-          onChange={(e) => onChange({ provider: e.target.value, model: '' })}
-          aria-label="Provider"
+          placeholder={hasProviders ? 'Select provider...' : 'No configured providers'}
+          options={providers}
           disabled={!hasProviders}
-          className="flex-1 bg-beast-control border border-beast-border rounded-lg px-3 py-2 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent"
-        >
-          <option value="">{hasProviders ? 'Select provider...' : 'No configured providers'}</option>
-          {providers.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
-          ))}
-        </select>
-        <select
+          onValueChange={(provider) => onChange({ provider, model: '' })}
+        />
+        <SelectField
+          label="Model"
           value={value.model}
-          onChange={(e) => onChange({ ...value, model: e.target.value })}
-          aria-label="Model"
-          aria-describedby={!selectedProvider ? modelGuidanceId : undefined}
+          placeholder="Select model..."
+          options={selectedProvider?.models ?? []}
           disabled={!selectedProvider}
-          className="flex-1 bg-beast-control border border-beast-border rounded-lg px-3 py-2 text-beast-text text-sm focus:outline-none focus:ring-2 focus:ring-beast-accent disabled:opacity-50"
-        >
-          <option value="">Select model...</option>
-          {selectedProvider?.models.map((m) => (
-            <option key={m.id} value={m.id}>{m.name}</option>
-          ))}
-        </select>
+          describedBy={!selectedProvider ? modelGuidanceId : undefined}
+          onValueChange={(model) => onChange({ ...value, model })}
+        />
       </div>
       {!selectedProvider && (
         <p id={modelGuidanceId} className="text-xs text-beast-muted">

--- a/packages/franken-web/src/components/beasts/steps/step-model-selectors.test.tsx
+++ b/packages/franken-web/src/components/beasts/steps/step-model-selectors.test.tsx
@@ -51,13 +51,16 @@ describe('Beast wizard model selectors', () => {
   it('renders LLM target selectors from the configured dashboard providers', () => {
     render(<StepLlmTargets />);
 
-    expect(screen.getAllByText('openai').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('codex').length).toBeGreaterThan(0);
+    const providerSelect = screen.getAllByLabelText('Provider')[0]!;
+    fireEvent.click(providerSelect);
+    expect(screen.getByRole('option', { name: 'openai' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'codex' })).toBeTruthy();
     expect(screen.queryByText('Claude Sonnet 4.6')).toBeNull();
 
-    fireEvent.change(screen.getAllByLabelText('Provider')[0]!, { target: { value: 'openai' } });
+    fireEvent.click(screen.getByRole('option', { name: 'openai' }));
+    fireEvent.click(screen.getAllByLabelText('Model')[0]!);
 
-    expect(screen.getByText('gpt-4.1')).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'gpt-4.1' })).toBeTruthy();
     expect(screen.queryByText('claude-sonnet-4-6')).toBeNull();
   });
 
@@ -67,13 +70,15 @@ describe('Beast wizard model selectors', () => {
     render(<StepModules />);
     fireEvent.click(screen.getByRole('button', { name: /Heartbeat\s+Configuration/i }));
 
-    expect(screen.getAllByText('openai').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('codex').length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByLabelText('Provider'));
+    expect(screen.getByRole('option', { name: 'openai' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'codex' })).toBeTruthy();
     expect(screen.queryByText('Claude Sonnet 4.6')).toBeNull();
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex' } });
+    fireEvent.click(screen.getByRole('option', { name: 'codex' }));
+    fireEvent.click(screen.getByLabelText('Model'));
 
-    expect(screen.getByText('gpt-5.3-codex-spark')).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'gpt-5.3-codex-spark' })).toBeTruthy();
     expect(screen.queryByText('claude-opus-4-6')).toBeNull();
   });
 });

--- a/packages/franken-web/src/pages/beasts-page.test.tsx
+++ b/packages/franken-web/src/pages/beasts-page.test.tsx
@@ -77,10 +77,13 @@ describe('BeastsPage', () => {
     await waitFor(() => expect(dashboardClient.fetchSnapshot).toHaveBeenCalledTimes(1));
     fireEvent.click(screen.getByRole('button', { name: 'Toggle form mode' }));
 
-    expect(await screen.findByText('openai')).toBeTruthy();
     expect(screen.getByRole('button', { name: /live-runtime-skill/i })).toBeTruthy();
-    fireEvent.change(screen.getAllByLabelText('Provider')[0]!, { target: { value: 'openai' } });
-    expect(screen.getByText('gpt-4.1')).toBeTruthy();
+    const providerSelect = (await screen.findAllByLabelText('Provider'))[0]!;
+    fireEvent.click(providerSelect);
+    expect(screen.getByRole('option', { name: 'openai' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('option', { name: 'openai' }));
+    fireEvent.click(screen.getAllByLabelText('Model')[0]!);
+    expect(screen.getByRole('option', { name: 'gpt-4.1' })).toBeTruthy();
   });
 
   it('displays actionable backend launch errors from Beast API failures', async () => {

--- a/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
@@ -55,6 +55,19 @@ describe('ProviderModelSelect', () => {
     expect(onChange).toHaveBeenCalledWith({ provider: 'anthropic', model: '' });
   });
 
+  it('allows selected provider and model overrides to be cleared', () => {
+    const onChange = vi.fn();
+    render(<ProviderModelSelect providers={providers} value={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText(/provider/i));
+    fireEvent.click(screen.getByRole('option', { name: 'Select provider...' }));
+    expect(onChange).toHaveBeenCalledWith({ provider: '', model: '' });
+
+    fireEvent.click(screen.getByLabelText(/model/i));
+    fireEvent.click(screen.getByRole('option', { name: 'Select model...' }));
+    expect(onChange).toHaveBeenCalledWith({ provider: 'anthropic', model: '' });
+  });
+
   it('shows "Use default" checkbox when showUseDefault is true', () => {
     const onUseDefaultChange = vi.fn();
     render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={vi.fn()} showUseDefault useDefault={true} onUseDefaultChange={onUseDefaultChange} />);

--- a/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
+++ b/packages/franken-web/tests/components/beasts/shared/provider-model-select.test.tsx
@@ -20,13 +20,21 @@ describe('ProviderModelSelect', () => {
     expect(screen.getByLabelText(/provider/i)).toBeTruthy();
   });
 
-  it('populates model select when provider is selected', () => {
+  it('opens the accessible model listbox with the selected provider models', () => {
     render(<ProviderModelSelect providers={providers} value={{ provider: 'anthropic', model: '' }} onChange={vi.fn()} />);
-    const modelSelect = screen.getByLabelText(/model/i);
-    expect(modelSelect).toBeTruthy();
-    // Should have anthropic models available
-    const options = modelSelect.querySelectorAll('option');
-    expect(options.length).toBeGreaterThan(1); // includes placeholder
+
+    fireEvent.click(screen.getByLabelText(/model/i));
+
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Claude Sonnet 4.6' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Claude Opus 4.6' })).toBeTruthy();
+  });
+
+  it('uses Radix select triggers instead of native selects', () => {
+    const { container } = render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={vi.fn()} />);
+
+    expect(container.querySelector('select')).toBeNull();
+    expect(screen.getByLabelText(/provider/i).getAttribute('role')).toBe('combobox');
   });
 
   it('explains how to enable the disabled model select', () => {
@@ -42,13 +50,19 @@ describe('ProviderModelSelect', () => {
   it('calls onChange when provider changes', () => {
     const onChange = vi.fn();
     render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={onChange} />);
-    fireEvent.change(screen.getByLabelText(/provider/i), { target: { value: 'anthropic' } });
+    fireEvent.click(screen.getByLabelText(/provider/i));
+    fireEvent.click(screen.getByRole('option', { name: 'Anthropic' }));
     expect(onChange).toHaveBeenCalledWith({ provider: 'anthropic', model: '' });
   });
 
   it('shows "Use default" checkbox when showUseDefault is true', () => {
-    render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={vi.fn()} showUseDefault useDefault={true} onUseDefaultChange={vi.fn()} />);
-    expect(screen.getByLabelText(/use default/i)).toBeTruthy();
+    const onUseDefaultChange = vi.fn();
+    render(<ProviderModelSelect providers={providers} value={{ provider: '', model: '' }} onChange={vi.fn()} showUseDefault useDefault={true} onUseDefaultChange={onUseDefaultChange} />);
+    const toggle = screen.getByLabelText(/use default/i);
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.tagName).toBe('BUTTON');
+    fireEvent.click(toggle);
+    expect(onUseDefaultChange).toHaveBeenCalledWith(false);
   });
 
   it('hides selects when "Use default" is checked', () => {

--- a/packages/franken-web/tests/components/beasts/steps/step-llm-targets.test.tsx
+++ b/packages/franken-web/tests/components/beasts/steps/step-llm-targets.test.tsx
@@ -47,13 +47,16 @@ describe('StepLlmTargets', () => {
 
     render(<StepLlmTargets />);
 
-    expect(screen.getAllByText('openai').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('gemini').length).toBeGreaterThan(0);
+    const providerSelect = screen.getAllByLabelText('Provider')[0]!;
+    fireEvent.click(providerSelect);
+    expect(screen.getByRole('option', { name: 'openai' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'gemini' })).toBeTruthy();
     expect(screen.queryByText('Claude Sonnet 4.6')).toBeNull();
 
-    fireEvent.change(screen.getAllByLabelText('Provider')[0]!, { target: { value: 'openai' } });
+    fireEvent.click(screen.getByRole('option', { name: 'openai' }));
+    fireEvent.click(screen.getAllByLabelText('Model')[0]!);
 
-    expect(screen.getByText('gpt-5.3')).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'gpt-5.3' })).toBeTruthy();
     expect(screen.queryByText('claude-sonnet-4-6')).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- migrate the shared provider/model cascade to Radix Select primitives
- migrate the “Use default” control to Radix Toggle while preserving its switch styling
- update dashboard tests around accessible listbox and toggle behavior
- document the dashboard Radix implementation status in ADR 022

## Test plan
- `npm run test --workspace @franken/web` (694 tests)
- `npm run typecheck --workspace @franken/web`
- `npm run lint --workspace @franken/web` (passes with 17 pre-existing warnings)
- `npm run build --workspace @franken/web`

Closes #3506