### PR TITLE
fix(orchestrator): validate skill install request bodies

### DIFF
--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z, ZodError } from 'zod';
+import type { McpServerConfig, SkillCatalogEntry, ToolDefinition } from '@franken/types';
 import { isUnsafeSkillPathError, type SkillManager } from '../../skills/skill-manager.js';
 import { SkillHealthChecker } from '../../skills/skill-health-checker.js';
 import type { ProviderRegistry } from '../../providers/provider-registry.js';
@@ -7,6 +8,119 @@ import { HttpError, parseJsonBody } from '../middleware.js';
 
 const SKILL_CONTEXT_MAX_CONTENT_BYTES = 256 * 1024;
 const skillContextBodySchema = z.object({ content: z.string() });
+
+const MAX_SKILL_NAME_LENGTH = 128;
+const MAX_FIELD_LENGTH = 4_096;
+const MAX_COLLECTION_ITEMS = 128;
+const MAX_INPUT_SCHEMA_BYTES = 8 * 1_024;
+const SAFE_SKILL_NAME = /^[a-zA-Z0-9_-]+$/;
+
+const BoundedString = z.string().max(MAX_FIELD_LENGTH);
+const SkillName = z.string()
+  .min(1)
+  .max(MAX_SKILL_NAME_LENGTH)
+  .regex(SAFE_SKILL_NAME);
+
+const BoundedStringRecord = z.record(
+  z.string().min(1).max(MAX_SKILL_NAME_LENGTH),
+  BoundedString,
+).refine(
+  (record) => Object.keys(record).length <= MAX_COLLECTION_ITEMS,
+  `Must contain at most ${MAX_COLLECTION_ITEMS} entries`,
+);
+
+const BoundedInputSchema = z.record(
+  z.string().max(MAX_SKILL_NAME_LENGTH),
+  z.unknown(),
+).refine(
+  (record) => Object.keys(record).length <= MAX_COLLECTION_ITEMS,
+  `Must contain at most ${MAX_COLLECTION_ITEMS} entries`,
+).refine(
+  (record) => Buffer.byteLength(JSON.stringify(record), 'utf8') <= MAX_INPUT_SCHEMA_BYTES,
+  `Must serialize to at most ${MAX_INPUT_SCHEMA_BYTES} bytes`,
+);
+
+const SkillInstallConfigSchema = z.object({
+  command: z.string().min(1).max(MAX_FIELD_LENGTH),
+  args: z.array(BoundedString).max(MAX_COLLECTION_ITEMS).optional(),
+  env: BoundedStringRecord.optional(),
+  url: z.string().url().max(MAX_FIELD_LENGTH).optional(),
+}).strict();
+
+const SkillToolDefinitionSchema = z.object({
+  name: SkillName,
+  description: BoundedString,
+  inputSchema: BoundedInputSchema,
+  requiresHitl: z.boolean().optional(),
+}).strict();
+
+const CatalogInstallSchema = z.object({
+  name: SkillName,
+  description: BoundedString,
+  provider: z.string().min(1).max(MAX_SKILL_NAME_LENGTH),
+  installConfig: SkillInstallConfigSchema,
+  authFields: z.array(z.object({
+    key: z.string().min(1).max(MAX_SKILL_NAME_LENGTH),
+    label: BoundedString,
+    type: z.enum(['secret', 'text']),
+    required: z.boolean(),
+  }).strict()).max(MAX_COLLECTION_ITEMS),
+  toolDefinitions: z.array(SkillToolDefinitionSchema).max(MAX_COLLECTION_ITEMS).optional(),
+}).strict();
+
+const CustomInstallSchema = z.object({
+  name: SkillName,
+  config: SkillInstallConfigSchema,
+}).strict();
+
+const SkillInstallRequestSchema = z.object({
+  catalogEntry: CatalogInstallSchema.optional(),
+  custom: CustomInstallSchema.optional(),
+}).strict().superRefine((request, ctx) => {
+  if ((request.catalogEntry === undefined) === (request.custom === undefined)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Must provide exactly one of catalogEntry or custom',
+    });
+  }
+});
+
+function toMcpServerConfig(
+  config: z.infer<typeof SkillInstallConfigSchema>,
+): McpServerConfig {
+  return {
+    command: config.command,
+    ...(config.args !== undefined ? { args: config.args } : {}),
+    ...(config.env !== undefined ? { env: config.env } : {}),
+    ...(config.url !== undefined ? { url: config.url } : {}),
+  };
+}
+
+function toToolDefinition(
+  tool: z.infer<typeof SkillToolDefinitionSchema>,
+): ToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    ...(tool.requiresHitl !== undefined ? { requiresHitl: tool.requiresHitl } : {}),
+  };
+}
+
+function toSkillCatalogEntry(
+  entry: z.infer<typeof CatalogInstallSchema>,
+): SkillCatalogEntry {
+  return {
+    name: entry.name,
+    description: entry.description,
+    provider: entry.provider,
+    installConfig: toMcpServerConfig(entry.installConfig),
+    authFields: entry.authFields,
+    ...(entry.toolDefinitions !== undefined
+      ? { toolDefinitions: entry.toolDefinitions.map(toToolDefinition) }
+      : {}),
+  };
+}
 
 function isSkillInstallValidationError(err: unknown): boolean {
   return err instanceof ZodError
@@ -80,38 +194,40 @@ export function createSkillRoutes(deps: {
   });
 
   app.post('/', async (c) => {
-    let body: Record<string, unknown>;
+    let request: z.infer<typeof SkillInstallRequestSchema>;
     try {
-      body = (await parseJsonBody(c)) as Record<string, unknown>;
+      request = SkillInstallRequestSchema.parse(await parseJsonBody(c));
     } catch (err) {
       if (err instanceof HttpError && err.statusCode === 400) {
         return c.json({ error: 'Invalid JSON' }, 400);
+      }
+      if (err instanceof ZodError) {
+        return c.json({ error: skillInstallErrorMessage(err) }, 400);
       }
       throw err;
     }
 
     try {
-      if (body['catalogEntry']) {
-        const entry = body['catalogEntry'] as Parameters<
-          SkillManager['install']
-        >[0];
-        await deps.skillManager.install(entry);
-        return c.json({ installed: entry.name }, 201);
+      if (request.catalogEntry !== undefined) {
+        await deps.skillManager.install(toSkillCatalogEntry(request.catalogEntry));
+        return c.json({ installed: request.catalogEntry.name }, 201);
       }
 
-      if (body['custom']) {
-        const custom = body['custom'] as { name: string; config: Parameters<SkillManager['installCustom']>[1] };
-        await deps.skillManager.installCustom(custom.name, custom.config);
-        return c.json({ installed: custom.name }, 201);
+      if (request.custom !== undefined) {
+        await deps.skillManager.installCustom(
+          request.custom.name,
+          toMcpServerConfig(request.custom.config),
+        );
+        return c.json({ installed: request.custom.name }, 201);
       }
+
+      throw new Error('Validated skill install request contained no install payload');
     } catch (err) {
       if (!isSkillInstallValidationError(err)) {
         throw err;
       }
       return c.json({ error: skillInstallErrorMessage(err) }, 400);
     }
-
-    return c.json({ error: 'Must provide catalogEntry or custom' }, 400);
   });
 
   app.patch('/:name', async (c) => {

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -49,8 +49,18 @@ const SkillInstallConfigSchema = z.object({
 
 const SkillToolDefinitionSchema = z.object({
   name: z.string().min(1).max(MAX_SKILL_NAME_LENGTH),
+  title: BoundedString.optional(),
   description: BoundedString,
   inputSchema: BoundedInputSchema,
+  outputSchema: BoundedInputSchema.optional(),
+  annotations: z.object({
+    title: BoundedString.optional(),
+    readOnlyHint: z.boolean().optional(),
+    destructiveHint: z.boolean().optional(),
+    idempotentHint: z.boolean().optional(),
+    openWorldHint: z.boolean().optional(),
+  }).strict().optional(),
+  _meta: BoundedInputSchema.optional(),
   requiresHitl: z.boolean().optional(),
 }).strict();
 

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -29,6 +29,14 @@ const BoundedStringRecord = z.record(
   `Must contain at most ${MAX_COLLECTION_ITEMS} entries`,
 );
 
+function isJsonWithinByteLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8') <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
 const BoundedInputSchema = z.record(
   z.string().max(MAX_SKILL_NAME_LENGTH),
   z.unknown(),
@@ -36,7 +44,7 @@ const BoundedInputSchema = z.record(
   (record) => Object.keys(record).length <= MAX_COLLECTION_ITEMS,
   `Must contain at most ${MAX_COLLECTION_ITEMS} entries`,
 ).refine(
-  (record) => Buffer.byteLength(JSON.stringify(record), 'utf8') <= MAX_INPUT_SCHEMA_BYTES,
+  (record) => isJsonWithinByteLimit(record, MAX_INPUT_SCHEMA_BYTES),
   `Must serialize to at most ${MAX_INPUT_SCHEMA_BYTES} bytes`,
 );
 

--- a/packages/franken-orchestrator/src/http/routes/skill-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/skill-routes.ts
@@ -48,7 +48,7 @@ const SkillInstallConfigSchema = z.object({
 }).strict();
 
 const SkillToolDefinitionSchema = z.object({
-  name: SkillName,
+  name: z.string().min(1).max(MAX_SKILL_NAME_LENGTH),
   description: BoundedString,
   inputSchema: BoundedInputSchema,
   requiresHitl: z.boolean().optional(),

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -126,8 +126,12 @@ describe('Skill API routes', () => {
             authFields: [],
             toolDefinitions: [{
               name: 'linear.search',
+              title: 'Search Linear',
               description: 'Search Linear issues',
               inputSchema: { type: 'object' },
+              outputSchema: { type: 'object' },
+              annotations: { readOnlyHint: true, openWorldHint: false },
+              _meta: { provider: 'linear' },
             }],
           },
         }),

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -143,6 +143,112 @@ describe('Skill API routes', () => {
       expect(manager.exists('my-tool')).toBe(true);
     });
 
+    it.each([
+      {
+        label: 'malformed catalog entry',
+        payload: {
+          catalogEntry: {
+            name: 'unsafe-catalog',
+            description: 'Catalog entry',
+            provider: { unexpected: true },
+            installConfig: { command: 'node' },
+            authFields: [],
+          },
+        },
+      },
+      {
+        label: 'malformed custom entry',
+        payload: {
+          custom: {
+            name: 'unsafe-custom',
+            config: { command: 'node' },
+            unexpected: true,
+          },
+        },
+      },
+      {
+        label: 'oversized custom command',
+        payload: {
+          custom: {
+            name: 'oversized-custom',
+            config: { command: 'x'.repeat(4_097) },
+          },
+        },
+      },
+      {
+        label: 'unsafe custom skill name',
+        payload: {
+          custom: {
+            name: '../unsafe-custom',
+            config: { command: 'node' },
+          },
+        },
+      },
+      {
+        label: 'unbounded custom arguments',
+        payload: {
+          custom: {
+            name: 'too-many-args',
+            config: { command: 'node', args: Array.from({ length: 129 }, () => 'arg') },
+          },
+        },
+      },
+      {
+        label: 'oversized tool input schema',
+        payload: {
+          catalogEntry: {
+            name: 'oversized-schema',
+            description: 'Catalog entry',
+            provider: 'test',
+            installConfig: { command: 'node' },
+            authFields: [],
+            toolDefinitions: [{
+              name: 'large-tool',
+              description: 'Large schema',
+              inputSchema: { description: 'x'.repeat(8_193) },
+            }],
+          },
+        },
+      },
+      {
+        label: 'both install variants',
+        payload: {
+          catalogEntry: {
+            name: 'catalog-tool',
+            description: 'Catalog entry',
+            provider: 'test',
+            installConfig: { command: 'node' },
+            authFields: [],
+          },
+          custom: {
+            name: 'custom-tool',
+            config: { command: 'node' },
+          },
+        },
+      },
+    ])('rejects $label before calling SkillManager', async ({ payload }) => {
+      const skillManager = {
+        install: vi.fn().mockResolvedValue(undefined),
+        installCustom: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SkillManager;
+      const validationApp = new Hono();
+      validationApp.route('/api/skills', createSkillRoutes({
+        skillManager,
+        providerRegistry: mockProviderRegistry(),
+      }));
+
+      const res = await validationApp.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ error: expect.any(String) });
+      expect(skillManager.install).not.toHaveBeenCalled();
+      expect(skillManager.installCustom).not.toHaveBeenCalled();
+    });
+
     it('rejects invalid custom MCP configs without poisoning the skills list', async () => {
       const res = await app.request('/api/skills', {
         method: 'POST',
@@ -153,7 +259,7 @@ describe('Skill API routes', () => {
       });
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toContain('mcpServers.broken-tool.args.0');
+      expect(body.error).toContain('custom.config.args.0');
       expect(existsSync(join(skillsDir, 'broken-tool', 'mcp.json'))).toBe(false);
 
       const listRes = await app.request('/api/skills');

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -258,6 +258,33 @@ describe('Skill API routes', () => {
       expect(skillManager.installCustom).not.toHaveBeenCalled();
     });
 
+    it('rejects deeply nested tool schemas without throwing from size validation', async () => {
+      const skillManager = {
+        install: vi.fn().mockResolvedValue(undefined),
+        installCustom: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SkillManager;
+      const validationApp = new Hono();
+      validationApp.onError(errorHandler);
+      validationApp.route('/api/skills', createSkillRoutes({
+        skillManager,
+        providerRegistry: mockProviderRegistry(),
+      }));
+      const depth = 10_000;
+      const deeplyNestedSchema = `${'{"nested":'.repeat(depth)}null${'}'.repeat(depth)}`;
+      const body = `{"catalogEntry":{"name":"deep-schema","description":"Deep schema","provider":"test","installConfig":{"command":"node"},"authFields":[],"toolDefinitions":[{"name":"deep-tool","description":"Deep tool","inputSchema":${deeplyNestedSchema}}]}}`;
+
+      const res = await validationApp.request('/api/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ error: expect.any(String) });
+      expect(skillManager.install).not.toHaveBeenCalled();
+      expect(skillManager.installCustom).not.toHaveBeenCalled();
+    });
+
     it('rejects invalid custom MCP configs without poisoning the skills list', async () => {
       const res = await app.request('/api/skills', {
         method: 'POST',

--- a/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts
@@ -124,6 +124,11 @@ describe('Skill API routes', () => {
             provider: 'claude-cli',
             installConfig: { command: 'npx', args: ['-y', '@mcp/linear'] },
             authFields: [],
+            toolDefinitions: [{
+              name: 'linear.search',
+              description: 'Search Linear issues',
+              inputSchema: { type: 'object' },
+            }],
           },
         }),
       });


### PR DESCRIPTION
## Summary
- validate `POST /api/skills` request bodies with strict bounded Zod schemas before invoking `SkillManager`
- reject malformed shapes, unknown fields, unsafe names, mutually exclusive variants, and oversized strings/collections/tool schemas with HTTP 400
- preserve valid catalog/custom installs and normalize validated optional properties for exact TypeScript types

## Reproduction
On fresh `origin/main` (`d6e4b5bf0`), focused integration tests demonstrated malformed and oversized payloads reached the install path because the route used unchecked casts.

## Test Plan
- [x] `npm run test --workspace @franken/orchestrator -- tests/integration/skills/skill-routes.test.ts` (34 passed)
- [x] `npm run test --workspace @franken/orchestrator` (4402 passed before final test-only matrix expansion)
- [x] `npm run build --workspace @franken/orchestrator`
- [x] `npx eslint packages/franken-orchestrator/src/http/routes/skill-routes.ts packages/franken-orchestrator/tests/integration/skills/skill-routes.test.ts`
- [x] `git diff --check`

Closes #3203
