### PR TITLE
fix(orchestrator): make chat session writes durable

### DIFF
--- a/packages/franken-orchestrator/src/chat/session-store.ts
+++ b/packages/franken-orchestrator/src/chat/session-store.ts
@@ -1,8 +1,9 @@
-import { chmodSync, readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, unlinkSync, mkdirSync, renameSync, statSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { join, resolve, sep } from 'node:path';
 import { ChatSessionSchema, type ChatSession } from './types.js';
 import { isoNow, now as deterministicNow } from '@franken/types';
+import { atomicWriteFileSync } from '../session/atomic-file.js';
 
 const MAX_CHAT_SESSION_ID_LENGTH = 128;
 
@@ -168,23 +169,11 @@ export class FileSessionStore implements ISessionStore {
     if (destination === undefined) {
       throw new Error(`Invalid chat session id: ${JSON.stringify(session.id)}`);
     }
-    const tmpPath = `${destination}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
-    try {
-      const existingMode = this.existingFileMode(destination);
-      writeFileSync(tmpPath, JSON.stringify(session, null, 2), { encoding: 'utf-8', mode: existingMode ?? 0o600 });
-      if (existingMode !== undefined) {
-        chmodSync(tmpPath, existingMode);
-      }
-      renameSync(tmpPath, destination);
-      this.corruptions.delete(session.id);
-    } catch (error) {
-      try {
-        unlinkSync(tmpPath);
-      } catch {
-        // Best-effort cleanup only; preserve the original write failure.
-      }
-      throw error;
-    }
+    const existingMode = this.existingFileMode(destination);
+    atomicWriteFileSync(destination, JSON.stringify(session, null, 2), {
+      mode: existingMode ?? 0o600,
+    });
+    this.corruptions.delete(session.id);
   }
 
   private existingFileMode(path: string): number | undefined {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -13,12 +13,14 @@ import {
   unlinkSync,
   writeSync,
 } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
 import { basename, dirname, join, resolve } from 'node:path';
 
 const STALE_JOURNAL_AGE_MS = 5 * 60_000;
 const JOURNAL_REFRESH_INTERVAL_MS = 5_000;
 const WRITE_CHUNK_BYTES = 1024 * 1024;
+const PROCESS_INSTANCE_ID = randomUUID();
 let writeCounter = 0;
 
 export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
@@ -31,6 +33,7 @@ export interface StateWriteTransactionJournal {
   readonly startedAt: string;
   readonly updatedAt: string;
   readonly writerPid?: number;
+  readonly writerInstanceId?: string;
 }
 
 export interface StateWriteJournalRecovery {
@@ -141,6 +144,9 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (value.writerPid !== undefined && (!Number.isSafeInteger(value.writerPid) || value.writerPid <= 0)) {
     throw new Error(`state write journal ${journalPath} writerPid must be a positive safe integer`);
   }
+  if (value.writerInstanceId !== undefined && (typeof value.writerInstanceId !== 'string' || value.writerInstanceId.length === 0)) {
+    throw new Error(`state write journal ${journalPath} writerInstanceId must be a non-empty string`);
+  }
   return {
     schemaVersion: 1,
     targetPath: value.targetPath,
@@ -149,6 +155,7 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
     startedAt: value.startedAt,
     updatedAt: value.updatedAt,
     ...(value.writerPid === undefined ? {} : { writerPid: value.writerPid }),
+    ...(value.writerInstanceId === undefined ? {} : { writerInstanceId: value.writerInstanceId }),
   };
 }
 
@@ -274,6 +281,9 @@ function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
     // the stale timeout so an active writer cannot be mistaken for a crash.
     return true;
   }
+  if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined) {
+    return journal.writerInstanceId === PROCESS_INSTANCE_ID;
+  }
   try {
     process.kill(journal.writerPid, 0);
     return true;
@@ -291,7 +301,8 @@ function sameStateWriteTransaction(
     pathsReferenceSameFile(left.targetPath, right.targetPath) &&
     pathsReferenceSameFile(left.tempPath, right.tempPath) &&
     left.startedAt === right.startedAt &&
-    left.writerPid === right.writerPid
+    left.writerPid === right.writerPid &&
+    left.writerInstanceId === right.writerInstanceId
   );
 }
 
@@ -443,6 +454,7 @@ export function atomicWriteFileSync(
     tempPath: resolve(tmpPath),
     startedAt,
     writerPid: process.pid,
+    writerInstanceId: PROCESS_INSTANCE_ID,
   };
   try {
     let fd: number;

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -13,15 +13,16 @@ import {
   unlinkSync,
   writeSync,
 } from 'node:fs';
-import { randomUUID } from 'node:crypto';
-import { threadId } from 'node:worker_threads';
+import { performance } from 'node:perf_hooks';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
 import { basename, dirname, join, resolve } from 'node:path';
 
 const STALE_JOURNAL_AGE_MS = 5 * 60_000;
 const JOURNAL_REFRESH_INTERVAL_MS = 5_000;
 const WRITE_CHUNK_BYTES = 1024 * 1024;
-const PROCESS_INSTANCE_ID = randomUUID();
+// Node exposes one time origin for the entire process, shared by worker threads
+// while changing across process restarts (including PID reuse).
+const PROCESS_INSTANCE_ID = performance.timeOrigin.toString();
 let writeCounter = 0;
 
 export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
@@ -34,7 +35,6 @@ export interface StateWriteTransactionJournal {
   readonly startedAt: string;
   readonly updatedAt: string;
   readonly writerPid?: number;
-  readonly writerThreadId?: number;
   readonly writerInstanceId?: string;
 }
 
@@ -146,9 +146,6 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (value.writerPid !== undefined && (!Number.isSafeInteger(value.writerPid) || value.writerPid <= 0)) {
     throw new Error(`state write journal ${journalPath} writerPid must be a positive safe integer`);
   }
-  if (value.writerThreadId !== undefined && (!Number.isSafeInteger(value.writerThreadId) || value.writerThreadId < 0)) {
-    throw new Error(`state write journal ${journalPath} writerThreadId must be a non-negative safe integer`);
-  }
   if (value.writerInstanceId !== undefined && (typeof value.writerInstanceId !== 'string' || value.writerInstanceId.length === 0)) {
     throw new Error(`state write journal ${journalPath} writerInstanceId must be a non-empty string`);
   }
@@ -160,7 +157,6 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
     startedAt: value.startedAt,
     updatedAt: value.updatedAt,
     ...(value.writerPid === undefined ? {} : { writerPid: value.writerPid }),
-    ...(value.writerThreadId === undefined ? {} : { writerThreadId: value.writerThreadId }),
     ...(value.writerInstanceId === undefined ? {} : { writerInstanceId: value.writerInstanceId }),
   };
 }
@@ -287,8 +283,8 @@ function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
     // the stale timeout so an active writer cannot be mistaken for a crash.
     return true;
   }
-  if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined && journal.writerThreadId !== undefined) {
-    return journal.writerThreadId !== threadId || journal.writerInstanceId === PROCESS_INSTANCE_ID;
+  if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined) {
+    return journal.writerInstanceId === PROCESS_INSTANCE_ID;
   }
   try {
     process.kill(journal.writerPid, 0);
@@ -308,7 +304,6 @@ function sameStateWriteTransaction(
     pathsReferenceSameFile(left.tempPath, right.tempPath) &&
     left.startedAt === right.startedAt &&
     left.writerPid === right.writerPid &&
-    left.writerThreadId === right.writerThreadId &&
     left.writerInstanceId === right.writerInstanceId
   );
 }
@@ -461,7 +456,6 @@ export function atomicWriteFileSync(
     tempPath: resolve(tmpPath),
     startedAt,
     writerPid: process.pid,
-    writerThreadId: threadId,
     writerInstanceId: PROCESS_INSTANCE_ID,
   };
   try {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -30,6 +30,7 @@ export interface StateWriteTransactionJournal {
   readonly phase: StateWriteJournalPhase;
   readonly startedAt: string;
   readonly updatedAt: string;
+  readonly writerPid?: number;
 }
 
 export interface StateWriteJournalRecovery {
@@ -137,6 +138,9 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (!Number.isFinite(Date.parse(value.updatedAt))) {
     throw new Error(`state write journal ${journalPath} updatedAt must be a valid ISO timestamp`);
   }
+  if (value.writerPid !== undefined && (!Number.isSafeInteger(value.writerPid) || value.writerPid <= 0)) {
+    throw new Error(`state write journal ${journalPath} writerPid must be a positive safe integer`);
+  }
   return {
     schemaVersion: 1,
     targetPath: value.targetPath,
@@ -144,6 +148,7 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
     phase: value.phase,
     startedAt: value.startedAt,
     updatedAt: value.updatedAt,
+    ...(value.writerPid === undefined ? {} : { writerPid: value.writerPid }),
   };
 }
 
@@ -263,6 +268,20 @@ function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
   return Date.now() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
 }
 
+function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
+  if (journal.writerPid === undefined) {
+    // Legacy journals predate writer ownership metadata and remain protected by
+    // the stale timeout so an active writer cannot be mistaken for a crash.
+    return true;
+  }
+  try {
+    process.kill(journal.writerPid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
 function sameStateWriteTransaction(
   left: StateWriteTransactionJournal,
   right: Omit<StateWriteTransactionJournal, 'updatedAt' | 'phase'>,
@@ -271,7 +290,8 @@ function sameStateWriteTransaction(
     left.schemaVersion === right.schemaVersion &&
     pathsReferenceSameFile(left.targetPath, right.targetPath) &&
     pathsReferenceSameFile(left.tempPath, right.tempPath) &&
-    left.startedAt === right.startedAt
+    left.startedAt === right.startedAt &&
+    left.writerPid === right.writerPid
   );
 }
 
@@ -332,7 +352,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
   }
 
   if (targetMatches && journal.phase === 'preparing') {
-    if (!isStaleJournal(journal)) {
+    if (!isStaleJournal(journal) && journalWriterIsAlive(journal)) {
       return {
         journalPath,
         targetPath: journal.targetPath,
@@ -365,7 +385,7 @@ export function recoverStateWriteTransaction(filePath: string): StateWriteJourna
   }
 
   if (targetMatches && existsSync(journal.tempPath)) {
-    if (!isStaleJournal(journal)) {
+    if (!isStaleJournal(journal) && journalWriterIsAlive(journal)) {
       return {
         journalPath,
         targetPath: journal.targetPath,
@@ -422,6 +442,7 @@ export function atomicWriteFileSync(
     targetPath: resolve(filePath),
     tempPath: resolve(tmpPath),
     startedAt,
+    writerPid: process.pid,
   };
   try {
     let fd: number;

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -23,6 +23,7 @@ const WRITE_CHUNK_BYTES = 1024 * 1024;
 // Node exposes one time origin for the entire process, shared by worker threads
 // while changing across process restarts (including PID reuse).
 const PROCESS_INSTANCE_ID = performance.timeOrigin.toString();
+const PROCESS_START_TIME_TICKS = readLinuxProcessStartTimeTicks(process.pid);
 let writeCounter = 0;
 
 export type StateWriteJournalPhase = 'preparing' | 'writing-temp' | 'renaming';
@@ -35,6 +36,7 @@ export interface StateWriteTransactionJournal {
   readonly startedAt: string;
   readonly updatedAt: string;
   readonly writerPid?: number;
+  readonly writerProcessStartTimeTicks?: string;
   readonly writerInstanceId?: string;
 }
 
@@ -146,6 +148,12 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (value.writerPid !== undefined && (!Number.isSafeInteger(value.writerPid) || value.writerPid <= 0)) {
     throw new Error(`state write journal ${journalPath} writerPid must be a positive safe integer`);
   }
+  if (
+    value.writerProcessStartTimeTicks !== undefined &&
+    (typeof value.writerProcessStartTimeTicks !== 'string' || value.writerProcessStartTimeTicks.length === 0)
+  ) {
+    throw new Error(`state write journal ${journalPath} writerProcessStartTimeTicks must be a non-empty string`);
+  }
   if (value.writerInstanceId !== undefined && (typeof value.writerInstanceId !== 'string' || value.writerInstanceId.length === 0)) {
     throw new Error(`state write journal ${journalPath} writerInstanceId must be a non-empty string`);
   }
@@ -157,6 +165,9 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
     startedAt: value.startedAt,
     updatedAt: value.updatedAt,
     ...(value.writerPid === undefined ? {} : { writerPid: value.writerPid }),
+    ...(value.writerProcessStartTimeTicks === undefined
+      ? {}
+      : { writerProcessStartTimeTicks: value.writerProcessStartTimeTicks }),
     ...(value.writerInstanceId === undefined ? {} : { writerInstanceId: value.writerInstanceId }),
   };
 }
@@ -277,6 +288,26 @@ function isStaleJournal(journal: StateWriteTransactionJournal): boolean {
   return Date.now() - updatedAtMs >= STALE_JOURNAL_AGE_MS;
 }
 
+function readLinuxProcessStartTimeTicks(pid: number): string | undefined {
+  if (process.platform !== 'linux' || !Number.isSafeInteger(pid) || pid <= 0) {
+    return undefined;
+  }
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const endOfCommand = stat.lastIndexOf(')');
+    if (endOfCommand < 0) {
+      return undefined;
+    }
+    const fieldsFromState = stat.slice(endOfCommand + 2).trim().split(/\s+/);
+    const startTimeTicks = fieldsFromState[19];
+    return typeof startTimeTicks === 'string' && startTimeTicks.length > 0
+      ? startTimeTicks
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
   if (journal.writerPid === undefined) {
     // Legacy journals predate writer ownership metadata and remain protected by
@@ -285,6 +316,12 @@ function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
   }
   if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined) {
     return journal.writerInstanceId === PROCESS_INSTANCE_ID;
+  }
+  if (journal.writerProcessStartTimeTicks !== undefined) {
+    const liveProcessStartTimeTicks = readLinuxProcessStartTimeTicks(journal.writerPid);
+    if (liveProcessStartTimeTicks !== undefined) {
+      return liveProcessStartTimeTicks === journal.writerProcessStartTimeTicks;
+    }
   }
   try {
     process.kill(journal.writerPid, 0);
@@ -304,6 +341,7 @@ function sameStateWriteTransaction(
     pathsReferenceSameFile(left.tempPath, right.tempPath) &&
     left.startedAt === right.startedAt &&
     left.writerPid === right.writerPid &&
+    left.writerProcessStartTimeTicks === right.writerProcessStartTimeTicks &&
     left.writerInstanceId === right.writerInstanceId
   );
 }
@@ -456,6 +494,9 @@ export function atomicWriteFileSync(
     tempPath: resolve(tmpPath),
     startedAt,
     writerPid: process.pid,
+    ...(PROCESS_START_TIME_TICKS === undefined
+      ? {}
+      : { writerProcessStartTimeTicks: PROCESS_START_TIME_TICKS }),
     writerInstanceId: PROCESS_INSTANCE_ID,
   };
   try {

--- a/packages/franken-orchestrator/src/session/atomic-file.ts
+++ b/packages/franken-orchestrator/src/session/atomic-file.ts
@@ -14,6 +14,7 @@ import {
   writeSync,
 } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { threadId } from 'node:worker_threads';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
 import { basename, dirname, join, resolve } from 'node:path';
 
@@ -33,6 +34,7 @@ export interface StateWriteTransactionJournal {
   readonly startedAt: string;
   readonly updatedAt: string;
   readonly writerPid?: number;
+  readonly writerThreadId?: number;
   readonly writerInstanceId?: string;
 }
 
@@ -144,6 +146,9 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
   if (value.writerPid !== undefined && (!Number.isSafeInteger(value.writerPid) || value.writerPid <= 0)) {
     throw new Error(`state write journal ${journalPath} writerPid must be a positive safe integer`);
   }
+  if (value.writerThreadId !== undefined && (!Number.isSafeInteger(value.writerThreadId) || value.writerThreadId < 0)) {
+    throw new Error(`state write journal ${journalPath} writerThreadId must be a non-negative safe integer`);
+  }
   if (value.writerInstanceId !== undefined && (typeof value.writerInstanceId !== 'string' || value.writerInstanceId.length === 0)) {
     throw new Error(`state write journal ${journalPath} writerInstanceId must be a non-empty string`);
   }
@@ -155,6 +160,7 @@ function parseStateWriteJournal(raw: string, journalPath: string): StateWriteTra
     startedAt: value.startedAt,
     updatedAt: value.updatedAt,
     ...(value.writerPid === undefined ? {} : { writerPid: value.writerPid }),
+    ...(value.writerThreadId === undefined ? {} : { writerThreadId: value.writerThreadId }),
     ...(value.writerInstanceId === undefined ? {} : { writerInstanceId: value.writerInstanceId }),
   };
 }
@@ -281,8 +287,8 @@ function journalWriterIsAlive(journal: StateWriteTransactionJournal): boolean {
     // the stale timeout so an active writer cannot be mistaken for a crash.
     return true;
   }
-  if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined) {
-    return journal.writerInstanceId === PROCESS_INSTANCE_ID;
+  if (journal.writerPid === process.pid && journal.writerInstanceId !== undefined && journal.writerThreadId !== undefined) {
+    return journal.writerThreadId !== threadId || journal.writerInstanceId === PROCESS_INSTANCE_ID;
   }
   try {
     process.kill(journal.writerPid, 0);
@@ -302,6 +308,7 @@ function sameStateWriteTransaction(
     pathsReferenceSameFile(left.tempPath, right.tempPath) &&
     left.startedAt === right.startedAt &&
     left.writerPid === right.writerPid &&
+    left.writerThreadId === right.writerThreadId &&
     left.writerInstanceId === right.writerInstanceId
   );
 }
@@ -454,6 +461,7 @@ export function atomicWriteFileSync(
     tempPath: resolve(tmpPath),
     startedAt,
     writerPid: process.pid,
+    writerThreadId: threadId,
     writerInstanceId: PROCESS_INSTANCE_ID,
   };
   try {

--- a/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/chat/session-store.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { FileSessionStore } from '../../../src/chat/session-store.js';
+import { atomicWriteFileSync } from '../../../src/session/atomic-file.js';
+
+vi.mock('../../../src/session/atomic-file.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/session/atomic-file.js')>();
+  return {
+    ...actual,
+    atomicWriteFileSync: vi.fn(actual.atomicWriteFileSync),
+  };
+});
 
 const TMP = join(__dirname, '__fixtures__/chat-store');
 
@@ -220,10 +229,17 @@ describe('FileSessionStore', () => {
     const session = store.create('proj');
     session.transcript.push({ role: 'user', content: 'Hello', timestamp: new Date().toISOString() });
 
+    vi.mocked(atomicWriteFileSync).mockClear();
+
     store.save(session);
 
     expect(store.get(session.id)!.transcript).toHaveLength(1);
     expect(readdirSync(TMP).filter((entry) => entry.includes('.tmp'))).toEqual([]);
+    expect(atomicWriteFileSync).toHaveBeenCalledWith(
+      join(TMP, `${session.id}.json`),
+      JSON.stringify(session, null, 2),
+      { mode: 0o600 },
+    );
   });
 
   it('preserves existing session file permissions during atomic saves', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { threadId } from 'node:worker_threads';
 import {
   atomicWriteFileSync,
   quarantineFile,
@@ -145,6 +146,7 @@ describe('atomic-file', () => {
           startedAt: '2999-01-01T00:00:00.000Z',
           updatedAt: '2999-01-01T00:00:01.000Z',
           writerPid: process.pid,
+          writerThreadId: threadId,
           writerInstanceId: 'crashed-process-instance',
         }),
         'utf8',
@@ -155,6 +157,35 @@ describe('atomic-file', () => {
       expect(existsSync(tempPath)).toBe(false);
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
       expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
+    });
+
+    it('retains a fresh journal owned by another worker thread in the same process', () => {
+      const dir = makeTmpDir('atomic-write-other-thread-');
+      const filePath = join(dir, 'session.json');
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000013`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+          writerPid: process.pid,
+          writerThreadId: threadId + 1,
+          writerInstanceId: 'other-live-worker-instance',
+        }),
+        'utf8',
+      );
+
+      expect(() => atomicWriteFileSync(filePath, '{"replacement":true}')).toThrow(/still active/);
+
+      expect(existsSync(tempPath)).toBe(true);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
+      expect(readFileSync(filePath, 'utf-8')).toBe('{"old":true}');
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -128,6 +128,34 @@ describe('atomic-file', () => {
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
       expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
     });
