### PR TITLE
test(sandbox): reject root Docker user groups

### DIFF
--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -80,6 +80,29 @@ function collectRequestedPaths(args: readonly string[]): string[] {
   return paths;
 }
 
+interface DockerUser {
+  user: string;
+  group?: string;
+}
+
+function parseDockerUser(contents: string): DockerUser | undefined {
+  const match = contents.match(/^USER\s+([^\s:]+)(?::([^\s:]+))?\s*$/mu);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  return { user: match[1], ...(match[2] ? { group: match[2] } : {}) };
+}
+
+function isNonRootDockerUser(contents: string): boolean {
+  const directive = parseDockerUser(contents);
+  if (!directive || directive.user === '0' || directive.user === 'root') {
+    return false;
+  }
+
+  return directive.group !== '0' && directive.group !== 'root';
+}
+
 const explicitDockerfileTestRequest = collectRequestedPaths(process.argv.slice(2))
   .includes('tests/sandbox-dockerfile.test.ts');
 const runDockerBuild = readVitestFlag(process.env, 'DOCKER_BUILD') || explicitDockerfileTestRequest;
@@ -119,11 +142,22 @@ describe('sandbox Dockerfile', () => {
     });
   }, 60_000);
 
-  it('declares a non-root default container UID', () => {
-    const userDirective = dockerfile.match(/^USER\s+([^\s:]+)(?::[^\s]+)?\s*$/mu);
+  it('declares a non-root default container UID and GID', () => {
+    const userDirective = parseDockerUser(dockerfile);
 
-    expect(userDirective, 'Dockerfile must declare a valid USER directive').not.toBeNull();
-    expect(userDirective?.[1]).not.toBe('root');
-    expect(userDirective?.[1]).not.toBe('0');
+    expect(userDirective, 'Dockerfile must declare a valid USER directive').toBeDefined();
+    expect(
+      isNonRootDockerUser(dockerfile),
+      'Dockerfile USER must not use the root user or group',
+    ).toBe(true);
+  });
+
+  it.each([
+    ['numeric root user', 'USER 0'],
+    ['named root user', 'USER root'],
+    ['numeric root group', 'USER 1000:0'],
+    ['named root group', 'USER sandbox:root'],
+  ])('rejects a %s in the USER directive', (_description, directive) => {
+    expect(isNonRootDockerUser(directive)).toBe(false);
   });
 });

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -85,8 +85,14 @@ interface DockerUser {
   group?: string;
 }
 
