### PR TITLE
fix(planner): preserve task dependencies in addTask

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -257,7 +257,7 @@ export class PlanGraph {
 
   // ─── Mutations (all return new PlanGraph — immutable) ──────────────────────
 
-  addTask(task: Task, dependsOn: TaskId[] = []): PlanGraph {
+  addTask(task: Task, dependsOn: TaskId[] = task.dependsOn): PlanGraph {
     if (this._nodes.has(task.id)) {
       throw new DuplicateTaskError(task.id);
     }

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -54,6 +54,12 @@ describe('PlanGraph — construction', () => {
     ).toThrow();
   });
 
+  it('validates task dependencies when the separate dependsOn argument is omitted', () => {
+    expect(() =>
+      PlanGraph.empty().addTask(makeTask('t-1', { dependsOn: [createTaskId('missing')] }))
+    ).toThrow("Dependency 'missing' not found in graph");
+  });
+
   it('getDependencies returns the declared deps', () => {
     const g = PlanGraph.empty()
       .addTask(makeTask('a'))
@@ -70,6 +76,15 @@ describe('PlanGraph — construction', () => {
       createTaskId('a'),
     ]);
     expect(b.dependsOn).toEqual([]);
+  });
+
+  it('uses the task dependencies when the separate dependsOn argument is omitted', () => {
+    const g = PlanGraph.empty()
+      .addTask(makeTask('a'))
+      .addTask(makeTask('b', { dependsOn: [createTaskId('a')] }));
+
+    expect(g.getDependencies(createTaskId('b'))).toEqual([createTaskId('a')]);
+    expect(g.topoSort().map((task) => task.id)).toEqual([createTaskId('a'), createTaskId('b')]);
   });
 
   it('getTasks returns all tasks in insertion order', () => {

--- a/tasks/issue-3339-add-task-dependencies-progress.md
+++ b/tasks/issue-3339-add-task-dependencies-progress.md
@@ -1,0 +1,13 @@
+# Issue #3339 — addTask dependency omission
+
+- [x] Verify issue remains open and is not labeled `good first issue`.
+- [x] Create isolated branch/worktree from current `origin/main`.
+- [x] Read shared issue-resolution lessons.
+- [x] Inspect `PlanGraph.addTask`, callers, tests, and prior dependency-sync change.
+- [x] Add a failing regression proving omitted `dependsOn` uses `task.dependsOn`.
+- [x] Implement the smallest contract-preserving fix.
+- [x] Run focused planner tests, package tests, typecheck, lint, and build.
+- [ ] Commit with the configured David Mendez identity and push.
+- [ ] Open a PR that closes only #3339.
+- [ ] Reach green CI and a fresh current-head clean GitHub Codex review.
+- [ ] Merge, verify issue closure, and complete the Kanban handoff.


### PR DESCRIPTION
## Summary
- use `task.dependsOn` when callers omit the separate `addTask` dependency argument
- preserve the existing explicit-argument precedence and dependency validation
- add regressions for graph ordering and missing task-dependency validation

## Test Plan
- [x] `npm exec -- vitest run tests/unit/core/dag.test.ts` (49 tests)
- [x] `npm test` (247 tests)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run build --workspace @franken/types`

## Formatting baseline
`prettier --check` remains red on pre-existing formatting in `dag.ts` and `dag.test.ts`; the new hunks match Prettier output.

Closes #3339