### PR TITLE
fix(observer): reset trace server state after stop

### DIFF
--- a/packages/franken-observer/src/ui/TraceServer.test.ts
+++ b/packages/franken-observer/src/ui/TraceServer.test.ts
@@ -399,12 +399,16 @@ describe('TraceServer', () => {
       await expect(s.stop()).resolves.toBeUndefined()
     })
 
-    it('server refuses connections after stop()', async () => {
+    it('clears listening state and remains idempotent after stop()', async () => {
       const s = new TraceServer({ adapter, port: 0 })
       await s.start()
-      const url = s.url
+      const listeningUrl = s.url
+
       await s.stop()
-      await expect(fetch(url + '/')).rejects.toThrow()
+
+      expect(s.url).toBe('http://127.0.0.1:0')
+      await expect(s.stop()).resolves.toBeUndefined()
+      await expect(fetch(listeningUrl + '/')).rejects.toThrow()
     })
   })
 })

--- a/packages/franken-observer/src/ui/TraceServer.ts
+++ b/packages/franken-observer/src/ui/TraceServer.ts
@@ -65,7 +65,12 @@ export class TraceServer {
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this.server) { resolve(); return }
-      this.server.close(err => (err ? reject(err) : resolve()))
+      this.server.close(err => {
+        if (err) { reject(err); return }
+        this.server = null
+        this._port = 0
+        resolve()
+      })
     })
   }
 


### PR DESCRIPTION
## Summary
- clear the retained HTTP server handle after a successful TraceServer shutdown
- reset the reported port so stopped instances no longer expose a stale live-looking URL
- cover idempotent repeated stop calls and refusal at the former listening URL

## Verification
- `npm run test --workspace @franken/observer -- src/ui/TraceServer.test.ts` (28 passed)
- `npm run test --workspace @franken/observer` (850 passed)
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/types`
- `npm run build --workspace @franken/observer`

Closes #3101