### PR TITLE
fix(orchestrator): handle CLI stdin errors

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -594,6 +594,15 @@ export class CliLlmAdapter implements IAdapter {
       let terminated = false;
       let hardKillTimer: ReturnType<typeof setTimeout> | undefined;
       let lineBuffer = '';
+      let stdinError: unknown;
+
+      const buildStdinFailure = (): Error => {
+        const message = stdinError instanceof Error ? stdinError.message : String(stdinError);
+        const failure = new Error(`Failed to write prompt to ${input.cmd} stdin: ${message}`, {
+          cause: stdinError,
+        });
+        return Object.assign(failure, { stdout, stderr, exitCode: 1 });
+      };
 
       const settle = (fn: () => void): void => {
         if (settled) return;
@@ -690,12 +699,21 @@ export class CliLlmAdapter implements IAdapter {
         if (this.opts.onStreamLine && lineBuffer.trim().length > 0) {
           this.opts.onStreamLine(lineBuffer);
         }
+        if (stdinError !== undefined) {
+          settle(() => reject(buildStdinFailure()));
+          return;
+        }
         if (terminated) return;
         settle(() => resolve({ stdout, stderr, exitCode: code ?? 1 }));
       });
 
       child.on('error', (err) => {
         if (terminated) {
+          if (stdinError !== undefined) {
+            clearTimers();
+            settle(() => reject(buildStdinFailure()));
+            return;
+          }
           // Preserve the scheduled SIGKILL fallback if termination failed.
           clearTimeout(timer);
           return;
@@ -705,14 +723,11 @@ export class CliLlmAdapter implements IAdapter {
       });
 
       child.stdin!.on('error', (error) => {
-        if (settled) return;
+        if (settled || stdinError !== undefined) return;
         clearTimeout(timer);
         input.signal?.removeEventListener('abort', abortRequest);
+        stdinError = error;
         terminate('stdin-failed');
-        const message = error instanceof Error ? error.message : String(error);
-        settle(() => reject(new Error(`Failed to write prompt to ${input.cmd} stdin: ${message}`, {
-          cause: error,
-        })));
       });
 
       if (!settled) {
@@ -720,11 +735,8 @@ export class CliLlmAdapter implements IAdapter {
           child.stdin!.write(input.prompt);
           child.stdin!.end();
         } catch (error) {
+          stdinError = error;
           terminate('stdin-failed');
-          const message = error instanceof Error ? error.message : String(error);
-          settle(() => reject(new Error(`Failed to write prompt to ${input.cmd} stdin: ${message}`, {
-            cause: error,
-          })));
         }
       }
     });

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -704,12 +704,15 @@ export class CliLlmAdapter implements IAdapter {
         settle(() => reject(err));
       });
 
-      child.stdin!.on('error', (err) => {
+      child.stdin!.on('error', (error) => {
         if (settled) return;
         clearTimeout(timer);
         input.signal?.removeEventListener('abort', abortRequest);
         terminate('stdin-failed');
-        settle(() => reject(err));
+        const message = error instanceof Error ? error.message : String(error);
+        settle(() => reject(new Error(`Failed to write prompt to ${input.cmd} stdin: ${message}`, {
+          cause: error,
+        })));
       });
 
       if (!settled) {
@@ -718,7 +721,10 @@ export class CliLlmAdapter implements IAdapter {
           child.stdin!.end();
         } catch (error) {
           terminate('stdin-failed');
-          settle(() => reject(error));
+          const message = error instanceof Error ? error.message : String(error);
+          settle(() => reject(new Error(`Failed to write prompt to ${input.cmd} stdin: ${message}`, {
+            cause: error,
+          })));
         }
       }
     });

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -588,9 +588,6 @@ export class CliLlmAdapter implements IAdapter {
         env: input.env,
       });
 
-      child.stdin!.write(input.prompt);
-      child.stdin!.end();
-
       let stdout = '';
       let stderr = '';
       let settled = false;
@@ -620,7 +617,7 @@ export class CliLlmAdapter implements IAdapter {
         hardKillTimer.unref();
       };
 
-      const terminate = (label: 'timed-out' | 'aborted'): void => {
+      const terminate = (label: 'timed-out' | 'aborted' | 'stdin-failed'): void => {
         terminated = true;
         try {
           child.kill('SIGTERM');
@@ -706,6 +703,24 @@ export class CliLlmAdapter implements IAdapter {
         clearTimers();
         settle(() => reject(err));
       });
+
+      child.stdin!.on('error', (err) => {
+        if (settled) return;
+        clearTimeout(timer);
+        input.signal?.removeEventListener('abort', abortRequest);
+        terminate('stdin-failed');
+        settle(() => reject(err));
+      });
+
+      if (!settled) {
+        try {
+          child.stdin!.write(input.prompt);
+          child.stdin!.end();
+        } catch (error) {
+          terminate('stdin-failed');
+          settle(() => reject(error));
+        }
+      }
     });
   }
 }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -177,6 +177,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
     let totalOutputTokens = 0;
     let emittedText = false;
     let emittedToolUse = false;
