### PR TITLE
fix(cli): preserve fatal error stack traces

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -2320,7 +2320,7 @@ export function runDirectCli(
       }
     })
     .catch((error) => {
-      console.error('Fatal:', error instanceof Error ? error.message : error);
+      console.error('Fatal:', error);
       exit(1);
     });
 }

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1163,10 +1163,11 @@ describe('runDirectCli', () => {
     expect(shouldForceDirectCliExit(['node', 'run.ts', 'beasts', 'catalog'])).toBe(false);
   });
 
-  it('exits nonzero when the direct CLI entrypoint rejects', async () => {
+  it('preserves the error stack and exits nonzero when the direct CLI entrypoint rejects', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fatalError = new Error('boom');
     const entrypoint = vi.fn(async () => {
-      throw new Error('boom');
+      throw fatalError;
     });
     const exit = vi.fn() as unknown as (code?: number) => never;
 
@@ -1175,7 +1176,7 @@ describe('runDirectCli', () => {
     await Promise.resolve();
 
     expect(exit).toHaveBeenCalledWith(1);
-    expect(errorSpy).toHaveBeenCalledWith('Fatal:', 'boom');
+    expect(errorSpy).toHaveBeenCalledWith('Fatal:', fatalError);
     errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- pass fatal `Error` objects directly to the CLI error sink so Node renders their stack traces
- retain non-zero exit behavior for rejected direct CLI entrypoints
- add a regression proving the original error object reaches `console.error`

## Verification
- `npm test --workspace @franken/orchestrator` (281 files, 4372 tests)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `npm run build --workspace @franken/orchestrator`

Closes #2577