### PR TITLE
feat(cli): add slash command tab completion

### DIFF
--- a/packages/franken-orchestrator/src/cli/chat-repl.ts
+++ b/packages/franken-orchestrator/src/cli/chat-repl.ts
@@ -8,6 +8,7 @@ import { sanitizeChatOutput } from '../chat/output-sanitizer.js';
 import { ANSI } from '../logging/beast-logger.js';
 import { withSpinner, QUIRKY_PHRASES } from './spinner.js';
 import { CHAT_COLOR, CHAT_GLYPHS, chatBanner, chatBlock, chatStatusLine, statusRule } from './chat-style.js';
+import { CHAT_SLASH_COMMAND_NAMES, completeSlashCommand } from './slash-command-completion.js';
 import { isoNow, type ProviderContext, type TokenUsage } from '@franken/types';
 
 
@@ -16,15 +17,7 @@ function printLine(...args: unknown[]): void {
 }
 export { sanitizeChatOutput } from '../chat/output-sanitizer.js';
 
-const SLASH_COMMANDS = new Set([
-  '/plan',
-  '/run',
-  '/status',
-  '/diff',
-  '/approve',
-  '/session',
-  '/quit',
-]);
+const SLASH_COMMANDS = new Set<string>(CHAT_SLASH_COMMAND_NAMES);
 
 export interface ChatIO {
   prompt(): Promise<string>;
@@ -59,7 +52,11 @@ export function createReadlineIO(): ChatIO {
   let rl: Interface | undefined;
   let activeQuestion: AbortController | undefined;
   const getReadline = (): Interface => {
-    rl ??= createInterface({ input: process.stdin, output: process.stdout });
+    rl ??= createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      completer: completeSlashCommand,
+    });
     return rl;
   };
   const cancelQuestion = (): void => {

--- a/packages/franken-orchestrator/src/cli/slash-command-completion.ts
+++ b/packages/franken-orchestrator/src/cli/slash-command-completion.ts
@@ -6,6 +6,7 @@ export const CHAT_SLASH_COMMANDS = [
   { name: '/status', description: 'Show the current session status' },
   { name: '/diff', description: 'Show changes from the current session' },
   { name: '/approve', description: 'Approve the pending action' },
+  { name: '/reject', description: 'Reject the pending action' },
   { name: '/session', description: 'Show the current session' },
   { name: '/quit', description: 'Exit chat' },
 ] as const;

--- a/packages/franken-orchestrator/src/cli/slash-command-completion.ts
+++ b/packages/franken-orchestrator/src/cli/slash-command-completion.ts
@@ -1,0 +1,34 @@
+import type { CompleterResult } from 'node:readline';
+
+export const CHAT_SLASH_COMMANDS = [
+  { name: '/plan', description: 'Create a plan for a task' },
+  { name: '/run', description: 'Run a task' },
+  { name: '/status', description: 'Show the current session status' },
+  { name: '/diff', description: 'Show changes from the current session' },
+  { name: '/approve', description: 'Approve the pending action' },
+  { name: '/session', description: 'Show the current session' },
+  { name: '/quit', description: 'Exit chat' },
+] as const;
+
+export const CHAT_SLASH_COMMAND_NAMES = CHAT_SLASH_COMMANDS.map(({ name }) => name);
+
+function isSubsequence(candidate: string, query: string): boolean {
+  let queryIndex = 0;
+  for (const character of candidate) {
+    if (character === query[queryIndex]) queryIndex++;
+  }
+  return queryIndex === query.length;
+}
+
+/** Complete only the command token; arguments remain ordinary chat input. */
+export function completeSlashCommand(line: string): CompleterResult {
+  if (!line.startsWith('/') || /\s/.test(line)) return [[], line];
+
+  const query = line.toLowerCase();
+  const prefixMatches = CHAT_SLASH_COMMAND_NAMES.filter((command) => command.startsWith(query));
+  const matches = prefixMatches.length > 0
+    ? prefixMatches
+    : CHAT_SLASH_COMMAND_NAMES.filter((command) => isSubsequence(command, query));
+
+  return [matches, line];
+}

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -5,6 +5,7 @@ import type { OrchestratorConfig } from '../config/orchestrator-config.js';
 import { sanitizeChatOutput } from '../chat/output-sanitizer.js';
 import { ANSI } from '../logging/beast-logger.js';
 import { CHAT_COLOR, CHAT_GLYPHS, chatBanner, chatBlock, chatStatusLine, statusRule } from '../cli/chat-style.js';
+import { completeSlashCommand } from '../cli/slash-command-completion.js';
 import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
@@ -207,7 +208,11 @@ function createIo(): {
   print(message: string): void;
   close(): void;
 } {
-  const rl: Interface = createInterface({ input: process.stdin, output: process.stdout });
+  const rl: Interface = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    completer: completeSlashCommand,
+  });
   return {
     prompt: () => new Promise((resolve) => rl.question(`${CHAT_COLOR.user}${CHAT_GLYPHS.user}${ANSI.reset} `, resolve)),
     print: (message: string) => printLine(message),

--- a/packages/franken-orchestrator/tests/unit/cli/slash-command-completion.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/slash-command-completion.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_SLASH_COMMANDS,
+  completeSlashCommand,
+} from '../../../src/cli/slash-command-completion.js';
+
+describe('slash command completion', () => {
+  it('lists every documented command for a bare slash', () => {
+    expect(completeSlashCommand('/')).toEqual([
+      CHAT_SLASH_COMMANDS.map(({ name }) => name),
+      '/',
+    ]);
+    expect(CHAT_SLASH_COMMANDS.every(({ description }) => description.length > 0)).toBe(true);
+  });
+
+  it('narrows prefix matches case-insensitively', () => {
+    expect(completeSlashCommand('/P')).toEqual([['/plan'], '/P']);
+    expect(completeSlashCommand('/s')).toEqual([['/status', '/session'], '/s']);
+  });
+
+  it('falls back to ordered fuzzy matches for mistyped prefixes', () => {
+    expect(completeSlashCommand('/stt')).toEqual([['/status'], '/stt']);
+    expect(completeSlashCommand('/pln')).toEqual([['/plan'], '/pln']);
+  });
+
+  it('does not complete chat text, command arguments, or unknown commands', () => {
+    expect(completeSlashCommand('hello')).toEqual([[], 'hello']);
+    expect(completeSlashCommand('/run fix tests')).toEqual([[], '/run fix tests']);
+    expect(completeSlashCommand('/xyz')).toEqual([[], '/xyz']);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/cli/slash-command-completion.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/slash-command-completion.test.ts
@@ -16,6 +16,7 @@ describe('slash command completion', () => {
   it('narrows prefix matches case-insensitively', () => {
     expect(completeSlashCommand('/P')).toEqual([['/plan'], '/P']);
     expect(completeSlashCommand('/s')).toEqual([['/status', '/session'], '/s']);
+    expect(completeSlashCommand('/rej')).toEqual([['/reject'], '/rej']);
   });
 
   it('falls back to ordered fuzzy matches for mistyped prefixes', () => {

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-22 — Shared chat command completion catalogs
+- When adding interactive completion for chat commands, derive or cross-check the catalog against every command accepted by the shared runtime, not only the commands handled locally by one CLI wrapper. Approval commands such as `/approve` and `/reject` can be runtime-owned even when the readline layer has no dedicated branch; keep both attached and local chat interfaces on one completer and test paired command prefixes explicitly.
+
 ## 2026-07-21 — Dashboard chat model precedence
 - For conversational dashboard replies, the selected provider's `providers.overrides.<provider>.model` wins over `chat.model`; `chat.model` only replaces the provider's built-in chat model when no selected-provider model override exists. Dashboard `/run` uses a separate execution adapter that ignores both model settings and provider `extraArgs`, although it does apply trusted command overrides. Trace both adapter construction paths and runtime provider override resolution before documenting dashboard behavior.
 


### PR DESCRIPTION
## Summary
- add a shared, described slash-command catalog and readline completer
- wire completion into both local chat and managed attach chat
- support case-insensitive prefix and ordered fuzzy matching without completing normal text or arguments

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/cli/slash-command-completion.test.ts tests/unit/cli/chat-repl.test.ts tests/unit/cli/chat-attach.test.ts`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with existing warnings)
- `npm run build`
- `npm run build --workspace @franken/orchestrator`
- `INTEGRATION=true npm run test --workspace @franken/orchestrator -- tests/integration/cli/terminal-input-ownership.test.ts`

Closes #3483