### PR TITLE
fix(observer): surface periodic batch drain failures

### DIFF
--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -137,6 +137,71 @@ describe('BatchAdapter — options', () => {
     expect(await inner.listTraceIds()).toEqual(['timer-drained'])
     expect(timer.unref).toHaveBeenCalledTimes(2)
   })
+
+  it('reports timer-triggered drain failures with bounded context and retains traces', async () => {
+    let intervalCallback!: () => void
+    const onDrainError = vi.fn()
+    const trace = makeTrace('private-trace-id')
+    const batch = new BatchAdapter({
+      adapter: new FailingFlushAdapter(),
+      maxBatchSize: 100,
+      flushIntervalMs: 1000,
+      setInterval(callback) {
+        intervalCallback = callback
+        return 42 as unknown as ReturnType<typeof globalThis.setInterval>
+      },
+      onDrainError,
+    })
+
+    await batch.flush(trace)
+    intervalCallback()
+
+    await vi.waitFor(() => expect(onDrainError).toHaveBeenCalledOnce())
+    const context = onDrainError.mock.calls[0]![0]
+    expect(context).toEqual({ batchSize: 1, attemptedAt: expect.any(Number) })
+    expect(JSON.stringify(context)).not.toContain(trace.id)
+    expect(JSON.stringify(context)).not.toContain('database temporarily locked')
+    expect(await batch.queryByTraceId(trace.id)).toEqual(trace)
+  })
+
+  it('continues timer drains after an error observer throws and reports recovery', async () => {
+    let intervalCallback!: () => void
+    let attempts = 0
+    const inner = new InMemoryAdapter()
+    vi.spyOn(inner, 'flush').mockImplementation(async trace => {
+      attempts += 1
+      if (attempts === 1) throw new Error('transient exporter failure')
+      await InMemoryAdapter.prototype.flush.call(inner, trace)
+    })
+    const onDrainError = vi.fn(() => { throw new Error('observer failed') })
+    const onDrainRecovery = vi.fn()
+    const batch = new BatchAdapter({
+      adapter: inner,
+      maxBatchSize: 100,
+      flushIntervalMs: 1000,
+      setInterval(callback) {
+        intervalCallback = callback
+        return 42 as unknown as ReturnType<typeof globalThis.setInterval>
+      },
+      onDrainError,
+      onDrainRecovery,
+    })
+
+    await batch.flush(makeTrace('retry-on-next-tick'))
+    intervalCallback()
+    await vi.waitFor(() => expect(onDrainError).toHaveBeenCalledOnce())
+
+    intervalCallback()
+    await vi.waitFor(() => expect(onDrainRecovery).toHaveBeenCalledOnce())
+
+    expect(attempts).toBe(2)
+    expect(onDrainRecovery).toHaveBeenCalledWith({
+      batchSize: 1,
+      attemptedAt: expect.any(Number),
+    })
+    expect(await batch.listTraceIds()).toEqual(['retry-on-next-tick'])
+    expect(await inner.listTraceIds()).toEqual(['retry-on-next-tick'])
+  })
 })
 
 // ── buffering ─────────────────────────────────────────────────────────────────
