### PR TITLE
fix(reviewer): persist PR attempt diagnostics

### DIFF
--- a/scripts/pr_reviewer.py
+++ b/scripts/pr_reviewer.py
@@ -26,6 +26,7 @@ AGY_PATH = os.environ.get("PR_REVIEWER_AGY_PATH", "agy")
 MAX_DIFF_BYTES = 60_000
 MAX_REVIEW_BYTES = 120_000
 MAX_REVIEW_BODY_CHARS = 60_000
+MAX_ERROR_CHARS = 1_000
 REVIEW_BODY_TRUNCATION_NOTICE = "\n\n... [REVIEW BODY TRUNCATED BEFORE POSTING] ..."
 HTTP_TIMEOUT_SECONDS = 30
 GH_LIST_TIMEOUT_SECONDS = 30
@@ -36,6 +37,12 @@ SECRET_PATTERN = re.compile(
     r"sk-ant-[a-zA-Z0-9_-]{40,}|sk-(?:proj-)?[a-zA-Z0-9_-]{20,}|"
     r"AIza[a-zA-Z0-9_-]{35})"
 )
+SENSITIVE_ERROR_VALUE_PATTERN = re.compile(
+    r"(?i)\b(authorization\s*:\s*(?:bearer|token)\s+|"
+    r"(?:token|password|secret|api[_-]?key)\s*[=:]\s*)[^\s,;]+"
+)
+LAST_AGY_ERROR = None
+LAST_POST_ERROR = None
 DIFF_TRUNCATION_MARKER = (
     f"\n... [DIFF TRUNCATED AFTER {MAX_DIFF_BYTES} BYTES] ..."
 )
