### PR TITLE
fix(observer): bound MultiAdapter list fan-out

### DIFF
--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.test.ts
@@ -157,6 +157,55 @@ describe('MultiAdapter', () => {
   })
 
   describe('listTraceIds()', () => {
+    it('bounds default fan-out when the adapter count exceeds the concurrency limit', async () => {
+      let active = 0
+      let maxActive = 0
+      const adapters = Array.from({ length: 6 }, (_, index): ExportAdapter => ({
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn(async () => {
+          active += 1
+          maxActive = Math.max(maxActive, active)
+          await Promise.resolve()
+          active -= 1
+          return [`trace-${index}`]
+        }),
+      }))
+      const multi = new MultiAdapter({ adapters })
+
+      await expect(multi.listTraceIds()).resolves.toHaveLength(6)
+      expect(maxActive).toBe(4)
+    })
+
+    it('uses the configured list fan-out concurrency', async () => {
+      let active = 0
+      let maxActive = 0
+      const adapters = Array.from({ length: 5 }, (_, index): ExportAdapter => ({
+        flush: vi.fn().mockResolvedValue(undefined),
+        queryByTraceId: vi.fn().mockResolvedValue(null),
+        listTraceIds: vi.fn(async () => {
+          active += 1
+          maxActive = Math.max(maxActive, active)
+          await Promise.resolve()
+          active -= 1
+          return [`trace-${index}`]
+        }),
+      }))
+      const multi = new MultiAdapter({ adapters, listTraceIdsConcurrency: 2 })
+
+      await expect(multi.listTraceIds()).resolves.toHaveLength(5)
+      expect(maxActive).toBe(2)
+    })
+
+    it.each([0, -1, 1.5, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+      'rejects invalid list fan-out concurrency %s',
+      listTraceIdsConcurrency => {
+        expect(() => new MultiAdapter({ adapters: [], listTraceIdsConcurrency })).toThrow(
+          'listTraceIdsConcurrency must be a positive safe integer',
+        )
+      },
+    )
+
     it('returns the union of all adapters trace ids', async () => {
       const a = new InMemoryAdapter()
       const b = new InMemoryAdapter()

--- a/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
+++ b/packages/franken-observer/src/adapters/multi/MultiAdapter.ts
@@ -6,12 +6,51 @@ export interface MultiAdapterOptions {
   /** Adapters to fan-out to. Order matters for queryByTraceId (first-wins). */
   adapters: ExportAdapter[]
   /**
+   * Maximum number of concurrent adapter calls made by `listTraceIds()`.
+   * Default: `4`.
+   */
+  listTraceIdsConcurrency?: number
+  /**
    * When true (default), `flush()` throws an AggregateError if any adapter
    * rejects. All adapters are still called regardless (allSettled semantics).
    * Set to false for best-effort delivery where a failing adapter is silently
    * ignored.
    */
   throwOnError?: boolean
+}
+
+const DEFAULT_LIST_TRACE_IDS_CONCURRENCY = 4
+
+function validatePositiveSafeInteger(value: number, optionName: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${optionName} must be a positive safe integer`)
+  }
+  return value
+}
+
+async function allSettledWithConcurrency<Item, Result>(
+  items: readonly Item[],
+  concurrency: number,
+  operation: (item: Item) => Promise<Result>,
+): Promise<PromiseSettledResult<Result>[]> {
+  const results = new Array<PromiseSettledResult<Result>>(items.length)
+  let nextIndex = 0
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      try {
+        results[index] = { status: 'fulfilled', value: await operation(items[index]!) }
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason }
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
+  )
+  return results
 }
 
 /**
@@ -33,10 +72,15 @@ export interface MultiAdapterOptions {
 export class MultiAdapter implements ExportAdapter {
   private readonly adapters: ExportAdapter[]
   private readonly throwOnError: boolean
+  private readonly listTraceIdsConcurrency: number
 
   constructor(options: MultiAdapterOptions) {
     this.adapters = options.adapters
     this.throwOnError = options.throwOnError ?? true
+    this.listTraceIdsConcurrency = validatePositiveSafeInteger(
+      options.listTraceIdsConcurrency ?? DEFAULT_LIST_TRACE_IDS_CONCURRENCY,
+      'listTraceIdsConcurrency',
+    )
   }
 
   async flush(trace: Trace): Promise<void> {
@@ -75,7 +119,11 @@ export class MultiAdapter implements ExportAdapter {
   }
 
   async listTraceIds(): Promise<string[]> {
-    const results = await Promise.allSettled(this.adapters.map(a => a.listTraceIds()))
+    const results = await allSettledWithConcurrency(
+      this.adapters,
+      this.listTraceIdsConcurrency,
+      adapter => adapter.listTraceIds(),
+    )
     const sets = results.filter((r): r is PromiseFulfilledResult<string[]> => r.status === 'fulfilled').map(r => r.value)
     const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
 

--- a/tasks/issue-3102-progress.md
+++ b/tasks/issue-3102-progress.md
@@ -1,0 +1,9 @@
+# Issue 3102 progress
+
+- [x] Confirm issue is open, lacks `good first issue`, and has no existing PR/branch.
+- [x] Read shared lessons and inspect `MultiAdapter` plus existing tests.
+- [x] Reproduce unbounded `listTraceIds` fan-out with a focused red test and record evidence.
+- [x] Implement the smallest bounded-concurrency option with a clear default and validation.
+- [x] Run focused tests, observer tests, typecheck, lint, and build.
+- [ ] Self-review, commit, push, and open a PR closing #3102.
+- [ ] Obtain current-head Codex clean plus green CI, merge, and record terminal handoff.


### PR DESCRIPTION
## Summary
- bound `MultiAdapter.listTraceIds()` to four concurrent backend calls by default
- add a validated `listTraceIdsConcurrency` option for deployment-specific tuning
- preserve settled-result ordering, partial-failure handling, and deduplicated unions

## Reproduction
Before the fix, six yielding adapters all became active in one `listTraceIds()` call (`maxActive = 6`) because `Promise.allSettled(this.adapters.map(...))` eagerly invoked every backend.

## Test plan
- `npm run test --workspace @franken/observer -- src/adapters/multi/MultiAdapter.test.ts` (30 passed)
- `npm run test --workspace @franken/observer` (850 passed)
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`

Closes #3102
