### PR TITLE
perf(planner): make topo sort queue linear

### DIFF
--- a/packages/franken-planner/src/core/dag.ts
+++ b/packages/franken-planner/src/core/dag.ts
@@ -371,8 +371,10 @@ export class PlanGraph {
     }
 
     const sorted: TaskId[] = [];
-    while (queue.length > 0) {
-      const current = queue.shift() as TaskId;
+    let queueHead = 0;
+    while (queueHead < queue.length) {
+      const current = queue[queueHead] as TaskId;
+      queueHead += 1;
       sorted.push(current);
       for (const dependent of dependents.get(current) ?? []) {
         const newDeg = (inDegree.get(dependent) ?? 0) - 1;

--- a/packages/franken-planner/tests/unit/core/dag.test.ts
+++ b/packages/franken-planner/tests/unit/core/dag.test.ts
@@ -239,6 +239,26 @@ describe('PlanGraph — topoSort', () => {
     expect(sorted).toContainEqual(a);
     expect(sorted).toContainEqual(b);
   });
+
+  it('does not dequeue ready tasks with linear-time front removal', () => {
+    const tasks = Array.from({ length: 1_024 }, (_, index) => makeTask(`task-${index}`));
+    const originalShift = Array.prototype.shift;
+    let taskQueueShiftCalls = 0;
+    Array.prototype.shift = function <T>(this: T[]): T | undefined {
+      if (typeof this[0] === 'string' && this[0].startsWith('task-')) {
+        taskQueueShiftCalls += 1;
+      }
+      return originalShift.call(this) as T | undefined;
+    };
+
+    try {
+      PlanGraph.fromTasks(tasks).topoSort();
+    } finally {
+      Array.prototype.shift = originalShift;
+    }
+
+    expect(taskQueueShiftCalls).toBe(0);
+  });
 });
 
 // ─── Cycle Detection ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace `Array.shift()` in Kahn traversal with an index-based queue head
- add a 1,024-task regression that detects linear-time front removal
- preserve topological ordering and cycle behavior while restoring O(V + E) traversal

## Verification
- `npm test` (planner): 248 passed
- `npm run typecheck` (planner)
- `npm run lint` (planner)
- `npm run build` (planner)

Closes #3573