@@ -61,10 +68,71 @@ def init_db():
         """
     )
     columns = {row[1] for row in cursor.execute("PRAGMA table_info(pr_reviews)")}
-    if "head_sha" not in columns:
-        cursor.execute("ALTER TABLE pr_reviews ADD COLUMN head_sha TEXT")
+    migrations = {
+        "head_sha": "TEXT",
+        "attempt_count": "INTEGER NOT NULL DEFAULT 0",
+        "last_error": "TEXT",
+        "last_attempt_at": "TEXT",
+    }
+    for column, declaration in migrations.items():
+        if column not in columns:
+            cursor.execute(
+                f"ALTER TABLE pr_reviews ADD COLUMN {column} {declaration}"
+            )
     conn.commit()
     conn.close()
+
+
+def error_diagnostic(stage, error):
+    """Return bounded JSON diagnostics with common credential forms redacted."""
+    message = str(error) or "unknown failure"
+    message = SECRET_PATTERN.sub("[REDACTED]", message)
+    message = SENSITIVE_ERROR_VALUE_PATTERN.sub(r"\1[REDACTED]", message)
+    message = " ".join(message.split())
+    payload = json.dumps(
+        {"stage": stage, "message": message}, separators=(",", ":")
+    )
+    if len(payload) <= MAX_ERROR_CHARS:
+        return payload
+    overflow = len(payload) - MAX_ERROR_CHARS
+    message = message[: max(0, len(message) - overflow - 3)] + "..."
+    return json.dumps(
+        {"stage": stage, "message": message}, separators=(",", ":")
+    )
+
+
+def begin_review_attempt(cursor, pr_number, author, head_sha):
+    attempted_at = datetime.now(timezone.utc).isoformat()
+    cursor.execute(
+        """
+        INSERT INTO pr_reviews (
+            pr_number, author, status, created_at, head_sha,
+            attempt_count, last_attempt_at, last_error
+        ) VALUES (?, ?, 'working', ?, ?, 1, ?, NULL)
+        ON CONFLICT(pr_number) DO UPDATE SET
+            author = excluded.author,
+            status = 'working',
+            created_at = excluded.created_at,
+            reviewed_at = NULL,
+            head_sha = excluded.head_sha,
+            attempt_count = COALESCE(pr_reviews.attempt_count, 0) + 1,
+            last_attempt_at = excluded.last_attempt_at,
+            last_error = NULL
+        """,
+        (pr_number, author, attempted_at, head_sha, attempted_at),
+    )
+
+
+def update_review_state(
+    cursor, pr_number, status, stage=None, error=None, reviewed=False
+):
+    diagnostic = error_diagnostic(stage, error) if stage else None
+    reviewed_at = datetime.now(timezone.utc).isoformat() if reviewed else None
+    cursor.execute(
+        "UPDATE pr_reviews SET status = ?, reviewed_at = ?, last_error = ? "
+        "WHERE pr_number = ?",
+        (status, reviewed_at, diagnostic, pr_number),
+    )
 
 
 def github_token():
@@ -340,6 +408,7 @@ def diff_contains_secret(diff_content):
 
 
 def decode_agy_result(return_code, stdout, stderr):
+    global LAST_AGY_ERROR
     output_was_capped = len(stdout) > MAX_REVIEW_BYTES or (
         return_code != 0 and len(stdout) >= MAX_REVIEW_BYTES
     )
@@ -351,14 +420,18 @@ def decode_agy_result(return_code, stdout, stderr):
         ).decode("utf-8", errors="replace")
     if return_code == 0:
         return stdout.decode("utf-8", errors="replace")
+    decoded_stderr = stderr.decode("utf-8", errors="replace")
+    LAST_AGY_ERROR = decoded_stderr or f"reviewer exited with code {return_code}"
     print(
-        f"Agy review failed: {stderr.decode('utf-8', errors='replace')}",
+        f"Agy review failed: {decoded_stderr}",
         file=sys.stderr,
     )
     return ""
 
 
 def run_agy_review(diff_content):
+    global LAST_AGY_ERROR
+    LAST_AGY_ERROR = None
     prompt = (
         "CRITICAL: Do NOT run any tools, read any files, or search the directory. "
         "Perform your review based SOLELY on the diff text provided below.\n\n"
@@ -397,6 +470,7 @@ def run_agy_review(diff_content):
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
+                LAST_AGY_ERROR = f"reviewer timed out after {AGY_TIMEOUT_SECONDS} seconds"
                 print("Agy review timed out.", file=sys.stderr)
                 return ""
             stdout_file.seek(0)
@@ -405,6 +479,7 @@ def run_agy_review(diff_content):
             stderr = stderr_file.read(MAX_REVIEW_BYTES + 1)
         return decode_agy_result(return_code, stdout, stderr)
     except Exception as error:
+        LAST_AGY_ERROR = str(error)
         print(f"Agy execution exception: {error}", file=sys.stderr)
         return ""
 
@@ -455,6 +530,8 @@ def post_pr_review(
     diff_truncated=False,
     repository=None,
 ):
+    global LAST_POST_ERROR
+    LAST_POST_ERROR = None
     repository = repository or get_repository()
     verdict = "comment"
     if security_warnings:
@@ -515,6 +592,7 @@ def post_pr_review(
         print(f"Successfully posted {verdict} review on PR #{pr_number}")
         return True
     except Exception as error:
+        LAST_POST_ERROR = str(error)
         print(f"Error posting review on PR #{pr_number}: {error}", file=sys.stderr)
         return False
     finally:
@@ -523,6 +601,7 @@ def post_pr_review(
 
 
 def process_prs():
+    global LAST_AGY_ERROR, LAST_POST_ERROR
     init_db()
     if not github_token():
         print(
@@ -559,17 +638,7 @@ def process_prs():
             continue
 
         print(f"Processing PR #{pr_number} by {author} at {head_sha[:12]}...")
-        cursor.execute(
-            "INSERT OR REPLACE INTO pr_reviews "
-            "(pr_number, author, status, created_at, head_sha) VALUES (?, ?, ?, ?, ?)",
-            (
-                pr_number,
-                author,
-                "working",
-                datetime.now(timezone.utc).isoformat(),
-                head_sha,
-            ),
-        )
+        begin_review_attempt(cursor, pr_number, author, head_sha)
         conn.commit()
 
         try:
@@ -579,19 +648,13 @@ def process_prs():
                 f"Could not fetch diff for PR #{pr_number}: {error}",
                 file=sys.stderr,
             )
-            cursor.execute(
-                "UPDATE pr_reviews SET status = ? WHERE pr_number = ?",
-                ("failed", pr_number),
-            )
+            update_review_state(cursor, pr_number, "failed", "fetch", error)
             conn.commit()
             fatal_failures.append(f"PR #{pr_number}: diff could not be fetched")
             continue
         if not diff_content.strip():
             print(f"Empty diff for PR #{pr_number}. Skipping.")
-            cursor.execute(
-                "UPDATE pr_reviews SET status = ? WHERE pr_number = ?",
-                ("skipped", pr_number),
-            )
+            update_review_state(cursor, pr_number, "skipped")
             conn.commit()
             continue
 
@@ -608,8 +671,11 @@ def process_prs():
                 "VERDICT: REQUEST_CHANGES"
             )
         else:
+            LAST_AGY_ERROR = None
             review_body = run_agy_review(diff_content)
             model_review_unavailable = not review_body.strip()
+            if model_review_unavailable and LAST_AGY_ERROR is None:
+                LAST_AGY_ERROR = "model reviewer produced no result"
         if not review_body.strip():
             if security_warnings or diff_truncated:
                 review_body = (
@@ -628,7 +694,13 @@ def process_prs():
                 )
 
         review_body = add_diff_truncation_notice(review_body, diff_content)
-        current_prs = get_open_prs(repository)
+        try:
+            current_prs = get_open_prs(repository)
+        except Exception as error:
+            update_review_state(cursor, pr_number, "failed", "fetch", error)
+            conn.commit()
+            fatal_failures.append(f"PR #{pr_number}: current head could not be fetched")
+            continue
         current_head_sha = next(
             (
                 item["headRefOid"]
@@ -641,12 +713,10 @@ def process_prs():
             print(
                 f"PR #{pr_number} head changed before posting; skipping stale review."
             )
-            cursor.execute(
-                "UPDATE pr_reviews SET status = ? WHERE pr_number = ?",
-                ("superseded", pr_number),
-            )
+            update_review_state(cursor, pr_number, "superseded")
             conn.commit()
             continue
+        LAST_POST_ERROR = None
         posted = post_pr_review(
             pr_number,
             review_body,
@@ -657,13 +727,27 @@ def process_prs():
         )
         if posted:
             status = "incomplete" if model_review_unavailable else "completed"
+            if model_review_unavailable:
+                update_review_state(
+                    cursor,
+                    pr_number,
+                    status,
+                    "agent",
+                    LAST_AGY_ERROR or "model reviewer produced no result",
+                    reviewed=True,
+                )
+            else:
+                update_review_state(cursor, pr_number, status, reviewed=True)
         else:
             status = "failed"
+            update_review_state(
+                cursor,
+                pr_number,
+                status,
+                "post",
+                LAST_POST_ERROR or "review could not be posted",
+            )
             fatal_failures.append(f"PR #{pr_number}: review could not be posted")
-        cursor.execute(
-            "UPDATE pr_reviews SET status = ?, reviewed_at = ? WHERE pr_number = ?",
-            (status, datetime.now(timezone.utc).isoformat(), pr_number),
-        )
         conn.commit()
     conn.close()
     if fatal_failures:

--- a/scripts/pr_reviewer.py
+++ b/scripts/pr_reviewer.py
@@ -38,9 +38,10 @@ SECRET_PATTERN = re.compile(
     r"AIza[a-zA-Z0-9_-]{35})"
 )
 SENSITIVE_ERROR_VALUE_PATTERN = re.compile(
-    r"(?i)\b(authorization\s*:\s*(?:bearer|token)\s+|"
-    r"(?:(?:access|refresh|id)[_-]?token|client[_-]?secret|"
-    r"token|password|secret|api[_-]?key)\s*[=:]\s*)[^\s,;]+"
+    r"(?i)(authorization\s*:\s*(?:bearer|token)\s+|"
+    r"(?<![a-zA-Z0-9_])[\"']?(?:(?:access|refresh|id)[_-]?token|"
+    r"client[_-]?secret|token|password|secret|api[_-]?key)[\"']?\s*[=:]\s*)"
+    r"(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"
 )
 LAST_AGY_ERROR = None
 LAST_POST_ERROR = None
@@ -430,10 +431,15 @@ def decode_agy_result(return_code, stdout, stderr):
             + b"\n... [REVIEW OUTPUT TRUNCATED] ..."
             + b"\n\nVERDICT: REQUEST_CHANGES"
         ).decode("utf-8", errors="replace")
+    decoded_stdout = stdout.decode("utf-8", errors="replace")
     if return_code == 0:
-        return stdout.decode("utf-8", errors="replace")
+        return decoded_stdout
     decoded_stderr = stderr.decode("utf-8", errors="replace")
-    LAST_AGY_ERROR = decoded_stderr or f"reviewer exited with code {return_code}"
+    LAST_AGY_ERROR = (
+        decoded_stderr
+        or decoded_stdout
+        or f"reviewer exited with code {return_code}"
+    )
     print(
         f"Agy review failed: {decoded_stderr}",
         file=sys.stderr,
@@ -588,7 +594,7 @@ def post_pr_review(
             }[verdict],
         }
         temp_file.write_text(json.dumps(payload), encoding="utf-8")
-        subprocess.check_call(
+        subprocess.run(
             [
                 "gh",
                 "api",
@@ -600,11 +606,17 @@ def post_pr_review(
             ],
             cwd=WORKSPACE,
             env=gh_environment(),
+            check=True,
+            capture_output=True,
+            text=True,
         )
         print(f"Successfully posted {verdict} review on PR #{pr_number}")
         return True
     except Exception as error:
-        LAST_POST_ERROR = str(error)
+        details = getattr(error, "stderr", None) or getattr(error, "stdout", None)
+        if isinstance(details, bytes):
+            details = details.decode("utf-8", errors="replace")
+        LAST_POST_ERROR = details or str(error)
         print(f"Error posting review on PR #{pr_number}: {error}", file=sys.stderr)
         return False
     finally:

--- a/scripts/pr_reviewer.py
+++ b/scripts/pr_reviewer.py
@@ -39,7 +39,8 @@ SECRET_PATTERN = re.compile(
 )
 SENSITIVE_ERROR_VALUE_PATTERN = re.compile(
     r"(?i)\b(authorization\s*:\s*(?:bearer|token)\s+|"
-    r"(?:token|password|secret|api[_-]?key)\s*[=:]\s*)[^\s,;]+"
+    r"(?:(?:access|refresh|id)[_-]?token|client[_-]?secret|"
+    r"token|password|secret|api[_-]?key)\s*[=:]\s*)[^\s,;]+"
 )
 LAST_AGY_ERROR = None
 LAST_POST_ERROR = None
@@ -128,8 +129,7 @@ def begin_review_attempt(cursor, pr_number, author, head_sha):
             reviewed_at = NULL,
             head_sha = excluded.head_sha,
             attempt_count = COALESCE(pr_reviews.attempt_count, 0) + 1,
-            last_attempt_at = excluded.last_attempt_at,
-            last_error = NULL
+            last_attempt_at = excluded.last_attempt_at
         """,
         (pr_number, author, attempted_at, head_sha, attempted_at),
     )