+
+    it('recovers when a restarted process reuses the crashed writer PID', () => {
+      const dir = makeTmpDir('atomic-write-reused-pid-');
+      const filePath = join(dir, 'session.json');
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000012`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+          writerPid: process.pid,
+          writerInstanceId: 'crashed-process-instance',
+        }),
+        'utf8',
+      );
+
+      atomicWriteFileSync(filePath, '{"new":true}');
+
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+      expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
+    });
   });
 
   describe('recoverStateWriteTransaction()', () => {

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
-import { threadId } from 'node:worker_threads';
+import { performance } from 'node:perf_hooks';
 import {
   atomicWriteFileSync,
   quarantineFile,
@@ -146,7 +146,6 @@ describe('atomic-file', () => {
           startedAt: '2999-01-01T00:00:00.000Z',
           updatedAt: '2999-01-01T00:00:01.000Z',
           writerPid: process.pid,
-          writerThreadId: threadId,
           writerInstanceId: 'crashed-process-instance',
         }),
         'utf8',
@@ -175,8 +174,7 @@ describe('atomic-file', () => {
           startedAt: '2999-01-01T00:00:00.000Z',
           updatedAt: '2999-01-01T00:00:01.000Z',
           writerPid: process.pid,
-          writerThreadId: threadId + 1,
-          writerInstanceId: 'other-live-worker-instance',
+          writerInstanceId: performance.timeOrigin.toString(),
         }),
         'utf8',
       );

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -15,6 +15,7 @@ describe('atomic-file', () => {
   const tmpDirs: string[] = [];
 
   afterEach(() => {
+    vi.restoreAllMocks();
     for (const dir of tmpDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -92,6 +93,37 @@ describe('atomic-file', () => {
 
       atomicWriteFileSync(filePath, '{"new":true}');
 
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
+      expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');
+    });
+
+    it('immediately recovers a fresh journal left by a dead writer', () => {
+      const dir = makeTmpDir('atomic-write-dead-writer-');
+      const filePath = join(dir, 'session.json');
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000011`;
+      writeFileSync(filePath, '{"old":true}');
+      writeFileSync(tempPath, '{"new":');
+      writeFileSync(
+        stateWriteJournalPath(filePath),
+        JSON.stringify({
+          schemaVersion: 1,
+          targetPath: filePath,
+          tempPath,
+          phase: 'writing-temp',
+          startedAt: '2999-01-01T00:00:00.000Z',
+          updatedAt: '2999-01-01T00:00:01.000Z',
+          writerPid: 424_242,
+        }),
+        'utf8',
+      );
+      vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw Object.assign(new Error('process not found'), { code: 'ESRCH' });
+      });
+
+      atomicWriteFileSync(filePath, '{"new":true}');
+
+      expect(process.kill).toHaveBeenCalledWith(424_242, 0);
       expect(existsSync(tempPath)).toBe(false);
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(false);
       expect(readFileSync(filePath, 'utf-8')).toBe('{"new":true}');

