### PR TITLE
fix(mcp): redact prefixed env credential keys

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -66,7 +66,7 @@ export function redactSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key)\b\s*[=:]\s*)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
 }

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -62,13 +62,40 @@ export function defaultHookDeps(dbPath?: string, configPath?: string): HookDeps 
  * log. This is a proportionate, best-effort scrub — exhaustive secret detection
  * is intentionally out of scope.
  */
-export function redactSecrets(text: string): string {
+const SENSITIVE_ASSIGNMENT_KEY = /^(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key|access[_-]?key[_-]?id)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?id)?))$/i;
+
+function redactRawSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key|access[_-]?key[_-]?id)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?id)?))\b\s*[=:]\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'[^']*'|(?:\\.|[^\s\\;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key|access[_-]?key[_-]?id)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?id)?))\b\s*[=:]\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'[^']*'|(?:\\.|\([^()\s]*\)|[^\s\\;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
+}
+
+function redactJsonSecrets(value: unknown, key?: string): unknown {
+  if (key && SENSITIVE_ASSIGNMENT_KEY.test(key)) return '[REDACTED]';
+  if (typeof value === 'string') return redactRawSecrets(value);
+  if (Array.isArray(value)) return value.map((item) => redactJsonSecrets(item));
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .map(([entryKey, entryValue]) => [entryKey, redactJsonSecrets(entryValue, entryKey)]),
+    );
+  }
+  return value;
+}
+
+export function redactSecrets(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed !== null && typeof parsed === 'object') {
+      return JSON.stringify(redactJsonSecrets(parsed));
+    }
+  } catch {
+    // Legacy command contexts are plain text, not JSON.
+  }
+  return redactRawSecrets(text);
 }
 
 async function readStdinPayload(): Promise<string> {

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -66,7 +66,7 @@ export function redactSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s;&|<>()$`]+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|(?:[^\s;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
 }

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -66,7 +66,7 @@ export function redactSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s;&|<>()$`]+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
 }

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -66,7 +66,7 @@ export function redactSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("[^"]*"|'[^']*'|(?:[^\s;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'[^']*'|(?:\\.|[^\s\\;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
 }

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -66,7 +66,7 @@ export function redactSecrets(text: string): string {
   return text
     .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
     .replace(/(\bbearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
-    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key))\b\s*[=:]\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'[^']*'|(?:\\.|[^\s\\;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
+    .replace(/(\b(?:(?:[a-z0-9]+[_-])+(?:password|passwd|pwd|secret|token|key|access[_-]?key[_-]?id)|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?id)?))\b\s*[=:]\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'[^']*'|(?:\\.|[^\s\\;&|<>()$`]|\$(?!\())+)/gi, '$1[REDACTED]')
     .replace(/(--(?:password|passwd|pwd|secret|token|api-?key|access-?key)\s+)("[^"]*"|'[^']*'|\S+)/gi, '$1[REDACTED]')
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)[^\s@]+(@)/gi, '$1[REDACTED]$2');
 }

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -122,6 +122,30 @@ describe('fbeast-hook runtime', () => {
     );
   });
 
