### PR TITLE
fix(live-bench): reject extra list arguments

### DIFF
--- a/packages/live-bench/src/cli/main.ts
+++ b/packages/live-bench/src/cli/main.ts
@@ -30,7 +30,7 @@ Commands:
 
 if (command === 'list') {
   const corpusRoot = process.argv[3];
-  if (!corpusRoot) {
+  if (!corpusRoot || process.argv.length !== 4) {
     console.error('Usage: fbeast-live-bench list <corpus-root>');
     process.exit(2);
   }

--- a/packages/live-bench/tests/cli-smoke.test.ts
+++ b/packages/live-bench/tests/cli-smoke.test.ts
@@ -230,6 +230,14 @@ describe('live-bench CLI smoke coverage', () => {
     expect(result.stderr).toContain('Usage: fbeast-live-bench list <corpus-root>');
   }, 35_000);
 
+  it('rejects extra list arguments instead of ignoring them', () => {
+    const result = runCli(['list', corpusRoot, '--unexpected']);
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Usage: fbeast-live-bench list <corpus-root>');
+  }, 35_000);
+
   it('exits with code 2 for unknown commands', () => {
     const result = runCli(['unsupported']);
 


### PR DESCRIPTION
## Summary
- reject missing or extra positional arguments for `fbeast-live-bench list`
- print the existing list usage guidance and exit with code 2
- add CLI regression coverage proving trailing arguments are not ignored

## Verification
- `npm run test --workspace @franken/live-bench` (128 passed, 1 skipped live test)
- `npm run lint --workspace @franken/live-bench`
- `npm run typecheck --workspace @franken/live-bench`
- `npm run build --workspace @franken/live-bench`

Closes #3070