### PR TITLE
fix(governor): validate Slack timestamp integers

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -545,7 +545,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
     // Reject stale timestamps to mitigate replay attacks.
     const tsSeconds = Number(timestamp);
     if (
-      !Number.isFinite(tsSeconds) ||
+      !Number.isSafeInteger(tsSeconds) ||
       Math.abs(Date.now() / 1000 - tsSeconds) > SLACK_MAX_TIMESTAMP_SKEW_SECONDS
     ) {
       return c.json({ error: { message: 'Stale or invalid Slack timestamp' } }, 401);

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -708,6 +708,24 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(401);
     });
 
+    it.each([
+      ['non-numeric', 'not-a-number'],
+      ['non-integer', `${Math.floor(Date.now() / 1000)}.5`],
+    ])('rejects a %s Slack timestamp', async (_description, invalidTimestamp) => {
+      const app = createGovernorApp({ slackSigningSecret: SLACK_SECRET, allowUnsignedApprovalsForTests: true });
+      await seedApproval(app, 'req-1');
+
+      const rawBody = JSON.stringify({ actions: [{ action_id: 'approve', value: 'req-1' }] });
+      const res = await app.request('/v1/webhook/slack', {
+        method: 'POST',
+        headers: { ...slackHeaders(rawBody, SLACK_SECRET, invalidTimestamp) },
+        body: rawBody,
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: { message: 'Stale or invalid Slack timestamp' } });
+    });
+
     it('fails closed when no Slack signing secret is configured', async () => {
       const app = createGovernorApp();
       const res = await app.request('/v1/webhook/slack', {


### PR DESCRIPTION
## Summary
- require Slack request timestamps to parse as safe integers before replay-skew checks
- reject non-numeric and fractional timestamp headers with the existing authentication error
- add targeted regression coverage for both invalid forms

## Verification
- `npm run test --workspace @franken/governor` (336 passed)
- `npm run typecheck --workspace @franken/governor`
- `npm run lint --workspace @franken/governor` (0 errors; 3 pre-existing warnings)
- `npm run build --workspace @franken/governor`
- `npm run build`

Closes #3537