### PR TITLE
fix(web): disable composer input with dispatch

### DIFF
--- a/packages/franken-web/src/components/composer.tsx
+++ b/packages/franken-web/src/components/composer.tsx
@@ -153,6 +153,7 @@ export function Composer({ connectionStatus, clearedFailedDraft, disabled, disab
           aria-describedby="composer-help composer-live-status"
           aria-disabled={disabled ? 'true' : undefined}
           className="field-control composer__textarea"
+          disabled={disabled}
           value={value}
           onChange={(event) => setValue(event.target.value)}
           onKeyDown={(event) => {

--- a/packages/franken-web/tests/components/composer.test.tsx
+++ b/packages/franken-web/tests/components/composer.test.tsx
@@ -35,10 +35,11 @@ describe('Composer', () => {
     expect(button).toHaveProperty('disabled', true);
   });
 
-  it('explains why dispatch is disabled and marks the textarea for assistive tech', () => {
+  it('disables the textarea and explains why dispatch is unavailable', () => {
     render(<Composer onSend={vi.fn()} disabled={true} connectionStatus="connected" status="streaming" />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(input.disabled).toBe(true);
     expect(input.getAttribute('aria-disabled')).toBe('true');
     expect(input.getAttribute('aria-describedby')).toContain('composer-help');
     expect(screen.getByText('Dispatch is disabled while Frankenbeast is responding.')).toBeTruthy();


### PR DESCRIPTION
## Summary
- disable the composer textarea whenever dispatch is disabled
- retain the accessible disabled reason and defensive submission guard
- add focused component coverage for the native disabled state

## Verification
- `npm run test --workspace @franken/web -- tests/components/composer.test.tsx` (14 passed)
- `npm run test --workspace @franken/web` (701 passed)
- `npm run lint --workspace @franken/web` (0 errors; 17 pre-existing warnings)
- `npm run typecheck --workspace @franken/web`
- `npm run build`

Closes #2787
