### PR TITLE
fix(brain): guard checkpoint serialization budgets

### DIFF
--- a/packages/franken-brain/src/index.ts
+++ b/packages/franken-brain/src/index.ts
@@ -1,6 +1,7 @@
 export {
   SqliteBrain,
   WorkingMemoryLimitError,
+  CheckpointSerializationError,
   WorkingMemoryKeyError,
   WorkingMemoryHydrationLimitError,
   CorruptWorkingMemoryRowError,
@@ -20,6 +21,7 @@ export {
   SqliteMemoryReviewQueue,
   SqliteMemoryAccessAuditTrail,
   type WorkingMemoryLimits,
+  type CheckpointSerializationErrorCode,
   type WorkingMemoryKeyErrorReason,
   type WorkingMemoryHydrationLimits,
   type SqliteBrainOptions,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -994,7 +994,10 @@ function stringifyWorkingMemoryValue(key: string, value: unknown): string {
   );
 }
 
-function stringifyCheckpointState(state: ExecutionState, maxBytes: number): string {
+function stringifyCheckpointState(
+  state: ExecutionState,
+  maxBytes?: number,
+): string {
   let serialized: string | undefined;
   try {
     serialized = JSON.stringify(state);
@@ -1013,12 +1016,13 @@ function stringifyCheckpointState(state: ExecutionState, maxBytes: number): stri
   }
 
   const byteLength = Buffer.byteLength(serialized, 'utf8');
-  if (byteLength > maxBytes) {
+  const byteLimit = maxBytes;
+  if (byteLimit !== undefined && byteLength > byteLimit) {
     throw new CheckpointSerializationError(
       'CHECKPOINT_SIZE_LIMIT_EXCEEDED',
-      `Checkpoint state is ${byteLength} bytes, exceeding maxValueBytes (${maxBytes})`,
+      `Checkpoint state is ${byteLength} bytes, exceeding maxValueBytes (${byteLimit})`,
       byteLength,
-      maxBytes,
+      byteLimit,
     );
   }
 
@@ -6494,12 +6498,8 @@ export class SqliteBrain implements IBrain {
     });
 
     try {
-      const checkpointMaxBytes = {
-        ...DEFAULT_WORKING_MEMORY_LIMITS,
-        ...workingMemoryLimits,
-      }.maxValueBytes;
       const serializedCheckpoint = snapshot.checkpoint
-        ? stringifyCheckpointState(snapshot.checkpoint, checkpointMaxBytes)
+        ? stringifyCheckpointState(snapshot.checkpoint)
         : undefined;
       const insertEvent = brain.db.prepare(
         `INSERT INTO episodic_events (id, type, step, summary, details, created_at)

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -879,6 +879,22 @@ export class WorkingMemoryLimitError extends Error {
   }
 }
 
+export type CheckpointSerializationErrorCode =
+  | 'CHECKPOINT_NOT_PERSISTABLE'
+  | 'CHECKPOINT_SIZE_LIMIT_EXCEEDED';
+
+export class CheckpointSerializationError extends Error {
+  constructor(
+    readonly code: CheckpointSerializationErrorCode,
+    message: string,
+    readonly byteLength?: number,
+    readonly maxBytes?: number,
+  ) {
+    super(message);
+    this.name = 'CheckpointSerializationError';
+  }
+}
+
 export type WorkingMemoryKeyErrorReason =
   | 'empty'
   | 'control_character'
@@ -976,6 +992,37 @@ function stringifyWorkingMemoryValue(key: string, value: unknown): string {
   throw new WorkingMemoryLimitError(
     `Working memory value for "${key}" is not JSON-serializable and could not be persisted`,
   );
+}
+
+function stringifyCheckpointState(state: ExecutionState, maxBytes: number): string {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(state);
+  } catch (error) {
+    throw new CheckpointSerializationError(
+      'CHECKPOINT_NOT_PERSISTABLE',
+      `Checkpoint state is not JSON-serializable and could not be persisted: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (serialized === undefined) {
+    throw new CheckpointSerializationError(
+      'CHECKPOINT_NOT_PERSISTABLE',
+      'Checkpoint state is not JSON-serializable and could not be persisted',
+    );
+  }
+
+  const byteLength = Buffer.byteLength(serialized, 'utf8');
+  if (byteLength > maxBytes) {
+    throw new CheckpointSerializationError(
+      'CHECKPOINT_SIZE_LIMIT_EXCEEDED',
+      `Checkpoint state is ${byteLength} bytes, exceeding maxValueBytes (${maxBytes})`,
+      byteLength,
+      maxBytes,
+    );
+  }
+
+  return serialized;
 }
 
 function hashMemoryAccessValue(
@@ -3163,14 +3210,22 @@ interface CheckpointRow {
 class SqliteRecoveryMemory implements IRecoveryMemory {
   constructor(
     private db: Database.Database,
+    private maxCheckpointBytes: number,
     private flushWorkingMemory?: () => (() => void) | void,
     private encryption?: MemoryCipher,
     private audit?: MemoryAccessAuditRecorder,
   ) {}
 
   checkpoint(state: ExecutionState): { id: string } {
+    let serializedState: string;
     try {
-      assertCheckpointNotDeletionGuarded(this.db, state, this.encryption);
+      serializedState = stringifyCheckpointState(state, this.maxCheckpointBytes);
+      assertCheckpointNotDeletionGuarded(
+        this.db,
+        state,
+        serializedState,
+        this.encryption,
+      );
     } catch (error) {
       this.audit?.({
         operation: 'recovery.checkpoint',
@@ -3194,8 +3249,7 @@ class SqliteRecoveryMemory implements IRecoveryMemory {
           `INSERT INTO checkpoints (state, created_at, schema_version) VALUES (?, ?, ${CURRENT_MEMORY_SCHEMA_VERSION})`,
         )
         .run(
-          this.encryption?.encrypt(JSON.stringify(state)) ??
-            JSON.stringify(state),
+          this.encryption?.encrypt(serializedState) ?? serializedState,
           state.timestamp,
         );
       const checkpoint = { id: String(result.lastInsertRowid) };
@@ -5512,13 +5566,14 @@ export class SqliteBrain implements IBrain {
     migrateMemorySchemaDatabase(this.db, dbPath, { dryRun: false });
     this.auditRecorder = (event) => insertMemoryAccessAuditEvent(this.db, event, encryption);
     this.accessAudit = new SqliteMemoryAccessAuditTrail(this.db, encryption);
+    const limits = {
+      ...DEFAULT_WORKING_MEMORY_LIMITS,
+      ...workingMemoryLimits,
+    };
     try {
       this.working = new SqliteWorkingMemory(
         this.db,
-        {
-          ...DEFAULT_WORKING_MEMORY_LIMITS,
-          ...workingMemoryLimits,
-        },
+        limits,
         options.hydrateWorkingMemoryFromDb ?? true,
         encryption,
         (event) => this.auditRecorder(event),
@@ -5536,6 +5591,7 @@ export class SqliteBrain implements IBrain {
     );
     this.recovery = new SqliteRecoveryMemory(
       this.db,
+      limits.maxValueBytes,
       () => this.working.flushToDb(),
       encryption,
       (event) => this.auditRecorder(event),
@@ -6438,6 +6494,13 @@ export class SqliteBrain implements IBrain {
     });
 
     try {
+      const checkpointMaxBytes = {
+        ...DEFAULT_WORKING_MEMORY_LIMITS,
+        ...workingMemoryLimits,
+      }.maxValueBytes;
+      const serializedCheckpoint = snapshot.checkpoint
+        ? stringifyCheckpointState(snapshot.checkpoint, checkpointMaxBytes)
+        : undefined;
       const insertEvent = brain.db.prepare(
         `INSERT INTO episodic_events (id, type, step, summary, details, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
@@ -6521,11 +6584,15 @@ export class SqliteBrain implements IBrain {
           );
         }
 
-        if (snapshot.checkpoint) {
-          assertCheckpointNotDeletionGuarded(brain.db, snapshot.checkpoint, brain.encryption);
+        if (snapshot.checkpoint && serializedCheckpoint) {
+          assertCheckpointNotDeletionGuarded(
+            brain.db,
+            snapshot.checkpoint,
+            serializedCheckpoint,
+            brain.encryption,
+          );
           insertCheckpoint.run(
-            brain.encryption?.encrypt(JSON.stringify(snapshot.checkpoint)) ??
-              JSON.stringify(snapshot.checkpoint),
+            brain.encryption?.encrypt(serializedCheckpoint) ?? serializedCheckpoint,
             snapshot.checkpoint.timestamp,
           );
         }
@@ -8011,13 +8078,18 @@ function hasAnyDeletionQueryGuard(db: Database.Database, scope: string, values: 
   return false;
 }
 
-function assertCheckpointNotDeletionGuarded(db: Database.Database, state: ExecutionState, encryption?: MemoryCipher): void {
+function assertCheckpointNotDeletionGuarded(
+  db: Database.Database,
+  state: ExecutionState,
+  serializedState: string,
+  encryption?: MemoryCipher,
+): void {
   const context = state.context;
   const candidates: Array<[string, string | undefined]> = [
     ...objectMetadataStrings(context, ['category', 'categories', 'kind']).map(value => ['category', value] as [string, string]),
-    ...extractStructuredMarkerValues(valueToSearchText(state), 'category').map(value => ['category', value] as [string, string]),
+    ...extractStructuredMarkerValues(serializedState, 'category').map(value => ['category', value] as [string, string]),
     ...objectMetadataStrings(context, ['sourceScope', 'source', 'scope', 'sourceId']).map(value => ['sourceScope', value] as [string, string]),
-    ...extractStructuredMarkerValues(valueToSearchText(state), 'sourceScope').map(value => ['sourceScope', value] as [string, string]),
+    ...extractStructuredMarkerValues(serializedState, 'sourceScope').map(value => ['sourceScope', value] as [string, string]),
   ];
   for (const [kind, value] of candidates) {
     if (!value) continue;
@@ -8029,8 +8101,7 @@ function assertCheckpointNotDeletionGuarded(db: Database.Database, state: Execut
   }
   const queryGuardIndex = readQueryGuardIndex(db, 'checkpoint');
   if (queryGuardIndex.lengths.size > 0 || queryGuardIndex.hasLegacyHashes) {
-    const text = valueToSearchText(state);
-    const values = queryGuardCandidatesForReplay(text, queryGuardIndex);
+    const values = queryGuardCandidatesForReplay(serializedState, queryGuardIndex);
     if (hasAnyDeletionQueryGuard(db, 'checkpoint', values, encryption)) {
       throw new MemoryDeletionGuardError('Refusing to store checkpoint because it matches a prior right-to-forget query guard');
     }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6576,9 +6576,47 @@ describe('SqliteBrain', () => {
     });
 
     it('checkpoint() stores execution state and returns id', () => {
-      const result = brain.recovery.checkpoint(makeState());
+      const state = makeState();
+      const result = brain.recovery.checkpoint(state);
       expect(result.id).toBeDefined();
       expect(typeof result.id).toBe('string');
+      expect(brain.recovery.lastCheckpoint()).toEqual(state);
+    });
+
+    it('checkpoint() rejects circular state with a controlled persistence error', () => {
+      const context: Record<string, unknown> = {};
+      context.self = context;
+
+      expect(() => brain.recovery.checkpoint(makeState({ context }))).toThrowError(
+        expect.objectContaining({
+          name: 'CheckpointSerializationError',
+          code: 'CHECKPOINT_NOT_PERSISTABLE',
+          message: expect.stringMatching(/not JSON-serializable.*could not be persisted/),
+        }),
+      );
+      expect(brain.recovery.lastCheckpoint()).toBeNull();
+    });
+
+    it('checkpoint() rejects state larger than the configured value byte budget without replacing the last usable state', () => {
+      const bounded = new SqliteBrain(':memory:', { maxValueBytes: 512 });
+      const previous = makeState();
+      bounded.recovery.checkpoint(previous);
+
+      expect(() =>
+        bounded.recovery.checkpoint(
+          makeState({ context: { payload: 'x'.repeat(1024) } }),
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          name: 'CheckpointSerializationError',
+          code: 'CHECKPOINT_SIZE_LIMIT_EXCEEDED',
+          maxBytes: 512,
+          message: expect.stringMatching(/Checkpoint state is \d+ bytes, exceeding maxValueBytes \(512\)/),
+        }),
+      );
+      expect(bounded.recovery.lastCheckpoint()).toEqual(previous);
+
+      bounded.close();
     });
 
     it('checkpoint() flushes working memory to SQLite', () => {

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -6619,6 +6619,28 @@ describe('SqliteBrain', () => {
       bounded.close();
     });
 
+    it('hydrate() restores legacy oversized checkpoints while enforcing the budget on new writes', () => {
+      const legacy = new SqliteBrain(':memory:', { maxValueBytes: 4096 });
+      const oversized = makeState({ context: { payload: 'x'.repeat(1024) } });
+      legacy.recovery.checkpoint(oversized);
+      const snapshot = legacy.serialize();
+      legacy.close();
+
+      const hydrated = SqliteBrain.hydrate(snapshot, ':memory:', {
+        maxValueBytes: 512,
+      });
+      expect(hydrated.recovery.lastCheckpoint()).toEqual(oversized);
+      expect(() => hydrated.recovery.checkpoint(oversized)).toThrowError(
+        expect.objectContaining({
+          code: 'CHECKPOINT_SIZE_LIMIT_EXCEEDED',
+          maxBytes: 512,
+        }),
+      );
+      expect(hydrated.recovery.lastCheckpoint()).toEqual(oversized);
+
+      hydrated.close();
+    });
+
     it('checkpoint() flushes working memory to SQLite', () => {
       brain.working.set('key1', 'value1');
 


### PR DESCRIPTION
## Summary
- serialize checkpoint state once before persistence and surface controlled serialization failures
- enforce the configured UTF-8 byte budget before checkpoint insertion or working-memory flush
- preserve the last usable checkpoint after rejected writes and apply the same guard during snapshot hydration

## Test Plan
- `npm run test --workspace @franken/brain` (340 passed)
- `npm run lint --workspace @franken/brain`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/brain`
- `npm run build --workspace @franken/brain`

Closes #3135