### PR TITLE
fix(brain): normalize episodic recall punctuation

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -8182,8 +8182,8 @@ const STOPWORDS = new Set([
 
 // --- Helpers ---
 
-const RECALL_LITERAL_LIKE_CHARACTERS = new Set(['%', '_', '\\']);
-const RECALL_BOUNDARY_PUNCTUATION = /[\p{P}\p{S}]/u;
+const RECALL_LEADING_WRAPPERS = new Set(Array.from('"\'`“‘«‹([{<（［｛〈《「『【〔〖〘〚,;:!?，；：！？'));
+const RECALL_TRAILING_WRAPPERS = new Set(Array.from('"\'`”’»›)]}>）］｝〉》」』】〕〗〙〛.,;:!?。，；：！？'));
 
 function normalizeRecallKeywords(query: string): string[] {
   return query
@@ -8193,23 +8193,15 @@ function normalizeRecallKeywords(query: string): string[] {
       const characters = Array.from(word);
       let start = 0;
       let end = characters.length;
-      while (
-        start < end
-        && RECALL_BOUNDARY_PUNCTUATION.test(characters[start]!)
-        && !RECALL_LITERAL_LIKE_CHARACTERS.has(characters[start]!)
-      ) {
+      while (start < end && RECALL_LEADING_WRAPPERS.has(characters[start]!)) {
         start += 1;
       }
-      while (
-        end > start
-        && RECALL_BOUNDARY_PUNCTUATION.test(characters[end - 1]!)
-        && !RECALL_LITERAL_LIKE_CHARACTERS.has(characters[end - 1]!)
-      ) {
+      while (end > start && RECALL_TRAILING_WRAPPERS.has(characters[end - 1]!)) {
         end -= 1;
       }
       return characters.slice(start, end).join('');
     })
-    .filter((word) => word.length > 2)
+    .filter((word) => word.length > 2 || /^[\p{L}\p{N}]#$/u.test(word))
     .filter((word) => !STOPWORDS.has(word));
 }
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -2879,11 +2879,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       if (this.encryption) {
         result = this.recallEncrypted(query, limit, reportCorruptDetails);
       } else {
-        const keywords = query
-          .toLowerCase()
-          .split(/\s+/)
-          .filter((w) => w.length > 2)
-          .filter((w) => !STOPWORDS.has(w));
+        const keywords = normalizeRecallKeywords(query);
 
         if (keywords.length === 0) {
           result = this.recent(limit, reportCorruptDetails);
@@ -2955,11 +2951,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     reportCorruptDetails?: CorruptEpisodicDetailsReporter,
   ): EpisodicEvent[] {
     if (limit === 0) return [];
-    const keywords = query
-      .toLowerCase()
-      .split(/\s+/)
-      .filter((w) => w.length > 2)
-      .filter((w) => !STOPWORDS.has(w));
+    const keywords = normalizeRecallKeywords(query);
     if (keywords.length === 0) {
       return this.recent(limit, reportCorruptDetails);
     }
@@ -8189,6 +8181,37 @@ const STOPWORDS = new Set([
 ]);
 
 // --- Helpers ---
+
+const RECALL_LITERAL_LIKE_CHARACTERS = new Set(['%', '_', '\\']);
+const RECALL_BOUNDARY_PUNCTUATION = /[\p{P}\p{S}]/u;
+
+function normalizeRecallKeywords(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((word) => {
+      const characters = Array.from(word);
+      let start = 0;
+      let end = characters.length;
+      while (
+        start < end
+        && RECALL_BOUNDARY_PUNCTUATION.test(characters[start]!)
+        && !RECALL_LITERAL_LIKE_CHARACTERS.has(characters[start]!)
+      ) {
+        start += 1;
+      }
+      while (
+        end > start
+        && RECALL_BOUNDARY_PUNCTUATION.test(characters[end - 1]!)
+        && !RECALL_LITERAL_LIKE_CHARACTERS.has(characters[end - 1]!)
+      ) {
+        end -= 1;
+      }
+      return characters.slice(start, end).join('');
+    })
+    .filter((word) => word.length > 2)
+    .filter((word) => !STOPWORDS.has(word));
+}
 
 const MAX_SKILL_EVOLUTION_TEXT_LENGTH = 240;
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -8186,23 +8186,31 @@ const RECALL_LEADING_WRAPPERS = new Set(Array.from('"\'`“‘«‹([{<（［｛
 const RECALL_TRAILING_WRAPPERS = new Set(Array.from('"\'`”’»›)]}>）］｝〉》」』】〕〗〙〛.,;:!?。，；：！？'));
 
 function normalizeRecallKeywords(query: string): string[] {
-  return query
-    .toLowerCase()
-    .split(/\s+/)
-    .map((word) => {
-      const characters = Array.from(word);
-      let start = 0;
-      let end = characters.length;
-      while (start < end && RECALL_LEADING_WRAPPERS.has(characters[start]!)) {
-        start += 1;
-      }
-      while (end > start && RECALL_TRAILING_WRAPPERS.has(characters[end - 1]!)) {
-        end -= 1;
-      }
-      return characters.slice(start, end).join('');
-    })
-    .filter((word) => word.length > 2 || /^[\p{L}\p{N}]#$/u.test(word))
-    .filter((word) => !STOPWORDS.has(word));
+  const primaryKeywords: string[] = [];
+  const literalAlternates: string[] = [];
+
+  for (const word of query.toLowerCase().split(/\s+/)) {
+    const characters = Array.from(word);
+    let start = 0;
+    let end = characters.length;
+    while (start < end && RECALL_LEADING_WRAPPERS.has(characters[start]!)) {
+      start += 1;
+    }
+    while (end > start && RECALL_TRAILING_WRAPPERS.has(characters[end - 1]!)) {
+      end -= 1;
+    }
+
+    const normalized = characters.slice(start, end).join('');
+    if (normalized && STOPWORDS.has(normalized)) continue;
+    if (isSearchableRecallKeyword(normalized)) primaryKeywords.push(normalized);
+    if (word !== normalized && isSearchableRecallKeyword(word)) literalAlternates.push(word);
+  }
+
+  return [...new Set([...primaryKeywords, ...literalAlternates])];
+}
+
+function isSearchableRecallKeyword(word: string): boolean {
+  return word.length > 2 || /^[\p{L}\p{N}]#$/u.test(word);
 }
 
 const MAX_SKILL_EVOLUTION_TEXT_LENGTH = 240;

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -82,14 +82,65 @@ describe('EpisodicMemory.recall()', () => {
     expect(results[0]!.createdAt).toBe('2026-03-18T11:00:00Z');
   });
 
-  it('handles LIKE wildcard characters in query', () => {
+  it('normalizes surrounding punctuation before ranking keyword matches', () => {
     brain.episodic.record({
-      type: 'observation',
-      summary: '100% completion rate achieved',
+      type: 'failure',
+      summary: 'error timeout',
       createdAt: '2026-03-18T10:30:00Z',
     });
-    const results = brain.episodic.recall('100%');
-    expect(results.length).toBeGreaterThan(0);
-    expect(results[0]!.summary).toContain('100%');
+    brain.episodic.record({
+      type: 'failure',
+      summary: 'timeout',
+      createdAt: '2026-03-18T10:31:00Z',
+    });
+
+    const results = brain.episodic.recall('error: timeout');
+
+    expect(results[0]!.summary).toBe('error timeout');
+  });
+
+  it('normalizes quotes before applying stopword filtering', () => {
+    const results = brain.episodic.recall('"the"');
+
+    expect(results).toHaveLength(5);
+    expect(results[0]!.summary).toContain('Rate limit');
+  });
+
+  it('normalizes punctuation for encrypted episodic recall', () => {
+    const encryptedBrain = new SqliteBrain(':memory:', undefined, {
+      encryption: { enabled: true, key: 'episodic-recall-test-key' },
+    });
+    try {
+      encryptedBrain.episodic.record({
+        type: 'failure',
+        summary: 'error timeout',
+        createdAt: '2026-03-18T10:30:00Z',
+      });
+
+      expect(encryptedBrain.episodic.recall('error: unavailable')).toHaveLength(1);
+    } finally {
+      encryptedBrain.close();
+    }
+  });
+
+  it.each([
+    ['percent', '100%', '100% completion rate achieved', '100 percent complete'],
+    ['underscore', 'token_ab', 'token_ab accepted', 'tokenXab accepted'],
+    ['backslash', String.raw`C:\\temp`, String.raw`C:\\temp created`, 'C:temp created'],
+  ])('escapes LIKE %s characters in query', (_name, query, exactSummary, distractorSummary) => {
+    brain.episodic.record({
+      type: 'observation',
+      summary: exactSummary,
+      createdAt: '2026-03-18T10:30:00Z',
+    });
+    brain.episodic.record({
+      type: 'observation',
+      summary: distractorSummary,
+      createdAt: '2026-03-18T10:31:00Z',
+    });
+
+    const results = brain.episodic.recall(query);
+
+    expect(results.map((event) => event.summary)).toEqual([exactSummary]);
   });
 });

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -124,6 +124,30 @@ describe('EpisodicMemory.recall()', () => {
   });
 
   it.each([
+    ['C++', 'C++ compiler selected', 'compiler selected'],
+    ['C#', 'C# compiler selected', 'compiler selected'],
+    ['F#', 'F# compiler selected', 'compiler selected'],
+    ['.env', '.env file missing', 'env file missing'],
+    ['--dry-run', '--dry-run enabled', 'dry-run enabled'],
+    ['/app/src/auth.ts', '/app/src/auth.ts failed', 'app/src/auth.ts failed'],
+  ])('preserves significant punctuation in %s recall terms', (query, exactSummary, distractorSummary) => {
+    brain.episodic.record({
+      type: 'observation',
+      summary: exactSummary,
+      createdAt: '2026-03-18T10:30:00Z',
+    });
+    brain.episodic.record({
+      type: 'observation',
+      summary: distractorSummary,
+      createdAt: '2026-03-18T10:31:00Z',
+    });
+
+    const results = brain.episodic.recall(query);
+
+    expect(results[0]!.summary).toBe(exactSummary);
+  });
+
+  it.each([
     ['percent', '100%', '100% completion rate achieved', '100 percent complete'],
     ['underscore', 'token_ab', 'token_ab accepted', 'tokenXab accepted'],
     ['backslash', String.raw`C:\\temp`, String.raw`C:\\temp created`, 'C:temp created'],

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -130,6 +130,11 @@ describe('EpisodicMemory.recall()', () => {
     ['.env', '.env file missing', 'env file missing'],
     ['--dry-run', '--dry-run enabled', 'dry-run enabled'],
     ['/app/src/auth.ts', '/app/src/auth.ts failed', 'app/src/auth.ts failed'],
+    ['[P1]', '[P1] incident', 'incident'],
+    ['[CI]', '[CI] failed', 'CI failed'],
+    ['<T>', '<T> generic type', 'generic type'],
+    ['<init>', '<init> method failed', 'init method failed'],
+    ['!important', '!important declaration', 'important declaration'],
   ])('preserves significant punctuation in %s recall terms', (query, exactSummary, distractorSummary) => {
     brain.episodic.record({
       type: 'observation',
@@ -145,6 +150,10 @@ describe('EpisodicMemory.recall()', () => {
     const results = brain.episodic.recall(query);
 
     expect(results[0]!.summary).toBe(exactSummary);
+  });
+
+  it('does not turn punctuation-only queries into recent-memory reads', () => {
+    expect(brain.episodic.recall('???')).toEqual([]);
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- centralize episodic recall keyword normalization for plaintext and encrypted stores
- strip syntactic wrapper punctuation before length and stopword filtering while retaining literal alternatives for technical identifiers and punctuation-only searches
- add regressions for punctuation ranking, quoted stopwords, encrypted recall, exact technical terms, and `%`/`_`/`\` escaping

## Test Plan
- `npm test -- --run tests/unit/episodic-recall.test.ts` (28 passed)
- `npm test` (packages/franken-brain; 358 passed)
- `npm run lint` (packages/franken-brain)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/brain`
- `npm run build --workspace @franken/brain`

Closes #3139