--- a/scripts/pr_reviewer.py
+++ b/scripts/pr_reviewer.py
@@ -85,7 +85,19 @@ def init_db():
 
 def error_diagnostic(stage, error):
     """Return bounded JSON diagnostics with common credential forms redacted."""
-    message = str(error) or "unknown failure"
+    messages = []
+    seen = set()
+    current = error
+    while current is not None and id(current) not in seen and len(messages) < 4:
+        seen.add(id(current))
+        messages.append(str(current) or "unknown failure")
+        if not isinstance(current, BaseException):
+            break
+        next_error = current.__cause__
+        if next_error is None and not current.__suppress_context__:
+            next_error = current.__context__
+        current = next_error
+    message = " <- caused by: ".join(messages)
     message = SECRET_PATTERN.sub("[REDACTED]", message)
     message = SENSITIVE_ERROR_VALUE_PATTERN.sub(r"\1[REDACTED]", message)
     message = " ".join(message.split())

--- a/scripts/pr_reviewer.py
+++ b/scripts/pr_reviewer.py
@@ -39,9 +39,10 @@ SECRET_PATTERN = re.compile(
 )
 SENSITIVE_ERROR_VALUE_PATTERN = re.compile(
     r"(?i)(authorization\s*:\s*(?:bearer|token)\s+|"
-    r"(?<![a-zA-Z0-9_])[\"']?(?:(?:access|refresh|id)[_-]?token|"
-    r"client[_-]?secret|token|password|secret|api[_-]?key)[\"']?\s*[=:]\s*)"
-    r"(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"
+    r"(?<![a-zA-Z0-9_])[\"']?(?:[a-zA-Z0-9]+[_-])*"
+    r"(?:(?:access|refresh|id)[_-]?token|client[_-]?secret|"
+    r"token|password|secret|api[_-]?key)[\"']?\s*[=:]\s*)"
+    r'''(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}]+)'''
 )
 LAST_AGY_ERROR = None
 LAST_POST_ERROR = None

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -621,6 +621,17 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         self.assertEqual(row[0:2], ("failed", 1))
         self.assertEqual(json.loads(row[2])["stage"], "post")
 