+    let sawTerminalFrame = false;
     let streamCompleted = false;
 
     try {
@@ -232,16 +233,10 @@ export class ClaudeCliAdapter implements ILlmProvider {
             };
             return;
           }
-          streamCompleted = true;
-          yield {
-            type: 'done',
-            usage: {
-              inputTokens: totalInputTokens,
-              outputTokens: totalOutputTokens,
-              totalTokens: totalInputTokens + totalOutputTokens,
-            },
-          };
-          return;
+          // Delay success until close so a late stdin EPIPE can preempt a
+          // terminal frame produced from a partial prompt.
+          sawTerminalFrame = true;
+          break;
         } else if (type === 'content_block_start') {
           const block = parsed['content_block'] as Record<string, unknown>;
           if (block?.['type'] === 'tool_use') {
@@ -337,16 +332,8 @@ export class ClaudeCliAdapter implements ILlmProvider {
             };
             return;
           }
-          streamCompleted = true;
-          yield {
-            type: 'done',
-            usage: {
-              inputTokens: totalInputTokens,
-              outputTokens: totalOutputTokens,
-              totalTokens: totalInputTokens + totalOutputTokens,
-            },
-          };
-          return;
+          sawTerminalFrame = true;
+          break;
         } else if (type === 'error') {
           const error = parsed['error'] as Record<string, unknown> | undefined;
           const message =
@@ -390,6 +377,16 @@ export class ClaudeCliAdapter implements ILlmProvider {
           type: 'error',
           error: `claude process exited with code ${exitCode}`,
           retryable: false,
+        };
+      } else if (sawTerminalFrame) {
+        streamCompleted = true;
+        yield {
+          type: 'done',
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            totalTokens: totalInputTokens + totalOutputTokens,
+          },
         };
       } else if (!emittedText) {
         yield {

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -57,9 +57,19 @@ export class ClaudeCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const spawnState: { message: string | undefined } = { message: undefined };
+    const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+      message: undefined,
+      source: undefined,
+    };
     proc.once('error', (error) => {
       spawnState.message = error.message;
+      spawnState.source = 'spawn';
+    });
+    proc.stdin!.on('error', (error) => {
+      if (spawnState.source !== 'spawn') {
+        spawnState.message = error.message;
+        spawnState.source = 'stdin';
+      }
     });
 
     const userContent = request.messages
@@ -148,7 +158,7 @@ export class ClaudeCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined },
+    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
@@ -349,7 +359,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
         streamCompleted = true;
         yield {
           type: 'error',
-          error: `claude process failed to start: ${spawnState.message}`,
+          error: spawnState.source === 'stdin'
+            ? `claude process stdin failed: ${spawnState.message}`
+            : `claude process failed to start: ${spawnState.message}`,
           retryable: false,
         };
         return;

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -57,9 +57,14 @@ export class ClaudeCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+    const spawnState: {
+      message: string | undefined;
+      source: 'spawn' | 'stdin' | undefined;
+      closeStream: (() => void) | undefined;
+    } = {
       message: undefined,
       source: undefined,
+      closeStream: undefined,
     };
     proc.once('error', (error) => {
       spawnState.message = error.message;
@@ -70,6 +75,8 @@ export class ClaudeCliAdapter implements ILlmProvider {
         spawnState.message = error.message;
         spawnState.source = 'stdin';
       }
+      spawnState.closeStream?.();
+      if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
     });
 
     const userContent = request.messages
@@ -158,9 +165,15 @@ export class ClaudeCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
+    spawnState: {
+      message: string | undefined;
+      source: 'spawn' | 'stdin' | undefined;
+      closeStream: (() => void) | undefined;
+    },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    spawnState.closeStream = () => rl.close();
+    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -351,10 +364,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
         }
       }
 
