### PR TITLE
fix(observer): use monotonic span durations

### DIFF
--- a/packages/franken-observer/src/core/TraceContext.test.ts
+++ b/packages/franken-observer/src/core/TraceContext.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { TraceContext } from './TraceContext.js'
 
 describe('TraceContext', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   describe('createTrace()', () => {
     it('returns a root trace with a unique id', () => {
       const a = TraceContext.createTrace('goal A')
@@ -86,6 +90,22 @@ describe('TraceContext', () => {
       const span = TraceContext.startSpan(trace, { name: 'step' })
       TraceContext.endSpan(span)
       expect(span.durationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it('uses a monotonic clock for duration when the wall clock moves backward', () => {
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1_000)
+        .mockReturnValueOnce(2_000)
+        .mockReturnValueOnce(1_500)
+      vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35)
+
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'step' })
+      TraceContext.endSpan(span)
+
+      expect(span.startedAt).toBe(2_000)
+      expect(span.endedAt).toBe(1_500)
+      expect(span.durationMs).toBe(25)
     })
 
     it('can mark a span as errored', () => {

--- a/packages/franken-observer/src/core/TraceContext.test.ts
+++ b/packages/franken-observer/src/core/TraceContext.test.ts
@@ -97,7 +97,7 @@ describe('TraceContext', () => {
         .mockReturnValueOnce(1_000)
         .mockReturnValueOnce(2_000)
         .mockReturnValueOnce(1_500)
-      vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35)
+      vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35.6)
 
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'step' })
@@ -105,7 +105,8 @@ describe('TraceContext', () => {
 
       expect(span.startedAt).toBe(2_000)
       expect(span.endedAt).toBe(1_500)
-      expect(span.durationMs).toBe(25)
+      expect(span.durationMs).toBe(26)
+      expect(Number.isInteger(span.durationMs)).toBe(true)
     })
 
     it('can mark a span as errored', () => {

--- a/packages/franken-observer/src/core/TraceContext.ts
+++ b/packages/franken-observer/src/core/TraceContext.ts
@@ -48,13 +48,12 @@ export const TraceContext = {
     }
     const endedAt = wallClockNow()
     const monotonicStartedAt = spanMonotonicStartTimes.get(span)
-    span.endedAt = endedAt
-    span.durationMs = Math.max(
-      0,
+    const durationMs =
       monotonicStartedAt === undefined
         ? endedAt - span.startedAt
-        : performance.now() - monotonicStartedAt,
-    )
+        : performance.now() - monotonicStartedAt
+    span.endedAt = endedAt
+    span.durationMs = Math.max(0, Math.round(durationMs))
     spanMonotonicStartTimes.delete(span)
     span.status = options.status ?? 'completed'
     if (options.errorMessage !== undefined) {

--- a/packages/franken-observer/src/core/TraceContext.ts
+++ b/packages/franken-observer/src/core/TraceContext.ts
@@ -10,6 +10,8 @@ import { randomUUID } from 'node:crypto';
 import { wallClockNow } from '@franken/types';
 import type { LoopDetector } from '../incident/LoopDetector.js'
 
+const spanMonotonicStartTimes = new WeakMap<Span, number>()
+
 export const TraceContext = {
   createTrace(goal: string): Trace {
     return {
@@ -35,6 +37,7 @@ export const TraceContext = {
       metadata: {},
       thoughtBlocks: [],
     }
+    spanMonotonicStartTimes.set(span, performance.now())
     trace.spans.push(span)
     return span
   },
@@ -44,8 +47,15 @@ export const TraceContext = {
       throw new Error(`Cannot end span that is already ${span.status} (id: ${span.id})`)
     }
     const endedAt = wallClockNow()
+    const monotonicStartedAt = spanMonotonicStartTimes.get(span)
     span.endedAt = endedAt
-    span.durationMs = endedAt - span.startedAt
+    span.durationMs = Math.max(
+      0,
+      monotonicStartedAt === undefined
+        ? endedAt - span.startedAt
+        : performance.now() - monotonicStartedAt,
+    )
+    spanMonotonicStartTimes.delete(span)
     span.status = options.status ?? 'completed'
     if (options.errorMessage !== undefined) {
       span.errorMessage = options.errorMessage


### PR DESCRIPTION
## Summary
- measure span durations with the monotonic Performance clock
- preserve wall-clock start/end timestamps for serialization
- cover backward wall-clock jumps with a regression test

## Verification
- `npm exec --workspace @franken/observer -- vitest run src/core/TraceContext.test.ts`
- `npm test --workspace @franken/observer` (843 tests)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)

Closes #2751