### PR TITLE
fix(orchestrator): guard Gemini prompt file writes

### DIFF
--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -1,20 +1,20 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import {
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  chmodSync,
-  lstatSync,
-  mkdtempSync,
-  readlinkSync,
-  realpathSync,
-  rmSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-} from 'node:fs';
+  chmod,
+  lstat,
+  mkdtemp,
+  readFile,
+  readlink,
+  realpath,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import { deterministicUuid } from '@franken/types';
 import type {
   ILlmProvider,
@@ -70,16 +70,29 @@ export class GeminiCliAdapter implements ILlmProvider {
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     const workspaceDir = resolve(this.workingDir);
-    const contextWorkingDir = resolve(mkdtempSync(join(tmpdir(), 'franken-gemini-context-')));
-    const settingsWorkingDir = resolve(mkdtempSync(join(tmpdir(), 'franken-gemini-settings-')));
+    let contextWorkingDir: string | undefined;
+    let settingsWorkingDir: string | undefined;
     let managedContextFileName: string | undefined;
 
     try {
-      this.removeManagedGeminiMd();
-      const contextSettings = this.writeContextSettings(settingsWorkingDir, contextWorkingDir);
-      const settingsPath = contextSettings.settingsPath;
-      managedContextFileName = contextSettings.managedContextFileName;
-      this.writeGeminiMd(request.systemPrompt, undefined, contextWorkingDir, managedContextFileName);
+      let settingsPath: string;
+      try {
+        contextWorkingDir = resolve(await mkdtemp(join(tmpdir(), 'franken-gemini-context-')));
+        settingsWorkingDir = resolve(await mkdtemp(join(tmpdir(), 'franken-gemini-settings-')));
+        await this.removeManagedGeminiMd();
+        const contextSettings = await this.writeContextSettings(settingsWorkingDir, contextWorkingDir);
+        settingsPath = contextSettings.settingsPath;
+        managedContextFileName = contextSettings.managedContextFileName;
+        await this.writeGeminiMd(request.systemPrompt, undefined, contextWorkingDir, managedContextFileName);
+      } catch (error) {
+        yield {
+          type: 'error',
+          error: `gemini prompt file setup failed: ${this.errorMessage(error)}`,
+          retryable: false,
+        };
+        return;
+      }
+
       const args = this.buildArgs(request);
       const proc = spawn(this.binaryPath, args, {
         cwd: workspaceDir,
@@ -106,9 +119,11 @@ export class GeminiCliAdapter implements ILlmProvider {
 
       yield* this.parseStream(proc, spawnState);
     } finally {
-      if (managedContextFileName) this.removeManagedGeminiMd(contextWorkingDir, managedContextFileName);
-      rmSync(contextWorkingDir, { recursive: true, force: true });
-      rmSync(settingsWorkingDir, { recursive: true, force: true });
+      if (managedContextFileName && contextWorkingDir) {
+        await this.removeManagedGeminiMd(contextWorkingDir, managedContextFileName).catch(() => undefined);
+      }
+      if (contextWorkingDir) await rm(contextWorkingDir, { recursive: true, force: true }).catch(() => undefined);
+      if (settingsWorkingDir) await rm(settingsWorkingDir, { recursive: true, force: true }).catch(() => undefined);
     }
   }
 
@@ -208,12 +223,12 @@ export class GeminiCliAdapter implements ILlmProvider {
     return result;
   }
 
-  writeGeminiMd(
+  async writeGeminiMd(
     systemPrompt: string,
     handoffContext?: string,
     targetDir = this.workingDir,
     fileName = 'GEMINI.md',
-  ): void {
+  ): Promise<void> {
     const geminiMdPath = join(targetDir, fileName);
     const managedContent = [
       MANAGED_START,
@@ -222,8 +237,8 @@ export class GeminiCliAdapter implements ILlmProvider {
       MANAGED_END,
     ].join('\n');
 
-    if (existsSync(geminiMdPath)) {
-      let existing = readFileSync(geminiMdPath, 'utf-8');
+    if (await this.pathExists(geminiMdPath)) {
+      let existing = await readFile(geminiMdPath, 'utf-8');
       const startIdx = existing.indexOf(MANAGED_START);
       const endIdx = existing.indexOf(MANAGED_END);
       if (startIdx !== -1 && endIdx !== -1) {
@@ -234,23 +249,23 @@ export class GeminiCliAdapter implements ILlmProvider {
       } else {
         existing = managedContent + '\n\n' + existing;
       }
-      this.writeFileAtomically(geminiMdPath, existing);
+      await this.writeFileAtomically(geminiMdPath, existing);
     } else {
-      this.writeFileAtomically(geminiMdPath, managedContent);
+      await this.writeFileAtomically(geminiMdPath, managedContent);
     }
   }
 
-  private writeContextSettings(
+  private async writeContextSettings(
     targetDir: string,
     managedContextDir: string,
-  ): { settingsPath: string; managedContextFileName: string } {
+  ): Promise<{ settingsPath: string; managedContextFileName: string }> {
     const existingPath = process.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH ?? this.defaultSystemSettingsPath();
     const existing = this.readSettingsFile(existingPath, 'Gemini system settings');
 
     const existingContext = this.asObject(existing['context']) ?? {};
     const managedContextFileName = this.managedContextFileName();
     const settingsPath = join(targetDir, 'settings.json');
-    writeFileSync(
+    await writeFile(
       settingsPath,
       JSON.stringify(
         {
@@ -448,11 +463,11 @@ export class GeminiCliAdapter implements ILlmProvider {
     return output;
   }
 
-  private removeManagedGeminiMd(targetDir = this.workingDir, fileName = 'GEMINI.md'): void {
+  private async removeManagedGeminiMd(targetDir = this.workingDir, fileName = 'GEMINI.md'): Promise<void> {
     const geminiMdPath = join(targetDir, fileName);
-    if (!existsSync(geminiMdPath)) return;
+    if (!(await this.pathExists(geminiMdPath))) return;
 
-    const existing = readFileSync(geminiMdPath, 'utf-8');
+    const existing = await readFile(geminiMdPath, 'utf-8');
     const startIdx = existing.indexOf(MANAGED_START);
     const endIdx = existing.indexOf(MANAGED_END);
     if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return;
@@ -464,40 +479,60 @@ export class GeminiCliAdapter implements ILlmProvider {
     }
     const next = before + after;
     if (next) {
-      this.writeFileAtomically(geminiMdPath, next);
-    } else if (this.isSymlink(geminiMdPath)) {
-      this.writeFileAtomically(geminiMdPath, '');
+      await this.writeFileAtomically(geminiMdPath, next);
+    } else if (await this.isSymlink(geminiMdPath)) {
+      await this.writeFileAtomically(geminiMdPath, '');
     } else {
-      unlinkSync(geminiMdPath);
+      await unlink(geminiMdPath);
     }
   }
 
-  private writeFileAtomically(path: string, content: string): void {
-    const writePath = this.isSymlink(path) ? this.resolveSymlinkTarget(path) : path;
+  private async writeFileAtomically(path: string, content: string): Promise<void> {
+    const writePath = (await this.isSymlink(path)) ? await this.resolveSymlinkTarget(path) : path;
     const tmpPath = `${writePath}.${process.pid}.${randomUUID()}.tmp`;
-    const existingMode = existsSync(writePath) ? statSync(writePath).mode : undefined;
-    writeFileSync(tmpPath, content);
-    if (existingMode !== undefined) {
-      chmodSync(tmpPath, existingMode);
+    const existingMode = (await this.pathExists(writePath)) ? (await stat(writePath)).mode : undefined;
+
+    try {
+      await writeFile(tmpPath, content);
+      if (existingMode !== undefined) {
+        await chmod(tmpPath, existingMode);
+      }
+      await rename(tmpPath, writePath);
+    } catch (error) {
+      await unlink(tmpPath).catch(() => undefined);
+      throw error;
     }
-    renameSync(tmpPath, writePath);
   }
 
-  private resolveSymlinkTarget(path: string): string {
+  private async resolveSymlinkTarget(path: string): Promise<string> {
     try {
-      return realpathSync(path);
+      return await realpath(path);
     } catch {
-      const target = readlinkSync(path);
+      const target = await readlink(path);
       return isAbsolute(target) ? target : resolve(dirname(path), target);
     }
   }
 
-  private isSymlink(path: string): boolean {
+  private async isSymlink(path: string): Promise<boolean> {
     try {
-      return lstatSync(path).isSymbolicLink();
+      return (await lstat(path)).isSymbolicLink();
     } catch {
       return false;
     }
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await stat(path);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private async *parseStream(

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync, statSync, lstatSync, symlinkSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync, chmodSync, statSync, lstatSync, symlinkSync, mkdirSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
 import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
@@ -28,14 +28,16 @@ function mockSpawn(stdoutLines: string[], exitCode = 0) {
     signalCode: null as NodeJS.Signals | null,
     kill: vi.fn(() => true),
   });
-  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
-  setImmediate(() => {
-    for (const line of stdoutLines) stdout.write(line + '\n');
-    stdout.end();
+  (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
     setImmediate(() => {
-      proc.exitCode = exitCode;
-      proc.emit('close', exitCode);
+      for (const line of stdoutLines) stdout.write(line + '\n');
+      stdout.end();
+      setImmediate(() => {
+        proc.exitCode = exitCode;
+        proc.emit('close', exitCode);
+      });
     });
+    return proc;
   });
   return proc;
 }
@@ -52,14 +54,16 @@ function mockSpawnError(errorMessage = 'spawn command not found') {
     signalCode: null as NodeJS.Signals | null,
     kill: vi.fn(() => true),
   });
-  (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
-  setImmediate(() => {
-    proc.emit('error', Object.assign(new Error(errorMessage), { code: 'ENOENT' }));
+  (spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
     setImmediate(() => {
-      stdout.end();
-      proc.exitCode = 127;
-      proc.emit('close', 127);
+      proc.emit('error', Object.assign(new Error(errorMessage), { code: 'ENOENT' }));
+      setImmediate(() => {
+        stdout.end();
+        proc.exitCode = 127;
+        proc.emit('close', 127);
+      });
     });
+    return proc;
   });
   return proc;
 }
@@ -134,7 +138,7 @@ describe('GeminiCliAdapter', () => {
   });
 
   describe('writeContextSettings()', () => {
-    it('merges inherited Gemini system settings while preserving scoped context files', () => {
+    it('merges inherited Gemini system settings while preserving scoped context files', async () => {
       const originalSettingsPath = process.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
       const originalSystemDefaultsPath = process.env.GEMINI_CLI_SYSTEM_DEFAULTS_PATH;
       const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
@@ -171,7 +175,7 @@ describe('GeminiCliAdapter', () => {
 
       try {
         const includeDir = join(tempDir, 'managed-context');
-        const { settingsPath, managedContextFileName } = (adapter as unknown as { writeContextSettings(dir: string, includeDir: string): { settingsPath: string; managedContextFileName: string } }).writeContextSettings(tempDir, includeDir);
+        const { settingsPath, managedContextFileName } = await (adapter as unknown as { writeContextSettings(dir: string, includeDir: string): Promise<{ settingsPath: string; managedContextFileName: string }> }).writeContextSettings(tempDir, includeDir);
         expect(managedContextFileName).toMatch(/^FRANKENBEAST_GEMINI_[0-9a-f-]+\.md$/);
         expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toEqual({
           sandbox: true,
@@ -201,7 +205,7 @@ describe('GeminiCliAdapter', () => {
       }
     });
 
-    it('leaves lower-scope include directories to Gemini trust handling', () => {
+    it('leaves lower-scope include directories to Gemini trust handling', async () => {
       const originalSettingsPath = process.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
       const originalSystemDefaultsPath = process.env.GEMINI_CLI_SYSTEM_DEFAULTS_PATH;
       const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
@@ -229,7 +233,7 @@ describe('GeminiCliAdapter', () => {
 
       try {
         const includeDir = join(tempDir, 'managed-context');
-        const { settingsPath, managedContextFileName } = (adapter as unknown as { writeContextSettings(dir: string, includeDir: string): { settingsPath: string; managedContextFileName: string } }).writeContextSettings(tempDir, includeDir);
+        const { settingsPath, managedContextFileName } = await (adapter as unknown as { writeContextSettings(dir: string, includeDir: string): Promise<{ settingsPath: string; managedContextFileName: string }> }).writeContextSettings(tempDir, includeDir);
         expect(JSON.parse(readFileSync(settingsPath, 'utf-8'))).toMatchObject({
           sandbox: true,
           context: {
@@ -335,6 +339,20 @@ describe('GeminiCliAdapter', () => {
         retryable: false,
       });
       expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('returns a provider-scoped error when the managed prompt cannot be written', async () => {
+      const writeSpy = vi.spyOn(adapter, 'writeGeminiMd').mockRejectedValueOnce(new Error('read-only file system'));
+
+      const events = await collectEvents(adapter.execute({ systemPrompt: 'sys', messages: [] }));
+      writeSpy.mockRestore();
+
+      expect(events).toEqual([{
+        type: 'error',
+        error: 'gemini prompt file setup failed: read-only file system',
+        retryable: false,
+      }]);
+      expect(spawn).not.toHaveBeenCalled();
     });
 
     it('parses stream-json text events', async () => {
@@ -570,76 +588,90 @@ describe('GeminiCliAdapter', () => {
   });
 
   describe('writeGeminiMd()', () => {
-    it('creates GEMINI.md if not exists', () => {
-      adapter.writeGeminiMd('System prompt here');
+    it('creates GEMINI.md if not exists', async () => {
+      await adapter.writeGeminiMd('System prompt here');
       const content = readFileSync(join(tempDir, 'GEMINI.md'), 'utf-8');
       expect(content).toContain('FRANKENBEAST MANAGED SECTION');
       expect(content).toContain('System prompt here');
       expect(content).toContain('END FRANKENBEAST SECTION');
     });
 
-    it('replaces managed section if exists', () => {
-      adapter.writeGeminiMd('Version 1');
-      adapter.writeGeminiMd('Version 2');
+    it('replaces managed section if exists', async () => {
+      await adapter.writeGeminiMd('Version 1');
+      await adapter.writeGeminiMd('Version 2');
       const content = readFileSync(join(tempDir, 'GEMINI.md'), 'utf-8');
       expect(content).toContain('Version 2');
       expect(content).not.toContain('Version 1');
     });
 
-    it('preserves user content outside managed section', () => {
+    it('preserves user content outside managed section', async () => {
       writeFileSync(join(tempDir, 'GEMINI.md'), `User notes\n\n<!-- FRANKENBEAST MANAGED SECTION - DO NOT EDIT -->\nOld\n<!-- END FRANKENBEAST SECTION -->\n`);
-      adapter.writeGeminiMd('New');
+      await adapter.writeGeminiMd('New');
       const content = readFileSync(join(tempDir, 'GEMINI.md'), 'utf-8');
       expect(content).toContain('User notes');
       expect(content).toContain('New');
     });
 
-    it('preserves GEMINI.md file mode when updating atomically', () => {
+    it('preserves GEMINI.md file mode when updating atomically', async () => {
       const geminiPath = join(tempDir, 'GEMINI.md');
       writeFileSync(geminiPath, 'User notes');
       chmodSync(geminiPath, 0o600);
 
-      adapter.writeGeminiMd('New');
+      await adapter.writeGeminiMd('New');
 
       expect(statSync(geminiPath).mode & 0o777).toBe(0o600);
     });
 
-    it('updates symlinked GEMINI.md targets without replacing the symlink', () => {
+    it('preserves the original target and removes the temp file when atomic rename fails', async () => {
+      const targetPath = join(tempDir, 'GEMINI.md');
+      mkdirSync(targetPath);
+      writeFileSync(join(targetPath, 'original.txt'), 'original content');
+
+      const writeFileAtomically = (adapter as unknown as {
+        writeFileAtomically(path: string, content: string): Promise<void>;
+      }).writeFileAtomically.bind(adapter);
+
+      await expect(writeFileAtomically(targetPath, 'replacement')).rejects.toThrow();
+      expect(readFileSync(join(targetPath, 'original.txt'), 'utf-8')).toBe('original content');
+      expect(readdirSync(tempDir)).toEqual(['GEMINI.md']);
+    });
+
+    it('updates symlinked GEMINI.md targets without replacing the symlink', async () => {
       const targetPath = join(tempDir, 'shared-GEMINI.md');
       const geminiPath = join(tempDir, 'GEMINI.md');
       writeFileSync(targetPath, 'user notes\n');
       symlinkSync(targetPath, geminiPath);
 
-      adapter.writeGeminiMd('System prompt here');
+      await adapter.writeGeminiMd('System prompt here');
 
       expect(lstatSync(geminiPath).isSymbolicLink()).toBe(true);
       expect(readFileSync(targetPath, 'utf-8')).toContain('System prompt here');
     });
 
-    it('creates the target for dangling symlinked GEMINI.md without replacing the link', () => {
+    it('creates the target for dangling symlinked GEMINI.md without replacing the link', async () => {
       const targetPath = join(tempDir, 'generated-later-GEMINI.md');
       const geminiPath = join(tempDir, 'GEMINI.md');
       symlinkSync(targetPath, geminiPath);
 
-      adapter.writeGeminiMd('System prompt here');
+      await adapter.writeGeminiMd('System prompt here');
 
       expect(lstatSync(geminiPath).isSymbolicLink()).toBe(true);
       expect(readFileSync(targetPath, 'utf-8')).toContain('System prompt here');
     });
 
-    it('prepends managed content to user GEMINI.md content', () => {
+    it('prepends managed content to user GEMINI.md content', async () => {
       writeFileSync(
         join(tempDir, 'GEMINI.md'),
         '# My Project\nUser content here\n',
       );
-      adapter.writeGeminiMd('System prompt');
+      await adapter.writeGeminiMd('System prompt');
       const content = readFileSync(join(tempDir, 'GEMINI.md'), 'utf-8');
       expect(content).toContain('System prompt');
       expect(content).toContain('User content here');
     });
 
-    it('includes handoff context when provided', () => {
-      adapter.writeGeminiMd('System', '--- HANDOFF ---');
+    it('includes handoff context when provided', async () => {
+      await adapter.writeGeminiMd('System', '--- HANDOFF ---');
       const content = readFileSync(join(tempDir, 'GEMINI.md'), 'utf-8');
       expect(content).toContain('--- HANDOFF ---');
     });


### PR DESCRIPTION
## Summary
- migrate Gemini prompt and temporary settings writes to `node:fs/promises`
- preserve atomic replacement semantics, symlink targets, file modes, and clean partial temp files on write/rename failures
- convert prompt setup filesystem failures into provider-scoped, non-retryable stream errors instead of raw crashes
- update process mocks for asynchronous setup and add regression coverage for read-only setup plus interrupted atomic replacement

## Test Plan
- `npm --workspace @franken/orchestrator test -- --run tests/unit/providers/gemini-cli-adapter.test.ts` (41 passed)
- `npm run build` (10/10 workspaces passed)
- `npm --workspace @franken/orchestrator run typecheck`
- `npm --workspace @franken/orchestrator run lint -- --quiet`

Closes #3048