### PR TITLE
fix(web): announce runtime activity updates

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -34,6 +34,32 @@ describe('ActivityPane', () => {
     expect(screen.getByText(/"traceId": "trace-1"/)).toBeTruthy();
   });
 
+  it('announces newly appended runtime activity with a concise polite status', () => {
+    const { rerender } = render(<ActivityPane events={[]} />);
+
+    const liveStatus = screen.getByRole('status');
+    expect(liveStatus.getAttribute('aria-live')).toBe('polite');
+    expect(liveStatus.getAttribute('aria-atomic')).toBe('true');
+    expect(liveStatus.textContent).toBe('');
+
+    rerender(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.execution.progress',
+            data: { message: 'Installing dependencies', traceId: 'trace-should-not-be-announced' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(liveStatus.textContent).toBe(
+      'Execution update at Jul 5, 2026, 1:02 AM — In progress: Installing dependencies',
+    );
+    expect(liveStatus.textContent).not.toContain('trace-should-not-be-announced');
+  });
+
   it('renders runtime activity as a readable timeline with status chips and artifact links', () => {
     render(
       <ActivityPane

--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -55,9 +55,30 @@ describe('ActivityPane', () => {
     );
 
     expect(liveStatus.textContent).toBe(
-      'Execution update at Jul 5, 2026, 1:02 AM — In progress: Installing dependencies',
+      'Execution update at Jul 5, 2026, 1:02 AM — In progress: Installing dependencies (activity 1)',
     );
     expect(liveStatus.textContent).not.toContain('trace-should-not-be-announced');
+
+    rerender(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.execution.progress',
+            data: { message: 'Installing dependencies' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+          {
+            type: 'turn.execution.progress',
+            data: { message: 'Installing dependencies' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(liveStatus.textContent).toBe(
+      'Execution update at Jul 5, 2026, 1:02 AM — In progress: Installing dependencies (activity 2)',
+    );
   });
 
   it('renders runtime activity as a readable timeline with status chips and artifact links', () => {

--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -81,6 +81,22 @@ describe('ActivityPane', () => {
     );
   });
 
+  it('does not re-announce historical activity when the pane mounts', () => {
+    render(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.execution.complete',
+            data: { summary: 'Historical completion' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+
   it('renders runtime activity as a readable timeline with status chips and artifact links', () => {
     render(
       <ActivityPane

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -171,9 +171,9 @@ function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
   };
 }
 
-function announcementForActivity(event: ActivityEvent): string {
+function announcementForActivity(event: ActivityEvent, activityNumber: number): string {
   const viewModel = viewModelForActivity(event);
-  return `${viewModel.title} at ${formatActivityTime(event.timestamp)} — ${viewModel.status}: ${viewModel.summary}`;
+  return `${viewModel.title} at ${formatActivityTime(event.timestamp)} — ${viewModel.status}: ${viewModel.summary} (activity ${activityNumber})`;
 }
 
 const UNABLE_TO_STRINGIFY_EVENT_DATA = '[unserializable event data]';
@@ -214,7 +214,7 @@ function safeEventDataSummary(data: Record<string, unknown>): string {
 
 export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
   const latestEvent = events[events.length - 1];
-  const latestAnnouncement = latestEvent ? announcementForActivity(latestEvent) : '';
+  const latestAnnouncement = latestEvent ? announcementForActivity(latestEvent, events.length) : '';
   const [announcement, setAnnouncement] = useState('');
   const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll<HTMLOListElement, HTMLLIElement>(
     events.length,

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ActivityEvent } from '../hooks/use-chat-session';
 import { SafeMarkdownText } from './safe-markdown-text';
 import { usePinnedScroll } from './use-pinned-scroll';
@@ -216,14 +216,26 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
   const latestEvent = events[events.length - 1];
   const latestAnnouncement = latestEvent ? announcementForActivity(latestEvent, events.length) : '';
   const [announcement, setAnnouncement] = useState('');
+  const previousEventCountRef = useRef(events.length);
+  const previousResetKeyRef = useRef(resetKey);
   const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll<HTMLOListElement, HTMLLIElement>(
     events.length,
     resetKey,
   );
 
   useEffect(() => {
+    const previousEventCount = previousEventCountRef.current;
+    const resetChanged = !Object.is(previousResetKeyRef.current, resetKey);
+    previousEventCountRef.current = events.length;
+    previousResetKeyRef.current = resetKey;
+
+    if (resetChanged || events.length <= previousEventCount) {
+      setAnnouncement('');
+      return;
+    }
+
     setAnnouncement(latestAnnouncement);
-  }, [latestAnnouncement]);
+  }, [events.length, latestAnnouncement, resetKey]);
 
   return (
     <section className="rail-card terminal-activity" aria-label="Activity">

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { ActivityEvent } from '../hooks/use-chat-session';
 import { SafeMarkdownText } from './safe-markdown-text';
 import { usePinnedScroll } from './use-pinned-scroll';
@@ -170,6 +171,11 @@ function viewModelForActivity(event: ActivityEvent): ActivityViewModel {
   };
 }
 
+function announcementForActivity(event: ActivityEvent): string {
+  const viewModel = viewModelForActivity(event);
+  return `${viewModel.title} at ${formatActivityTime(event.timestamp)} — ${viewModel.status}: ${viewModel.summary}`;
+}
+
 const UNABLE_TO_STRINGIFY_EVENT_DATA = '[unserializable event data]';
 
 function formatEventData(data: Record<string, unknown>): string {
@@ -207,10 +213,17 @@ function safeEventDataSummary(data: Record<string, unknown>): string {
 }
 
 export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
+  const latestEvent = events[events.length - 1];
+  const latestAnnouncement = latestEvent ? announcementForActivity(latestEvent) : '';
+  const [announcement, setAnnouncement] = useState('');
   const { containerRef, endRef, hasNewItems, handleScroll, scrollToLatest } = usePinnedScroll<HTMLOListElement, HTMLLIElement>(
     events.length,
     resetKey,
   );
+
+  useEffect(() => {
+    setAnnouncement(latestAnnouncement);
+  }, [latestAnnouncement]);
 
   return (
     <section className="rail-card terminal-activity" aria-label="Activity">
@@ -218,6 +231,9 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
         <p className="eyebrow">Activity</p>
         <h2>Runtime Events</h2>
       </div>
+      <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </p>
       {events.length === 0 && <p className="rail-card__empty">Waiting for execution events.</p>}
       <ol ref={containerRef} className="activity-list" aria-label="Runtime activity timeline" onScroll={handleScroll}>
         {events.map((event, index) => {


### PR DESCRIPTION
## Summary
- keep a polite, atomic live region mounted in the activity rail
- announce only newly appended runtime events using their readable title, timestamp, status, summary, and monotonic activity position
- suppress historical/remount announcements and exclude verbose raw payloads

## Test plan
- `npm test --workspace @franken/web` (701 passed)
- `npm run typecheck --workspace @franken/web`
- `npm run lint --workspace @franken/web` (0 errors; 17 pre-existing warnings)
- `npm run build --workspace @franken/web`

Closes #3543