### PR TITLE
docs(mcp): use canonical registry tool IDs

### DIFF
--- a/docs/adr/038-mcp-central-governance.md
+++ b/docs/adr/038-mcp-central-governance.md
@@ -67,8 +67,9 @@ tool calls are checked regardless of whether client hooks are installed. We
   Scanning that payload only yields false-positive denials, so:
   - **Non-executing tools** (`NON_EXECUTING_TOOLS`) — every read/analyze/store/
     log tool across the registry (`search_tools`, the firewall scanners,
-    `fbeast_governor_check`/`_budget`, `fbeast_memory_store`/`_query`/
-    `_frontload`, the planner tools, `fbeast_critique_evaluate`/`_compare`, the
+    `fbeast_governor_check`/`fbeast_governor_budget`,
+    `fbeast_memory_store`/`fbeast_memory_query`/`fbeast_memory_frontload`, the
+    planner tools, `fbeast_critique_evaluate`/`fbeast_critique_compare`, the
     observer tools, the skills tools) — are **exempt** and approved. Their
     payload is data, not an operation to authorize; governing it would break
     legitimate critique/audit/store workflows on risky content (e.g. critiquing
@@ -152,8 +153,9 @@ absent. The two are complementary and share the same governor policy.
 ### Out of scope
 - Firewall (prompt-injection) scanning is **not** added to the dispatch gate.
   The hook path does not firewall-scan either (`cli/hook.ts pre-tool` only runs
-  the governor); the firewall is an agent-invoked tool (`fbeast_firewall_scan` /
-  `_scan_file`) for vetting untrusted input before acting. Making it a blocking
+  the governor); the firewall is an agent-invoked tool
+  (`fbeast_firewall_scan` / `fbeast_firewall_scan_file`) for vetting untrusted
+  input before acting. Making it a blocking
   per-dispatch gate would self-block those scan tools (it would refuse to scan
   the very content meant to be scanned) and cause false-positive denials on
   legitimate stores. Defense-in-depth firewall integration, if desired, belongs

--- a/docs/walkthrough-mcp-suite.md
+++ b/docs/walkthrough-mcp-suite.md
@@ -269,8 +269,16 @@ Once installed, your MCP-compatible client has access to the tools registered in
 | `fbeast_memory_store` | memory | Store a key/value entry in working, episodic, or recovery memory |
 | `fbeast_memory_query` | memory | Search memory entries by keyword substring |
 | `fbeast_memory_frontload` | memory | Load all memory entries from this database as context |
+| `fbeast_memory_export` | memory | Export project memory as structured JSON with safe redaction by default |
+| `fbeast_memory_retention_report` | memory | Inspect retention and compaction policy status by memory class |
 | `fbeast_memory_forget` | memory | Delete a working memory entry by key |
 | `fbeast_memory_right_to_forget` | memory | Delete memory by key, category, source scope, or sensitive query and return hashed deletion evidence |
+| `fbeast_memory_review_propose` | memory | Queue a proposed working-memory promotion for operator review |
+| `fbeast_memory_review_list` | memory | List queued memory promotion candidates by review status |
+| `fbeast_memory_source_attribution` | memory | View source attribution and approval provenance for working-memory entries |
+| `fbeast_memory_review_conflicts` | memory | Inspect conflicts and guidance for a pending memory promotion candidate |
+| `fbeast_memory_review_decide` | memory | Decide or resolve a queued memory promotion |
+| `fbeast_memory_access_audit_report` | memory | Report redacted memory access by agent, profile, repo, tool, operation, and decision |
 | `fbeast_plan_decompose` | planner | Create a scaffold DAG for a task objective |
 | `fbeast_plan_status` | planner | Get status and visualization for a plan |
 | `fbeast_plan_validate` | planner | Validate a plan DAG for cycles and missing dependencies |

--- a/tests/docs-issue-3565.test.ts
+++ b/tests/docs-issue-3565.test.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TOOL_REGISTRY } from '../packages/franken-mcp-suite/src/shared/tool-registry.js';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+const canonicalToolIds = new Set(TOOL_REGISTRY.keys());
+
+const maintainedMcpDocs = [
+  ...readdirSync(resolve(ROOT, 'docs/adr'))
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => `docs/adr/${name}`),
+  'docs/walkthrough-mcp-suite.md',
+  'packages/franken-mcp-suite/README.md',
+];
+
+describe('issue #3565 canonical MCP tool references', () => {
+  it('uses complete canonical tool IDs instead of slash-prefixed shorthand', () => {
+    for (const path of maintainedMcpDocs) {
+      const doc = readDoc(path);
+
+      expect(doc, path).not.toMatch(/`fbeast_[a-z0-9_]+`\s*\/\s*`_[a-z0-9_]+`/);
+    }
+  });
+
+  it('keeps maintained MCP documentation references in the registry', () => {
+    for (const path of maintainedMcpDocs) {
+      const references = readDoc(path).match(/`(fbeast_[a-z0-9_]+)`/g) ?? [];
+
+      for (const reference of references) {
+        const toolId = reference.slice(1, -1);
+        expect(canonicalToolIds.has(toolId), `${path}: ${toolId}`).toBe(true);
+      }
+    }
+  });
+
+  it('keeps the walkthrough tool table synchronized with the registry', () => {
+    const walkthrough = readDoc('docs/walkthrough-mcp-suite.md');
+    const referenceSection = walkthrough.slice(
+      walkthrough.indexOf('## MCP Tools Reference'),
+      walkthrough.indexOf('## Switching to Beast Mode'),
+    );
+    const documentedToolIds = [...referenceSection.matchAll(/^\| `(fbeast_[a-z0-9_]+)` \|/gm)]
+      .map((match) => match[1]);
+
+    expect(new Set(documentedToolIds)).toEqual(canonicalToolIds);
+    expect(documentedToolIds).toHaveLength(canonicalToolIds.size);
+  });
+});


### PR DESCRIPTION
## Summary
- replace shorthand MCP tool aliases in the central-governance ADR with canonical registry IDs
- synchronize the MCP walkthrough tool table with the live registry
- add a registry-backed docs regression test for canonical IDs and inventory drift

## Verification
- `npm run test:root -- tests/docs-issue-3565.test.ts`
- `npm run lint --workspace @franken/mcp-suite` (passes with 26 pre-existing warnings)
- `npm run build --workspace @franken/mcp-suite`
- `npm run typecheck --workspace @franken/mcp-suite`

Closes #3565