### PR TITLE
fix(web): preserve shared agent DTO exports

### DIFF
--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -26,6 +26,8 @@ import { toError } from './http-error';
 
 export { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 export type {
+  AgentGitConfig,
+  AgentLlmConfig,
   BeastCatalogEntry,
   BeastContainerRuntimeStatus,
   BeastInterviewPrompt,

--- a/packages/franken-web/tests/lib/beast-api-contracts-source.test.ts
+++ b/packages/franken-web/tests/lib/beast-api-contracts-source.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'src/lib/beast-api.ts'), 'utf8');
+const sharedAgentTypes = [
+  'TrackedAgentSummary',
+  'TrackedAgentEvent',
+  'TrackedAgentDetail',
+  'AgentLlmConfig',
+  'AgentGitConfig',
+] as const;
+
+describe('Beast API agent model contracts', () => {
+  it('forwards agent DTOs from the shared @franken/types contract', () => {
+    const sharedReExport = source.match(/export type \{(?<types>[\s\S]*?)\} from '@franken\/types';/);
+
+    expect(sharedReExport).toBeTruthy();
+    for (const typeName of sharedAgentTypes) {
+      expect(sharedReExport?.groups?.types, typeName).toMatch(new RegExp(`\\b${typeName}\\b`));
+      expect(source, typeName).not.toMatch(new RegExp(`(?:interface|type)\\s+${typeName}\\b`));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- re-export all five agent model DTOs from the canonical `@franken/types` contract through `beast-api.ts`
- add a source-level regression that rejects local redeclarations and guards the shared export surface

## Test plan
- `npm run build`
- `npm --workspace @franken/web test` (699 tests)
- `npm --workspace @franken/web run typecheck`
- `npm --workspace @franken/web run lint` (0 errors; pre-existing warnings only)

Closes #3489