### PR TITLE
docs(examples): add runnable sample projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ npm run test:root
 
 For CI-style validation without mutating files or installing dependencies, run `./scripts/bootstrap.sh --dry-run`. If you intentionally need a manual dependency install instead of bootstrap, run it from the repository root with the Corepack-activated npm version from `packageManager`, copy or merge `.env.example` into `.env`, and note that you are skipping bootstrap's environment validation and optional Docker-service prompts.
 
+Browse the standalone [examples](examples/README.md) for copyable CLI planning, MCP registration, and minimal orchestrator configuration projects. Each example has its own locked dependencies and can be scaffolded with `npm run create:project -- <example-name> <target-directory>`.
+
 The root Vitest suite also checks local Markdown links in README/docs/package READMEs. Local link targets are treated as untrusted input: keep them simple repository-relative paths and do not add shell metacharacters such as backticks, `$`, `;`, `&`, `|`, `<`, or `>`. External `http(s)` links and same-page anchors are ignored by that local filesystem check.
 
 See [ONBOARDING.md](ONBOARDING.md) for the complete first-time setup checklist, including prerequisites, bootstrap, UI startup, troubleshooting, and secret backends. See [docs/guides/quickstart.md](docs/guides/quickstart.md) for the shorter setup guide including Docker services.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -828,7 +828,7 @@ fbeast mcp init / client config
 
 ## Examples
 
