### PR TITLE
fix(brain): expose episodic snapshot truncation

### DIFF
--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -206,11 +206,20 @@ const checkpoint = brain.recovery.checkpoint({
 const last = brain.recovery.lastCheckpoint();
 
 // serialize/hydrate is useful for process handoff and tests.
+// The default snapshot includes the 100 most recent episodic events and reports
+// whether that bounded export is partial in metadata.episodicExport.
 const snapshot = brain.serialize();
+if (snapshot.metadata.episodicExport?.truncated) {
+  console.warn(`Snapshot contains ${snapshot.metadata.episodicExport.exportedEvents} of ${snapshot.metadata.episodicExport.totalEvents} episodic events`);
+}
+// Callers that need more history can raise the bound explicitly.
+const largerSnapshot = brain.serialize({ episodicLimit: 1_000 });
 brain.close();
 const restored = SqliteBrain.hydrate(snapshot);
 restored.close();
 ```
+
+`hydrate()` restores exactly the events present in `snapshot.episodic`; it cannot recover events omitted from a partial snapshot. Inspect `metadata.episodicExport.truncated` before hydrating when a complete episodic history is required. Legacy snapshots without `episodicExport` metadata remain accepted.
 
 ## Persistence atomicity
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -14,6 +14,7 @@ import type {
   IEpisodicMemory,
   IRecoveryMemory,
   BrainSnapshot,
+  BrainSerializeOptions,
   MemoryDeletionGuardSnapshot,
   EpisodicEvent,
   ExecutionState,
@@ -6475,14 +6476,21 @@ export class SqliteBrain implements IBrain {
     return count;
   }
 
-  serialize(): BrainSnapshot {
+  serialize(options: BrainSerializeOptions = {}): BrainSnapshot {
+    const episodicLimit = options.episodicLimit ?? 100;
+    if (!Number.isSafeInteger(episodicLimit) || episodicLimit <= 0) {
+      throw new RangeError('episodicLimit must be a positive safe integer');
+    }
+
     this.flush();
     const deletionGuardHashKey = readDeletionHashKey(this.db, this.encryption);
+    const totalEvents = this.episodic.count();
+    const episodic = this.episodic.snapshotForHandoff(episodicLimit);
     return {
       version: 1,
       timestamp: isoNow(),
       working: this.working.snapshot(),
-      episodic: this.episodic.snapshotForHandoff(100),
+      episodic,
       checkpoint: this.recovery.lastCheckpoint(),
       deletionGuards: readDeletionGuardSnapshot(this.db),
       ...(deletionGuardHashKey ? { deletionGuardHashKey } : {}),
@@ -6490,6 +6498,12 @@ export class SqliteBrain implements IBrain {
         lastProvider: '',
         switchReason: '',
         totalTokensUsed: 0,
+        episodicExport: {
+          limit: episodicLimit,
+          totalEvents,
+          exportedEvents: episodic.length,
+          truncated: episodic.length < totalEvents,
+        },
       },
     };
   }

--- a/packages/franken-brain/tests/integration/brain-serialize-hydrate.test.ts
+++ b/packages/franken-brain/tests/integration/brain-serialize-hydrate.test.ts
@@ -90,4 +90,42 @@ describe('Brain serialize/hydrate integration', () => {
     brain1.close();
     brain2.close();
   });
+
+  it('reports default episodic truncation and allows callers to request a larger export', () => {
+    const brain = new SqliteBrain();
+    for (let index = 0; index < 105; index += 1) {
+      brain.episodic.record({
+        type: 'observation',
+        summary: `Event ${index}`,
+        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
+      });
+    }
+
+    const partial = brain.serialize();
+    expect(partial.episodic).toHaveLength(100);
+    expect(partial.metadata.episodicExport).toEqual({
+      limit: 100,
+      totalEvents: 105,
+      exportedEvents: 100,
+      truncated: true,
+    });
+
+    const complete = brain.serialize({ episodicLimit: 105 });
+    expect(complete.episodic).toHaveLength(105);
+    expect(complete.metadata.episodicExport).toEqual({
+      limit: 105,
+      totalEvents: 105,
+      exportedEvents: 105,
+      truncated: false,
+    });
+    expect(() => brain.serialize({ episodicLimit: 0 })).toThrow(
+      'episodicLimit must be a positive safe integer',
+    );
+
+    const restored = SqliteBrain.hydrate(partial);
+    expect(restored.episodic.count()).toBe(100);
+
+    brain.close();
+    restored.close();
+  });
 });

--- a/packages/franken-orchestrator/src/providers/format-handoff.ts
+++ b/packages/franken-orchestrator/src/providers/format-handoff.ts
@@ -245,9 +245,21 @@ export function truncateSnapshot(
 
   // Phase 1: trim episodic events (oldest first, keep most recent)
   while (trimmed.episodic.length > 0 && estimateChars(trimmed) > maxChars) {
+    const episodic = trimmed.episodic.slice(1);
+    const episodicExport = trimmed.metadata.episodicExport;
     trimmed = {
       ...trimmed,
-      episodic: trimmed.episodic.slice(1),
+      episodic,
+      metadata: episodicExport
+        ? {
+            ...trimmed.metadata,
+            episodicExport: {
+              ...episodicExport,
+              exportedEvents: episodic.length,
+              truncated: episodic.length < episodicExport.totalEvents,
+            },
+          }
+        : trimmed.metadata,
     };
   }
 

--- a/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/format-handoff.test.ts
@@ -1624,6 +1624,39 @@ describe('truncateSnapshot', () => {
     expect(truncated.episodic[0]!.summary).not.toContain('Step 0');
   });
 
+  it('updates episodic export metadata when budget trimming drops events', () => {
+    const events = Array.from({ length: 50 }, (_, i) => ({
+      type: 'observation' as const,
+      summary: `Step ${i}: ${'x'.repeat(200)}`,
+      createdAt: '2026-03-22T00:00:00.000Z',
+    }));
+    const snapshot = makeSnapshot({
+      episodic: events,
+      metadata: {
+        lastProvider: 'claude-cli',
+        switchReason: 'rate-limit',
+        totalTokensUsed: 5000,
+        episodicExport: {
+          limit: 50,
+          totalEvents: 50,
+          exportedEvents: 50,
+          truncated: false,
+        },
+      },
+    });
+
+    const truncated = truncateSnapshot(snapshot, 500);
+
+    expect(truncated.metadata.episodicExport).toEqual({
+      limit: 50,
+      totalEvents: 50,
+      exportedEvents: truncated.episodic.length,
+      truncated: true,
+    });
+    expect(snapshot.metadata.episodicExport?.exportedEvents).toBe(50);
+    expect(snapshot.metadata.episodicExport?.truncated).toBe(false);
+  });
+
   it('trims working memory largest-values-first after episodic', () => {
     const snapshot = makeSnapshot({
       episodic: [],

--- a/packages/franken-types/src/brain.ts
+++ b/packages/franken-types/src/brain.ts
@@ -7,7 +7,12 @@ export interface IBrain {
   readonly episodic: IEpisodicMemory;
   readonly recovery: IRecoveryMemory;
   rightToForget(selector: RightToForgetSelector): RightToForgetReport;
-  serialize(): BrainSnapshot;
+  serialize(options?: BrainSerializeOptions): BrainSnapshot;
+}
+
+export interface BrainSerializeOptions {
+  /** Number of recent episodic events to include. Defaults to 100. */
+  episodicLimit?: number;
 }
 
 export type RightToForgetMemoryType = 'working' | 'episodic' | 'all';
@@ -143,6 +148,13 @@ export interface BrainSnapshot {
     lastProvider: string;
     switchReason: string;
     totalTokensUsed: number;
+    /** Describes the bounded episodic export. Missing on legacy snapshots. */
+    episodicExport?: {
+      limit: number;
+      totalEvents: number;
+      exportedEvents: number;
+      truncated: boolean;
+    };
   };
 }
 
@@ -190,5 +202,11 @@ export const BrainSnapshotSchema = z.object({
     lastProvider: z.string(),
     switchReason: z.string(),
     totalTokensUsed: z.number().nonnegative(),
+    episodicExport: z.object({
+      limit: z.number().int().positive(),
+      totalEvents: z.number().int().nonnegative(),
+      exportedEvents: z.number().int().nonnegative(),
+      truncated: z.boolean(),
+    }).optional(),
   }),
 });

--- a/packages/franken-types/src/brain.ts
+++ b/packages/franken-types/src/brain.ts
@@ -209,4 +209,33 @@ export const BrainSnapshotSchema = z.object({
       truncated: z.boolean(),
     }).optional(),
   }),
+}).superRefine((snapshot, ctx) => {
+  const episodicExport = snapshot.metadata.episodicExport;
+  if (!episodicExport) return;
+
+  if (episodicExport.exportedEvents !== snapshot.episodic.length) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['metadata', 'episodicExport', 'exportedEvents'],
+      message: 'exportedEvents must match the episodic event count',
+    });
+  }
+  if (episodicExport.exportedEvents > episodicExport.totalEvents) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['metadata', 'episodicExport', 'totalEvents'],
+      message: 'totalEvents must be at least exportedEvents',
+    });
+  }
+  if (
+    episodicExport.truncated !==
+    (episodicExport.exportedEvents < episodicExport.totalEvents)
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['metadata', 'episodicExport', 'truncated'],
+      message:
+        'truncated must indicate whether exportedEvents is less than totalEvents',
+    });
+  }
 });

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -76,6 +76,7 @@ export type {
   SkillFailureSignature,
   ExecutionState,
   BrainSnapshot,
+  BrainSerializeOptions,
   MemoryDeletionGuardSnapshot,
   RightToForgetMemoryType,
   RightToForgetSelector,

--- a/packages/franken-types/tests/brain.test.ts
+++ b/packages/franken-types/tests/brain.test.ts
@@ -76,6 +76,23 @@ describe('BrainSnapshot schema', () => {
     };
     expect(() => BrainSnapshotSchema.parse(bad)).toThrow();
   });
+
+  it('accepts explicit episodic export metadata', () => {
+    const snapshot: BrainSnapshot = {
+      ...validSnapshot,
+      metadata: {
+        ...validSnapshot.metadata,
+        episodicExport: {
+          limit: 100,
+          totalEvents: 125,
+          exportedEvents: 100,
+          truncated: true,
+        },
+      },
+    };
+
+    expect(BrainSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+  });
 });
 
 describe('EpisodicEvent schema', () => {

--- a/packages/franken-types/tests/brain.test.ts
+++ b/packages/franken-types/tests/brain.test.ts
@@ -84,14 +84,30 @@ describe('BrainSnapshot schema', () => {
         ...validSnapshot.metadata,
         episodicExport: {
           limit: 100,
-          totalEvents: 125,
-          exportedEvents: 100,
+          totalEvents: 2,
+          exportedEvents: 1,
           truncated: true,
         },
       },
     };
 
     expect(BrainSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+  });
+
+  it.each([
+    { exportedEvents: 2, totalEvents: 2, truncated: false },
+    { exportedEvents: 1, totalEvents: 0, truncated: false },
+    { exportedEvents: 1, totalEvents: 2, truncated: false },
+  ])('rejects inconsistent episodic export metadata: %o', (episodicExport) => {
+    const snapshot = {
+      ...validSnapshot,
+      metadata: {
+        ...validSnapshot.metadata,
+        episodicExport: { limit: 100, ...episodicExport },
+      },
+    };
+
+    expect(() => BrainSnapshotSchema.parse(snapshot)).toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- report bounded episodic export counts and truncation in snapshot metadata
- allow callers to raise the episodic export limit explicitly
- document that hydrate restores only the events present in partial snapshots

## Test plan
- `npm test` in `packages/franken-brain` (341 tests)
- `npm run test:integration --workspace @franken/brain -- brain-serialize-hydrate.test.ts`
- typecheck, lint, and build for `@franken/types` and `@franken/brain`

Closes #3142