### PR TITLE
fix(critique): bound complexity evaluator input size

### DIFF
--- a/packages/franken-critique/src/evaluators/complexity.ts
+++ b/packages/franken-critique/src/evaluators/complexity.ts
@@ -10,6 +10,7 @@ import { createScore } from '../types/common.js';
 const MAX_PARAMS = 5;
 const MAX_NESTING = 4;
 const MAX_FUNCTION_LINES = 50;
+const MAX_CONTENT_LENGTH = 1024 * 1024;
 
 interface FunctionBlock {
   params: string;
@@ -599,6 +600,22 @@ export class ComplexityEvaluator implements Evaluator {
   readonly category = 'heuristic' as const;
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
+    if (input.content.length > MAX_CONTENT_LENGTH) {
+      return {
+        evaluatorName: this.name,
+        verdict: 'warn',
+        score: createScore(0.5),
+        findings: [
+          {
+            message: `Complexity evaluation skipped because content exceeds the ${MAX_CONTENT_LENGTH} character limit.`,
+            severity: 'warning',
+            suggestion:
+              'Split the content into smaller units before evaluating complexity',
+          },
+        ],
+      };
+    }
+
     if (!input.content.trim()) {
       return {
         evaluatorName: this.name,

--- a/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/complexity.test.ts
@@ -22,6 +22,23 @@ describe('ComplexityEvaluator', () => {
     expect(result.score).toBeGreaterThan(0.5);
   });
 
+  it('skips complexity scans when content exceeds the input limit', async () => {
+    const evaluator = new ComplexityEvaluator();
+    const content = '{'.repeat(1024 * 1024 + 1);
+
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('warn');
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'exceeds the 1048576 character limit',
+        ),
+        severity: 'warning',
+      }),
+    ]);
+  });
+
   it('ignores braces and nested patterns inside comments', async () => {
     const evaluator = new ComplexityEvaluator();
     const content = `function sample(value: boolean) {\n  // if (value) {\n  //   doThing();\n  // }\n  return value ? 'ok' : 'skip';\n}`;


### PR DESCRIPTION
## Summary
- cap critique complexity analysis at 1,048,576 characters before any sanitizer or scanner traversal
- return a deterministic warning when oversized content is skipped
- cover the oversized-input path with a focused regression test

## Reproduction
Before the guard, synthetic content was fully scanned with elapsed time scaling by size:
- 1 MiB: 139.1 ms
- 4 MiB: 589.8 ms
- 8 MiB: 1025.0 ms

After the guard, 4 MiB and 8 MiB inputs return the warning path in approximately 0.1 ms.

## Test Plan
- `npm run build --workspace @franken/types`
- `npm test --workspace @franken/critique` (783 passed)
- `npm run typecheck --workspace @franken/critique`
- `npm run build --workspace @franken/critique`
- `npm run lint --workspace @franken/critique`
- `git diff --check`

Note: the package-wide Prettier check already reports formatting debt across 36 files; this PR introduces no whitespace errors.

Closes #3600
