### PR TITLE
test: strengthen removed workspace wiring assertions

### DIFF
--- a/tests/helpers/removed-workspace-wiring.ts
+++ b/tests/helpers/removed-workspace-wiring.ts
@@ -1,0 +1,33 @@
+export type WiringFile = {
+  path: string;
+  content: string;
+};
+
+export type RemovedWorkspaceReference = {
+  path: string;
+  reference: string;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+
+export const findRemovedWorkspaceReferences = (
+  files: readonly WiringFile[],
+  removedReferences: readonly string[],
+): RemovedWorkspaceReference[] => {
+  const matches: RemovedWorkspaceReference[] = [];
+
+  for (const file of files) {
+    for (const reference of removedReferences) {
+      const exactReference = new RegExp(
+        `(?<![A-Za-z0-9_-])${escapeRegExp(reference)}(?![A-Za-z0-9_-])`,
+        "u",
+      );
+      if (exactReference.test(file.content)) {
+        matches.push({ path: file.path, reference });
+      }
+    }
+  }
+
+  return matches;
+};

--- a/tests/removed-workspace-wiring.test.ts
+++ b/tests/removed-workspace-wiring.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { findRemovedWorkspaceReferences } from "./helpers/removed-workspace-wiring.js";
+
+const REMOVED_WORKSPACE_REFERENCES = [
+  "@franken/firewall",
+  "@franken/skills",
+  "franken-heartbeat",
+  "@franken/mcp",
+  "franken-comms",
+] as const;
+
+describe("removed workspace wiring", () => {
+  it("reports removed workspace references in active configuration", () => {
+    const references = findRemovedWorkspaceReferences(
+      [
+        {
+          path: "package.json",
+          content: JSON.stringify({
+            dependencies: { "@franken/mcp": "workspace:*" },
+          }),
+        },
+        {
+          path: "tsconfig.json",
+          content: JSON.stringify({
+            compilerOptions: {
+              paths: {
+                "franken-heartbeat": [
+                  "./packages/franken-heartbeat/src/index.ts",
+                ],
+              },
+            },
+          }),
+        },
+      ],
+      REMOVED_WORKSPACE_REFERENCES,
+    );
+
+    expect(references).toEqual([
+      { path: "package.json", reference: "@franken/mcp" },
+      { path: "tsconfig.json", reference: "franken-heartbeat" },
+    ]);
+  });
+
+  it("does not confuse active workspace names with removed prefixes", () => {
+    const references = findRemovedWorkspaceReferences(
+      [
+        {
+          path: "vitest.config.ts",
+          content:
+            "alias: { '@franken/mcp-suite': 'packages/franken-mcp-suite/src/index.ts' }",
+        },
+      ],
+      REMOVED_WORKSPACE_REFERENCES,
+    );
+
+    expect(references).toEqual([]);
+  });
+});

--- a/tests/removed-workspace-wiring.test.ts
+++ b/tests/removed-workspace-wiring.test.ts
@@ -6,6 +6,7 @@ const REMOVED_WORKSPACE_REFERENCES = [
   "@franken/skills",
   "franken-heartbeat",
   "@franken/mcp",
+  "@frankenbeast/mcp",
   "franken-comms",
 ] as const;
 
@@ -31,6 +32,10 @@ describe("removed workspace wiring", () => {
             },
           }),
         },
+        {
+          path: "vitest.integration.config.ts",
+          content: "alias: { '@frankenbeast/mcp': './removed-mcp.ts' }",
+        },
       ],
       REMOVED_WORKSPACE_REFERENCES,
     );
