### PR TITLE
test(brain): lock in atomic working-memory flushes

### DIFF
--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -212,6 +212,12 @@ const restored = SqliteBrain.hydrate(snapshot);
 restored.close();
 ```
 
+## Persistence atomicity
+
+`SqliteBrain` persists each working-memory flush as one immediate SQLite transaction. All dirty upserts, deletions, provenance cleanup, and the success audit record commit together; if any statement fails, SQLite rolls the entire batch back and the in-memory changes remain pending for a later retry. Recovery checkpoints include their working-memory flush in the same transaction, so a checkpoint cannot commit against a partially persisted memory snapshot.
+
+Keep future multi-row modifications inside `db.transaction(...)` rather than issuing independent statements. This preserves the same all-or-nothing contract for failures and concurrent writers.
+
 ## Encryption at rest
 
 `SqliteBrain` can encrypt persisted working memory rows, episodic summaries/details, and recovery checkpoint states with AES-256-GCM. Supply a key directly or point to an environment variable:

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -5819,6 +5819,31 @@ describe('SqliteBrain', () => {
       expect(snapshot.working).toEqual({ task: 'test-flush' });
     });
 
+    it('rolls back every row when a working-memory batch fails mid-flush', () => {
+      const db = (brain as unknown as { db: Database.Database }).db;
+      db.exec(`
+        CREATE TEMP TRIGGER fail_second_working_memory_insert
+        BEFORE INSERT ON working_memory
+        WHEN NEW.key = 'beta'
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated mid-batch failure');
+        END;
+      `);
+
+      brain.working.set('alpha', 'one');
+      brain.working.set('beta', 'two');
+
+      expect(() => brain.flush()).toThrow('simulated mid-batch failure');
+      expect(db.prepare('SELECT key FROM working_memory ORDER BY key').all()).toEqual([]);
+
+      db.exec('DROP TRIGGER fail_second_working_memory_insert');
+      brain.flush();
+      expect(db.prepare('SELECT key FROM working_memory ORDER BY key').all()).toEqual([
+        { key: 'alpha' },
+        { key: 'beta' },
+      ]);
+    });
+
     it('persists only changed working-memory rows on subsequent flushes', () => {
       const db = (
         brain as unknown as {

--- a/tasks/issue-3551-progress.md
+++ b/tasks/issue-3551-progress.md
@@ -1,0 +1,10 @@
+# Issue 3551 Progress
+
+- [x] Verify live issue labels and confirm it is not reserved as `good first issue`.
+- [x] Inspect `SqliteBrain` batch-write paths, adapter wiring, existing tests, and shared lessons.
+- [x] Add a regression test proving a mid-batch SQLite failure rolls back every working-memory row and leaves the batch retryable.
+- [x] Document the transaction invariant for multi-row working-memory flushes.
+- [x] Run targeted tests and `@franken/brain` test/typecheck/build/lint checks.
+- [ ] Commit with the required identity, push the issue branch, and open a single issue-closing PR.
+- [ ] Obtain green CI and a current-head clean GitHub Codex review, then merge.
+- [ ] Record any reusable lesson and complete or block the Kanban card.


### PR DESCRIPTION
## Summary
- prove a simulated failure on the second row rolls back the entire working-memory flush
- verify failed in-memory changes remain retryable after the SQLite error is removed
- document the existing immediate-transaction contract for working-memory batches and checkpoints

## Context
The current `SqliteBrain` implementation already executes working-memory flushes through `db.transaction(...).immediate()`. This PR adds the missing regression contract and documentation so future batch-write changes cannot silently reintroduce partial persistence.

## Test plan
- `npm run test --workspace @franken/brain -- tests/unit/sqlite-brain.test.ts -t "rolls back every row when a working-memory batch fails mid-flush"`
- `npm run test --workspace @franken/brain` (338 tests)
- `npm run typecheck --workspace @franken/brain`
- `npm run build --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`

Closes #3551