### PR TITLE
fix(orchestrator): verify webhook signatures over raw bytes

### DIFF
--- a/packages/franken-orchestrator/src/comms/security/discord-signature.ts
+++ b/packages/franken-orchestrator/src/comms/security/discord-signature.ts
@@ -57,8 +57,8 @@ export function discordSignatureMiddleware(options: DiscordSignatureOptions) {
     }
 
     try {
-      const body = await c.req.text();
-      const message = Buffer.from(timestamp + body);
+      const body = Buffer.from(await c.req.arrayBuffer());
+      const message = Buffer.concat([Buffer.from(timestamp), body]);
       const signatureBuffer = Buffer.from(signature, 'hex');
 
       const isValid = verify(null, message, keyObject, signatureBuffer);

--- a/packages/franken-orchestrator/src/comms/security/whatsapp-signature.ts
+++ b/packages/franken-orchestrator/src/comms/security/whatsapp-signature.ts
@@ -21,7 +21,7 @@ export function whatsappSignatureMiddleware(options: WhatsAppSignatureOptions) {
     }
 
     try {
-      const body = await c.req.text();
+      const body = Buffer.from(await c.req.arrayBuffer());
       const hmac = createHmac('sha256', appSecret);
       hmac.update(body);
       const expectedSignature = `sha256=${hmac.digest('hex')}`;

--- a/packages/franken-orchestrator/tests/unit/comms/security/discord-signature.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/security/discord-signature.test.ts
@@ -40,6 +40,34 @@ describe('discordSignatureMiddleware', () => {
     expect(res.status).toBe(200);
   });
 
+  it('verifies signatures against the exact UTF-8 request bytes', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');
+
+    const localApp = new Hono();
+    localApp.use('/discord/*', discordSignatureMiddleware({ publicKey: rawPublicKey }));
+    localApp.post('/discord/interactions', (c) => c.json({ ok: true }));
+
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const body = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(JSON.stringify({ content: 'Hello, 世界 👋' }), 'utf8'),
+    ]);
+    const signature = sign(null, Buffer.concat([Buffer.from(timestamp), body]), keys.privateKey).toString('hex');
+
+    const res = await localApp.request('/discord/interactions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-Signature-Ed25519': signature,
+        'X-Signature-Timestamp': timestamp,
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+  });
+
   it('rejects requests with a stale (expired) timestamp', async () => {
     const keys = generateKeyPairSync('ed25519');
     const rawPublicKey = keys.publicKey.export({ type: 'spki', format: 'der' }).slice(-32).toString('hex');

--- a/packages/franken-orchestrator/tests/unit/comms/security/whatsapp-signature.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/security/whatsapp-signature.test.ts
@@ -1,0 +1,30 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { whatsappSignatureMiddleware } from '../../../../src/comms/security/whatsapp-signature.js';
+
+describe('whatsappSignatureMiddleware', () => {
+  it('verifies signatures against the exact UTF-8 request bytes', async () => {
+    const appSecret = 'whatsapp-test-secret';
+    const localApp = new Hono();
+    localApp.use('/whatsapp/*', whatsappSignatureMiddleware({ appSecret }));
+    localApp.post('/whatsapp/webhook', (c) => c.json({ ok: true }));
+
+    const body = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(JSON.stringify({ text: 'Olá, 世界 👋' }), 'utf8'),
+    ]);
+    const signature = `sha256=${createHmac('sha256', appSecret).update(body).digest('hex')}`;
+
+    const res = await localApp.request('/whatsapp/webhook', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-Hub-Signature-256': signature,
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- verify Discord interaction signatures over the exact request bytes
- verify WhatsApp webhook HMACs over the exact request bytes
- add UTF-8/BOM regression coverage for both providers

## Test Plan
- [x] `npm run test --workspace @franken/orchestrator -- --run tests/unit/comms/security/discord-signature.test.ts tests/unit/comms/security/whatsapp-signature.test.ts`
- [x] related webhook/router/route suite (53 tests)
- [x] `npm run test --workspace @franken/orchestrator` (4,380 tests)
- [x] `npm run typecheck --workspace @franken/orchestrator`
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings only)

Closes #3330