@@ -562,6 +627,32 @@ describe('BatchAdapter — stop()', () => {
 
     expect(await batch.queryByTraceId('shutdown-retry')).toEqual(trace)
     expect(await batch.listTraceIds()).toEqual(['shutdown-retry'])
+  })
+
+  it('cancels the timer and surfaces shutdown failure after a failed periodic drain', async () => {
+    let intervalCallback!: () => void
+    const clearIntervalFn = vi.fn()
+    const onDrainError = vi.fn()
+    const trace = makeTrace('periodic-then-shutdown')
+    const batch = new BatchAdapter({
+      adapter: new FailingFlushAdapter(),
+      maxBatchSize: 100,
+      flushIntervalMs: 1000,
+      setInterval(callback) {
+        intervalCallback = callback
+        return 42 as unknown as ReturnType<typeof globalThis.setInterval>
+      },
+      clearInterval: clearIntervalFn,
+      onDrainError,
+    })
+
+    await batch.flush(trace)
+    intervalCallback()
+    await vi.waitFor(() => expect(onDrainError).toHaveBeenCalledOnce())
+
+    await expect(batch.stop()).rejects.toThrow('database temporarily locked')
+    expect(clearIntervalFn).toHaveBeenCalledWith(42)
+    expect(await batch.queryByTraceId(trace.id)).toEqual(trace)
   })
 
   it('does not call clearInterval when no timer was started', async () => {

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.test.ts
@@ -164,17 +164,23 @@ describe('BatchAdapter — options', () => {
     expect(await batch.queryByTraceId(trace.id)).toEqual(trace)
   })
 
-  it('continues timer drains after an error observer throws and reports recovery', async () => {
+  it('continues timer drains after async observers reject and reports recovery', async () => {
     let intervalCallback!: () => void
     let attempts = 0
+    const errorObserverResult = Promise.reject(new Error('error observer failed'))
+    const recoveryObserverResult = Promise.reject(new Error('recovery observer failed'))
+    void errorObserverResult.catch(() => undefined)
+    void recoveryObserverResult.catch(() => undefined)
+    const errorObserverCatch = vi.spyOn(errorObserverResult, 'catch')
+    const recoveryObserverCatch = vi.spyOn(recoveryObserverResult, 'catch')
     const inner = new InMemoryAdapter()
     vi.spyOn(inner, 'flush').mockImplementation(async trace => {
       attempts += 1
       if (attempts === 1) throw new Error('transient exporter failure')
       await InMemoryAdapter.prototype.flush.call(inner, trace)
     })
-    const onDrainError = vi.fn(() => { throw new Error('observer failed') })
-    const onDrainRecovery = vi.fn()
+    const onDrainError = vi.fn(() => errorObserverResult)
+    const onDrainRecovery = vi.fn(() => recoveryObserverResult)
     const batch = new BatchAdapter({
       adapter: inner,
       maxBatchSize: 100,
@@ -194,6 +200,8 @@ describe('BatchAdapter — options', () => {
     intervalCallback()
     await vi.waitFor(() => expect(onDrainRecovery).toHaveBeenCalledOnce())
 
+    expect(errorObserverCatch).toHaveBeenCalledOnce()
+    expect(recoveryObserverCatch).toHaveBeenCalledOnce()
     expect(attempts).toBe(2)
     expect(onDrainRecovery).toHaveBeenCalledWith({
       batchSize: 1,

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -34,12 +34,12 @@ export interface BatchAdapterOptions {
    * bounded and intentionally excludes trace payloads and exporter errors.
    * Observer failures are ignored so they cannot interrupt future drains.
    */
-  onDrainError?: (context: Readonly<BatchDrainContext>) => void
+  onDrainError?: (context: Readonly<BatchDrainContext>) => void | PromiseLike<void>
   /**
    * Best-effort observer invoked when a timer drain succeeds after one or more
    * failed timer drains. It receives the same bounded, payload-free context.
    */
-  onDrainRecovery?: (context: Readonly<BatchDrainContext>) => void
+  onDrainRecovery?: (context: Readonly<BatchDrainContext>) => void | PromiseLike<void>
 }
 
 function validatePositiveSafeInteger(value: number, optionName: string): number {
@@ -87,8 +87,10 @@ export class BatchAdapter implements ExportAdapter {
   private readonly buffer: Trace[] = []
   private timer: ReturnType<typeof globalThis.setInterval> | null = null
   private readonly clearIntervalFn: (id: ReturnType<typeof globalThis.setInterval>) => void
-  private readonly onDrainError: ((context: Readonly<BatchDrainContext>) => void) | undefined
-  private readonly onDrainRecovery: ((context: Readonly<BatchDrainContext>) => void) | undefined
+  private readonly onDrainError:
+    ((context: Readonly<BatchDrainContext>) => void | PromiseLike<void>) | undefined
+  private readonly onDrainRecovery:
+    ((context: Readonly<BatchDrainContext>) => void | PromiseLike<void>) | undefined
   private backgroundDrainFailed = false
   private drainPromise: Promise<void> | null = null
 
@@ -119,7 +121,7 @@ export class BatchAdapter implements ExportAdapter {
   private reportDrainError(context: Readonly<BatchDrainContext>): void {
     this.backgroundDrainFailed = true
     try {
-      this.onDrainError?.(context)
+      void Promise.resolve(this.onDrainError?.(context)).catch(() => undefined)
     } catch {
       // Background observers are best-effort and must not break future drains.
     }
@@ -129,7 +131,7 @@ export class BatchAdapter implements ExportAdapter {
     if (!this.backgroundDrainFailed) return
     this.backgroundDrainFailed = false
     try {
-      this.onDrainRecovery?.(context)
+      void Promise.resolve(this.onDrainRecovery?.(context)).catch(() => undefined)
     } catch {
       // Recovery observers are also best-effort.
     }

--- a/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
+++ b/packages/franken-observer/src/adapters/batch/BatchAdapter.ts
@@ -2,6 +2,14 @@ import type { Trace } from '../../core/types.js'
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 
+/** Bounded, payload-free context for a background drain notification. */
+export interface BatchDrainContext {
+  /** Number of traces included in the background drain attempt. */
+  batchSize: number
+  /** Unix timestamp in milliseconds when the background drain was attempted. */
+  attemptedAt: number
+}
+
 export interface BatchAdapterOptions {
   /** Underlying adapter that receives traces when the batch is drained. */
   adapter: ExportAdapter
@@ -21,6 +29,17 @@ export interface BatchAdapterOptions {
   setInterval?: (fn: () => void, ms: number) => ReturnType<typeof globalThis.setInterval>
   /** Injectable for testing. Defaults to `globalThis.clearInterval`. */
   clearInterval?: (id: ReturnType<typeof globalThis.setInterval>) => void
+  /**
+   * Best-effort observer for failed timer-triggered drains. The context is
+   * bounded and intentionally excludes trace payloads and exporter errors.
+   * Observer failures are ignored so they cannot interrupt future drains.
+   */
+  onDrainError?: (context: Readonly<BatchDrainContext>) => void
+  /**
+   * Best-effort observer invoked when a timer drain succeeds after one or more
+   * failed timer drains. It receives the same bounded, payload-free context.
+   */
+  onDrainRecovery?: (context: Readonly<BatchDrainContext>) => void
 }
 
 function validatePositiveSafeInteger(value: number, optionName: string): number {
@@ -68,18 +87,51 @@ export class BatchAdapter implements ExportAdapter {
   private readonly buffer: Trace[] = []
   private timer: ReturnType<typeof globalThis.setInterval> | null = null
   private readonly clearIntervalFn: (id: ReturnType<typeof globalThis.setInterval>) => void
+  private readonly onDrainError: ((context: Readonly<BatchDrainContext>) => void) | undefined
+  private readonly onDrainRecovery: ((context: Readonly<BatchDrainContext>) => void) | undefined
+  private backgroundDrainFailed = false
   private drainPromise: Promise<void> | null = null
 
   constructor(options: BatchAdapterOptions) {
     this.inner = options.adapter
     this.maxBatchSize = validatePositiveSafeInteger(options.maxBatchSize ?? 10, 'maxBatchSize')
     this.clearIntervalFn = options.clearInterval ?? globalThis.clearInterval
+    this.onDrainError = options.onDrainError
+    this.onDrainRecovery = options.onDrainRecovery
 
     if (options.flushIntervalMs !== undefined) {
       const flushIntervalMs = validatePositiveSafeInteger(options.flushIntervalMs, 'flushIntervalMs')
       const si = options.setInterval ?? globalThis.setInterval
-      this.timer = si(() => { void this.drain().catch(() => undefined) }, flushIntervalMs)
+      this.timer = si(() => {
+        const context: BatchDrainContext = {
+          batchSize: this.buffer.length,
+          attemptedAt: Date.now(),
+        }
+        void this.drain().then(
+          () => { this.reportDrainRecovery(context) },
+          () => { this.reportDrainError(context) },
+        )
+      }, flushIntervalMs)
       setTimerRefState(this.timer, false)
+    }
+  }
+
+  private reportDrainError(context: Readonly<BatchDrainContext>): void {
+    this.backgroundDrainFailed = true
+    try {
+      this.onDrainError?.(context)
+    } catch {
+      // Background observers are best-effort and must not break future drains.
+    }
+  }
+
+  private reportDrainRecovery(context: Readonly<BatchDrainContext>): void {
+    if (!this.backgroundDrainFailed) return
+    this.backgroundDrainFailed = false
+    try {
+      this.onDrainRecovery?.(context)
+    } catch {
+      // Recovery observers are also best-effort.
     }
   }
 

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -55,7 +55,7 @@ export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 
 export type { ExportAdapter, TraceSummary } from './export/ExportAdapter.js'
 export type { MultiAdapterOptions } from './adapters/multi/MultiAdapter.js'
-export type { BatchAdapterOptions } from './adapters/batch/BatchAdapter.js'
+export type { BatchAdapterOptions, BatchDrainContext } from './adapters/batch/BatchAdapter.js'
 export type { SamplerStrategy, SamplingAdapterOptions, RateLimitedSamplerOptions } from './sampling/TraceSampler.js'
 export type { TraceparentFields, ExtractedTraceContext } from './propagation/W3CTraceContext.js'
 export type { RedactionAction, RedactionRule, SpanRedactorOptions } from './redaction/SpanRedactor.js'


### PR DESCRIPTION
## Summary
- add bounded `onDrainError` notifications for timer-triggered BatchAdapter failures
- report recovery after a later periodic retry succeeds
- isolate observer exceptions while preserving buffered traces and shutdown behavior

## Test plan
- `npm run test --workspace @franken/observer -- src/adapters/batch/BatchAdapter.test.ts`
- `npm run test --workspace @franken/observer` (853 passed)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)

Closes #3590