### PR TITLE
fix(mcp-suite): reject malformed observer metadata

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -104,6 +104,43 @@ describe('ObserverAdapter', () => {
     }
   });
 
+  it('preserves and surfaces malformed metadata already stored by older adapters', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+    const sessionId = randomUUID();
+    const metadata = '{"token":"must-not-leak"';
+    const auditEvent = createAuditEvent('tool_call', metadata, {
+      phase: 'mcp',
+      provider: 'fbeast-mcp',
+      input: metadata,
+    });
+    const hash = hashContent(`${sessionId}:tool_call:${auditEvent.inputHash ?? ''}:${metadata}`);
+    mutateAuditTrailDirectly(dbPath, (db) => {
+      db.prepare(`
+        INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(sessionId, 'tool_call', metadata, hash, null);
+    });
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await expect(observer.verify(sessionId)).resolves.toEqual({ ok: true, checked: 1 });
+      await expect(observer.log({
+        event: 'tool_result',
+        metadata: JSON.stringify({ ok: true }),
+        sessionId,
+      })).resolves.toEqual(expect.objectContaining({ hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/) }));
+
+      expect(await observer.trail(sessionId)).toHaveLength(2);
+      const warnings = stderr.mock.calls.map(([message]) => String(message));
+      expect(warnings).toHaveLength(2);
+      expect(warnings.every((warning) => warning.includes('"code":"OBSERVER_STORED_METADATA_INVALID_JSON"'))).toBe(true);
+      expect(warnings.join('\n')).not.toContain('must-not-leak');
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it('chains later audit hashes through the previous entry hash', async () => {
     const secondHashFrom = async (firstMetadata: string): Promise<string> => {
       const observer = createObserverAdapter(tracked(tmpDbPath()));

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -69,6 +69,41 @@ describe('ObserverAdapter', () => {
     await expect(observer.trail('close-test')).rejects.toThrow(/database connection is not open/i);
   });
 
+  it('rejects malformed metadata with a counted structured warning', async () => {
+    const observer = createObserverAdapter(tracked(tmpDbPath()));
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await expect(observer.log({
+        event: 'tool_call',
+        metadata: '{"token":"must-not-leak"',
+        sessionId: 'malformed-metadata',
+      })).rejects.toMatchObject({
+        name: 'ObserverMetadataParseError',
+        code: 'OBSERVER_METADATA_INVALID_JSON',
+        rejectionCount: 1,
+      });
+      await expect(observer.log({
+        event: 'tool_result',
+        metadata: '{not-json',
+        sessionId: 'malformed-metadata',
+      })).rejects.toMatchObject({
+        code: 'OBSERVER_METADATA_INVALID_JSON',
+        rejectionCount: 2,
+      });
+
+      expect(await observer.trail('malformed-metadata')).toEqual([]);
+      expect(stderr).toHaveBeenCalledTimes(2);
+      const warnings = stderr.mock.calls.map(([message]) => String(message));
+      expect(warnings[0]).toContain('"code":"OBSERVER_METADATA_INVALID_JSON"');
+      expect(warnings[0]).toContain('"rejectionCount":1');
+      expect(warnings[1]).toContain('"rejectionCount":2');
+      expect(warnings.join('\n')).not.toContain('must-not-leak');
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it('chains later audit hashes through the previous entry hash', async () => {
     const secondHashFrom = async (firstMetadata: string): Promise<string> => {
       const observer = createObserverAdapter(tracked(tmpDbPath()));

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -18,6 +18,19 @@ export interface ObserverLogResult {
   hash: string;
 }
 
+export class ObserverMetadataParseError extends Error {
+  readonly code = 'OBSERVER_METADATA_INVALID_JSON';
+
+  constructor(
+    readonly event: string,
+    readonly rejectionCount: number,
+    options?: ErrorOptions,
+  ) {
+    super('Observer metadata must be valid JSON', options);
+    this.name = 'ObserverMetadataParseError';
+  }
+}
+
 export interface ObserverCostSummary {
   totalPromptTokens: number;
   totalCompletionTokens: number;
@@ -91,6 +104,7 @@ function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; m
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
   let closed = false;
+  let metadataParseRejections = 0;
   const costCalculator = new CostCalculator(DEFAULT_PRICING, {
     onUnknownModel: (model) => {
       process.stderr.write(`[fbeast-observer] Unknown model "${model}" — cost will be recorded as $0.0000 until pricing is configured.\n`);
@@ -99,8 +113,23 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
 
   return {
     async log(input) {
-      const payload = parseMetadata(input.metadata);
-      const metadata = canonicalMetadata(input.metadata);
+      let payload: unknown;
+      try {
+        payload = parseMetadata(input.metadata);
+      } catch (cause) {
+        metadataParseRejections += 1;
+        const error = new ObserverMetadataParseError(input.event, metadataParseRejections, { cause });
+        process.stderr.write(`[fbeast-observer] ${JSON.stringify({
+          level: 'warn',
+          code: error.code,
+          event: input.event.slice(0, 128),
+          rejectionCount: error.rejectionCount,
+          metadataBytes: Buffer.byteLength(input.metadata),
+          metadataHash: hashContent(input.metadata),
+        })}\n`);
+        throw error;
+      }
+      const metadata = canonicalMetadata(payload);
       const auditEvent = createAuditEvent(input.event, payload, {
         phase: 'mcp',
         provider: 'fbeast-mcp',
@@ -248,7 +277,7 @@ function validateAuditTail(
   const matchesCurrent = tail.hash === buildAuditHash(baseHash, previousHash);
   const legacyParentIsValid = previousHash === undefined || isLegacy16Hash(previousHash);
   const matchesLegacy16 = legacyParentIsValid
-    && buildMatchingLegacy16Hash(tail, previousHash) === tail.hash;
+    && buildMatchingLegacy16Hash(tail, previousHash, payload) === tail.hash;
 
   if (actualParentHash !== previousHash || (!matchesCurrent && !matchesLegacy16)) {
     throw new Error('Cannot append audit row to invalid trail tail');
@@ -290,7 +319,7 @@ function inspectAuditTrail(
     const baseHash = buildEventBaseHash(sessionId, row.eventType, metadata, auditEvent.inputHash);
     const expectedHash = buildAuditHash(baseHash, expectedParentHash);
     const expectedHashFromStoredParent = buildAuditHash(baseHash, previousStoredHash);
-    const expectedLegacy16Hash = buildMatchingLegacy16Hash(row, expectedLegacy16ParentHash);
+    const expectedLegacy16Hash = buildMatchingLegacy16Hash(row, expectedLegacy16ParentHash, payload);
     const actualParentHash = row.parentHash ?? undefined;
     const matchesCurrent = actualParentHash === expectedParentHash && row.hash === expectedHash;
     const matchesStoredParent = !matchesCurrent
@@ -374,10 +403,14 @@ function buildLegacy16AuditHash(inputHash?: string, parentHash?: string): string
   return hashContent(`${parentHash}:${baseHash}`).slice(0, 16);
 }
 
-function buildMatchingLegacy16Hash(row: AuditTrailRow, parentHash?: string): string | undefined {
+function buildMatchingLegacy16Hash(
+  row: AuditTrailRow,
+  parentHash: string | undefined,
+  parsedMetadata: unknown,
+): string | undefined {
   if (!isLegacy16Hash(row.hash)) return undefined;
 
-  for (const metadata of legacyMetadataCandidates(row.payload)) {
+  for (const metadata of legacyMetadataCandidates(row.payload, parsedMetadata)) {
     const expected = buildLegacy16AuditHash(hashContent(metadata), parentHash);
     if (row.hash === expected) return expected;
   }
@@ -389,16 +422,11 @@ function isLegacy16Hash(hash: string | undefined): hash is string {
   return /^sha256:[a-f0-9]{9}$/.test(hash ?? '');
 }
 
-function legacyMetadataCandidates(storedMetadata: string): string[] {
+function legacyMetadataCandidates(storedMetadata: string, parsedMetadata: unknown): string[] {
   const candidates = [storedMetadata];
-  try {
-    const parsed = JSON.parse(storedMetadata) as unknown;
-    candidates.push(JSON.stringify(parsed, null, 2));
-    if (isPlainObject(parsed)) {
-      candidates.push(prettyOneLineJson(parsed));
-    }
-  } catch {
-    // Non-JSON legacy metadata has no alternate insignificant-whitespace form.
+  candidates.push(JSON.stringify(parsedMetadata, null, 2));
+  if (isPlainObject(parsedMetadata)) {
+    candidates.push(prettyOneLineJson(parsedMetadata));
   }
 
   return [...new Set(candidates)];
@@ -433,17 +461,9 @@ function migrateAuditRow(store: ReturnType<typeof createSqliteStore>, id: number
 }
 
 function parseMetadata(metadata: string): unknown {
-  try {
-    return JSON.parse(metadata);
-  } catch {
-    return metadata;
-  }
+  return JSON.parse(metadata);
 }
 
-function canonicalMetadata(metadata: string): string {
-  try {
-    return JSON.stringify(JSON.parse(metadata));
-  } catch {
-    return metadata;
-  }
+function canonicalMetadata(metadata: unknown): string {
+  return JSON.stringify(metadata);
 }

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -115,7 +115,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
     async log(input) {
       let payload: unknown;
       try {
-        payload = parseMetadata(input.metadata);
+        payload = JSON.parse(input.metadata);
       } catch (cause) {
         metadataParseRejections += 1;
         const error = new ObserverMetadataParseError(input.event, metadataParseRejections, { cause });
@@ -267,7 +267,7 @@ function validateAuditTail(
   const previousHash = rows[1]?.hash;
   const actualParentHash = tail.parentHash ?? undefined;
   const metadata = tail.payload;
-  const payload = parseMetadata(metadata);
+  const payload = parseStoredMetadata(metadata);
   const auditEvent = createAuditEvent(tail.eventType, payload, {
     phase: 'mcp',
     provider: 'fbeast-mcp',
@@ -310,7 +310,7 @@ function inspectAuditTrail(
 
   for (const [index, row] of rows.entries()) {
     const metadata = row.payload;
-    const payload = parseMetadata(metadata);
+    const payload = parseStoredMetadata(metadata);
     const auditEvent = createAuditEvent(row.eventType, payload, {
       phase: 'mcp',
       provider: 'fbeast-mcp',
@@ -439,7 +439,7 @@ function prettyOneLineJson(value: Record<string, unknown>): string {
 }
 
 function legacy16RowIsBoundToTrail(row: AuditTrailRow, sessionId: string): boolean {
-  const payload = parseMetadata(row.payload);
+  const payload = parseStoredMetadata(row.payload);
   if (!isPlainObject(payload)) return false;
 
   const payloadSession = payload['sessionId'] ?? payload['session_id'];
@@ -460,8 +460,18 @@ function migrateAuditRow(store: ReturnType<typeof createSqliteStore>, id: number
   }
 }
 
-function parseMetadata(metadata: string): unknown {
-  return JSON.parse(metadata);
+function parseStoredMetadata(metadata: string): unknown {
+  try {
+    return JSON.parse(metadata);
+  } catch {
+    process.stderr.write(`[fbeast-observer] ${JSON.stringify({
+      level: 'warn',
+      code: 'OBSERVER_STORED_METADATA_INVALID_JSON',
+      metadataBytes: Buffer.byteLength(metadata),
+      metadataHash: hashContent(metadata),
+    })}\n`);
+    return metadata;
+  }
 }
 
 function canonicalMetadata(metadata: unknown): string {

--- a/packages/franken-mcp-suite/src/index.ts
+++ b/packages/franken-mcp-suite/src/index.ts
@@ -21,7 +21,11 @@ export {
   type BrainAdapterOptions,
 } from './adapters/brain-adapter.js';
 export { WorkingMemoryHydrationLimitError } from '@franken/brain';
-export { createObserverAdapter, type ObserverAdapter } from './adapters/observer-adapter.js';
+export {
+  createObserverAdapter,
+  ObserverMetadataParseError,
+  type ObserverAdapter,
+} from './adapters/observer-adapter.js';
 export { createGovernorAdapter, type GovernorAdapter } from './adapters/governor-adapter.js';
 export { createPlannerAdapter, type PlannerAdapter } from './adapters/planner-adapter.js';
 export { createCritiqueAdapter, type CritiqueAdapter } from './adapters/critique-adapter.js';


### PR DESCRIPTION
## Summary
- reject malformed observer metadata before it can be silently persisted or omitted from downstream trace processing
- emit a counted, structured warning containing only metadata size and digest rather than raw potentially sensitive payloads
- expose a typed `ObserverMetadataParseError` and reuse parsed metadata during legacy hash verification
- add regression coverage proving rejected events are not appended and warning output does not leak payload contents

## Test plan
- `npm test --workspace @franken/mcp-suite -- --run src/adapters/observer-adapter.test.ts src/shared/package-exports.test.ts`
- `npm test --workspace @franken/mcp-suite` (39 files, 610 tests)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (passes with 27 pre-existing warnings)
- `npm run build`

Closes #3541
