### PR TITLE
fix(web): align dashboard approval requirement type

### DIFF
--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DashboardApiClient, type DashboardSnapshot } from './dashboard-api';
+import { describe, it, expect, expectTypeOf, vi, beforeEach, afterEach } from 'vitest';
+import { DashboardApiClient, type DashboardSecurity, type DashboardSnapshot } from './dashboard-api';
 
 const BASE_URL = 'http://localhost:3737';
 
@@ -41,6 +41,11 @@ describe('DashboardApiClient', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it('keeps approval requirements aligned with the backend security schema', () => {
+    expectTypeOf<DashboardSecurity['requireApproval']>()
+      .toEqualTypeOf<'all' | 'destructive' | 'none' | undefined>();
   });
 
   describe('fetchSnapshot', () => {

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -7,12 +7,14 @@ export interface DashboardSkill {
   mcpServerCount: number;
 }
 
+export type DashboardApprovalRequirement = 'all' | 'destructive' | 'none';
+
 export interface DashboardSecurity {
   profile: string;
   injectionDetection: boolean;
   piiMasking: boolean;
   outputValidation: boolean;
-  requireApproval?: string;
+  requireApproval?: DashboardApprovalRequirement;
 }
 
 export interface DashboardProvider {


### PR DESCRIPTION
## Summary
- align `DashboardSecurity.requireApproval` with the backend enum
- add a compile-time regression that rejects future widening of the DTO field

## Test plan
- [x] `npm run build`
- [x] `npm run test --workspace @franken/web -- src/lib/dashboard-api.test.ts` (21 passed)
- [x] `npm run test --workspace @franken/web` (698 passed)
- [x] `npm run typecheck --workspace @franken/web`
- [x] `npm run lint --workspace @franken/web` (0 errors; 17 pre-existing warnings)

Closes #3490