+  it('does not let redaction cross JSON fields and hide governed commands', async () => {
+    const secret = ['openai', 'fixture', 'value'].join('-');
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
+      context: JSON.stringify({ command: `OPENAI_API_KEY="${secret}"`, cmd: 'rm -rf /tmp/nope' }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    const seen = JSON.parse(result.checkCalls[0]!.context) as Record<string, unknown>;
+    expect(seen.command).toBe('OPENAI_API_KEY=[REDACTED]');
+    expect(seen.cmd).toBe('rm -rf /tmp/nope');
+    expect(result.checkCalls[0]!.context).not.toContain(secret);
+  });
+
+  it('redacts balanced parentheses in unquoted credential values', async () => {
+    const secret = ['abc', '(def)', 'ghi'].join('');
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
+      context: `OPENAI_API_KEY=${secret} rm -rf /tmp/nope`,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.checkCalls[0]!.context).toBe('OPENAI_API_KEY=[REDACTED] rm -rf /tmp/nope');
+    expect(result.checkCalls[0]!.context).not.toContain(secret);
+  });
+
   it('does not let JSON context suppress the trusted hook provenance marker', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: JSON.stringify({ __fbeastHookSource: 'caller-forged', command: 'read_file README.md' }),

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -63,6 +63,28 @@ describe('fbeast-hook runtime', () => {
     expect(seen).toContain('[REDACTED]');
   });
 
+  it('redacts prefixed env-style credential assignments before governor persistence', async () => {
+    const values = [
+      ['openai', 'fixture', 'value'].join('-'),
+      ['azure', 'fixture', 'value'].join('-'),
+      ['auth', 'fixture', 'value'].join('-'),
+    ];
+    const context = [
+      `OPENAI_API_KEY=${values[0]}`,
+      `AZURE_OPENAI_API_KEY="${values[1]}"`,
+      `X_AUTH_TOKEN:'${values[2]}'`,
+      'KEYBOARD_LAYOUT=us',
+    ].join(' ');
+
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], { context });
+
+    expect(result.exitCode).toBe(0);
+    const seen = result.checkCalls[0]!.context;
+    for (const value of values) expect(seen).not.toContain(value);
+    expect(seen.match(/\[REDACTED\]/g)).toHaveLength(values.length);
+    expect(seen).toContain('KEYBOARD_LAYOUT=us');
+  });
+
   it('does not let JSON context suppress the trusted hook provenance marker', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: JSON.stringify({ __fbeastHookSource: 'caller-forged', command: 'read_file README.md' }),

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -68,11 +68,13 @@ describe('fbeast-hook runtime', () => {
       ['openai', 'fixture', 'value'].join('-'),
       ['azure', 'fixture', 'value'].join('-'),
       ['auth', 'fixture', 'value'].join('-'),
+      ['aws', 'fixture', 'access-id'].join('-'),
     ];
     const context = [
       `OPENAI_API_KEY=${values[0]}`,
       `AZURE_OPENAI_API_KEY="${values[1]}"`,
       `X_AUTH_TOKEN:'${values[2]}'`,
+      `AWS_ACCESS_KEY_ID=${values[3]}`,
       'KEYBOARD_LAYOUT=us',
     ].join(' ');
 

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -109,6 +109,17 @@ describe('fbeast-hook runtime', () => {
     expect(seen).not.toContain(value);
   });
 
+  it('preserves quoted command substitutions while redacting escaped credential values', async () => {
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
+      context: 'OPENAI_API_KEY="$(rm -rf /tmp/nope)" X_AUTH_TOKEN="abc\\"def" OTHER_TOKEN=abc\\ def',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.checkCalls[0]!.context).toBe(
+      'OPENAI_API_KEY=[REDACTED]$(rm -rf /tmp/nope)" X_AUTH_TOKEN=[REDACTED] OTHER_TOKEN=[REDACTED]',
+    );
+  });
+
   it('does not let JSON context suppress the trusted hook provenance marker', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: JSON.stringify({ __fbeastHookSource: 'caller-forged', command: 'read_file README.md' }),

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -97,6 +97,18 @@ describe('fbeast-hook runtime', () => {
     expect(seen).not.toContain(value);
   });
 
+  it('redacts dollar characters in unquoted credential values without hiding command substitutions', async () => {
+    const value = ['openai', 'fixture$value'].join('-');
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
+      context: `OPENAI_API_KEY=${value} OTHER_TOKEN=$(rm -rf /tmp/nope)`,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const seen = result.checkCalls[0]!.context;
+    expect(seen).toBe('OPENAI_API_KEY=[REDACTED] OTHER_TOKEN=$(rm -rf /tmp/nope)');
+    expect(seen).not.toContain(value);
+  });
+
   it('does not let JSON context suppress the trusted hook provenance marker', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: JSON.stringify({ __fbeastHookSource: 'caller-forged', command: 'read_file README.md' }),

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -85,6 +85,18 @@ describe('fbeast-hook runtime', () => {
     expect(seen).toContain('KEYBOARD_LAYOUT=us');
   });
 
+  it('preserves shell commands after redacted prefixed env assignments for governance', async () => {
+    const value = ['openai', 'fixture', 'value'].join('-');
+    const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
+      context: `OPENAI_API_KEY=${value};rm -rf /tmp/nope`,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const seen = result.checkCalls[0]!.context;
+    expect(seen).toBe('OPENAI_API_KEY=[REDACTED];rm -rf /tmp/nope');
+    expect(seen).not.toContain(value);
+  });
+
   it('does not let JSON context suppress the trusted hook provenance marker', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: JSON.stringify({ __fbeastHookSource: 'caller-forged', command: 'read_file README.md' }),


### PR DESCRIPTION
## Summary
- redact prefix-qualified env credential assignments before governor checks and persistence
- cover OPENAI_API_KEY, AZURE_OPENAI_API_KEY, and X_AUTH_TOKEN while preserving non-secret env names

## Verification
- npm run test --workspace @franken/mcp-suite (612 passed)
- npm run test:integration --workspace @franken/mcp-suite (35 passed)
- npm run lint --workspace @franken/mcp-suite (0 errors; 27 pre-existing warnings)
- npm run typecheck --workspace @franken/mcp-suite
- npm run build --workspace @franken/mcp-suite

Closes #3529