### PR TITLE
fix(live-bench): bound run timestamp years

### DIFF
--- a/packages/live-bench/src/workspace/workspace-provisioner.ts
+++ b/packages/live-bench/src/workspace/workspace-provisioner.ts
@@ -372,6 +372,9 @@ function fdPath(fd: number): string {
 }
 
 const RUN_TIMESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|[+-]\d{2}:\d{2})$/;
+// Live-bench run directories and retention reports support this inclusive operational window.
+const MIN_RUN_TIMESTAMP_YEAR = 2000;
+const MAX_RUN_TIMESTAMP_YEAR = 2100;
 
 function dateSegment(timestamp: string): string {
   const match = RUN_TIMESTAMP_PATTERN.exec(timestamp);
@@ -389,7 +392,9 @@ function dateSegment(timestamp: string): string {
   const millisecond = Number(millisecondText);
 
   if (
-    month < 1
+    year < MIN_RUN_TIMESTAMP_YEAR
+    || year > MAX_RUN_TIMESTAMP_YEAR
+    || month < 1
     || month > 12
     || day < 1
     || day > daysInMonth(year, month)
@@ -403,6 +408,10 @@ function dateSegment(timestamp: string): string {
 
   const parsed = new Date(timestamp);
   if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid runTimestamp: ${timestamp}`);
+  }
+  const normalizedYear = parsed.getUTCFullYear();
+  if (normalizedYear < MIN_RUN_TIMESTAMP_YEAR || normalizedYear > MAX_RUN_TIMESTAMP_YEAR) {
     throw new Error(`Invalid runTimestamp: ${timestamp}`);
   }
   const normalized = parsed.toISOString();

--- a/packages/live-bench/tests/workspace-provisioner.test.ts
+++ b/packages/live-bench/tests/workspace-provisioner.test.ts
@@ -258,11 +258,36 @@ describe('workspace provisioning', () => {
 
     const offsetResult = provisioner.provision({ ...row, runId: 'run-offset', runTimestamp: '2026-05-23T23:30:00+02:00' }, task);
     expect(offsetResult.runDir).toContain(join('2026-05-23', 'run-offset'));
-    const yearZeroLeapDay = provisioner.provision({ ...row, runId: 'run-year-zero', runTimestamp: '0000-02-29T00:00:00.000Z' }, task);
-    expect(yearZeroLeapDay.runDir).toContain(join('0000-02-29', 'run-year-zero'));
-    expect(() => provisioner.provision({ ...row, runTimestamp: '0001-02-29T00:00:00.000Z' }, task)).toThrow(/Invalid runTimestamp/);
-    expect(() => provisioner.provision({ ...row, runTimestamp: '0000-01-01T00:00:00+01:00' }, task)).toThrow(/Invalid runTimestamp/);
-    expect(() => provisioner.provision({ ...row, runTimestamp: '9999-12-31T23:30:00-01:00' }, task)).toThrow(/Invalid runTimestamp/);
+    expect(() => provisioner.provision({ ...row, runTimestamp: '2001-02-29T00:00:00.000Z' }, task)).toThrow(/Invalid runTimestamp/);
+  });
+
+  it('accepts benchmark timestamp years from 2000 through 2100 and rejects dates outside that policy', () => {
+    const fixturesRoot = tempRoot('live-bench-fixtures-');
+    const runsRoot = tempRoot('live-bench-runs-');
+    createFixture(fixturesRoot);
+
+    const provisioner = new WorkspaceProvisioner({
+      fixtures: new FixtureStore(fixturesRoot),
+      runsRoot,
+    });
+
+    const lowerBoundary = provisioner.provision({
+      ...row,
+      runId: 'run-year-lower-boundary',
+      runTimestamp: '2000-01-01T00:00:00.000Z',
+    }, task);
+    const upperBoundary = provisioner.provision({
+      ...row,
+      runId: 'run-year-upper-boundary',
+      runTimestamp: '2100-12-31T23:59:59.999Z',
+    }, task);
+
+    expect(lowerBoundary.runDir).toContain(join('2000-01-01', 'run-year-lower-boundary'));
+    expect(upperBoundary.runDir).toContain(join('2100-12-31', 'run-year-upper-boundary'));
+    expect(() => provisioner.provision({ ...row, runTimestamp: '1999-12-31T23:59:59.999Z' }, task)).toThrow(/Invalid runTimestamp/);
+    expect(() => provisioner.provision({ ...row, runTimestamp: '2101-01-01T00:00:00.000Z' }, task)).toThrow(/Invalid runTimestamp/);
+    expect(() => provisioner.provision({ ...row, runTimestamp: '2000-01-01T00:30:00+01:00' }, task)).toThrow(/Invalid runTimestamp/);
+    expect(() => provisioner.provision({ ...row, runTimestamp: '2100-12-31T23:30:00-01:00' }, task)).toThrow(/Invalid runTimestamp/);
   });
 
   it('rejects mismatched benchmark rows and tasks before persisting metadata', () => {


### PR DESCRIPTION
## Summary
- bound accepted live-bench run timestamp years to the documented 2000–2100 operational window
- reject timezone offsets that normalize filesystem date segments outside the supported window
- cover accepted boundaries and rejected out-of-policy timestamps

## Test plan
- `npm test -- --run tests/workspace-provisioner.test.ts`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #3060