### PR TITLE
fix(critique): honor request evaluator selectors

### DIFF
--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -112,7 +112,11 @@ export {
 export type { CritiqueErrorOptions } from './errors/index.js';
 
 // Core components
-export { CritiquePipeline } from './pipeline/critique-pipeline.js';
+export {
+  CritiquePipeline,
+  UnknownEvaluatorError,
+} from './pipeline/critique-pipeline.js';
+export type { CritiquePipelineRunOptions } from './pipeline/critique-pipeline.js';
 export { CritiqueLoop } from './loop/critique-loop.js';
 export {
   LessonRecorder,

--- a/packages/franken-critique/src/index.ts
+++ b/packages/franken-critique/src/index.ts
@@ -114,6 +114,7 @@ export type { CritiqueErrorOptions } from './errors/index.js';
 // Core components
 export {
   CritiquePipeline,
+  RequiredEvaluatorSelectionError,
   UnknownEvaluatorError,
 } from './pipeline/critique-pipeline.js';
 export type { CritiquePipelineRunOptions } from './pipeline/critique-pipeline.js';

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -57,6 +57,19 @@ export class UnknownEvaluatorError extends ConfigurationError {
   }
 }
 
+export class RequiredEvaluatorSelectionError extends ConfigurationError {
+  readonly requiredEvaluatorNames: readonly string[];
+
+  constructor(requiredEvaluatorNames: readonly string[]) {
+    super(
+      `Evaluator selection must include required evaluators: ${requiredEvaluatorNames.join(', ')}`,
+      { context: { requiredEvaluatorNames } },
+    );
+    this.name = 'RequiredEvaluatorSelectionError';
+    this.requiredEvaluatorNames = requiredEvaluatorNames;
+  }
+}
+
 export class CritiquePipeline {
   private readonly evaluators: readonly Evaluator[];
 
@@ -83,6 +96,12 @@ export class CritiquePipeline {
       ];
       if (unknownNames.length > 0) {
         throw new UnknownEvaluatorError(unknownNames);
+      }
+      if (
+        registeredNames.has(SAFETY_EVALUATOR_NAME) &&
+        !selectedNames.includes(SAFETY_EVALUATOR_NAME)
+      ) {
+        throw new RequiredEvaluatorSelectionError([SAFETY_EVALUATOR_NAME]);
       }
     }
     const evaluators = hasSelector

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -1,5 +1,10 @@
 import { EVALUATOR_EXCEPTION_LOCATION } from '../types/evaluation.js';
-import type { Evaluator, EvaluationInput, EvaluationResult, CritiquePipelineResult } from '../types/evaluation.js';
+import type {
+  Evaluator,
+  EvaluationInput,
+  EvaluationResult,
+  CritiquePipelineResult,
+} from '../types/evaluation.js';
 import { createScore } from '../types/common.js';
 
 const SAFETY_EVALUATOR_NAME = 'safety';
@@ -15,7 +20,9 @@ function logEvaluatorException(evaluator: Evaluator, error: unknown): void {
   });
 }
 
-function createEvaluatorExceptionResult(evaluator: Evaluator): EvaluationResult {
+function createEvaluatorExceptionResult(
+  evaluator: Evaluator,
+): EvaluationResult {
   return {
     evaluatorName: evaluator.name,
     verdict: 'fail',
@@ -25,10 +32,26 @@ function createEvaluatorExceptionResult(evaluator: Evaluator): EvaluationResult 
         message: `Evaluator "${evaluator.name}" failed because an internal evaluator error occurred.`,
         severity: 'critical',
         location: EVALUATOR_EXCEPTION_LOCATION,
-        suggestion: 'Inspect trusted evaluator logs or dependencies before retrying the critique run.',
+        suggestion:
+          'Inspect trusted evaluator logs or dependencies before retrying the critique run.',
       },
     ],
   };
+}
+
+export interface CritiquePipelineRunOptions {
+  /** Optional allowlist of registered evaluator names to run. */
+  readonly evaluatorNames?: readonly string[] | undefined;
+}
+
+export class UnknownEvaluatorError extends Error {
+  readonly evaluatorNames: readonly string[];
+
+  constructor(evaluatorNames: readonly string[]) {
+    super(`Unknown evaluator selection: ${evaluatorNames.join(', ')}`);
+    this.name = 'UnknownEvaluatorError';
+    this.evaluatorNames = evaluatorNames;
+  }
 }
 
 export class CritiquePipeline {
@@ -42,15 +65,41 @@ export class CritiquePipeline {
     });
   }
 
