### PR TITLE
docs(readme): clarify ADR reference status

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,10 @@ Required HITL approvals fail closed when a run has no interactive TTY. In truste
 
 ### References
 
+The ADRs are historical decision records: they capture original design rationale,
+not current implementation guidance. For current behavior, cross-check the relevant
+package READMEs, architecture docs, and source.
+
 - [ADR-018](docs/adr/018-secret-store-architecture.md) — secret store design and backend selection rationale
 - [ADR-017](docs/adr/017-network-operator-control-plane.md) — network operator control plane and token auth
 - [Worker push rollback runbook](docs/runbooks/worker-push-rollback.md) — dry-run planning and approval runner routing for failed or bad worker branch publishes

--- a/tests/docs-issue-3482.test.ts
+++ b/tests/docs-issue-3482.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const README = readFileSync(resolve(ROOT, "README.md"), "utf8");
+const REFERENCES = README.match(
+  /### References([\s\S]*?)## Configuration/,
+)?.[1];
+
+describe("issue #3482 ADR reference guidance", () => {
+  it("identifies ADRs as historical rationale rather than current implementation guidance", () => {
+    expect(REFERENCES).toContain("ADRs are historical decision records");
+    expect(REFERENCES).toContain("not current implementation guidance");
+    expect(REFERENCES).toContain(
+      "package READMEs, architecture docs, and source",
+    );
+  });
+
+  it("retains the secret-store and network-operator ADR links", () => {
+    expect(REFERENCES).toContain(
+      "[ADR-018](docs/adr/018-secret-store-architecture.md)",
+    );
+    expect(REFERENCES).toContain(
+      "[ADR-017](docs/adr/017-network-operator-control-plane.md)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- identify ADR-017 and ADR-018 as historical decision records rather than current implementation guidance
- direct readers to current package READMEs, architecture docs, and source for operational behavior
- add focused regression coverage for the qualifier and ADR links

## Verification
- `npm run test:root` (670 passed, 1 skipped)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (passes with pre-existing warnings)
- `npx prettier --check tests/docs-issue-3482.test.ts`

Closes #3482