### PR TITLE
fix(planner): advance versions on graph mutations

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -270,7 +270,7 @@ export class PlanGraph {
     newNodes.set(task.id, { ...task, dependsOn: [...dependsOn] });
     const newEdges = new Map(this._edges);
     newEdges.set(task.id, new Set(dependsOn));
-    return new PlanGraph(newNodes, newEdges, this.version, this.reason);
+    return new PlanGraph(newNodes, newEdges, this.version + 1, `task added: '${task.id}'`);
   }
 
   removeTask(taskId: TaskId): PlanGraph {
@@ -290,7 +290,7 @@ export class PlanGraph {
         newNodes.set(id, { ...task, dependsOn: [...cleaned] });
       }
     }
-    return new PlanGraph(newNodes, newEdges, this.version, this.reason);
+    return new PlanGraph(newNodes, newEdges, this.version + 1, `task removed: '${taskId}'`);
   }
 
   /**

--- a/packages/franken-planner/src/hitl/plan-modifier.ts
+++ b/packages/franken-planner/src/hitl/plan-modifier.ts
@@ -14,8 +14,10 @@ export function applyModifications(graph: PlanGraph, changes: TaskModification[]
   const changeMap = new Map(changes.map((c) => [c.taskId, c]));
 
   const updatedTasks: Task[] = [];
+  let modified = false;
   for (const task of graph.topoSort()) {
     const change = changeMap.get(task.id);
+    if (change !== undefined) modified = true;
     const updatedTask: Task = change
       ? {
           ...task,
@@ -27,5 +29,9 @@ export function applyModifications(graph: PlanGraph, changes: TaskModification[]
       : task;
     updatedTasks.push({ ...updatedTask, dependsOn: graph.getDependencies(task.id) });
   }
-  return PlanGraph.fromTasks(updatedTasks, { version: graph.version, reason: graph.reason });
+  if (!modified) return graph;
+  return PlanGraph.fromTasks(updatedTasks, {
+    version: graph.version + 1,
+    reason: 'human modifications applied',
+  });
 }

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -491,10 +491,16 @@ describe('PlanGraph — versioning', () => {
     expect(PlanGraph.empty().version).toBe(0);
   });
 
-  it('addTask and removeTask preserve version', () => {
-    const g = PlanGraph.empty().addTask(makeTask('a'));
-    expect(g.version).toBe(0);
-    expect(g.removeTask(createTaskId('a')).version).toBe(0);
+  it('addTask increments the graph version', () => {
+    const graph = PlanGraph.empty();
+
+    expect(graph.addTask(makeTask('a')).version).toBe(graph.version + 1);
+  });
+
+  it('removeTask increments the graph version', () => {
+    const graph = PlanGraph.empty().addTask(makeTask('a'));
+
+    expect(graph.removeTask(createTaskId('a')).version).toBe(graph.version + 1);
   });
 
   it('fromTasks can carry a supplied version and reason', () => {

--- a/packages/franken-planner/tests/unit/hitl/hitl-gate.test.ts
+++ b/packages/franken-planner/tests/unit/hitl/hitl-gate.test.ts
@@ -75,6 +75,16 @@ describe('applyModifications', () => {
     expect(g2.getTask(createTaskId('a'))?.objective).toBe('New objective');
   });
 
+  it('increments the existing version when a task is modified', () => {
+    const graph = PlanGraph.fromTasks([makeTask('a')], { version: 7, reason: 'approved plan' });
+    const change: TaskModification = {
+      taskId: createTaskId('a'),
+      objective: 'New objective',
+    };
+
+    expect(applyModifications(graph, [change]).version).toBe(8);
+  });
+
   it('updates requiredSkills from TaskModification', () => {
     const graph = PlanGraph.empty().addTask(makeTask('a'));
     const change: TaskModification = {
@@ -104,14 +114,16 @@ describe('applyModifications', () => {
     expect(g2.getDependencies(createTaskId('b'))).toContain(createTaskId('a'));
   });
 
-  it('ignores modifications for unknown task ids', () => {
+  it('ignores modifications for unknown task ids without advancing the version', () => {
     const graph = PlanGraph.empty().addTask(makeTask('a'));
     const change: TaskModification = {
       taskId: createTaskId('does-not-exist'),
       objective: 'Ghost',
     };
     const g2 = applyModifications(graph, [change]);
+    expect(g2).toBe(graph);
     expect(g2.size()).toBe(1);
+    expect(g2.version).toBe(graph.version);
   });
 
   it('original graph is unchanged (immutable)', () => {


### PR DESCRIPTION
## Summary
- advance `PlanGraph` versions when tasks are added or removed
- preserve the existing version history and advance once when HITL modifications affect a known task
- keep unknown HITL modification targets as identity-preserving no-ops
- add regression coverage for mutation and modification version tracking

## Test Plan
- [x] `npm exec -- vitest run tests/unit/core/dag.test.ts tests/unit/hitl/hitl-gate.test.ts`
- [x] `npm test` (245 tests)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run build --workspace @franken/types`

## Formatting baseline
`npm run format:check` remains red on the existing package baseline (30 files). A changed-files-only check flags three already-unformatted files; the newly changed lines match the configured Prettier output.

Closes #3340