-There is no current top-level `examples/` directory in this repo. For runnable usage examples, prefer the package READMEs, `docs/guides/quickstart.md`, `docs/guides/run-cli-beast.md`, and tests next to the implementation. Older examples that mention Claude/OpenAI/Ollama adapters or a Docker firewall proxy describe pre-consolidation surfaces.
+The top-level [`examples/`](../examples/README.md) directory contains standalone, scaffoldable sample projects for CLI planning, MCP registration, and orchestrator configuration. Package READMEs, `docs/guides/quickstart.md`, `docs/guides/run-cli-beast.md`, and tests next to the implementation provide deeper usage details. Older examples that mention Claude/OpenAI/Ollama adapters or a Docker firewall proxy describe pre-consolidation surfaces.
 
 ## Chat System Architecture
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -38,6 +38,8 @@ If Corepack is not available yet, install it first with `npm install -g corepack
 
 Dependency locking is centralized at the workspace root: commit updates to the root `package-lock.json` only. Package workspaces under `packages/*` must not carry their own nested `package-lock.json` files; run installs from the repository root so npm records workspace dependency changes in the root lockfile. Standalone example projects under `examples/` may keep their own lockfiles because they are scaffolded outside the monorepo workspace.
 
+For focused, copyable starting points, browse the standalone [sample projects](../../examples/README.md): a dependency-free smoke test, a CLI planning project with a design document, project-scoped MCP setup, and a minimal orchestrator configuration. Scaffold one from the repository root with `npm run create:project -- <example-name> <target-directory>`.
+
 Run reproducible dependency audits through the guarded script so the live npm
 binary still matches the root `packageManager` pin before `npm audit` runs:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# Frankenbeast examples
+
+These standalone sample projects are intentionally outside the monorepo workspaces. Each one has its own locked dependencies and can be copied with `npm run create:project -- <name> <target-directory>` from the repository root.
+
+| Example                                              | What it demonstrates                                             |
+| ---------------------------------------------------- | ---------------------------------------------------------------- |
+| [Quick start](quick-start/README.md)                 | A dependency-free scaffold and environment-file smoke test       |
+| [CLI plan](cli-plan/README.md)                       | Running `frankenbeast plan` against a small design document      |
+| [MCP suite](mcp-suite/README.md)                     | Registering project-scoped MCP servers and removing them cleanly |
+| [Orchestrator config](orchestrator-config/README.md) | Starting the orchestrator with a minimal validated JSON config   |
+
+## Use an example
+
+From the Frankenbeast repository root:
+
+```bash
+npm run create:project -- quick-start ../my-frankenbeast-app
+cd ../my-frankenbeast-app
+npm start
+```
+
+The scaffold command copies the selected directory, creates `.env` from `.env.example` when present, and runs `npm ci`. You can also copy an example yourself and run `npm ci` inside it.
+
+The CLI, MCP, and orchestrator examples may call an external AI provider. Review each example's README and configure only the provider credentials it needs; never commit credentials or generated `.env` files.

--- a/examples/cli-plan/README.md
+++ b/examples/cli-plan/README.md
@@ -1,0 +1,17 @@
+# CLI plan example
+
+This project supplies a small design document to the Frankenbeast planner. From a Frankenbeast checkout, first run `npm run local:link` at the repository root so the current `frankenbeast` binary is available on `PATH`, then copy or scaffold this project.
+
+```bash
+npm ci
+npm run help
+npm run plan
+```
+
+`npm run plan` executes:
+
+```bash
+frankenbeast plan --design-doc docs/sample-design.md
+```
+
+The planner writes generated chunks under `.fbeast/plans/`. Configure the credentials for your selected provider before running the planner. The example defaults to the CLI's normal provider selection; pass additional supported CLI arguments after `--`, for example `npm run plan -- --provider codex`.

--- a/examples/cli-plan/docs/sample-design.md
+++ b/examples/cli-plan/docs/sample-design.md
@@ -1,0 +1,23 @@
+# Greeting command design
+
+## Goal
+
+Add a tiny command-line program that prints a configurable greeting.
+
+## Requirements
+
+- Add `src/greet.js` with an exported `greet(name)` function.
+- Default an omitted name to `world`.
+- Add a `greet` package script that accepts a name argument.
+- Add deterministic unit tests for explicit and default names.
+- Document the command in this project's README.
+
+## Out of scope
+
+- Network calls
+- Persistent storage
+- A graphical interface
+
+## Acceptance criteria
+
+Running `npm run greet -- Ada` prints `Hello, Ada!`, and the unit tests pass without provider credentials or network access.

--- a/examples/cli-plan/package-lock.json
+++ b/examples/cli-plan/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "frankenbeast-cli-plan-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frankenbeast-cli-plan-example",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/examples/cli-plan/package.json
+++ b/examples/cli-plan/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "frankenbeast-cli-plan-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "help": "frankenbeast --help",
+    "plan": "frankenbeast plan --design-doc docs/sample-design.md"
+  }
+}

--- a/examples/mcp-suite/README.md
+++ b/examples/mcp-suite/README.md
@@ -1,0 +1,20 @@
+# MCP suite example
+
+From a Frankenbeast checkout, first run `npm run local:link` at the repository root so the current `fbeast` CLI and its server binaries are available on `PATH`, then copy or scaffold this project. Run setup from the example directory so registration and `.fbeast/beast.db` stay project-scoped.
+
+```bash
+npm ci
+
+# Register the standard server set for the auto-detected client.
+npm run mcp:init
+
+# Or register the lower-context proxy server.
+fbeast mcp init --mode=proxy
+
+# Remove the generated client registration when finished.
+npm run mcp:uninstall
+```
+
+The scripts invoke `fbeast mcp init` and `fbeast mcp uninstall`. Add `-- --client=claude`, `-- --client=gemini`, or `-- --client=codex` to an npm script when auto-detection is ambiguous. Add `--hooks` only after reviewing the generated project-scoped hook settings.
+
+Do not use a one-shot `npx` invocation for initialization: registered clients launch the `fbeast-*` server binaries later, so the linked server commands must remain on `PATH`.

--- a/examples/mcp-suite/package-lock.json
+++ b/examples/mcp-suite/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "frankenbeast-mcp-suite-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frankenbeast-mcp-suite-example",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/examples/mcp-suite/package.json
+++ b/examples/mcp-suite/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "frankenbeast-mcp-suite-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "mcp:init": "fbeast mcp init",
+    "mcp:proxy": "fbeast mcp init --mode=proxy",
+    "mcp:uninstall": "fbeast mcp uninstall"
+  }
+}

--- a/examples/orchestrator-config/.fbeast/config.json
+++ b/examples/orchestrator-config/.fbeast/config.json
@@ -1,0 +1,8 @@
+{
+  "maxCritiqueIterations": 2,
+  "maxTotalTokens": 20000,
+  "maxDurationMs": 120000,
+  "minCritiqueScore": 0.7,
+  "enableHeartbeat": false,
+  "enableTracing": false
+}

--- a/examples/orchestrator-config/.gitignore
+++ b/examples/orchestrator-config/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.fbeast/*
+!.fbeast/config.json

--- a/examples/orchestrator-config/README.md
+++ b/examples/orchestrator-config/README.md
@@ -12,6 +12,6 @@ npm run plan
 npm start
 ```
 
-`npm run setup` initializes the Git repository required for isolated chunk execution. Configure a Git user name and email first if your environment does not already provide them. `npm run plan` then creates chunks under `.fbeast/plans/` from the bundled design document, and `npm start` runs those chunks with `frankenbeast run --config .fbeast/config.json`. Replace the bundled document or pass an existing plan directory using supported CLI arguments after `--` when adapting the example.
+`npm run setup` initializes the `main` branch and creates the base commit required for isolated chunk execution. Configure a Git user name and email first if your environment does not already provide them. The bundled `.gitignore` keeps dependencies and generated plans out of that commit while preserving the sample config. `npm run plan` then creates chunks under `.fbeast/plans/` from the bundled design document, and `npm start` runs those chunks with `frankenbeast run --config .fbeast/config.json`. Replace the bundled document or pass an existing plan directory using supported CLI arguments after `--` when adapting the example.
 
 Configuration precedence is CLI flags, then `FRANKEN_*` environment variables, then this JSON file, then built-in defaults. The sample uses valid conservative budgets and keeps heartbeat/tracing opt-in features disabled.

--- a/examples/orchestrator-config/README.md
+++ b/examples/orchestrator-config/README.md
@@ -1,0 +1,15 @@
+# Minimal orchestrator configuration
+
+This example shows the smallest useful project-local runtime configuration while leaving provider selection and credentials outside version control.
+
+From a Frankenbeast checkout, first run `npm run local:link` at the repository root so the current `frankenbeast` binary is available on `PATH`, then copy or scaffold this project.
+
+```bash
+npm ci
+npm run help
+npm start
+```
+
+`npm start` runs `frankenbeast run --config .fbeast/config.json`. A run needs generated chunks under `.fbeast/plans/`; create them with `frankenbeast plan --design-doc <path>` first or pass an existing plan directory using supported CLI arguments after `--`.
+
+Configuration precedence is CLI flags, then `FRANKEN_*` environment variables, then this JSON file, then built-in defaults. The sample uses valid conservative budgets and keeps heartbeat/tracing opt-in features disabled.

--- a/examples/orchestrator-config/README.md
+++ b/examples/orchestrator-config/README.md
@@ -7,9 +7,10 @@ From a Frankenbeast checkout, first run `npm run local:link` at the repository r
 ```bash
 npm ci
 npm run help
+npm run plan
 npm start
 ```
 
-`npm start` runs `frankenbeast run --config .fbeast/config.json`. A run needs generated chunks under `.fbeast/plans/`; create them with `frankenbeast plan --design-doc <path>` first or pass an existing plan directory using supported CLI arguments after `--`.
+`npm run plan` creates chunks under `.fbeast/plans/` from the bundled design document. `npm start` then runs those chunks with `frankenbeast run --config .fbeast/config.json`. Replace the bundled document or pass an existing plan directory using supported CLI arguments after `--` when adapting the example.
 
 Configuration precedence is CLI flags, then `FRANKEN_*` environment variables, then this JSON file, then built-in defaults. The sample uses valid conservative budgets and keeps heartbeat/tracing opt-in features disabled.

--- a/examples/orchestrator-config/README.md
+++ b/examples/orchestrator-config/README.md
@@ -7,10 +7,11 @@ From a Frankenbeast checkout, first run `npm run local:link` at the repository r
 ```bash
 npm ci
 npm run help
+npm run setup
 npm run plan
 npm start
 ```
 
-`npm run plan` creates chunks under `.fbeast/plans/` from the bundled design document. `npm start` then runs those chunks with `frankenbeast run --config .fbeast/config.json`. Replace the bundled document or pass an existing plan directory using supported CLI arguments after `--` when adapting the example.
+`npm run setup` initializes the Git repository required for isolated chunk execution. Configure a Git user name and email first if your environment does not already provide them. `npm run plan` then creates chunks under `.fbeast/plans/` from the bundled design document, and `npm start` runs those chunks with `frankenbeast run --config .fbeast/config.json`. Replace the bundled document or pass an existing plan directory using supported CLI arguments after `--` when adapting the example.
 
 Configuration precedence is CLI flags, then `FRANKEN_*` environment variables, then this JSON file, then built-in defaults. The sample uses valid conservative budgets and keeps heartbeat/tracing opt-in features disabled.

--- a/examples/orchestrator-config/docs/sample-design.md
+++ b/examples/orchestrator-config/docs/sample-design.md
@@ -1,0 +1,16 @@
+# Configured greeting design
+
+## Goal
+
+Create a tiny command-line greeting project that demonstrates an orchestrated plan and run.
+
+## Requirements
+
+- Add a script that prints `Hello from the configured orchestrator!`.
+- Add a package script that runs the greeting.
+- Add a deterministic test for the exact output.
+- Document how to run the script and test.
+
+## Acceptance criteria
+
+The implementation and its test run without network access after the planning phase.

--- a/examples/orchestrator-config/package-lock.json
+++ b/examples/orchestrator-config/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "frankenbeast-orchestrator-config-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frankenbeast-orchestrator-config-example",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/examples/orchestrator-config/package.json
+++ b/examples/orchestrator-config/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "help": "frankenbeast --help",
+    "setup": "git init",
     "plan": "frankenbeast plan --design-doc docs/sample-design.md",
     "start": "frankenbeast run --config .fbeast/config.json"
   }

--- a/examples/orchestrator-config/package.json
+++ b/examples/orchestrator-config/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "help": "frankenbeast --help",
+    "plan": "frankenbeast plan --design-doc docs/sample-design.md",
     "start": "frankenbeast run --config .fbeast/config.json"
   }
 }

--- a/examples/orchestrator-config/package.json
+++ b/examples/orchestrator-config/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "help": "frankenbeast --help",
-    "setup": "git init",
+    "setup": "git init -b main && git add . && git commit -m \"chore: initialize example\"",
     "plan": "frankenbeast plan --design-doc docs/sample-design.md",
     "start": "frankenbeast run --config .fbeast/config.json"
   }

--- a/examples/orchestrator-config/package.json
+++ b/examples/orchestrator-config/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "frankenbeast-orchestrator-config-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "help": "frankenbeast --help",
+    "start": "frankenbeast run --config .fbeast/config.json"
+  }
+}

--- a/examples/quick-start/README.md
+++ b/examples/quick-start/README.md
@@ -1,11 +1,17 @@
 # Frankenbeast Quick Start Example
 
-This is the minimal example used by `scripts/create-project.sh quick-start`.
-
-## Run
+This is the minimal dependency-free example used by `scripts/create-project.sh quick-start`. It verifies that the example scaffold and its environment-file handling work before you configure an AI provider.
 
 ```bash
+npm ci
+cp .env.example .env
 npm start
 ```
 
-The script prints `FRANKENBEAST_EXAMPLE_MESSAGE` from `.env` when your shell exports it, or a built-in greeting otherwise.
+From the Frankenbeast repository root, the supported shortcut performs all three setup steps in a fresh target directory:
+
+```bash
+npm run create:project -- quick-start ../my-frankenbeast-app
+```
+
+The script prints `FRANKENBEAST_EXAMPLE_MESSAGE` from `.env`, or a built-in greeting when the variable is absent.

--- a/scripts/create-project.sh
+++ b/scripts/create-project.sh
@@ -95,15 +95,6 @@ fi
   npm ci
 )
 
-if node -e '
-  const manifest = require(process.argv[1]);
-  process.exit(Object.hasOwn(manifest.scripts ?? {}, "start") ? 0 : 1);
-' "$target_dir/package.json"; then
-  next_command="npm start"
-else
-  next_command="See README.md for this example's commands"
-fi
-
 cat <<EOF
 Created Frankenbeast example project
   Example: $example_name
@@ -112,5 +103,5 @@ Created Frankenbeast example project
 
 Next steps:
   cd "$target_dir"
-  $next_command
+  See README.md for this example's commands
 EOF

--- a/scripts/create-project.sh
+++ b/scripts/create-project.sh
@@ -95,6 +95,15 @@ fi
   npm ci
 )
 
+if node -e '
+  const manifest = require(process.argv[1]);
+  process.exit(Object.hasOwn(manifest.scripts ?? {}, "start") ? 0 : 1);
+' "$target_dir/package.json"; then
+  next_command="npm start"
+else
+  next_command="See README.md for this example's commands"
+fi
+
 cat <<EOF
 Created Frankenbeast example project
   Example: $example_name
@@ -103,5 +112,5 @@ Created Frankenbeast example project
 
 Next steps:
   cd "$target_dir"
-  npm start
+  $next_command
 EOF

--- a/tests/docs-issue-3480.test.ts
+++ b/tests/docs-issue-3480.test.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { OrchestratorConfigSchema } from "../packages/franken-orchestrator/src/config/orchestrator-config.js";
 
@@ -25,6 +27,9 @@ describe("issue #3480 runnable example projects", () => {
     expect(readText("README.md")).toContain("[examples](examples/README.md)");
     expect(readText("docs/guides/quickstart.md")).toContain(
       "[sample projects](../../examples/README.md)",
+    );
+    expect(readText("docs/ARCHITECTURE.md")).toContain(
+      "[`examples/`](../examples/README.md)",
     );
   });
 
@@ -77,5 +82,34 @@ describe("issue #3480 runnable example projects", () => {
       enableTracing: false,
     });
     expect(OrchestratorConfigSchema.safeParse(config).success).toBe(true);
+
+    const readme = readText("examples/orchestrator-config/README.md");
+    expect(readme.indexOf("npm run plan")).toBeLessThan(
+      readme.indexOf("npm start"),
+    );
+    expect(
+      existsSync(
+        resolve(ROOT, "examples/orchestrator-config/docs/sample-design.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("prints package-specific next steps for examples without start scripts", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "frankenbeast-examples-"));
+    const target = join(tempRoot, "cli-plan");
+
+    try {
+      const result = spawnSync(
+        "bash",
+        [resolve(ROOT, "scripts/create-project.sh"), "cli-plan", target],
+        { cwd: ROOT, encoding: "utf8" },
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain("See README.md");
+      expect(result.stdout).not.toContain("npm start");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/docs-issue-3480.test.ts
+++ b/tests/docs-issue-3480.test.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { OrchestratorConfigSchema } from "../packages/franken-orchestrator/src/config/orchestrator-config.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), "utf8");
+}
+
+function readJson(relativePath: string): Record<string, unknown> {
+  return JSON.parse(readText(relativePath)) as Record<string, unknown>;
+}
+
+const examples = [
+  "quick-start",
+  "cli-plan",
+  "mcp-suite",
+  "orchestrator-config",
+] as const;
+
+describe("issue #3480 runnable example projects", () => {
+  it("exposes the examples from the root README and quickstart guide", () => {
+    expect(readText("README.md")).toContain("[examples](examples/README.md)");
+    expect(readText("docs/guides/quickstart.md")).toContain(
+      "[sample projects](../../examples/README.md)",
+    );
+  });
+
+  it("keeps every listed example self-contained and scaffoldable", () => {
+    const index = readText("examples/README.md");
+
+    for (const example of examples) {
+      expect(index).toContain(`(${example}/README.md)`);
+      expect(existsSync(resolve(ROOT, `examples/${example}/README.md`))).toBe(
+        true,
+      );
+      expect(
+        existsSync(resolve(ROOT, `examples/${example}/package.json`)),
+      ).toBe(true);
+      expect(
+        existsSync(resolve(ROOT, `examples/${example}/package-lock.json`)),
+      ).toBe(true);
+      expect(readJson(`examples/${example}/package.json`).private).toBe(true);
+    }
+  });
+
+  it("provides a CLI plan design doc and exact plan command", () => {
+    const readme = readText("examples/cli-plan/README.md");
+
+    expect(readme).toContain(
+      "frankenbeast plan --design-doc docs/sample-design.md",
+    );
+    expect(
+      existsSync(resolve(ROOT, "examples/cli-plan/docs/sample-design.md")),
+    ).toBe(true);
+  });
+
+  it("provides project-scoped MCP setup commands", () => {
+    const readme = readText("examples/mcp-suite/README.md");
+
+    expect(readme).toContain("fbeast mcp init");
+    expect(readme).toContain("fbeast mcp init --mode=proxy");
+    expect(readme).toContain("fbeast mcp uninstall");
+  });
+
+  it("provides a valid minimal orchestrator config", () => {
+    const config = readJson("examples/orchestrator-config/.fbeast/config.json");
+
+    expect(config).toEqual({
+      maxCritiqueIterations: 2,
+      maxTotalTokens: 20000,
+      maxDurationMs: 120000,
+      minCritiqueScore: 0.7,
+      enableHeartbeat: false,
+      enableTracing: false,
+    });
+    expect(OrchestratorConfigSchema.safeParse(config).success).toBe(true);
+  });
+});

--- a/tests/docs-issue-3480.test.ts
+++ b/tests/docs-issue-3480.test.ts
@@ -84,9 +84,15 @@ describe("issue #3480 runnable example projects", () => {
     expect(OrchestratorConfigSchema.safeParse(config).success).toBe(true);
 
     const readme = readText("examples/orchestrator-config/README.md");
+    expect(readme.indexOf("npm run setup")).toBeLessThan(
+      readme.indexOf("npm run plan"),
+    );
     expect(readme.indexOf("npm run plan")).toBeLessThan(
       readme.indexOf("npm start"),
     );
+    expect(
+      readJson("examples/orchestrator-config/package.json").scripts,
+    ).toMatchObject({ setup: "git init" });
     expect(
       existsSync(
         resolve(ROOT, "examples/orchestrator-config/docs/sample-design.md"),

--- a/tests/docs-issue-3480.test.ts
+++ b/tests/docs-issue-3480.test.ts
@@ -90,9 +90,13 @@ describe("issue #3480 runnable example projects", () => {
     expect(readme.indexOf("npm run plan")).toBeLessThan(
       readme.indexOf("npm start"),
     );
-    expect(
-      readJson("examples/orchestrator-config/package.json").scripts,
-    ).toMatchObject({ setup: "git init" });
+    const scripts = readJson("examples/orchestrator-config/package.json")
+      .scripts as Record<string, string>;
+    expect(scripts.setup).toContain("git init -b main");
+    expect(scripts.setup).toContain("git commit");
+    expect(readText("examples/orchestrator-config/.gitignore")).toContain(
+      "!.fbeast/config.json",
+    );
     expect(
       existsSync(
         resolve(ROOT, "examples/orchestrator-config/docs/sample-design.md"),


### PR DESCRIPTION
## Summary
- add a discoverable top-level examples index and standalone CLI planning, MCP setup, and orchestrator configuration projects
- expand the existing quick-start example and link all samples from root documentation
- add a regression test covering the examples contract and schema-valid orchestrator config

## Test plan
- `npx vitest run tests/docs-issue-3480.test.ts tests/docs-issue-1094.test.ts tests/local-setup-scripts.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm ci` in each standalone example

Closes #3480