### PR TITLE
fix(brain): audit corrupt recovery checkpoints

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3233,6 +3233,7 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
 
   lastCheckpoint(): ExecutionState | null {
     try {
+      const quarantinedCheckpointIds: number[] = [];
       const stmt = this.db.prepare(
         `SELECT * FROM checkpoints ORDER BY id DESC LIMIT ? OFFSET ?`,
       );
@@ -3248,15 +3249,22 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
               operation: 'recovery.lastCheckpoint',
               store: 'recovery',
               outcome: 'success',
+              ...(quarantinedCheckpointIds.length > 0
+                ? { details: { quarantinedCheckpointIds } }
+                : {}),
             });
             return state;
           }
+          quarantinedCheckpointIds.push(row.id);
         }
         if (rows.length < CORRUPT_JSON_SCAN_BATCH_SIZE) {
           this.audit?.({
             operation: 'recovery.lastCheckpoint',
             store: 'recovery',
             outcome: 'miss',
+            ...(quarantinedCheckpointIds.length > 0
+              ? { details: { quarantinedCheckpointIds } }
+              : {}),
           });
           return null;
         }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6666,12 +6666,19 @@ describe('SqliteBrain', () => {
           };
         }
       ).db;
+      const corruptCheckpointId = Number(brain.recovery.listCheckpoints().at(-1)!.id);
       db.prepare(
         `UPDATE checkpoints SET state = ? WHERE id = (SELECT MAX(id) FROM checkpoints)`,
       ).run('{');
 
       expect(() => brain.recovery.lastCheckpoint()).not.toThrow();
       expect(brain.recovery.lastCheckpoint()?.step).toBe(1);
+      expect(
+        brain.accessAudit.list({ operation: 'recovery.lastCheckpoint' })[0],
+      ).toMatchObject({
+        outcome: 'success',
+        details: { quarantinedCheckpointIds: [corruptCheckpointId] },
+      });
       expect(() => brain.serialize()).not.toThrow();
       expect(brain.serialize().checkpoint?.step).toBe(1);
     });


### PR DESCRIPTION
## Summary
- continue recovery past malformed checkpoint JSON
- record skipped checkpoint IDs in the recovery access-audit diagnostic
- cover corrupt-latest fallback with a regression assertion

## Test plan
- `npm run test --workspace @franken/brain`
- `npm run lint --workspace @franken/brain`
- `npm run typecheck --workspace @franken/brain`
- `npm run build`

Closes #3136