--- a/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/atomic-file.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -184,6 +185,48 @@ describe('atomic-file', () => {
       expect(existsSync(tempPath)).toBe(true);
       expect(existsSync(stateWriteJournalPath(filePath))).toBe(true);
       expect(readFileSync(filePath, 'utf-8')).toBe('{"old":true}');
+    });
+
+    it.runIf(process.platform === 'linux')('recovers when an unrelated live process reused the writer PID', () => {
+      const dir = makeTmpDir('atomic-write-reused-pid-');
+      const filePath = join(dir, 'session.json');
+      const tempPath = `${filePath}.tmp.123.00000000-0000-0000-0000-000000000014`;
+      const journalPath = stateWriteJournalPath(filePath);
+      const unrelatedProcess = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], {
+        stdio: 'ignore',
+      });
+      const writerPid = unrelatedProcess.pid;
+      if (writerPid === undefined) {
+        unrelatedProcess.kill();
+        throw new Error('Expected the unrelated test process to have a PID');
+      }
+
+      try {
+        writeFileSync(tempPath, '{"new":');
+        writeFileSync(
+          journalPath,
+          JSON.stringify({
+            schemaVersion: 1,
+            targetPath: filePath,
+            tempPath,
+            phase: 'writing-temp',
+            startedAt: '2999-01-01T00:00:00.000Z',
+            updatedAt: '2999-01-01T00:00:01.000Z',
+            writerPid,
+            writerProcessStartTimeTicks: 'reused-process-start',
+            writerInstanceId: 'crashed-process-instance',
+          }),
+          'utf8',
+        );
+
+        atomicWriteFileSync(filePath, '{"replacement":true}');
+
+        expect(existsSync(tempPath)).toBe(false);
+        expect(existsSync(journalPath)).toBe(false);
+        expect(readFileSync(filePath, 'utf8')).toBe('{"replacement":true}');
+      } finally {
+        unrelatedProcess.kill();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- route chat session persistence through the shared crash-safe atomic writer
- preserve existing session file modes and secure defaults
- tag write journals with PID, a worker-shared Node process identity, and Linux process start time so recovery distinguishes restarts, worker threads, and PID reuse
- add regression coverage for shared atomic writes, dead writers, PID reuse, and concurrent worker ownership

## Test plan
- `npm test -- --run tests/unit/session/atomic-file.test.ts tests/unit/chat/session-store.test.ts` (44 passed)
- `npm test` (4,384 passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 228 pre-existing warnings)

Closes #3329