### PR TITLE
fix(critique): decode braced unicode class escapes

### DIFF
--- a/packages/franken-critique/src/evaluators/safety.ts
+++ b/packages/franken-critique/src/evaluators/safety.ts
@@ -1073,6 +1073,16 @@ export class SafetyEvaluator implements Evaluator {
       return String.fromCharCode(Number.parseInt(unicodeSingleton[1]!, 16));
     }
 
+    if (this.parsingUnicodeSets) {
+      const bracedUnicodeSingleton = characterClass.match(
+        /^\[\\u\{([0-9A-Fa-f]{1,6})\}\]$/,
+      );
+      if (bracedUnicodeSingleton) {
+        const codePoint = Number.parseInt(bracedUnicodeSingleton[1]!, 16);
+        if (codePoint <= 0x10ffff) return String.fromCodePoint(codePoint);
+      }
+    }
+
     const range = characterClass.match(/^\[([^\\\]])-([^\\\]])\]$/);
     if (range) return `RANGE:${range[1]!}-${range[2]!}`;
 

--- a/packages/franken-critique/tests/unit/evaluators/safety.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/safety.test.ts
@@ -883,6 +883,23 @@ describe('SafetyEvaluator', () => {
     expect(evaluator.hasUnsafeRegexShape('^(?s:(.|\\n\\n))+!$')).toBe(true);
   });
 
+  it('decodes braced Unicode singleton character classes in v mode', () => {
+    const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
+      parsingUnicodeSets: boolean;
+      characterClassToken(characterClass: string): string;
+    };
+
+    evaluator.parsingUnicodeSets = true;
+
+    expect(evaluator.characterClassToken('[\\u{1F600}]')).toBe('😀');
+    expect(evaluator.characterClassToken('[\\u{10FFFF}]')).toBe(
+      String.fromCodePoint(0x10ffff),
+    );
+    expect(evaluator.characterClassToken('[\\u{110000}]')).toBe(
+      'CLASS:[\\u{110000}]',
+    );
+  });
+
   it('skips complete unicodeSets character classes only in v mode', () => {
     const evaluator = new SafetyEvaluator(createMockGuardrailsPort()) as unknown as {
       skipCharacterClass(pattern: string, start: number, unicodeSets?: boolean): number;


### PR DESCRIPTION
## Summary
- decode ES6 braced Unicode singleton escapes in `characterClassToken` while parsing `v`-mode sets
- reject code points above the Unicode maximum and retain conservative class fallback
- add focused coverage for astral, boundary, and out-of-range values

## Test plan
- `npm run test --workspace @franken/critique` (782 tests)
- `npm run lint --workspace @franken/critique`
- `npm run typecheck --workspace @franken/critique`
- `npm run build --workspace @franken/critique`

Closes #3486