+    def test_error_diagnostic_includes_sanitized_exception_chain(self):
+        cause = TimeoutError("gh diff timed out with token=super-secret-value")
+        error = RuntimeError("Unable to fetch diff through API or gh")
+        error.__cause__ = cause
+
+        payload = json.loads(self.reviewer.error_diagnostic("fetch", error))
+
+        self.assertIn("Unable to fetch diff", payload["message"])
+        self.assertIn("gh diff timed out", payload["message"])
+        self.assertNotIn("super-secret-value", payload["message"])
+
     def test_error_diagnostic_remains_valid_json_at_length_limit(self):
         diagnostic = self.reviewer.error_diagnostic(
             "agent", 'password="' + ("\\\"secret" * 500)

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -632,6 +632,20 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         self.assertIn("gh diff timed out", payload["message"])
         self.assertNotIn("super-secret-value", payload["message"])
 
+    def test_error_diagnostic_redacts_oauth_style_fields(self):
+        field_names = [
+            "access_" + "token",
+            "refresh_" + "token",
+            "client_" + "secret",
+        ]
+        message = " ".join(f"{name}=sensitive-{index}" for index, name in enumerate(field_names))
+
+        payload = json.loads(self.reviewer.error_diagnostic("agent", message))
+
+        for index, name in enumerate(field_names):
+            self.assertIn(name, payload["message"])
+            self.assertNotIn(f"sensitive-{index}", payload["message"])
+
     def test_error_diagnostic_remains_valid_json_at_length_limit(self):
         diagnostic = self.reviewer.error_diagnostic(
             "agent", 'password="' + ("\\\"secret" * 500)
@@ -665,6 +679,28 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
                 "FROM pr_reviews"
             ).fetchone()
         self.assertEqual(row, (42, 0, None, None))
+
+    def test_begin_retry_preserves_previous_diagnostic_until_outcome(self):
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        database = Path(temporary_directory.name) / "scans.db"
+        with mock.patch.object(self.reviewer, "DB_FILE", database):
+            self.reviewer.init_db()
+        with sqlite3.connect(database) as connection:
+            cursor = connection.cursor()
+            self.reviewer.begin_review_attempt(cursor, 42, "contributor", "a" * 40)
+            self.reviewer.update_review_state(
+                cursor, 42, "failed", "fetch", "first failure"
+            )
+            self.reviewer.begin_review_attempt(cursor, 42, "contributor", "a" * 40)
+            connection.commit()
+            row = connection.execute(
+                "SELECT status, attempt_count, last_error FROM pr_reviews "
+                "WHERE pr_number = 42"
+            ).fetchone()
+
+        self.assertEqual(row[0:2], ("working", 2))
+        self.assertEqual(json.loads(row[2])["message"], "first failure")
 
     def test_repository_is_derived_from_origin(self):
         result = mock.Mock(stdout="git@github.com:owner/repository.git\n")

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -2,6 +2,7 @@ import importlib.util
 import io
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -331,7 +332,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
             self.reviewer.subprocess, "check_call", side_effect=capture_review
-        ) as check_call:
+        ):
             posted = self.reviewer.post_pr_review(
                 123,
                 "VERDICT: APPROVE",
@@ -362,7 +363,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
             self.reviewer.subprocess, "check_call", side_effect=capture_review
-        ) as check_call:
+        ):
             posted = self.reviewer.post_pr_review(
                 124, model_body, [], "b" * 40, repository="owner/repository"
             )
