### PR TITLE
fix(ci): bound root release tag selection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,9 @@ jobs:
           # Component releases are prefixed (franken-brain-v0.3.0).
           # GitHub auto-marks the most recently created release as "latest",
           # which could be any sub-package. Fix that.
-          release_json=$(gh release list --limit 1000 --json tagName,isLatest)
+          # Bound the API response, then sort valid root tags ourselves rather
+          # than relying on GitHub's creation-date ordering.
+          release_json=$(gh release list --limit 100 --json tagName,isLatest)
           latest_tag=$(jq -r '([.[] | select(.isLatest)][0].tagName // empty)' <<<"$release_json")
           if [ -z "$latest_tag" ]; then
             echo "No latest release found; nothing to repair"
@@ -80,18 +82,25 @@ jobs:
           fi
 
           # If the current "latest" is already a root release, nothing to do
-          if [[ "$latest_tag" =~ ^v[0-9] ]]; then
+          if [[ "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Latest is already root release: $latest_tag"
             exit 0
           fi
 
-          # Promote the most recent root release back to latest. If no root
-          # release exists yet, keep the current latest marker in place rather
-          # than demoting the component release and leaving no latest release.
-          root_tag=$(jq -r '([.[] | select(.tagName | test("^v[0-9]"))][0].tagName // empty)' <<<"$release_json")
+          # Select the greatest stable semantic version deterministically.
+          root_tag=$(jq -r '
+            [
+              .[]
+              | .tagName
+              | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+              | { tag: ., version: (ltrimstr("v") | split(".") | map(tonumber)) }
+            ]
+            | sort_by(.version) | reverse
+            | .[0].tag // empty
+          ' <<<"$release_json")
           if [ -z "$root_tag" ]; then
-            echo "No root release found; leaving component latest unchanged: $latest_tag"
-            exit 0
+            echo "No unambiguous root release found in bounded release list; refusing to change latest: $latest_tag" >&2
+            exit 1
           fi
 
           # Demote the component release, then promote the root release.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,7 +74,7 @@ jobs:
           # which could be any sub-package. Fix that.
           # Bound the API response, then sort valid root tags ourselves rather
           # than relying on GitHub's creation-date ordering.
-          release_json=$(gh release list --limit 100 --json tagName,isLatest)
+          release_json=$(gh release list --limit 1000 --exclude-drafts --exclude-pre-releases --json tagName,isLatest)
           latest_tag=$(jq -r '([.[] | select(.isLatest)][0].tagName // empty)' <<<"$release_json")
           if [ -z "$latest_tag" ]; then
             echo "No latest release found; nothing to repair"

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-22 — Deterministic root release repair
+- When repairing GitHub's latest-release marker in a multi-package repository, fetch a bounded but churn-tolerant release window with explicit draft/prerelease exclusion, filter only bare root semver tags, and sort parsed numeric version tuples instead of trusting API creation order. Resolve the replacement candidate before demoting the current latest release so an empty bounded result fails without leaving the repository markerless.
+
 ## 2026-07-22 — Shared chat command completion catalogs
 - When adding interactive completion for chat commands, derive or cross-check the catalog against every command accepted by the shared runtime, not only the commands handled locally by one CLI wrapper. Approval commands such as `/approve` and `/reject` can be runtime-owned even when the readline layer has no dedicated branch; keep both attached and local chat interfaces on one completer and test paired command prefixes explicitly.
 

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -590,7 +590,9 @@ jobs:
     const promoteIndex = releaseLatestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(releaseLatestRun).toContain('gh release list --limit 100 --json tagName,isLatest');
+    expect(releaseLatestRun).toContain(
+      'gh release list --limit 1000 --exclude-drafts --exclude-pre-releases --json tagName,isLatest',
+    );
     expect(releaseLatestRun).toContain('[[ "$latest_tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]');
     expect(releaseLatestRun).toContain('test("^v[0-9]+\\\\.[0-9]+\\\\.[0-9]+$")');
     expect(releaseLatestRun).toContain('split(".") | map(tonumber)');
@@ -645,7 +647,9 @@ jobs:
     const promoteIndex = latestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(latestRun).toContain('gh release list --limit 100 --json tagName,isLatest');
+    expect(latestRun).toContain(
+      'gh release list --limit 1000 --exclude-drafts --exclude-pre-releases --json tagName,isLatest',
+    );
     expect(missingRootGuardIndex).toBeGreaterThan(rootLookupIndex);
     expect(demoteIndex).toBeGreaterThan(missingRootGuardIndex);
     expect(promoteIndex).toBeGreaterThan(demoteIndex);

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { load } from 'js-yaml';
 
 const ROOT = resolve(import.meta.dirname, '..', '..');
@@ -577,7 +577,7 @@ jobs:
     expect(releaseLatestRun).toContain('exit 1');
   });
 
-  it('does not demote component-only latest releases unless a root release exists to promote', () => {
+  it('selects a root release deterministically from a bounded semantic-version sort', () => {
     const releaseLatestStep = expectSteps(releasePlease).find(
       (step) => step.name === 'Ensure only root release is marked latest',
     );
@@ -585,21 +585,44 @@ jobs:
     const releaseLatestRun = String(releaseLatestStep?.run ?? '');
 
     const rootLookupIndex = releaseLatestRun.indexOf('root_tag=$(jq -r');
-    const emptyRootNormalizationIndex = releaseLatestRun.indexOf('.tagName // empty', rootLookupIndex);
-    const noRootGuardIndex = releaseLatestRun.indexOf(
-      'No root release found; leaving component latest unchanged',
-    );
+    const noRootGuardIndex = releaseLatestRun.indexOf('No unambiguous root release found in bounded release list');
     const demoteIndex = releaseLatestRun.indexOf('gh release edit "$latest_tag" --latest=false');
     const promoteIndex = releaseLatestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(releaseLatestRun).toContain('gh release list --limit 1000 --json tagName,isLatest');
-    expect(emptyRootNormalizationIndex).toBeGreaterThan(rootLookupIndex);
-    expect(noRootGuardIndex).toBeGreaterThan(emptyRootNormalizationIndex);
+    expect(releaseLatestRun).toContain('gh release list --limit 100 --json tagName,isLatest');
+    expect(releaseLatestRun).toContain('[[ "$latest_tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]');
+    expect(releaseLatestRun).toContain('test("^v[0-9]+\\\\.[0-9]+\\\\.[0-9]+$")');
+    expect(releaseLatestRun).toContain('split(".") | map(tonumber)');
+    expect(releaseLatestRun).toContain('sort_by(.version) | reverse');
+    expect(noRootGuardIndex).toBeGreaterThan(rootLookupIndex);
     expect(demoteIndex).toBeGreaterThan(noRootGuardIndex);
     expect(promoteIndex).toBeGreaterThan(demoteIndex);
     expect(releaseLatestRun).toContain('if [ -z "$root_tag" ]; then');
-    expect(releaseLatestRun).toContain('exit 0');
+    expect(releaseLatestRun.slice(noRootGuardIndex, demoteIndex)).toContain('exit 1');
+  });
+
+  it('orders root tags by semantic version instead of release-list position', () => {
+    const releaseLatestStep = expectSteps(releasePlease).find(
+      (step) => step.name === 'Ensure only root release is marked latest',
+    );
+    const releaseLatestRun = String(releaseLatestStep?.run ?? '');
+    const rootSelector = releaseLatestRun.match(/root_tag=\$\(jq -r '([\s\S]*?)' <<<"\$release_json"\)/)?.[1];
+    expect(rootSelector).toBeTruthy();
+
+    const releases = [
+      { tagName: 'component-v99.0.0', isLatest: true },
+      { tagName: 'v2.10.0', isLatest: false },
+      { tagName: 'v10.0.0', isLatest: false },
+      { tagName: 'v2.9.0', isLatest: false },
+      { tagName: 'v11.0.0-rc.1', isLatest: false },
+    ];
+    const selected = execFileSync('jq', ['-r', rootSelector as string], {
+      input: JSON.stringify(releases),
+      encoding: 'utf8',
+    }).trim();
+
+    expect(selected).toBe('v10.0.0');
   });
 
   it('defers npm token enforcement until a public package needs publishing', () => {
@@ -611,22 +634,22 @@ jobs:
     expect(publishRun).toContain('npm publish "$package_path" --access public --provenance');
   });
 
-  it('does not demote a component latest release unless a root release can be promoted', () => {
+  it('fails before demotion when the bounded release list has no valid root semantic version', () => {
     const latestStep = expectSteps(releasePlease).find((step) => step.name === 'Ensure only root release is marked latest');
     expect(latestStep).toBeTruthy();
 
     const latestRun = String(latestStep?.run ?? '');
     const rootLookupIndex = latestRun.indexOf('root_tag=$(jq -r');
-    const missingRootGuardIndex = latestRun.indexOf('No root release found; leaving component latest unchanged');
+    const missingRootGuardIndex = latestRun.indexOf('No unambiguous root release found in bounded release list');
     const demoteIndex = latestRun.indexOf('gh release edit "$latest_tag" --latest=false');
     const promoteIndex = latestRun.indexOf('gh release edit "$root_tag" --latest');
 
     expect(rootLookupIndex).toBeGreaterThan(-1);
-    expect(latestRun).toContain('gh release list --limit 1000 --json tagName,isLatest');
+    expect(latestRun).toContain('gh release list --limit 100 --json tagName,isLatest');
     expect(missingRootGuardIndex).toBeGreaterThan(rootLookupIndex);
     expect(demoteIndex).toBeGreaterThan(missingRootGuardIndex);
     expect(promoteIndex).toBeGreaterThan(demoteIndex);
-    expect(latestRun).toContain('[0].tagName // empty');
+    expect(latestRun.slice(missingRootGuardIndex, demoteIndex)).toContain('exit 1');
   });
 });
 


### PR DESCRIPTION
## Summary
- bound release metadata lookup to 100 results
- select the newest root release by parsed semantic version instead of API order
- fail before mutating the latest marker when no valid root release is available
- execute the workflow jq selector against an out-of-order regression fixture

## Verification
- `npm run test:root -- tests/unit/ci-workflow.test.ts` (47 tests)
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `actionlint .github/workflows/release-please.yml`

Closes #3072