### PR TITLE
fix(orchestrator): bound skill context writes

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono';
-import { ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 import { isUnsafeSkillPathError, type SkillManager } from '../../skills/skill-manager.js';
 import { SkillHealthChecker } from '../../skills/skill-health-checker.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
 import { HttpError, parseJsonBody } from '../middleware.js';
+
+const SKILL_CONTEXT_MAX_CONTENT_BYTES = 256 * 1024;
+const skillContextBodySchema = z.object({ content: z.string() });
 
 function isSkillInstallValidationError(err: unknown): boolean {
   return err instanceof ZodError
@@ -168,17 +171,29 @@ export function createSkillRoutes(deps: {
 
   app.put('/:name/context', async (c) => {
     const name = c.req.param('name');
-    let body: { content: string };
+    let rawBody: unknown;
     try {
-      body = (await parseJsonBody(c)) as { content: string };
+      rawBody = await parseJsonBody(c);
     } catch (err) {
       if (err instanceof HttpError && err.statusCode === 400) {
         return c.json({ error: 'Invalid JSON' }, 400);
       }
       throw err;
     }
+
+    const parsedBody = skillContextBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return c.json({ error: 'Context content must be a string' }, 400);
+    }
+    if (Buffer.byteLength(parsedBody.data.content, 'utf8') > SKILL_CONTEXT_MAX_CONTENT_BYTES) {
+      return c.json(
+        { error: `Context content exceeds the ${SKILL_CONTEXT_MAX_CONTENT_BYTES}-byte limit` },
+        413,
+      );
+    }
+
     try {
-      deps.skillManager.writeContext(name, body.content);
+      deps.skillManager.writeContext(name, parsedBody.data.content);
       return c.json({ updated: true });
     } catch (err) {
       return c.json(

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -415,6 +415,44 @@ describe('Skill API routes', () => {
       expect(writeContextSpy).not.toHaveBeenCalled();
     });
 
+    it('returns 400 without writing when context content is not a string', async () => {
+      await manager.install({
+        name: 'github', description: 'GH', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+      const writeContextSpy = vi.spyOn(manager, 'writeContext');
+
+      const res = await app.request('/api/skills/github/context', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: { markdown: '# Team rules' } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Context content must be a string' });
+      expect(writeContextSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns 413 without writing when UTF-8 context content exceeds 256 KiB', async () => {
+      await manager.install({
+        name: 'github', description: 'GH', provider: 'cli',
+        installConfig: { command: 'npx' }, authFields: [],
+      });
+      const writeContextSpy = vi.spyOn(manager, 'writeContext');
+
+      const res = await app.request('/api/skills/github/context', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'é'.repeat((256 * 1024) / 2 + 1) }),
+      });
+
+      expect(res.status).toBe(413);
+      expect(await res.json()).toEqual({
+        error: 'Context content exceeds the 262144-byte limit',
+      });
+      expect(writeContextSpy).not.toHaveBeenCalled();
+    });
+
     it('returns generic unsafe path errors for unsafe context writes', async () => {
       mkdirSync(join(skillsDir, 'github'), { recursive: true });
       writeFileSync(join(skillsDir, 'github', 'mcp.json'), JSON.stringify({


### PR DESCRIPTION
## Summary
- validate skill context payload content as a runtime string before writing
- cap accepted context content at 256 KiB measured in UTF-8 bytes
- add route-level regressions for malformed and oversized context content

## Reproduction
On `d6e4b5bf0`, the focused context-content tests failed because malformed and oversized payloads reached the write path.

## Verification
- `npm test` (franken-orchestrator): 283 files, 4,402 tests passed
- `npm run typecheck` (franken-orchestrator)
- `npm run build` (franken-orchestrator)
- `npm run lint` (franken-orchestrator; 0 errors, pre-existing warnings only)
- `npx vitest run tests/integration/skills/skill-routes.test.ts tests/unit/http/skill-routes-mounting.test.ts`: 33 tests passed
- focused ESLint and `git diff --check`

Closes #3204