### PR TITLE
feat(web): centralize wizard dirty tracking

### DIFF
--- a/docs/adr/024-introduce-zustand-for-form-state.md
+++ b/docs/adr/024-introduce-zustand-for-form-state.md
@@ -24,7 +24,7 @@ The rest of the dashboard continues using React hooks. No migration of existing 
 
 ## Implementation
 
-The accepted design is implemented in `packages/franken-web/src/stores/beast-store.ts`. Wizard values, navigation, mode, and validation errors live in `useBeastStore`; the wizard dialog and every step component subscribe through scoped selectors rather than subscribing to the entire store. `BeastsPage` calls `resetWizard()` before each new create flow so state survives step unmounts but does not leak between launches.
+The accepted design is implemented in `packages/franken-web/src/stores/beast-store.ts`. Wizard values, navigation, mode, validation errors, and the canonical `isWizardDirty` flag live in `useBeastStore`; updates from any step mark the draft dirty, and `resetWizard()` clears both the draft and its dirty state. The wizard dialog and every step component subscribe through scoped selectors rather than subscribing to the entire store. `BeastsPage` calls `resetWizard()` before each new create flow so state survives step unmounts but does not leak between launches.
 
 Local-only presentation state, such as the skills search query or dialog loading state, remains in React hooks as required by the boundary above. Store behavior is covered by `src/stores/beast-store.test.ts`, dialog behavior by `src/components/beasts/wizard-dialog.test.tsx`, and the scoped-selector boundary by `tests/components/beasts/wizard-zustand-architecture.test.ts`.
 

--- a/packages/franken-web/src/stores/beast-store.test.ts
+++ b/packages/franken-web/src/stores/beast-store.test.ts
@@ -35,6 +35,28 @@ describe('beast-store wizardSlice', () => {
     expect(useBeastStore.getState().wizardMode).toBe('form');
     expect(useBeastStore.getState().stepValues[0]).toEqual({ name: 'Keep' });
   });
+
+  it('tracks wizard changes across steps in one canonical dirty flag', () => {
+    const { setStepValues } = useBeastStore.getState();
+
+    expect(useBeastStore.getState().isWizardDirty).toBe(false);
+
+    setStepValues(0, { name: 'TestAgent' });
+    expect(useBeastStore.getState().isWizardDirty).toBe(true);
+
+    setStepValues(4, { selectedSkills: ['code-review'] });
+    expect(useBeastStore.getState().isWizardDirty).toBe(true);
+  });
+
+  it('clears wizard dirty state with the rest of the wizard draft', () => {
+    const { setStepValues } = useBeastStore.getState();
+    setStepValues(6, { preset: 'feature-branch' });
+
+    useBeastStore.getState().resetWizard();
+
+    expect(useBeastStore.getState().isWizardDirty).toBe(false);
+    expect(useBeastStore.getState().stepValues).toEqual({});
+  });
 });
 
 describe('beast-store agentEditSlice', () => {

--- a/packages/franken-web/src/stores/beast-store.ts
+++ b/packages/franken-web/src/stores/beast-store.ts
@@ -14,6 +14,7 @@ interface WizardSlice {
   wizardStep: number;
   highestCompleted: number;
   wizardMode: WizardMode;
+  isWizardDirty: boolean;
   stepValues: StepValues;
   validationErrors: ValidationErrors;
   nextStep: () => void;
@@ -52,6 +53,7 @@ export const useBeastStore = create<BeastStore>()((set, get) => ({
   wizardStep: 0,
   highestCompleted: -1,
   wizardMode: 'wizard' as WizardMode,
+  isWizardDirty: false,
   stepValues: {},
   validationErrors: {},
 
@@ -72,6 +74,7 @@ export const useBeastStore = create<BeastStore>()((set, get) => ({
   setStepValues: (step, values) =>
     set((s) => ({
       stepValues: { ...s.stepValues, [step]: values },
+      isWizardDirty: true,
     })),
 
   setValidationErrors: (step, errors) =>
@@ -101,6 +104,7 @@ export const useBeastStore = create<BeastStore>()((set, get) => ({
       wizardStep: 0,
       highestCompleted: -1,
       wizardMode: 'wizard' as WizardMode,
+      isWizardDirty: false,
       stepValues: {},
       validationErrors: {},
     }),

--- a/tasks/issue-3374-centralized-wizard-dirty-state-progress.md
+++ b/tasks/issue-3374-centralized-wizard-dirty-state-progress.md
@@ -1,0 +1,11 @@
+# Issue 3374 centralized wizard dirty state progress
+
+- [x] Verify issue remains open, is not reserved as `good first issue`, and has no existing PR.
+- [x] Read shared lessons and ADR-024.
+- [x] Confirm the merged wizard migration centralizes cross-step values, but the wizard slice still lacks canonical dirty state.
+- [x] Add failing store tests for cross-step dirty tracking and reset behavior.
+- [x] Implement the smallest store-level dirty flag and document its ownership boundary.
+- [x] Run targeted tests, package tests, lint, typecheck, and build.
+- [ ] Commit, push, and open a PR closing only #3374.
+- [ ] Drive CI and the GitHub Codex connector to a current-head clean state.
+- [ ] Merge, record any reusable lesson, and finish the Kanban card.


### PR DESCRIPTION
## Summary
- add canonical `isWizardDirty` state to the Zustand wizard slice
- mark drafts dirty from any step update and clear dirty state with `resetWizard()`
- cover cross-step updates and reset behavior and document the ADR ownership boundary

## Test plan
- `npm test -- src/stores/beast-store.test.ts`
- `npm test` (77 files, 697 tests)
- `npm run lint` (0 errors, 17 pre-existing warnings)
- `npm run typecheck`
- `npm run build --workspace @franken/types`
- `npm run build`

Closes #3374