@@ -38,6 +43,10 @@ describe("removed workspace wiring", () => {
     expect(references).toEqual([
       { path: "package.json", reference: "@franken/mcp" },
       { path: "tsconfig.json", reference: "franken-heartbeat" },
+      {
+        path: "vitest.integration.config.ts",
+        reference: "@frankenbeast/mcp",
+      },
     ]);
   });
 

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -18,15 +18,28 @@ const ALL_PACKAGES = getWorkspacePackageDirNames();
 const REMOVED_WORKSPACES = [
   {
     dir: "frankenfirewall",
-    references: ["frankenfirewall", "@franken/firewall"],
+    references: [
+      "frankenfirewall",
+      "@franken/firewall",
+      "@frankenbeast/firewall",
+    ],
   },
   {
     dir: "franken-skills",
-    references: ["franken-skills", "@franken/skills"],
+    references: ["franken-skills", "@franken/skills", "@frankenbeast/skills"],
   },
-  { dir: "franken-heartbeat", references: ["franken-heartbeat"] },
-  { dir: "franken-mcp", references: ["franken-mcp", "@franken/mcp"] },
-  { dir: "franken-comms", references: ["franken-comms"] },
+  {
+    dir: "franken-heartbeat",
+    references: ["franken-heartbeat", "@frankenbeast/heartbeat"],
+  },
+  {
+    dir: "franken-mcp",
+    references: ["franken-mcp", "@franken/mcp", "@frankenbeast/mcp"],
+  },
+  {
+    dir: "franken-comms",
+    references: ["franken-comms", "@frankenbeast/comms"],
+  },
 ] as const;
 const REMOVED_WORKSPACE_REFERENCES = REMOVED_WORKSPACES.flatMap(
   ({ references }) => references,
@@ -39,7 +52,7 @@ const isWorkspaceWiringFile = (fileName: string): boolean =>
   fileName === "release-please-config.json" ||
   fileName === ".release-please-manifest.json" ||
   /^tsconfig(?:\.[^.]+)?\.json$/u.test(fileName) ||
-  /^vitest\.config(?:\.[^.]+)?\.ts$/u.test(fileName);
+  /^vitest(?:\.[^.]+)*\.config(?:\.[^.]+)*\.ts$/u.test(fileName);
 
 const getActiveWorkspaceWiringPaths = (): string[] => {
   const paths = readdirSync(ROOT, { withFileTypes: true })
@@ -232,7 +245,8 @@ describe("Chunk 10: full verification pass", () => {
 
   describe("removed workspace consolidation", () => {
     for (const { dir } of REMOVED_WORKSPACES) {
-      it(`packages/${dir}/ should not exist`, () => {
+      it(`${dir}/ should not exist at root or under packages/`, () => {
+        expect(existsSync(resolve(ROOT, dir))).toBe(false);
         expect(existsSync(resolve(ROOT, "packages", dir))).toBe(false);
       });
     }

--- a/tests/verify-everything.test.ts
+++ b/tests/verify-everything.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { getWorkspacePackageDirNames } from "./helpers/workspaces.js";
+import {
+  getWorkspacePackageDirNames,
+  getWorkspacePackageManifestPaths,
+} from "./helpers/workspaces.js";
+import { findRemovedWorkspaceReferences } from "./helpers/removed-workspace-wiring.js";
 import { validateVerificationTaskWiring } from "./helpers/verification-task-wiring.js";
 
 const ROOT = resolve(import.meta.dirname, "..");
@@ -11,6 +15,50 @@ const exec = (command: string, args: string[]) =>
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const ALL_PACKAGES = getWorkspacePackageDirNames();
+const REMOVED_WORKSPACES = [
+  {
+    dir: "frankenfirewall",
+    references: ["frankenfirewall", "@franken/firewall"],
+  },
+  {
+    dir: "franken-skills",
+    references: ["franken-skills", "@franken/skills"],
+  },
+  { dir: "franken-heartbeat", references: ["franken-heartbeat"] },
+  { dir: "franken-mcp", references: ["franken-mcp", "@franken/mcp"] },
+  { dir: "franken-comms", references: ["franken-comms"] },
+] as const;
+const REMOVED_WORKSPACE_REFERENCES = REMOVED_WORKSPACES.flatMap(
+  ({ references }) => references,
+);
+
+const isWorkspaceWiringFile = (fileName: string): boolean =>
+  fileName === "package.json" ||
+  fileName === "package-lock.json" ||
+  fileName === "turbo.json" ||
+  fileName === "release-please-config.json" ||
+  fileName === ".release-please-manifest.json" ||
+  /^tsconfig(?:\.[^.]+)?\.json$/u.test(fileName) ||
+  /^vitest\.config(?:\.[^.]+)?\.ts$/u.test(fileName);
+
+const getActiveWorkspaceWiringPaths = (): string[] => {
+  const paths = readdirSync(ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && isWorkspaceWiringFile(entry.name))
+    .map((entry) => entry.name);
+
+  for (const manifestPath of getWorkspacePackageManifestPaths()) {
+    const packageDir = manifestPath.slice(0, -"/package.json".length);
+    for (const entry of readdirSync(resolve(ROOT, packageDir), {
+      withFileTypes: true,
+    })) {
+      if (entry.isFile() && isWorkspaceWiringFile(entry.name)) {
+        paths.push(`${packageDir}/${entry.name}`);
+      }
+    }
+  }
+
+  return [...new Set(paths)].sort();
+};
 
 type NpmLsResult = {
   status: number | null;
@@ -180,6 +228,28 @@ describe("Chunk 10: full verification pass", () => {
         expect(existsSync(resolve(ROOT, dir))).toBe(false);
       });
     }
+  });
+
+  describe("removed workspace consolidation", () => {
+    for (const { dir } of REMOVED_WORKSPACES) {
+      it(`packages/${dir}/ should not exist`, () => {
+        expect(existsSync(resolve(ROOT, "packages", dir))).toBe(false);
+      });
+    }
+
+    it("has no removed package names in active workspace wiring", () => {
+      const wiringFiles = getActiveWorkspaceWiringPaths().map((path) => ({
+        path,
+        content: readFileSync(resolve(ROOT, path), "utf8"),
+      }));
+
+      expect(
+        findRemovedWorkspaceReferences(
+          wiringFiles,
+          REMOVED_WORKSPACE_REFERENCES,
+        ),
+      ).toEqual([]);
+    });
   });
 
   describe("no .git dirs inside packages", () => {


### PR DESCRIPTION
## Summary
- keep explicit directory-absence assertions for the five consolidated workspaces
- scan active root and package workspace wiring for exact stale package names and aliases
- avoid false positives for active names such as `@franken/mcp-suite`

## Test plan
- `npx vitest run tests/removed-workspace-wiring.test.ts tests/verify-everything.test.ts`
- `npm run test:root`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check tests/verify-everything.test.ts tests/removed-workspace-wiring.test.ts tests/helpers/removed-workspace-wiring.ts`

Closes #3481