### PR TITLE
fix(orchestrator): close session readline interface

### DIFF
--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1672,6 +1672,8 @@ export async function main(): Promise<void> {
   // Create IO for non-chat interactive prompts (chat owns its own readline)
   const io = createStdinIO();
 
+  try {
+
   // Resolve base branch. Resume usually starts from the interrupted run's
   // feature branch, so infer the original base from git reflog unless the
   // user supplied an explicit --base-branch override.
@@ -1760,6 +1762,9 @@ export async function main(): Promise<void> {
   // invoking frankenbeast for no-change tasks would see a spurious nonzero exit.
   if (result && result.status !== 'completed' && result.status !== 'no-op') {
     process.exit(1);
+  }
+  } finally {
+    io.close();
   }
 }
 

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1370,6 +1370,22 @@ describe('main() execution', () => {
     expect(mockSessionStart).toHaveBeenCalled();
   });
 
+  it('closes the session readline interface after successful execution', async () => {
+    await main();
+
+    const readline = vi.mocked(createInterface).mock.results.at(-1)?.value;
+    expect(readline?.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes the session readline interface when execution throws', async () => {
+    mockSessionStart.mockRejectedValueOnce(new Error('execution failed'));
+
+    await expect(main()).rejects.toThrow('execution failed');
+
+    const readline = vi.mocked(createInterface).mock.results.at(-1)?.value;
+    expect(readline?.close).toHaveBeenCalledOnce();
+  });
+
   it('prints network credentials as parseable JSON without a banner', async () => {
     const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     mockParseArgs.mockReturnValue({


### PR DESCRIPTION
## Summary
- close the non-chat session readline interface in a `finally` block
- cover both successful and exceptional session termination
- preserve existing cleanup for subcommand-specific and chat-owned interfaces

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/cli/run.test.ts`
- `npm run lint --workspace @franken/orchestrator`
- `npm run build`
- `npm run typecheck --workspace @franken/orchestrator`

Closes #3335