-function parseDockerUser(contents: string): DockerUser | undefined {
-  const match = contents.match(/^USER\s+([^\s:]+)(?::([^\s:]+))?\s*$/mu);
+function parseFinalDockerUser(contents: string): DockerUser | undefined {
+  const finalStage = contents.split(/^FROM\s+.*$/gmu).at(-1);
+  if (!finalStage || finalStage === contents) {
+    return undefined;
+  }
+
+  const directives = [...finalStage.matchAll(/^USER\s+([^\s:]+)(?::([^\s:]+))?\s*$/gmu)];
+  const match = directives.at(-1);
   if (!match?.[1]) {
     return undefined;
   }
@@ -94,13 +100,23 @@ function parseDockerUser(contents: string): DockerUser | undefined {
   return { user: match[1], ...(match[2] ? { group: match[2] } : {}) };
 }
 
+function isNumericRootId(value: string): boolean {
+  return /^[+-]?0+$/u.test(value);
+}
+
 function isNonRootDockerUser(contents: string): boolean {
-  const directive = parseDockerUser(contents);
-  if (!directive || directive.user === '0' || directive.user === 'root') {
+  const directive = parseFinalDockerUser(contents);
+  if (
+    !directive?.group
+    || directive.user === 'root'
+    || directive.group === 'root'
+    || isNumericRootId(directive.user)
+    || isNumericRootId(directive.group)
+  ) {
     return false;
   }
 
-  return directive.group !== '0' && directive.group !== 'root';
+  return true;
 }
 
 const explicitDockerfileTestRequest = collectRequestedPaths(process.argv.slice(2))
@@ -143,7 +159,7 @@ describe('sandbox Dockerfile', () => {
   }, 60_000);
 
   it('declares a non-root default container UID and GID', () => {
-    const userDirective = parseDockerUser(dockerfile);
+    const userDirective = parseFinalDockerUser(dockerfile);
 
     expect(userDirective, 'Dockerfile must declare a valid USER directive').toBeDefined();
     expect(
@@ -153,11 +169,14 @@ describe('sandbox Dockerfile', () => {
   });
 
   it.each([
-    ['numeric root user', 'USER 0'],
-    ['named root user', 'USER root'],
-    ['numeric root group', 'USER 1000:0'],
-    ['named root group', 'USER sandbox:root'],
-  ])('rejects a %s in the USER directive', (_description, directive) => {
-    expect(isNonRootDockerUser(directive)).toBe(false);
+    ['numeric root user', 'FROM node\nUSER 00:1000'],
+    ['named root user', 'FROM node\nUSER root:1000'],
+    ['numeric root group', 'FROM node\nUSER 1000:+0'],
+    ['named root group', 'FROM node\nUSER sandbox:root'],
+    ['missing explicit group', 'FROM node\nUSER 1000'],
+    ['later root-group override', 'FROM node\nUSER 1000:1000\nUSER 1000:0'],
+    ['missing final-stage user', 'FROM node\nUSER 1000:1000\nFROM scratch'],
+  ])('rejects a %s in the USER directive', (_description, contents) => {
+    expect(isNonRootDockerUser(contents)).toBe(false);
   });
 });

--- a/tests/sandbox-dockerfile.test.ts
+++ b/tests/sandbox-dockerfile.test.ts
@@ -86,12 +86,14 @@ interface DockerUser {
 }
 
 function parseFinalDockerUser(contents: string): DockerUser | undefined {
-  const finalStage = contents.split(/^FROM\s+.*$/gmu).at(-1);
+  const finalStage = contents.split(/^[ \t]*FROM\s+.*$/gmu).at(-1);
   if (!finalStage || finalStage === contents) {
     return undefined;
   }
 
-  const directives = [...finalStage.matchAll(/^USER\s+([^\s:]+)(?::([^\s:]+))?\s*$/gmu)];
+  const directives = [
+    ...finalStage.matchAll(/^[ \t]*USER\s+([^\s:]+)(?::([^\s:]+))?\s*$/gmu),
+  ];
   const match = directives.at(-1);
   if (!match?.[1]) {
     return undefined;
@@ -108,6 +110,8 @@ function isNonRootDockerUser(contents: string): boolean {
   const directive = parseFinalDockerUser(contents);
   if (
     !directive?.group
+    || directive.user.includes('$')
+    || directive.group.includes('$')
     || directive.user === 'root'
     || directive.group === 'root'
     || isNumericRootId(directive.user)
@@ -175,6 +179,8 @@ describe('sandbox Dockerfile', () => {
     ['named root group', 'FROM node\nUSER sandbox:root'],
     ['missing explicit group', 'FROM node\nUSER 1000'],
     ['later root-group override', 'FROM node\nUSER 1000:1000\nUSER 1000:0'],
+    ['indented root override', 'FROM node\nUSER 1000:1000\n  USER root:0'],
+    ['variable-based identity', 'FROM node\nUSER ${SANDBOX_UID}:${SANDBOX_GID}'],
     ['missing final-stage user', 'FROM node\nUSER 1000:1000\nFROM scratch'],
   ])('rejects a %s in the USER directive', (_description, contents) => {
     expect(isNonRootDockerUser(contents)).toBe(false);


### PR DESCRIPTION
## Summary
- parse the full sandbox Dockerfile `USER` identity
- reject numeric and named root users and groups
- cover `USER 1000:0` as an explicit regression fixture

## Test plan
- `npm run test:root -- tests/sandbox-dockerfile.test.ts --run`
- `npm run typecheck`
- `npm run test:root` (687 passed; one unrelated hardcoded-secret scanner timeout, isolated rerun passed)
- `npm run test:root -- tests/unit/hardcoded-secrets.test.ts --run -t "passes the repository fixtures that keep secret examples commented or env-backed"`

Closes #3479