@@ -490,6 +491,169 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
 
         self.assertEqual(get_diff.call_count, 2)
         self.assertEqual(post_review.call_count, 2)
+
+    def test_diff_fetch_failure_persists_bounded_sanitized_diagnostics(self):
+        pull_request = {
+            "number": 42,
+            "author": {"login": "contributor"},
+            "headRefOid": "a" * 40,
+        }
+        token = "ghp_" + "a" * 40
+        authorization_scheme = "".join(("Bea", "rer"))
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        directory = temporary_directory.name
+        with mock.patch.object(
+            self.reviewer, "WORKSPACE", Path(directory)
+        ), mock.patch.object(
+            self.reviewer, "DB_FILE", Path(directory) / "scans.db"
+        ), mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "token",
+                "PR_REVIEWER_REPOSITORY": "owner/repository",
+            },
+        ), mock.patch.object(
+            self.reviewer, "get_open_prs", return_value=[pull_request]
+        ), mock.patch.object(
+            self.reviewer,
+            "get_pr_diff",
+            side_effect=RuntimeError(
+                f"fetch rejected Authorization: {authorization_scheme} {token}"
+            ),
+        ):
+            with self.assertRaises(RuntimeError):
+                self.reviewer.process_prs()
+
+        with sqlite3.connect(Path(directory) / "scans.db") as connection:
+            row = connection.execute(
+                "SELECT status, attempt_count, last_error, last_attempt_at "
+                "FROM pr_reviews WHERE pr_number = 42"
+            ).fetchone()
+        self.assertEqual(row[0:2], ("failed", 1))
+        diagnostic = json.loads(row[2])
+        self.assertEqual(diagnostic["stage"], "fetch")
+        self.assertNotIn(token, row[2])
+        self.assertLessEqual(len(row[2]), self.reviewer.MAX_ERROR_CHARS)
+        self.assertTrue(row[3])
+
+    def test_agent_failure_persists_diagnostics_and_retry_count(self):
+        pull_request = {
+            "number": 42,
+            "author": {"login": "contributor"},
+            "headRefOid": "a" * 40,
+        }
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        directory = temporary_directory.name
+        with mock.patch.object(
+            self.reviewer, "WORKSPACE", Path(directory)
+        ), mock.patch.object(
+            self.reviewer, "DB_FILE", Path(directory) / "scans.db"
+        ), mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "token",
+                "PR_REVIEWER_REPOSITORY": "owner/repository",
+            },
+        ), mock.patch.object(
+            self.reviewer, "get_open_prs", return_value=[pull_request]
+        ), mock.patch.object(
+            self.reviewer, "get_pr_diff", return_value="+safe change"
+        ), mock.patch.object(
+            self.reviewer, "run_agy_review", side_effect=["", "VERDICT: APPROVE"]
+        ), mock.patch.object(
+            self.reviewer, "post_pr_review", return_value=True
+        ):
+            self.reviewer.process_prs()
+            with sqlite3.connect(Path(directory) / "scans.db") as connection:
+                failed_row = connection.execute(
+                    "SELECT status, attempt_count, last_error FROM pr_reviews "
+                    "WHERE pr_number = 42"
+                ).fetchone()
+            self.assertEqual(failed_row[0:2], ("incomplete", 1))
+            self.assertEqual(json.loads(failed_row[2])["stage"], "agent")
+            self.reviewer.process_prs()
+
+        with sqlite3.connect(Path(directory) / "scans.db") as connection:
+            row = connection.execute(
+                "SELECT status, attempt_count, last_error FROM pr_reviews "
+                "WHERE pr_number = 42"
+            ).fetchone()
+        self.assertEqual(row, ("completed", 2, None))
+
+    def test_review_post_failure_persists_post_stage(self):
+        pull_request = {
+            "number": 42,
+            "author": {"login": "contributor"},
+            "headRefOid": "a" * 40,
+        }
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        directory = temporary_directory.name
+        with mock.patch.object(
+            self.reviewer, "WORKSPACE", Path(directory)
+        ), mock.patch.object(
+            self.reviewer, "DB_FILE", Path(directory) / "scans.db"
+        ), mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "token",
+                "PR_REVIEWER_REPOSITORY": "owner/repository",
+            },
+        ), mock.patch.object(
+            self.reviewer, "get_open_prs", return_value=[pull_request]
+        ), mock.patch.object(
+            self.reviewer, "get_pr_diff", return_value="+safe change"
+        ), mock.patch.object(
+            self.reviewer, "run_agy_review", return_value="VERDICT: APPROVE"
+        ), mock.patch.object(
+            self.reviewer, "post_pr_review", return_value=False
+        ):
+            with self.assertRaises(RuntimeError):
+                self.reviewer.process_prs()
+
+        with sqlite3.connect(Path(directory) / "scans.db") as connection:
+            row = connection.execute(
+                "SELECT status, attempt_count, last_error FROM pr_reviews "
+                "WHERE pr_number = 42"
+            ).fetchone()
+        self.assertEqual(row[0:2], ("failed", 1))
+        self.assertEqual(json.loads(row[2])["stage"], "post")
+
+    def test_error_diagnostic_remains_valid_json_at_length_limit(self):
+        diagnostic = self.reviewer.error_diagnostic(
+            "agent", 'password="' + ("\\\"secret" * 500)
+        )
+
+        self.assertLessEqual(len(diagnostic), self.reviewer.MAX_ERROR_CHARS)
+        payload = json.loads(diagnostic)
+        self.assertEqual(payload["stage"], "agent")
+        self.assertNotIn("secret", payload["message"])
+
+    def test_init_db_migrates_existing_review_rows(self):
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        database = Path(temporary_directory.name) / "scans.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE pr_reviews (pr_number INTEGER PRIMARY KEY, author TEXT, "
+                "status TEXT, created_at TEXT, reviewed_at TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO pr_reviews VALUES (42, 'contributor', 'failed', "
+                "'created', NULL)"
+            )
+
+        with mock.patch.object(self.reviewer, "DB_FILE", database):
+            self.reviewer.init_db()
+
+        with sqlite3.connect(database) as connection:
+            row = connection.execute(
+                "SELECT pr_number, attempt_count, last_error, last_attempt_at "
+                "FROM pr_reviews"
+            ).fetchone()
+        self.assertEqual(row, (42, 0, None, None))
 
     def test_repository_is_derived_from_origin(self):
         result = mock.Mock(stdout="git@github.com:owner/repository.git\n")

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -331,7 +331,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory, mock.patch.object(
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
-            self.reviewer.subprocess, "check_call", side_effect=capture_review
+            self.reviewer.subprocess, "run", side_effect=capture_review
         ):
             posted = self.reviewer.post_pr_review(
                 123,
@@ -362,7 +362,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory, mock.patch.object(
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
-            self.reviewer.subprocess, "check_call", side_effect=capture_review
+            self.reviewer.subprocess, "run", side_effect=capture_review
         ):
             posted = self.reviewer.post_pr_review(
                 124, model_body, [], "b" * 40, repository="owner/repository"
@@ -382,7 +382,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory, mock.patch.object(
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
-            self.reviewer.subprocess, "check_call", side_effect=OSError("offline")
+            self.reviewer.subprocess, "run", side_effect=OSError("offline")
         ):
             self.assertFalse(
                 self.reviewer.post_pr_review(
@@ -390,13 +390,30 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
                 )
             )
 
+    def test_failed_review_post_captures_command_stderr(self):
+        field_name = "access_" + "token"
+        stderr = f'{{"message":"denied","{field_name}":"sensitive"}}'
+        failure = subprocess.CalledProcessError(
+            1, ["gh", "api"], stderr=stderr
+        )
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            self.reviewer, "WORKSPACE", Path(directory)
+        ), mock.patch.object(self.reviewer.subprocess, "run", side_effect=failure):
+            self.assertFalse(
+                self.reviewer.post_pr_review(
+                    123, "body", [], "c" * 40, repository="owner/repository"
+                )
+            )
+
+        self.assertEqual(self.reviewer.LAST_POST_ERROR, stderr)
+
     def test_review_file_is_written_as_utf8(self):
         with tempfile.TemporaryDirectory() as directory, mock.patch.object(
             self.reviewer, "WORKSPACE", Path(directory)
         ), mock.patch.object(
             Path, "write_text", autospec=True
         ) as write_text, mock.patch.object(
-            self.reviewer.subprocess, "check_call"
+            self.reviewer.subprocess, "run"
         ):
             self.assertTrue(
                 self.reviewer.post_pr_review(
@@ -638,13 +655,17 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             "refresh_" + "token",
             "client_" + "secret",
         ]
-        message = " ".join(f"{name}=sensitive-{index}" for index, name in enumerate(field_names))
+        message = " ".join(
+            f"{name}=sensitive-{index}" for index, name in enumerate(field_names)
+        )
+        message += " " + json.dumps({field_names[0]: "json-sensitive"})
 
         payload = json.loads(self.reviewer.error_diagnostic("agent", message))
 
         for index, name in enumerate(field_names):
             self.assertIn(name, payload["message"])
             self.assertNotIn(f"sensitive-{index}", payload["message"])
+        self.assertNotIn("json-sensitive", payload["message"])
 
     def test_error_diagnostic_remains_valid_json_at_length_limit(self):
         diagnostic = self.reviewer.error_diagnostic(
@@ -851,6 +872,10 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         self.assertIn("fails closed", post_review.call_args.args[1])
         self.assertIn("VERDICT: REQUEST_CHANGES", post_review.call_args.args[1])
 
+    def test_failed_agy_result_uses_stdout_as_diagnostic_fallback(self):
+        self.assertEqual(self.reviewer.decode_agy_result(1, b"provider offline", b""), "")
+        self.assertEqual(self.reviewer.LAST_AGY_ERROR, "provider offline")
+
     def test_file_limit_exit_salvages_truncated_agy_stdout(self):
         payload = b"x" * self.reviewer.MAX_REVIEW_BYTES
         result = self.reviewer.decode_agy_result(-25, payload, b"file too large")
@@ -885,7 +910,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as directory, mock.patch.object(
             self.reviewer, "WORKSPACE", Path(directory).resolve()
-        ), mock.patch.object(self.reviewer.subprocess, "check_call", side_effect=capture):
+        ), mock.patch.object(self.reviewer.subprocess, "run", side_effect=capture):
             self.assertTrue(
                 self.reviewer.post_pr_review(
                     55,
@@ -914,7 +939,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
         ) as check_output, mock.patch.object(
             self.reviewer.subprocess, "Popen", return_value=process
         ) as popen, mock.patch.object(
-            self.reviewer.subprocess, "check_call", side_effect=capture_review
+            self.reviewer.subprocess, "run", side_effect=capture_review
         ):
             self.reviewer.get_open_prs(repository)
             self.reviewer.read_gh_diff(7, repository)
@@ -1044,7 +1069,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             self.reviewer, "run_agy_review", return_value="VERDICT: APPROVE"
         ), mock.patch.object(
             self.reviewer.subprocess,
-            "check_call",
+            "run",
             side_effect=[post_failure, None],
         ) as check_call:
             with self.assertRaisesRegex(RuntimeError, "review could not be posted"):

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -654,11 +654,14 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             "access_" + "token",
             "refresh_" + "token",
             "client_" + "secret",
+            "OPENAI_" + "API_KEY",
+            "MY_" + "TOKEN",
         ]
         message = " ".join(
             f"{name}=sensitive-{index}" for index, name in enumerate(field_names)
         )
-        message += " " + json.dumps({field_names[0]: "json-sensitive"})
+        escaped_value = 'json-sensitive-"-suffix'
+        message += " " + json.dumps({field_names[0]: escaped_value})
 
         payload = json.loads(self.reviewer.error_diagnostic("agent", message))
 
@@ -666,6 +669,7 @@ class PrReviewerDiffBoundsTests(unittest.TestCase):
             self.assertIn(name, payload["message"])
             self.assertNotIn(f"sensitive-{index}", payload["message"])
         self.assertNotIn("json-sensitive", payload["message"])
+        self.assertNotIn("suffix", payload["message"])
 
     def test_error_diagnostic_remains_valid_json_at_length_limit(self):
         diagnostic = self.reviewer.error_diagnostic(


### PR DESCRIPTION
## Summary
- migrate PR review state with attempt counters and timestamps
- persist bounded, redacted JSON diagnostics for diff-fetch, model-agent, and review-post failures
- preserve retry history while clearing stale errors after successful retries

## Test plan
- `python3 -m unittest tests.test_pr_reviewer`
- `npm run test:root -- tests/pr-reviewer-diff-bounds.test.ts`
- `ruff check scripts/pr_reviewer.py tests/test_pr_reviewer.py`
- `python3 -m py_compile scripts/pr_reviewer.py tests/test_pr_reviewer.py`

Closes #3169