### PR TITLE
fix(mcp-suite): accept 16-hex legacy audit hashes

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -23,6 +23,14 @@ function legacy16AuditHash(metadata: string, parentHash?: string): string {
   return parentHash ? legacy16(`${parentHash}:${inputHash}`) : inputHash.slice(0, 16);
 }
 
+function legacy16HexAuditHash(metadata: string, parentHash?: string): string {
+  const inputHash = `sha256:${createHash('sha256').update(metadata).digest('hex')}`;
+  const chainedHash = parentHash
+    ? `sha256:${createHash('sha256').update(`${parentHash}:${inputHash}`).digest('hex')}`
+    : inputHash;
+  return `sha256:${chainedHash.slice('sha256:'.length, 'sha256:'.length + 16)}`;
+}
+
 function mutateAuditTrailDirectly(dbPath: string, mutation: (db: ReturnType<typeof createSqliteStore>['db']) => void): void {
   const store = createSqliteStore(dbPath);
   store.setAuditTrailMutationEnabled(true);
@@ -351,6 +359,34 @@ describe('ObserverAdapter', () => {
     expect(verification).toEqual({ ok: true, checked: 2 });
     expect(trail[0]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(trail[0]!.parentHash).toBeNull();
+    expect(trail[1]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(trail[1]!.parentHash).toBe(trail[0]!.hash);
+  });
+
+  it('verifies and migrates legacy audit hashes with 16 hexadecimal digest characters', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const observer = createObserverAdapter(dbPath);
+    const sessionId = randomUUID();
+    const firstMetadata = JSON.stringify({ sessionId, eventType: 'tool_call', tool: 'memory', step: 1 });
+    const secondMetadata = JSON.stringify({ sessionId, eventType: 'tool_result', tool: 'memory', ok: true });
+    const firstLegacyHash = legacy16HexAuditHash(firstMetadata);
+    const secondLegacyHash = legacy16HexAuditHash(secondMetadata, firstLegacyHash);
+    const db = new Database(dbPath);
+    db.prepare(`
+      INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(sessionId, 'tool_call', firstMetadata, firstLegacyHash, null);
+    db.prepare(`
+      INSERT INTO audit_trail (session_id, event_type, payload, hash, parent_hash)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(sessionId, 'tool_result', secondMetadata, secondLegacyHash, firstLegacyHash);
+    db.close();
+
+    expect(firstLegacyHash).toMatch(/^sha256:[a-f0-9]{16}$/);
+    expect(secondLegacyHash).toMatch(/^sha256:[a-f0-9]{16}$/);
+    await expect(observer.verify(sessionId)).resolves.toEqual({ ok: true, checked: 2 });
+    const trail = await observer.trail(sessionId);
+    expect(trail[0]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(trail[1]!.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(trail[1]!.parentHash).toBe(trail[0]!.hash);
   });

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -394,13 +394,19 @@ function buildEventBaseHash(sessionId: string, eventType: string, metadata: stri
   return hashContent(`${sessionId}:${eventType}:${inputHash ?? ''}:${metadata}`);
 }
 
-function buildLegacy16AuditHash(inputHash?: string, parentHash?: string): string {
-  const baseHash = inputHash ?? hashContent('');
-  if (!parentHash) {
-    return baseHash.slice(0, 16);
-  }
+const SHA256_PREFIX = 'sha256:';
+const LEGACY_AUDIT_DIGEST_HEX_LENGTH = 16;
+// Older adapters truncated the entire prefixed hash to 16 characters, leaving nine digest characters.
+const HISTORICAL_LEGACY_AUDIT_DIGEST_HEX_LENGTH = 16 - SHA256_PREFIX.length;
 
-  return hashContent(`${parentHash}:${baseHash}`).slice(0, 16);
+function buildLegacy16AuditHash(
+  inputHash?: string,
+  parentHash?: string,
+  digestHexLength = LEGACY_AUDIT_DIGEST_HEX_LENGTH,
+): string {
+  const baseHash = inputHash ?? hashContent('');
+  const fullHash = parentHash ? hashContent(`${parentHash}:${baseHash}`) : baseHash;
+  return `${SHA256_PREFIX}${fullHash.slice(SHA256_PREFIX.length, SHA256_PREFIX.length + digestHexLength)}`;
 }
 
 function buildMatchingLegacy16Hash(
@@ -408,10 +414,11 @@ function buildMatchingLegacy16Hash(
   parentHash: string | undefined,
   parsedMetadata: unknown,
 ): string | undefined {
-  if (!isLegacy16Hash(row.hash)) return undefined;
+  const digestHexLength = legacy16DigestHexLength(row.hash);
+  if (digestHexLength === undefined) return undefined;
 
   for (const metadata of legacyMetadataCandidates(row.payload, parsedMetadata)) {
-    const expected = buildLegacy16AuditHash(hashContent(metadata), parentHash);
+    const expected = buildLegacy16AuditHash(hashContent(metadata), parentHash, digestHexLength);
     if (row.hash === expected) return expected;
   }
 
@@ -419,7 +426,18 @@ function buildMatchingLegacy16Hash(
 }
 
 function isLegacy16Hash(hash: string | undefined): hash is string {
-  return /^sha256:[a-f0-9]{9}$/.test(hash ?? '');
+  return legacy16DigestHexLength(hash) !== undefined;
+}
+
+function legacy16DigestHexLength(hash: string | undefined): number | undefined {
+  if (!hash?.startsWith(SHA256_PREFIX)) return undefined;
+  const digest = hash.slice(SHA256_PREFIX.length);
+  if (!/^[a-f0-9]+$/.test(digest)) return undefined;
+  if (digest.length === LEGACY_AUDIT_DIGEST_HEX_LENGTH) return LEGACY_AUDIT_DIGEST_HEX_LENGTH;
+  if (digest.length === HISTORICAL_LEGACY_AUDIT_DIGEST_HEX_LENGTH) {
+    return HISTORICAL_LEGACY_AUDIT_DIGEST_HEX_LENGTH;
+  }
+  return undefined;
 }
 
 function legacyMetadataCandidates(storedMetadata: string, parsedMetadata: unknown): string[] {


### PR DESCRIPTION
## Summary
- recognize legacy observer audit hashes containing 16 hexadecimal digest characters
- preserve migration support for historical hashes truncated to 16 total prefixed characters
- add a two-row migration regression for the intended 16-hex format

## Test plan
- `npm run test --workspace @franken/mcp-suite -- src/adapters/observer-adapter.test.ts`
- `npm run test --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build`

Closes #3516