### PR TITLE
test(web): cover chat client auth plumbing

### DIFF
--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -167,7 +167,7 @@ export class ChatApiClient {
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     // Browser chat requests authenticate through the same-origin server/BFF
     // layer (or HttpOnly/SameSite cookies), never by accepting an operator
-    // bearer token in bundled client code.
+    // credential in bundled client code.
     const effectiveInit: RequestInit = {
       ...init,
       credentials: init.credentials ?? this.requestCredentials,

--- a/packages/franken-web/tests/browser-token-plumbing.test.ts
+++ b/packages/franken-web/tests/browser-token-plumbing.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 const CLIENT_SOURCES = [
   'src/lib/network-api.ts',
+  'src/lib/api.ts',
   'src/lib/beast-api.ts',
   'src/lib/dashboard-api.ts',
   'src/lib/analytics-api.ts',


### PR DESCRIPTION
## Summary
- extend the browser control-plane auth regression to cover `ChatApiClient`
- keep the source comment aligned with the regression terminology
- lock in the existing server-side/BFF operator-auth boundary across every affected web API client

## Test plan
- `npm test -- --run tests/browser-token-plumbing.test.ts` (red before comment cleanup, green after)
- `npm test` (697 passed)
- `npm run lint` (0 errors; 17 existing warnings)
- `npm run typecheck`
- root `npm run build` (10/10 packages)

Closes #2669