### PR TITLE
fix(orchestrator): clarify functional heartbeat wiring

### DIFF
--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -149,7 +149,10 @@ const stubSkills: ISkillsModule = {
   getAvailableSkills: () => [],
   execute: async (skillId: string) => { throw new Error(`Skills module is disabled; cannot execute ${skillId}`); },
 };
-const stubHeartbeat: IHeartbeatModule = {
+// Module toggles are independent from the runtime enableHeartbeat flag. Keep an
+// explicit disabled implementation for --no-heartbeat; enabled CLI sessions
+// use the functional ReflectionHeartbeatAdapter created by createBeastDeps.
+const disabledHeartbeat: IHeartbeatModule = {
   pulse: async () => ({ summary: 'Heartbeat module disabled.', improvements: [], techDebt: [] }),
 };
 
@@ -1171,7 +1174,7 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
       firewall: config.modules.firewall ? consolidated.firewall : stubFirewall,
       skills: config.modules.skills ? createSkillDeps(consolidated, config.skills) : stubSkills,
       memory: config.modules.memory ? consolidated.memory : stubMemory,
-      heartbeat: config.modules.heartbeat ? consolidated.heartbeat : stubHeartbeat,
+      heartbeat: config.modules.heartbeat ? consolidated.heartbeat : disabledHeartbeat,
     };
     const issueDeps = createIssueDeps(options, options.paths, stack, executor, llm);
     finalize = appendAuditFinalize(finalize, observer, consolidated);

--- a/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
@@ -126,7 +126,7 @@ describe('dep-factory wiring integration', () => {
     if (prev !== undefined) process.env.FRANKENBEAST_ALLOW_NONINTERACTIVE_APPROVAL = prev;
   });
 
-  it('uses real adapters via createBeastDeps even when enabledModules disables flags', async () => {
+  it('uses disabled adapters only for modules explicitly disabled by the CLI', async () => {
     const paths = createTempPaths();
     cleanups.push(paths.root);
 
@@ -138,16 +138,19 @@ describe('dep-factory wiring integration', () => {
       noPr: true,
       verbose: false,
       reset: false,
-      enabledModules: { firewall: false, memory: false },
+      enabledModules: { firewall: false, memory: false, heartbeat: false },
     });
 
-    // createBeastDeps now always provides real adapters — module toggles
-    // only affect critique/governor dynamic imports, not firewall/memory/skills/heartbeat
-    expect(deps.memory).toBeInstanceOf(SqliteBrainMemoryAdapter);
-    expect(deps.firewall).toBeInstanceOf(MiddlewareChainFirewallAdapter);
-    // Real memory adapter still returns valid context (empty from fresh db)
+    expect(deps.memory).not.toBeInstanceOf(SqliteBrainMemoryAdapter);
+    expect(deps.firewall).not.toBeInstanceOf(MiddlewareChainFirewallAdapter);
+    expect(deps.heartbeat).not.toBeInstanceOf(ReflectionHeartbeatAdapter);
     const ctx = await deps.memory.getContext('test');
     expect(ctx).toEqual({ adrs: [], knownErrors: [], rules: [] });
+    await expect(deps.heartbeat.pulse()).resolves.toEqual({
+      summary: 'Heartbeat module disabled.',
+      improvements: [],
+      techDebt: [],
+    });
     await finalize();
   });
 


### PR DESCRIPTION
## Summary
- make the CLI's explicit disabled-heartbeat fallback unambiguous instead of labeling it as the runtime stub
- preserve the functional `ReflectionHeartbeatAdapter` for enabled CLI sessions
- repair module-toggle integration coverage and verify `--no-heartbeat` alone selects the deterministic disabled implementation

The reported no-op is only selected when heartbeat is explicitly disabled. Normal CLI wiring already constructs and exposes the functional reflection heartbeat adapter; this change locks that distinction into regression coverage so the disabled fallback cannot be mistaken for the enabled path.

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/integration/cli/dep-factory-wiring.test.ts -t "uses disabled adapters only|creates real consolidated adapters"`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator -- --quiet`
- `npm run build`

Known baseline: the full dep-factory wiring file still has one unrelated critique-adapter expectation failure (`unknown package` returns `pass`); the two heartbeat wiring tests pass.

Closes #3463