### PR TITLE
fix(critique): redact token budget breaker reasons

### DIFF
--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -25,7 +25,7 @@ export class TokenBudgetBreaker implements CircuitBreaker {
     if (config.costBudgetUsd !== undefined && spend.estimatedCostUsd > config.costBudgetUsd) {
       return {
         tripped: true,
-        reason: `Cost budget exceeded: $${spend.estimatedCostUsd.toFixed(4)} > $${config.costBudgetUsd.toFixed(4)} (${spend.totalTokens} tokens)`,
+        reason: 'Cost budget exceeded',
         action: 'halt',
       };
     }
@@ -33,7 +33,7 @@ export class TokenBudgetBreaker implements CircuitBreaker {
     if (spend.totalTokens >= config.tokenBudget) {
       return {
         tripped: true,
-        reason: `Token budget exceeded: ${spend.totalTokens} >= ${config.tokenBudget} (estimated cost: $${spend.estimatedCostUsd.toFixed(4)})`,
+        reason: 'Token budget exceeded',
         action: 'halt',
       };
     }

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -50,7 +50,7 @@ describe('TokenBudgetBreaker', () => {
     expect(result.tripped).toBe(true);
     if (result.tripped) {
       expect(result.action).toBe('halt');
-      expect(result.reason).toContain('Token budget');
+      expect(result.reason).toBe('Token budget exceeded');
     }
   });
 
@@ -93,7 +93,7 @@ describe('TokenBudgetBreaker', () => {
       expect(result.tripped).toBe(true);
       if (result.tripped) {
         expect(result.action).toBe('halt');
-        expect(result.reason).toContain('Cost budget');
+        expect(result.reason).toBe('Cost budget exceeded');
       }
     });
 


### PR DESCRIPTION
## Summary
- replace observable token-budget failure details with generic reasons
- prevent exact token counts, estimated USD cost, and configured limits from appearing in breaker errors
- tighten token- and cost-budget regression assertions

## Verification
- `npm test -- --run tests/unit/breakers/token-budget.test.ts` (11 passed)
- `npm test` in `packages/franken-critique` (782 passed)
- `npm run lint` in `packages/franken-critique`
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/critique`
- `npm run build --workspace @franken/critique`

Closes #3549