-  async run(input: EvaluationInput): Promise<CritiquePipelineResult> {
-    if (this.evaluators.length === 0) {
-      return { verdict: 'pass', overallScore: createScore(1), results: [], shortCircuited: false };
+  async run(
+    input: EvaluationInput,
+    options: CritiquePipelineRunOptions = {},
+  ): Promise<CritiquePipelineResult> {
+    const selectedNames = options.evaluatorNames;
+    if (selectedNames) {
+      const registeredNames = new Set(
+        this.evaluators.map((evaluator) => evaluator.name),
+      );
+      const unknownNames = [
+        ...new Set(selectedNames.filter((name) => !registeredNames.has(name))),
+      ];
+      if (unknownNames.length > 0) {
+        throw new UnknownEvaluatorError(unknownNames);
+      }
+    }
+    const evaluators = selectedNames
+      ? this.evaluators.filter((evaluator) =>
+          selectedNames.includes(evaluator.name),
+        )
+      : this.evaluators;
+
+    if (evaluators.length === 0) {
+      return {
+        verdict: 'pass',
+        overallScore: createScore(1),
+        results: [],
+        shortCircuited: false,
+      };
     }
 
     const results: EvaluationResult[] = [];
     let shortCircuited = false;
 
-    for (const evaluator of this.evaluators) {
+    for (const evaluator of evaluators) {
       let result: EvaluationResult;
 
       try {
@@ -68,7 +117,10 @@ export class CritiquePipeline {
       results.push(result);
 
       // Short-circuit on safety failure
-      if (evaluator.name === SAFETY_EVALUATOR_NAME && result.verdict === 'fail') {
+      if (
+        evaluator.name === SAFETY_EVALUATOR_NAME &&
+        result.verdict === 'fail'
+      ) {
         shortCircuited = true;
         break;
       }
@@ -79,7 +131,8 @@ export class CritiquePipeline {
     );
     const hasFailure = results.some((r) => r.verdict === 'fail');
     const hasWarning = results.some(
-      (r) => r.verdict === 'warn' || (r.verdict === 'pass' && hasWarningFinding(r)),
+      (r) =>
+        r.verdict === 'warn' || (r.verdict === 'pass' && hasWarningFinding(r)),
     );
 
     return {

--- a/packages/franken-critique/src/pipeline/critique-pipeline.ts
+++ b/packages/franken-critique/src/pipeline/critique-pipeline.ts
@@ -6,6 +6,7 @@ import type {
   CritiquePipelineResult,
 } from '../types/evaluation.js';
 import { createScore } from '../types/common.js';
+import { ConfigurationError } from '../errors/index.js';
 
 const SAFETY_EVALUATOR_NAME = 'safety';
 
@@ -44,11 +45,13 @@ export interface CritiquePipelineRunOptions {
   readonly evaluatorNames?: readonly string[] | undefined;
 }
 
-export class UnknownEvaluatorError extends Error {
+export class UnknownEvaluatorError extends ConfigurationError {
   readonly evaluatorNames: readonly string[];
 
   constructor(evaluatorNames: readonly string[]) {
-    super(`Unknown evaluator selection: ${evaluatorNames.join(', ')}`);
+    super(`Unknown evaluator selection: ${evaluatorNames.join(', ')}`, {
+      context: { evaluatorNames },
+    });
     this.name = 'UnknownEvaluatorError';
     this.evaluatorNames = evaluatorNames;
   }
@@ -70,7 +73,8 @@ export class CritiquePipeline {
     options: CritiquePipelineRunOptions = {},
   ): Promise<CritiquePipelineResult> {
     const selectedNames = options.evaluatorNames;
-    if (selectedNames) {
+    const hasSelector = selectedNames !== undefined && selectedNames.length > 0;
+    if (hasSelector) {
       const registeredNames = new Set(
         this.evaluators.map((evaluator) => evaluator.name),
       );
@@ -81,7 +85,7 @@ export class CritiquePipeline {
         throw new UnknownEvaluatorError(unknownNames);
       }
     }
-    const evaluators = selectedNames
+    const evaluators = hasSelector
       ? this.evaluators.filter((evaluator) =>
           selectedNames.includes(evaluator.name),
         )

--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import type { CritiquePipeline } from '../pipeline/critique-pipeline.js';
+import {
+  UnknownEvaluatorError,
+  type CritiquePipeline,
+} from '../pipeline/critique-pipeline.js';
+import type { CritiquePipelineResult } from '../types/evaluation.js';
 import { wallClockNow } from '@franken/types';
 import { timingSafeBearerTokenMatches } from './token-auth.js';
 
@@ -177,10 +181,30 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
       );
     }
 
-    const result = await options.pipeline.run({
-      content: parsed.data.code,
-      metadata: parsed.data.context ?? {},
-    });
+    let result: CritiquePipelineResult;
+    try {
+      result = await options.pipeline.run(
+        {
+          content: parsed.data.code,
+          metadata: parsed.data.context ?? {},
+        },
+        { evaluatorNames: parsed.data.evaluators },
+      );
+    } catch (error) {
+      if (error instanceof UnknownEvaluatorError) {
+        return c.json(
+          {
+            error: {
+              message: 'Unknown evaluator selection',
+              type: 'invalid_evaluators',
+              unknownEvaluators: error.evaluatorNames,
+            },
+          },
+          400,
+        );
+      }
+      throw error;
+    }
 
     return c.json({
       verdict: result.verdict,

--- a/packages/franken-critique/src/server/app.ts
+++ b/packages/franken-critique/src/server/app.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import {
+  RequiredEvaluatorSelectionError,
   UnknownEvaluatorError,
   type CritiquePipeline,
 } from '../pipeline/critique-pipeline.js';
@@ -191,6 +192,18 @@ export function createCritiqueApp(options: CritiqueAppOptions = {}): Hono {
         { evaluatorNames: parsed.data.evaluators },
       );
     } catch (error) {
+      if (error instanceof RequiredEvaluatorSelectionError) {
+        return c.json(
+          {
+            error: {
+              message: 'Evaluator selection must include required evaluators',
+              type: 'invalid_evaluators',
+              missingRequiredEvaluators: error.requiredEvaluatorNames,
+            },
+          },
+          400,
+        );
+      }
       if (error instanceof UnknownEvaluatorError) {
         return c.json(
           {

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -103,6 +103,23 @@ describe('Critique Hono Server', () => {
       expect((await res.json()).evaluatorsRun).toEqual(['selected']);
     });
 
+    it('treats an empty evaluator selector as the default evaluator set', async () => {
+      const app = createCritiqueApp({
+        pipeline: new CritiquePipeline([
+          makePassEvaluator('first'),
+          makePassEvaluator('second'),
+        ]),
+      });
+      const res = await app.request('/v1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: 'const x = 1;', evaluators: [] }),
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).evaluatorsRun).toEqual(['first', 'second']);
+    });
+
     it('rejects evaluator selectors that are not registered', async () => {
       const app = createCritiqueApp({ pipeline: makePipeline() });
       const res = await app.request('/v1/review', {

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -83,6 +83,47 @@ describe('Critique Hono Server', () => {
       expect(body.shortCircuited).toBe(false);
     });
 
+    it('runs only the evaluators selected by the request', async () => {
+      const app = createCritiqueApp({
+        pipeline: new CritiquePipeline([
+          makePassEvaluator('selected'),
+          makePassEvaluator('not-selected'),
+        ]),
+      });
+      const res = await app.request('/v1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: 'const x = 1;',
+          evaluators: ['selected'],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).evaluatorsRun).toEqual(['selected']);
+    });
+
+    it('rejects evaluator selectors that are not registered', async () => {
+      const app = createCritiqueApp({ pipeline: makePipeline() });
+      const res = await app.request('/v1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: 'const x = 1;',
+          evaluators: ['test-eval', 'missing-eval'],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: {
+          message: 'Unknown evaluator selection',
+          type: 'invalid_evaluators',
+          unknownEvaluators: ['missing-eval'],
+        },
+      });
+    });
+
     it('returns 400 for invalid request', async () => {
       const app = createCritiqueApp({ pipeline: makePipeline() });
       const res = await app.request('/v1/review', {

--- a/packages/franken-critique/tests/unit/server/app.test.ts
+++ b/packages/franken-critique/tests/unit/server/app.test.ts
@@ -103,6 +103,32 @@ describe('Critique Hono Server', () => {
       expect((await res.json()).evaluatorsRun).toEqual(['selected']);
     });
 
+    it('rejects a selector that omits the registered safety evaluator', async () => {
+      const app = createCritiqueApp({
+        pipeline: new CritiquePipeline([
+          makePassEvaluator('safety'),
+          makePassEvaluator('complexity'),
+        ]),
+      });
+      const res = await app.request('/v1/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: 'const x = 1;',
+          evaluators: ['complexity'],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: {
+          message: 'Evaluator selection must include required evaluators',
+          type: 'invalid_evaluators',
+          missingRequiredEvaluators: ['safety'],
+        },
+      });
+    });
+
     it('treats an empty evaluator selector as the default evaluator set', async () => {
       const app = createCritiqueApp({
         pipeline: new CritiquePipeline([

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -4,7 +4,11 @@ import type {
   ProviderCritiqueFinding,
   Score as SharedScore,
 } from '@franken/types';
-import { createScore, UnknownEvaluatorError } from '@franken/critique';
+import {
+  ConfigurationError,
+  createScore,
+  UnknownEvaluatorError,
+} from '@franken/critique';
 import type {
   CritiquePipelineRunOptions,
   CritiquePipelineResult,
@@ -25,6 +29,8 @@ describe('public critique type contracts', () => {
 
     expect(options.evaluatorNames).toEqual(['safety']);
     expect(error.evaluatorNames).toEqual(['missing']);
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error.code).toBe('CONFIGURATION_INVALID');
   });
 
   it('imports provider findings and critique pipeline results without alias confusion', () => {

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { createSessionId } from '@franken/types';
-import type { ProviderCritiqueFinding, Score as SharedScore } from '@franken/types';
-import { createScore } from '@franken/critique';
 import type {
+  ProviderCritiqueFinding,
+  Score as SharedScore,
+} from '@franken/types';
+import { createScore, UnknownEvaluatorError } from '@franken/critique';
+import type {
+  CritiquePipelineRunOptions,
   CritiquePipelineResult,
   CritiqueResult,
   LessonRollbackWorkflow,
@@ -13,6 +17,16 @@ import type {
 } from '@franken/critique';
 
 describe('public critique type contracts', () => {
+  it('exports evaluator selection options and errors', () => {
+    const options: CritiquePipelineRunOptions = {
+      evaluatorNames: ['safety'],
+    };
+    const error = new UnknownEvaluatorError(['missing']);
+
+    expect(options.evaluatorNames).toEqual(['safety']);
+    expect(error.evaluatorNames).toEqual(['missing']);
+  });
+
   it('imports provider findings and critique pipeline results without alias confusion', () => {
     const providerFinding: ProviderCritiqueFinding = {
       evaluator: 'reflection',
@@ -104,7 +118,9 @@ describe('public critique type contracts', () => {
         info: 0,
         total: 1,
       },
-      improvementSignals: ['Recovered from 1 failing critique iteration before pass.'],
+      improvementSignals: [
+        'Recovered from 1 failing critique iteration before pass.',
+      ],
       guidance: 'copy into PM handoff',
     };
 

--- a/packages/franken-critique/tests/unit/types/public-contracts.test.ts
+++ b/packages/franken-critique/tests/unit/types/public-contracts.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   ConfigurationError,
   createScore,
+  RequiredEvaluatorSelectionError,
   UnknownEvaluatorError,
 } from '@franken/critique';
 import type {
@@ -31,6 +32,10 @@ describe('public critique type contracts', () => {
     expect(error.evaluatorNames).toEqual(['missing']);
     expect(error).toBeInstanceOf(ConfigurationError);
     expect(error.code).toBe('CONFIGURATION_INVALID');
+
+    const requiredError = new RequiredEvaluatorSelectionError(['safety']);
+    expect(requiredError).toBeInstanceOf(ConfigurationError);
+    expect(requiredError.requiredEvaluatorNames).toEqual(['safety']);
   });
 
   it('imports provider findings and critique pipeline results without alias confusion', () => {


### PR DESCRIPTION
## Summary
- pass the validated request evaluator allowlist into the critique pipeline
- run only registered evaluators selected by the caller
- reject unknown evaluator names with a structured 400 response
- export the selector options and typed error through the package API

## Test plan
- `npm run test --workspace @franken/critique` (786 passed)
- `npm run typecheck --workspace @franken/critique`
- `npm run lint --workspace @franken/critique`
- `npm run build --workspace @franken/critique`
- Prettier check on all changed files

Closes #3536