### PR TITLE
fix(orchestrator): validate provider session records

### DIFF
--- a/packages/franken-orchestrator/src/cache/provider-session-store.ts
+++ b/packages/franken-orchestrator/src/cache/provider-session-store.ts
@@ -93,6 +93,16 @@ export class ProviderSessionStore {
       description: 'provider session',
       onCorrupt: warnJsonQuarantined,
     });
+    if (
+      stored !== null &&
+      typeof stored === 'object' &&
+      'schemaVersion' in stored &&
+      typeof stored.schemaVersion === 'number' &&
+      stored.schemaVersion !== this.options.schemaVersion
+    ) {
+      return undefined;
+    }
+
     const parsed = StoredProviderSessionRecordSchema.safeParse(stored);
     if (parsed.success) {
       return parsed.data;

--- a/packages/franken-orchestrator/src/cache/provider-session-store.ts
+++ b/packages/franken-orchestrator/src/cache/provider-session-store.ts
@@ -1,6 +1,13 @@
-import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
-import { readJsonFileOrDefault, warnJsonQuarantined, writeJsonFileAtomic } from '../init/init-json-file.js';
+import { join } from 'node:path';
+import { z } from 'zod';
+import {
+  quarantineJsonFile,
+  readJsonFileOrDefault,
+  warnJsonQuarantined,
+  writeJsonFileAtomic,
+  type JsonCorruptionRecovery,
+} from '../init/init-json-file.js';
 import type {
   CacheStoreOptions,
   ProviderSessionLookup,
@@ -8,6 +15,24 @@ import type {
   StoredProviderSessionRecord,
 } from './llm-cache-types.js';
 import { encodeCachePathSegment } from './llm-cache-types.js';
+
+const StoredProviderSessionRecordSchema = z.object({
+  projectId: z.string(),
+  workId: z.string(),
+  provider: z.string(),
+  model: z.string(),
+  sessionId: z.string(),
+  promptFingerprint: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  schemaVersion: z.number(),
+}) satisfies z.ZodType<StoredProviderSessionRecord>;
+
+function warnInvalidProviderSession({ filePath, quarantinePath, error }: JsonCorruptionRecovery): void {
+  console.warn(
+    `Invalid provider session record in ${filePath}; quarantined original at ${quarantinePath} and continuing with a cache miss. ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
 
 export class ProviderSessionStore {
   constructor(
@@ -64,9 +89,23 @@ export class ProviderSessionStore {
   }
 
   private async read(filePath: string): Promise<StoredProviderSessionRecord | undefined> {
-    return readJsonFileOrDefault<StoredProviderSessionRecord | undefined>(filePath, () => undefined, {
+    const stored = await readJsonFileOrDefault<unknown>(filePath, () => undefined, {
       description: 'provider session',
       onCorrupt: warnJsonQuarantined,
     });
+    const parsed = StoredProviderSessionRecordSchema.safeParse(stored);
+    if (parsed.success) {
+      return parsed.data;
+    }
+    if (stored === undefined) {
+      return undefined;
+    }
+
+    await quarantineJsonFile(filePath, {
+      description: 'provider session record',
+      error: parsed.error,
+      onCorrupt: warnInvalidProviderSession,
+    });
+    return undefined;
   }
 }

--- a/packages/franken-orchestrator/src/init/init-json-file.ts
+++ b/packages/franken-orchestrator/src/init/init-json-file.ts
@@ -45,6 +45,38 @@ async function resolveExistingOrSymlinkTarget(filePath: string): Promise<string>
   }
 }
 
+export async function quarantineJsonFile(
+  filePath: string,
+  options: {
+    description: string;
+    error: unknown;
+    onCorrupt?: (recovery: JsonCorruptionRecovery) => void;
+  },
+): Promise<boolean> {
+  const targetPath = await resolveExistingOrSymlinkTarget(filePath);
+  const quarantinePath = quarantinePathFor(targetPath);
+  const targetMode = await stat(targetPath).then((info) => info.mode & 0o777).catch(() => undefined);
+  try {
+    await rename(targetPath, quarantinePath);
+  } catch (renameError) {
+    if ((renameError as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw renameError;
+  }
+  if (targetMode !== undefined) {
+    recoveredFileModes.set(filePath, targetMode);
+    recoveredFileModes.set(targetPath, targetMode);
+  }
+  options.onCorrupt?.({
+    description: options.description,
+    filePath,
+    quarantinePath,
+    error: options.error,
+  });
+  return true;
+}
+
 export async function readJsonFileOrDefault<T>(
   filePath: string,
   fallback: () => T,
@@ -69,22 +101,11 @@ export async function readJsonFileOrDefault<T>(
     if (!isJsonSyntaxError(error)) {
       throw error;
     }
-    const targetPath = await resolveExistingOrSymlinkTarget(filePath);
-    const quarantinePath = quarantinePathFor(targetPath);
-    const targetMode = await stat(targetPath).then((info) => info.mode & 0o777).catch(() => undefined);
-    try {
-      await rename(targetPath, quarantinePath);
-    } catch (renameError) {
-      if ((renameError as NodeJS.ErrnoException).code === 'ENOENT') {
-        return fallback();
-      }
-      throw renameError;
-    }
-    if (targetMode !== undefined) {
-      recoveredFileModes.set(filePath, targetMode);
-      recoveredFileModes.set(targetPath, targetMode);
-    }
-    options.onCorrupt?.({ description: options.description, filePath, quarantinePath, error });
+    await quarantineJsonFile(filePath, {
+      description: options.description,
+      error,
+      ...(options.onCorrupt === undefined ? {} : { onCorrupt: options.onCorrupt }),
+    });
     return fallback();
   }
 }

--- a/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
@@ -176,6 +176,36 @@ describe('ProviderSessionStore', () => {
     });
   });
 
+  it('leaves unsupported provider-session schema versions untouched', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-provider-session-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const sessionPath = join(rootDir, 'work', 'frankenbeast', 'issue%3A99', 'provider-session.json');
+    await mkdir(dirname(sessionPath), { recursive: true });
+    await writeFile(sessionPath, JSON.stringify({
+      schemaVersion: 4,
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: 'sess-99',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      updatedAt: '2026-03-13T00:00:00.000Z',
+    }), 'utf8');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new ProviderSessionStore(rootDir, { schemaVersion: 3 });
+    await expect(store.load({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      promptFingerprint: 'fp-99',
+    })).resolves.toBeUndefined();
+    await expect(readFile(sessionPath, 'utf8')).resolves.toContain('"schemaVersion":4');
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('quarantines schema-invalid provider-session records and treats them as explicit misses', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-provider-session-'));
     const rootDir = join(workDir, '.fbeast', '.cache', 'llm');

--- a/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cache/provider-session-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ProviderSessionStore } from '../../../src/cache/provider-session-store.js';
@@ -174,6 +174,39 @@ describe('ProviderSessionStore', () => {
       sessionId: 'sess-99-replacement',
       schemaVersion: 3,
     });
+  });
+
+  it('quarantines schema-invalid provider-session records and treats them as explicit misses', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-provider-session-'));
+    const rootDir = join(workDir, '.fbeast', '.cache', 'llm');
+    const sessionDir = join(rootDir, 'work', 'frankenbeast', 'issue%3A99');
+    const sessionPath = join(sessionDir, 'provider-session.json');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(sessionPath, JSON.stringify({
+      schemaVersion: 3,
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      sessionId: null,
+      promptFingerprint: 'fp-99',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      updatedAt: '2026-03-13T00:00:00.000Z',
+    }), 'utf8');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new ProviderSessionStore(rootDir, { schemaVersion: 3 });
+    await expect(store.load({
+      projectId: 'frankenbeast',
+      workId: 'issue:99',
+      provider: 'claude',
+      model: 'claude-sonnet-4-6',
+      promptFingerprint: 'fp-99',
+    })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Invalid provider session record'));
+    await expect(readFile(sessionPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect((await readdir(sessionDir)).filter((entry) => entry.startsWith('provider-session.json.corrupt-'))).toHaveLength(1);
+    warn.mockRestore();
   });
 
   it('quarantines malformed provider-session JSON and treats corruption as an explicit miss', async () => {


### PR DESCRIPTION
## Summary
- validate persisted provider-session records with a runtime schema before reuse
- quarantine schema-invalid records with an operator-visible warning
- reuse the existing JSON quarantine path so recovery preserves file permissions

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/cache/provider-session-store.test.ts`
- `npm run test --workspace @franken/orchestrator -- tests/unit/cache`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- `npm run build`

Closes #3066