### PR TITLE
fix(orchestrator): propagate governor approval tokens

### DIFF
--- a/packages/franken-orchestrator/src/adapters/governor-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/governor-adapter.ts
@@ -1,5 +1,6 @@
 import type { IGovernorModule, ApprovalPayload, ApprovalOutcome } from '../deps.js';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
+import type { SessionToken } from '@franken/governor';
 
 export type GovernorDecision = ApprovalOutcome['decision'];
 
@@ -25,7 +26,7 @@ export interface ApprovalRequestPort {
 }
 
 export type ApprovalOutcomePort =
-  | { decision: 'APPROVE'; token?: unknown }
+  | { decision: 'APPROVE'; token?: SessionToken }
   | { decision: 'REGEN'; feedback: string }
   | { decision: 'ABORT'; reason?: string }
   | { decision: 'DEBUG' };
@@ -103,7 +104,9 @@ export class GovernorPortAdapter implements IGovernorModule {
 function mapOutcome(outcome: ApprovalOutcomePort): ApprovalOutcome {
   switch (outcome.decision) {
     case 'APPROVE':
-      return { decision: 'approved' };
+      return outcome.token === undefined
+        ? { decision: 'approved' }
+        : { decision: 'approved', token: outcome.token };
     case 'ABORT':
       return { decision: 'abort', reason: outcome.reason };
     case 'REGEN':

--- a/packages/franken-orchestrator/src/adapters/governor-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/governor-adapter.ts
@@ -1,6 +1,5 @@
-import type { IGovernorModule, ApprovalPayload, ApprovalOutcome } from '../deps.js';
+import type { IGovernorModule, ApprovalPayload, ApprovalOutcome, ApprovalSessionToken } from '../deps.js';
 import { deterministicUuid, now as deterministicNow } from '@franken/types';
-import type { SessionToken } from '@franken/governor';
 
 export type GovernorDecision = ApprovalOutcome['decision'];
 
@@ -26,7 +25,7 @@ export interface ApprovalRequestPort {
 }
 
 export type ApprovalOutcomePort =
-  | { decision: 'APPROVE'; token?: SessionToken }
+  | { decision: 'APPROVE'; token?: ApprovalSessionToken }
   | { decision: 'REGEN'; feedback: string }
   | { decision: 'ABORT'; reason?: string }
   | { decision: 'DEBUG' };

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -1,6 +1,7 @@
 import type { CliSkillExecutor } from './skills/cli-skill-executor.js';
 import type { PrCreator } from './closure/pr-creator.js';
 import type { GraphBuilder } from './planning/chunk-file-graph-builder.js';
+import type { SessionToken } from '@franken/governor';
 
 /**
  * BeastLoopDeps — dependency injection interface for the orchestrator.
@@ -179,6 +180,8 @@ export interface ApprovalPayload {
 export interface ApprovalOutcome {
   readonly decision: 'approved' | 'rejected' | 'abort';
   readonly reason?: string | undefined;
+  /** Scope-bound authorization artifact issued by the governor for an approval. */
+  readonly token?: SessionToken | undefined;
 }
 
 /** What the orchestrator needs from MOD-08 (Heartbeat). */

--- a/packages/franken-orchestrator/src/deps.ts
+++ b/packages/franken-orchestrator/src/deps.ts
@@ -1,7 +1,6 @@
 import type { CliSkillExecutor } from './skills/cli-skill-executor.js';
 import type { PrCreator } from './closure/pr-creator.js';
 import type { GraphBuilder } from './planning/chunk-file-graph-builder.js';
-import type { SessionToken } from '@franken/governor';
 
 /**
  * BeastLoopDeps — dependency injection interface for the orchestrator.
@@ -181,7 +180,17 @@ export interface ApprovalOutcome {
   readonly decision: 'approved' | 'rejected' | 'abort';
   readonly reason?: string | undefined;
   /** Scope-bound authorization artifact issued by the governor for an approval. */
-  readonly token?: SessionToken | undefined;
+  readonly token?: ApprovalSessionToken | undefined;
+}
+
+/** Minimal governor session-token contract exposed across the orchestrator port. */
+export interface ApprovalSessionToken {
+  readonly tokenId: string;
+  readonly approvalId: string;
+  readonly scope: string;
+  readonly grantedBy: string;
+  readonly grantedAt: Date;
+  readonly expiresAt: Date;
 }
 
 /** What the orchestrator needs from MOD-08 (Heartbeat). */

--- a/packages/franken-orchestrator/tests/unit/adapters/governor-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/governor-adapter.test.ts
@@ -50,6 +50,34 @@ describe('GovernorPortAdapter', () => {
     );
   });
 
+  it('preserves the governor approval session token', async () => {
+    const token = {
+      tokenId: 'token-1',
+      approvalId: 'req-2',
+      scope: 'project-1:hitl_required:task-2',
+      grantedBy: 'operator',
+      grantedAt: new Date('2026-01-01T00:00:00.000Z'),
+      expiresAt: new Date('2026-01-01T00:05:00.000Z'),
+    };
+    const gateway = {
+      requestApproval: vi.fn().mockResolvedValue({ decision: 'APPROVE', token }),
+    };
+
+    const adapter = new GovernorPortAdapter({
+      gateway,
+      projectId: 'project-1',
+      idFactory: () => 'req-2',
+    });
+
+    const result = await adapter.requestApproval({
+      taskId: 'task-2',
+      summary: 'Sensitive task',
+      requiresHitl: true,
+    });
+
+    expect(result).toEqual({ decision: 'approved', token });
+  });
+
   it('defaultDecision=approved auto-approves everything', async () => {
     const gateway = { requestApproval: vi.fn() };
     const adapter = new GovernorPortAdapter({


### PR DESCRIPTION
## Summary
- type governor approval outcomes with the concrete session-token contract
- preserve issued governor session tokens across the orchestrator adapter boundary
- add a regression test proving approved outcomes retain the token

## Test plan
- `npm run test --workspace @franken/orchestrator` (4,381 tests)
- `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build`

Closes #3533