-      // If process exited without message_stop, check spawn/exit status
-      const exitCode = await new Promise<number | null>((resolve) => {
-        proc.on('close', resolve);
-      });
       if (spawnState.message) {
         streamCompleted = true;
         yield {
@@ -366,6 +375,10 @@ export class ClaudeCliAdapter implements ILlmProvider {
         };
         return;
       }
+      // If process exited without message_stop, check its exit status.
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
       if (exitCode !== 0) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -236,7 +236,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
           // Delay success until close so a late stdin EPIPE can preempt a
           // terminal frame produced from a partial prompt.
           sawTerminalFrame = true;
-          break;
         } else if (type === 'content_block_start') {
           const block = parsed['content_block'] as Record<string, unknown>;
           if (block?.['type'] === 'tool_use') {
@@ -333,7 +332,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
             return;
           }
           sawTerminalFrame = true;
-          break;
         } else if (type === 'error') {
           const error = parsed['error'] as Record<string, unknown> | undefined;
           const message =

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -60,11 +60,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
     const spawnState: {
       message: string | undefined;
       source: 'spawn' | 'stdin' | undefined;
-      closeStream: (() => void) | undefined;
     } = {
       message: undefined,
       source: undefined,
-      closeStream: undefined,
     };
     proc.once('error', (error) => {
       spawnState.message = error.message;
@@ -75,7 +73,6 @@ export class ClaudeCliAdapter implements ILlmProvider {
         spawnState.message = error.message;
         spawnState.source = 'stdin';
       }
-      spawnState.closeStream?.();
       if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
     });
 
@@ -168,12 +165,9 @@ export class ClaudeCliAdapter implements ILlmProvider {
     spawnState: {
       message: string | undefined;
       source: 'spawn' | 'stdin' | undefined;
-      closeStream: (() => void) | undefined;
     },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
-    spawnState.closeStream = () => rl.close();
-    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -379,6 +373,18 @@ export class ClaudeCliAdapter implements ILlmProvider {
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      // stdin errors can arrive after stdout reaches EOF but before process close.
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: spawnState.source === 'stdin'
+            ? `claude process stdin failed: ${spawnState.message}`
+            : `claude process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -210,7 +210,6 @@ export class CodexCliAdapter implements ILlmProvider {
           if (type === 'done') {
             // Do not report success until the child closes: a late stdin EPIPE
             // means the terminal frame may describe only a partial prompt.
-            break;
           }
         } else if (type === 'error') {
           const message =

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -56,9 +56,14 @@ export class CodexCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+    const spawnState: {
+      message: string | undefined;
+      source: 'spawn' | 'stdin' | undefined;
+      closeStream: (() => void) | undefined;
+    } = {
       message: undefined,
       source: undefined,
+      closeStream: undefined,
     };
     proc.once('error', (error) => {
       spawnState.message = error.message;
@@ -69,6 +74,8 @@ export class CodexCliAdapter implements ILlmProvider {
         spawnState.message = error.message;
         spawnState.source = 'stdin';
       }
+      spawnState.closeStream?.();
+      if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
     });
 
     const userContent = request.messages
@@ -160,9 +167,15 @@ export class CodexCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
+    spawnState: {
+      message: string | undefined;
+      source: 'spawn' | 'stdin' | undefined;
+      closeStream: (() => void) | undefined;
+    },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    spawnState.closeStream = () => rl.close();
+    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -222,10 +235,6 @@ export class CodexCliAdapter implements ILlmProvider {
         }
       }
 
-      // Stream ended without a done/error frame — check spawn/exit status
-      const exitCode = await new Promise<number | null>((resolve) => {
-        proc.on('close', resolve);
-      });
       if (spawnState.message) {
         streamCompleted = true;
         yield {
@@ -237,6 +246,10 @@ export class CodexCliAdapter implements ILlmProvider {
         };
         return;
       }
+      // Stream ended without a done/error frame — check its exit status.
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -59,11 +59,9 @@ export class CodexCliAdapter implements ILlmProvider {
     const spawnState: {
       message: string | undefined;
       source: 'spawn' | 'stdin' | undefined;
-      closeStream: (() => void) | undefined;
     } = {
       message: undefined,
       source: undefined,
-      closeStream: undefined,
     };
     proc.once('error', (error) => {
       spawnState.message = error.message;
@@ -74,7 +72,6 @@ export class CodexCliAdapter implements ILlmProvider {
         spawnState.message = error.message;
         spawnState.source = 'stdin';
       }
-      spawnState.closeStream?.();
       if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
     });
 
@@ -170,12 +167,9 @@ export class CodexCliAdapter implements ILlmProvider {
     spawnState: {
       message: string | undefined;
       source: 'spawn' | 'stdin' | undefined;
-      closeStream: (() => void) | undefined;
     },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
-    spawnState.closeStream = () => rl.close();
-    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -250,6 +244,18 @@ export class CodexCliAdapter implements ILlmProvider {
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      // stdin errors can arrive after stdout reaches EOF but before process close.
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: spawnState.source === 'stdin'
+            ? `codex process stdin failed: ${spawnState.message}`
+            : `codex process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -56,9 +56,19 @@ export class CodexCliAdapter implements ILlmProvider {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const spawnState: { message: string | undefined } = { message: undefined };
+    const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+      message: undefined,
+      source: undefined,
+    };
     proc.once('error', (error) => {
       spawnState.message = error.message;
+      spawnState.source = 'spawn';
+    });
+    proc.stdin!.on('error', (error) => {
+      if (spawnState.source !== 'spawn') {
+        spawnState.message = error.message;
+        spawnState.source = 'stdin';
+      }
     });
 
     const userContent = request.messages
@@ -150,7 +160,7 @@ export class CodexCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined },
+    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
@@ -220,7 +230,9 @@ export class CodexCliAdapter implements ILlmProvider {
         streamCompleted = true;
         yield {
           type: 'error',
-          error: `codex process failed to start: ${spawnState.message}`,
+          error: spawnState.source === 'stdin'
+            ? `codex process stdin failed: ${spawnState.message}`
+            : `codex process failed to start: ${spawnState.message}`,
           retryable: false,
         };
         return;

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -208,16 +208,9 @@ export class CodexCliAdapter implements ILlmProvider {
           totalOutputTokens =
             (usage['output_tokens'] as number) ?? totalOutputTokens;
           if (type === 'done') {
-            streamCompleted = true;
-            yield {
-              type: 'done',
-              usage: {
-                inputTokens: totalInputTokens,
-                outputTokens: totalOutputTokens,
-                totalTokens: totalInputTokens + totalOutputTokens,
-              },
-            };
-            return;
+            // Do not report success until the child closes: a late stdin EPIPE
+            // means the terminal frame may describe only a partial prompt.
+            break;
           }
         } else if (type === 'error') {
           const message =

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -104,9 +104,14 @@ export class GeminiCliAdapter implements ILlmProvider {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
-      const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+      const spawnState: {
+        message: string | undefined;
+        source: 'spawn' | 'stdin' | undefined;
+        closeStream: (() => void) | undefined;
+      } = {
         message: undefined,
         source: undefined,
+        closeStream: undefined,
       };
       proc.once('error', (error) => {
         spawnState.message = error.message;
@@ -117,6 +122,8 @@ export class GeminiCliAdapter implements ILlmProvider {
           spawnState.message = error.message;
           spawnState.source = 'stdin';
         }
+        spawnState.closeStream?.();
+        if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
       });
 
       const userContent = request.messages
@@ -547,9 +554,15 @@ export class GeminiCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
+    spawnState: {
+      message: string | undefined;
+      source: 'spawn' | 'stdin' | undefined;
+      closeStream: (() => void) | undefined;
+    },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
+    spawnState.closeStream = () => rl.close();
+    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -736,10 +749,6 @@ export class GeminiCliAdapter implements ILlmProvider {
         }
       }
 
-      // Stream ended without message_stop/result/error — check exit code
-      const exitCode = await new Promise<number | null>((resolve) => {
-        proc.on('close', resolve);
-      });
       if (spawnState.message) {
         streamCompleted = true;
         yield {
@@ -751,6 +760,10 @@ export class GeminiCliAdapter implements ILlmProvider {
         };
         return;
       }
+      // Stream ended without message_stop/result/error — check its exit code.
+      const exitCode = await new Promise<number | null>((resolve) => {
+        proc.on('close', resolve);
+      });
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -107,11 +107,9 @@ export class GeminiCliAdapter implements ILlmProvider {
       const spawnState: {
         message: string | undefined;
         source: 'spawn' | 'stdin' | undefined;
-        closeStream: (() => void) | undefined;
       } = {
         message: undefined,
         source: undefined,
-        closeStream: undefined,
       };
       proc.once('error', (error) => {
         spawnState.message = error.message;
@@ -122,7 +120,6 @@ export class GeminiCliAdapter implements ILlmProvider {
           spawnState.message = error.message;
           spawnState.source = 'stdin';
         }
-        spawnState.closeStream?.();
         if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
       });
 
@@ -557,12 +554,9 @@ export class GeminiCliAdapter implements ILlmProvider {
     spawnState: {
       message: string | undefined;
       source: 'spawn' | 'stdin' | undefined;
-      closeStream: (() => void) | undefined;
     },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
-    spawnState.closeStream = () => rl.close();
-    if (spawnState.source === 'stdin') rl.close();
     proc.once('error', () => {
       rl.close();
     });
@@ -764,6 +758,18 @@ export class GeminiCliAdapter implements ILlmProvider {
       const exitCode = await new Promise<number | null>((resolve) => {
         proc.on('close', resolve);
       });
+      // stdin errors can arrive after stdout reaches EOF but before process close.
+      if (spawnState.message) {
+        streamCompleted = true;
+        yield {
+          type: 'error',
+          error: spawnState.source === 'stdin'
+            ? `gemini process stdin failed: ${spawnState.message}`
+            : `gemini process failed to start: ${spawnState.message}`,
+          retryable: false,
+        };
+        return;
+      }
       if (exitCode !== 0 && exitCode !== null) {
         yield {
           type: 'error',

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -625,18 +625,7 @@ export class GeminiCliAdapter implements ILlmProvider {
             return;
           }
           sawTerminalFrame = true;
-
-          streamCompleted = true;
-          yield {
-            type: 'done',
-            usage: {
-              inputTokens: totalInputTokens,
-              outputTokens: totalOutputTokens,
-              totalTokens: totalInputTokens + totalOutputTokens,
-
-            },
-          };
-          return;
+          break;
         } else if (type === 'content_block_delta') {
           const delta = parsed['delta'] as Record<string, unknown>;
           if (delta?.['type'] === 'text_delta') {
@@ -712,16 +701,9 @@ export class GeminiCliAdapter implements ILlmProvider {
             };
             return;
           }
-          streamCompleted = true;
-          yield {
-            type: 'done',
-            usage: {
-              inputTokens: totalInputTokens,
-              outputTokens: totalOutputTokens,
-              totalTokens: totalInputTokens + totalOutputTokens,
-            },
-          };
-          return;
+          // Delay success until close so a late stdin EPIPE can preempt a
+          // terminal frame produced from a partial prompt.
+          break;
         } else if (type === 'error') {
           const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
           yield {

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -104,9 +104,19 @@ export class GeminiCliAdapter implements ILlmProvider {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
-      const spawnState: { message: string | undefined } = { message: undefined };
+      const spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined } = {
+        message: undefined,
+        source: undefined,
+      };
       proc.once('error', (error) => {
         spawnState.message = error.message;
+        spawnState.source = 'spawn';
+      });
+      proc.stdin!.on('error', (error) => {
+        if (spawnState.source !== 'spawn') {
+          spawnState.message = error.message;
+          spawnState.source = 'stdin';
+        }
       });
 
       const userContent = request.messages
@@ -537,7 +547,7 @@ export class GeminiCliAdapter implements ILlmProvider {
 
   private async *parseStream(
     proc: ChildProcess,
-    spawnState: { message: string | undefined },
+    spawnState: { message: string | undefined; source: 'spawn' | 'stdin' | undefined },
   ): AsyncGenerator<LlmStreamEvent> {
     const rl = createInterface({ input: proc.stdout! });
     proc.once('error', () => {
@@ -734,7 +744,9 @@ export class GeminiCliAdapter implements ILlmProvider {
         streamCompleted = true;
         yield {
           type: 'error',
-          error: `gemini process failed to start: ${spawnState.message}`,
+          error: spawnState.source === 'stdin'
+            ? `gemini process stdin failed: ${spawnState.message}`
+            : `gemini process failed to start: ${spawnState.message}`,
           retryable: false,
         };
         return;

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -625,7 +625,6 @@ export class GeminiCliAdapter implements ILlmProvider {
             return;
           }
           sawTerminalFrame = true;
-          break;
         } else if (type === 'content_block_delta') {
           const delta = parsed['delta'] as Record<string, unknown>;
           if (delta?.['type'] === 'text_delta') {
@@ -703,7 +702,6 @@ export class GeminiCliAdapter implements ILlmProvider {
           }
           // Delay success until close so a late stdin EPIPE can preempt a
           // terminal frame produced from a partial prompt.
-          break;
         } else if (type === 'error') {
           const message = this.stringifyGeminiContent(parsed['message'] ?? parsed['error'] ?? 'Unknown error');
           yield {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -508,7 +508,9 @@ describe('CliLlmAdapter', () => {
           vi.spyOn(stdin, 'write').mockImplementation(() => {
             hadErrorListener = stdin.listenerCount('error') > 0;
             setImmediate(() => {
-              if (hadErrorListener) stdin.emit('error', new Error('write EPIPE'));
+              if (hadErrorListener) {
+                stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+              }
               proc.emit('close', 1);
             });
             return true;
@@ -517,8 +519,14 @@ describe('CliLlmAdapter', () => {
         };
         const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
 
-        await expect(adapter.execute({ prompt: 'x'.repeat(128 * 1024), maxTurns: 1 }))
-          .rejects.toThrow('write EPIPE');
+        try {
+          await adapter.execute({ prompt: 'x'.repeat(128 * 1024), maxTurns: 1 });
+          throw new Error('expected execute to throw');
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect((error as Error).message).toContain('write EPIPE');
+          expect((error as Error & { cause?: { kind?: string } }).cause?.kind).toBe('command_failed');
+        }
         expect(hadErrorListener).toBe(true);
       });
 

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -493,6 +493,35 @@ describe('CliLlmAdapter', () => {
           .rejects.toThrow('something went wrong');
       });
 
+      it('rejects child stdin errors instead of emitting an unhandled stream error', async () => {
+        let hadErrorListener = false;
+        const spawnFn = (): ChildProcess => {
+          const proc = new EventEmitter() as ChildProcess;
+          const stdin = new PassThrough();
+          const stdout = new PassThrough();
+          const stderr = new PassThrough();
+          Object.defineProperty(proc, 'stdin', { value: stdin });
+          Object.defineProperty(proc, 'stdout', { value: stdout });
+          Object.defineProperty(proc, 'stderr', { value: stderr });
+          Object.defineProperty(proc, 'pid', { value: 12345 });
+          Object.defineProperty(proc, 'kill', { value: vi.fn(() => true) });
+          vi.spyOn(stdin, 'write').mockImplementation(() => {
+            hadErrorListener = stdin.listenerCount('error') > 0;
+            setImmediate(() => {
+              if (hadErrorListener) stdin.emit('error', new Error('write EPIPE'));
+              proc.emit('close', 1);
+            });
+            return true;
+          });
+          return proc;
+        };
+        const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+
+        await expect(adapter.execute({ prompt: 'x'.repeat(128 * 1024), maxTurns: 1 }))
+          .rejects.toThrow('write EPIPE');
+        expect(hadErrorListener).toBe(true);
+      });
+
       it('strips ANSI from non-zero failure summaries in plain mode', async () => {
         setPlainOutput(true);
         try {

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -508,6 +508,7 @@ describe('CliLlmAdapter', () => {
           vi.spyOn(stdin, 'write').mockImplementation(() => {
             hadErrorListener = stdin.listenerCount('error') > 0;
             setImmediate(() => {
+              stderr.write('rate limit exceeded before prompt was accepted');
               if (hadErrorListener) {
                 stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
               }
@@ -524,8 +525,13 @@ describe('CliLlmAdapter', () => {
           throw new Error('expected execute to throw');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
-          expect((error as Error).message).toContain('write EPIPE');
-          expect((error as Error & { cause?: { kind?: string } }).cause?.kind).toBe('command_failed');
+          expect((error as Error).message).toContain('rate limit exceeded before prompt was accepted');
+          expect((error as Error & { cause?: { kind?: string; stderr?: string } }).cause).toEqual(
+            expect.objectContaining({
+              kind: 'rate_limit',
+              stderr: 'rate limit exceeded before prompt was accepted',
+            }),
+          );
         }
         expect(hadErrorListener).toBe(true);
       });

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -65,7 +65,7 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
-function mockStdinError(errorMessage = 'write EPIPE') {
+function mockStdinError(errorMessage = 'write EPIPE', stdoutFrame?: string) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
   let hadErrorListener = false;
@@ -76,7 +76,14 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     pid: 1234,
     exitCode: null as number | null,
     signalCode: null as NodeJS.Signals | null,
-    kill: vi.fn(() => true),
+    kill: vi.fn(() => {
+      setImmediate(() => {
+        if (stdoutFrame) stdout.write(`${stdoutFrame}\n`);
+        stdout.end();
+        setImmediate(() => proc.emit('close', 1));
+      });
+      return true;
+    }),
   });
   vi.spyOn(stdin, 'write').mockImplementation(() => {
     hadErrorListener = stdin.listenerCount('error') > 0;
@@ -234,6 +241,25 @@ describe('ClaudeCliAdapter', () => {
         type: 'error',
         error: expect.stringContaining('write EPIPE'),
         retryable: false,
+      }]);
+    });
+
+    it('preserves a provider error frame emitted after stdin fails', async () => {
+      const providerError = JSON.stringify({
+        type: 'error',
+        error: { message: 'rate limit exceeded while rejecting prompt' },
+      });
+      mockStdinError('write EPIPE', providerError);
+
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(events).toEqual([{
+        type: 'error',
+        error: 'rate limit exceeded while rejecting prompt',
+        retryable: true,
       }]);
     });
 

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -82,16 +82,11 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     hadErrorListener = stdin.listenerCount('error') > 0;
     setImmediate(() => {
       if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
-      stdout.end();
-      setImmediate(() => {
-        proc.exitCode = 1;
-        proc.emit('close', 1);
-      });
     });
     return true;
   });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
-  return { hadErrorListener: () => hadErrorListener };
+  return { hadErrorListener: () => hadErrorListener, proc };
 }
 
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
@@ -227,13 +222,14 @@ describe('ClaudeCliAdapter', () => {
     });
 
     it('handles child stdin errors through the provider error path', async () => {
-      const { hadErrorListener } = mockStdinError();
+      const { hadErrorListener, proc } = mockStdinError();
       const events = await collectEvents(adapter.execute({
         systemPrompt: '',
         messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
       }));
 
       expect(hadErrorListener()).toBe(true);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
       expect(events).toEqual([{
         type: 'error',
         error: expect.stringContaining('write EPIPE'),

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -275,6 +275,26 @@ describe('ClaudeCliAdapter', () => {
       expect(events[1]).toEqual({ type: 'done', usage: { inputTokens: 50, outputTokens: 10, totalTokens: 60 } });
     });
 
+    it('keeps draining partial-message output after message_stop', async () => {
+      mockSpawn([
+        JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'prefix' } }),
+        JSON.stringify({ type: 'message_stop' }),
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'suffix' }] } }),
+      ]);
+
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'Hi' }],
+        extraArgs: ['--include-partial-messages'],
+      }));
+
+      expect(events).toEqual([
+        { type: 'text', content: 'prefix' },
+        { type: 'text', content: 'suffix' },
+        { type: 'done', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+      ]);
+    });
+
     it('parses Claude CLI result wrapper frames', async () => {
       mockSpawn([
         JSON.stringify({

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -65,6 +65,35 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
+function mockStdinError(errorMessage = 'write EPIPE') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  let hadErrorListener = false;
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1234,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  vi.spyOn(stdin, 'write').mockImplementation(() => {
+    hadErrorListener = stdin.listenerCount('error') > 0;
+    setImmediate(() => {
+      if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
+      stdout.end();
+      setImmediate(() => {
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      });
+    });
+    return true;
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+  return { hadErrorListener: () => hadErrorListener };
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -195,6 +224,21 @@ describe('ClaudeCliAdapter', () => {
         retryable: false,
       });
       expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('handles child stdin errors through the provider error path', async () => {
+      const { hadErrorListener } = mockStdinError();
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(hadErrorListener()).toBe(true);
+      expect(events).toEqual([{
+        type: 'error',
+        error: expect.stringContaining('write EPIPE'),
+        retryable: false,
+      }]);
     });
 
     it('parses text stream events', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -62,6 +62,35 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
+function mockStdinError(errorMessage = 'write EPIPE') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  let hadErrorListener = false;
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  vi.spyOn(stdin, 'write').mockImplementation(() => {
+    hadErrorListener = stdin.listenerCount('error') > 0;
+    setImmediate(() => {
+      if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
+      stdout.end();
+      setImmediate(() => {
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      });
+    });
+    return true;
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+  return { hadErrorListener: () => hadErrorListener };
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -249,6 +278,21 @@ describe('CodexCliAdapter', () => {
         retryable: false,
       });
       expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('handles child stdin errors through the provider error path', async () => {
+      const { hadErrorListener } = mockStdinError();
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(hadErrorListener()).toBe(true);
+      expect(events).toEqual([{
+        type: 'error',
+        error: expect.stringContaining('write EPIPE'),
+        retryable: false,
+      }]);
     });
 
     it('parses tool call events', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -79,16 +79,11 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     hadErrorListener = stdin.listenerCount('error') > 0;
     setImmediate(() => {
       if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
-      stdout.end();
-      setImmediate(() => {
-        proc.exitCode = 1;
-        proc.emit('close', 1);
-      });
     });
     return true;
   });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
-  return { hadErrorListener: () => hadErrorListener };
+  return { hadErrorListener: () => hadErrorListener, proc };
 }
 
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
@@ -281,13 +276,14 @@ describe('CodexCliAdapter', () => {
     });
 
     it('handles child stdin errors through the provider error path', async () => {
-      const { hadErrorListener } = mockStdinError();
+      const { hadErrorListener, proc } = mockStdinError();
       const events = await collectEvents(adapter.execute({
         systemPrompt: '',
         messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
       }));
 
       expect(hadErrorListener()).toBe(true);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
       expect(events).toEqual([{
         type: 'error',
         error: expect.stringContaining('write EPIPE'),

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -62,7 +62,7 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
-function mockStdinError(errorMessage = 'write EPIPE') {
+function mockStdinError(errorMessage = 'write EPIPE', late = false) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
   let hadErrorListener = false;
@@ -73,12 +73,28 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     pid: 1,
     exitCode: null as number | null,
     signalCode: null as NodeJS.Signals | null,
-    kill: vi.fn(() => true),
+    kill: vi.fn(() => {
+      if (!late) {
+        setImmediate(() => {
+          stdout.end();
+          setImmediate(() => proc.emit('close', 1));
+        });
+      }
+      return true;
+    }),
   });
   vi.spyOn(stdin, 'write').mockImplementation(() => {
     hadErrorListener = stdin.listenerCount('error') > 0;
     setImmediate(() => {
-      if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
+      if (late) {
+        stdout.end();
+        setImmediate(() => {
+          if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
+          setImmediate(() => proc.emit('close', 0));
+        });
+      } else if (hadErrorListener) {
+        stdin.emit('error', new Error(errorMessage));
+      }
     });
     return true;
   });
@@ -289,6 +305,21 @@ describe('CodexCliAdapter', () => {
         error: expect.stringContaining('write EPIPE'),
         retryable: false,
       }]);
+    });
+
+    it('reports stdin errors that arrive after stdout ends but before process close', async () => {
+      const { proc } = mockStdinError('late write EPIPE', true);
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(events).toEqual([{
+        type: 'error',
+        error: expect.stringContaining('late write EPIPE'),
+        retryable: false,
+      }]);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
     });
 
     it('parses tool call events', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -62,7 +62,7 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
-function mockStdinError(errorMessage = 'write EPIPE', late = false) {
+function mockStdinError(errorMessage = 'write EPIPE', late = false, stdoutFrame?: string) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
   let hadErrorListener = false;
@@ -87,6 +87,7 @@ function mockStdinError(errorMessage = 'write EPIPE', late = false) {
     hadErrorListener = stdin.listenerCount('error') > 0;
     setImmediate(() => {
       if (late) {
+        if (stdoutFrame) stdout.write(`${stdoutFrame}\n`);
         stdout.end();
         setImmediate(() => {
           if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
@@ -317,6 +318,25 @@ describe('CodexCliAdapter', () => {
       expect(events).toEqual([{
         type: 'error',
         error: expect.stringContaining('late write EPIPE'),
+        retryable: false,
+      }]);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('lets a late stdin error preempt a successful terminal frame', async () => {
+      const { proc } = mockStdinError(
+        'partial prompt EPIPE',
+        true,
+        JSON.stringify({ type: 'done', usage: { input_tokens: 1, output_tokens: 1 } }),
+      );
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(events).toEqual([{
+        type: 'error',
+        error: expect.stringContaining('partial prompt EPIPE'),
         retryable: false,
       }]);
       expect(proc.kill).toHaveBeenCalledWith('SIGTERM');

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -85,16 +85,11 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     hadErrorListener = stdin.listenerCount('error') > 0;
     setImmediate(() => {
       if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
-      stdout.end();
-      setImmediate(() => {
-        proc.exitCode = 1;
-        proc.emit('close', 1);
-      });
     });
     return true;
   });
   (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
-  return { hadErrorListener: () => hadErrorListener };
+  return { hadErrorListener: () => hadErrorListener, proc };
 }
 
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
@@ -385,13 +380,14 @@ describe('GeminiCliAdapter', () => {
     });
 
     it('handles child stdin errors through the provider error path', async () => {
-      const { hadErrorListener } = mockStdinError();
+      const { hadErrorListener, proc } = mockStdinError();
       const events = await collectEvents(adapter.execute({
         systemPrompt: 'sys',
         messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
       }));
 
       expect(hadErrorListener()).toBe(true);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
       expect(events).toEqual([{
         type: 'error',
         error: expect.stringContaining('write EPIPE'),

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -79,7 +79,13 @@ function mockStdinError(errorMessage = 'write EPIPE') {
     pid: 1,
     exitCode: null as number | null,
     signalCode: null as NodeJS.Signals | null,
-    kill: vi.fn(() => true),
+    kill: vi.fn(() => {
+      setImmediate(() => {
+        stdout.end();
+        setImmediate(() => proc.emit('close', 1));
+      });
+      return true;
+    }),
   });
   vi.spyOn(stdin, 'write').mockImplementation(() => {
     hadErrorListener = stdin.listenerCount('error') > 0;

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -68,6 +68,35 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
   return proc;
 }
 
+function mockStdinError(errorMessage = 'write EPIPE') {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  let hadErrorListener = false;
+  const proc = Object.assign(new EventEmitter(), {
+    stdout,
+    stdin,
+    stderr: new PassThrough(),
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: vi.fn(() => true),
+  });
+  vi.spyOn(stdin, 'write').mockImplementation(() => {
+    hadErrorListener = stdin.listenerCount('error') > 0;
+    setImmediate(() => {
+      if (hadErrorListener) stdin.emit('error', new Error(errorMessage));
+      stdout.end();
+      setImmediate(() => {
+        proc.exitCode = 1;
+        proc.emit('close', 1);
+      });
+    });
+    return true;
+  });
+  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+  return { hadErrorListener: () => hadErrorListener };
+}
+
 async function collectEvents(iterable: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> {
   const events: LlmStreamEvent[] = [];
   for await (const e of iterable) events.push(e);
@@ -353,6 +382,21 @@ describe('GeminiCliAdapter', () => {
         retryable: false,
       }]);
       expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('handles child stdin errors through the provider error path', async () => {
+      const { hadErrorListener } = mockStdinError();
+      const events = await collectEvents(adapter.execute({
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'x'.repeat(128 * 1024) }],
+      }));
+
+      expect(hadErrorListener()).toBe(true);
+      expect(events).toEqual([{
+        type: 'error',
+        error: expect.stringContaining('write EPIPE'),
+        retryable: false,
+      }]);
     });
 
     it('parses stream-json text events', async () => {


### PR DESCRIPTION
## Summary
- attach stdin error listeners before prompt writes in all four CLI adapters
- route generic adapter stdin failures through its existing rejection and child-termination path
- report provider stdin failures as structured stream errors and add large-prompt regressions

## Test plan
- `npm test --workspace @franken/orchestrator -- --run` (4,391 tests)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build`
- `npm run lint --workspace @franken/orchestrator` (existing warnings only)

Closes #2311