### PR TITLE
fix(orchestrator): bound rate-limit stderr warnings

### DIFF
--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -31,6 +31,11 @@ import {
   parseResetTimeText,
   type CommandFailure,
 } from '../errors/command-failure.js';
+import { redactSensitiveText } from '../logging/redaction.js';
+
+const MAX_RATE_LIMIT_WARNING_STDERR_CHARS = 256;
+const MAX_RATE_LIMIT_WARNING_DIAGNOSTICS_CHARS = 768;
+const TRUNCATION_MARKER = '[truncated]';
 
 type RunLoopRateLimitState = {
   readonly activeProvider: string;
@@ -65,6 +70,12 @@ function abortError(reason?: unknown): Error {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
+}
+
+function sanitizeWarningText(text: string, maxChars: number): string {
+  const sanitized = redactSensitiveText(text).replace(/\s+/gu, ' ').trim();
+  if (sanitized.length <= maxChars) return sanitized;
+  return `${sanitized.slice(0, maxChars - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`;
 }
 
 /** Exported for tests: regression coverage that no abort listeners leak (issue #39). */
@@ -901,10 +912,14 @@ export class MartinLoop {
       return { sleepMs: shortestSleep * 1000, sleepSource: shortestSource };
     }
 
-    const rawStderrs = [...exhaustedProviders.entries()]
-      .map(([p, d]) => `${p}: ${d.stderr}`)
+    const providerDiagnostics = [...exhaustedProviders.entries()]
+      .map(([provider, failure]) => {
+        const stderr = sanitizeWarningText(failure.stderr || '<empty>', MAX_RATE_LIMIT_WARNING_STDERR_CHARS);
+        return `provider=${provider} status=rate-limited stderr=${stderr}`;
+      })
       .join(' | ');
-    console.warn(`[MartinLoop] Rate limit reset time could not be determined. Raw stderr: ${rawStderrs}`);
+    const boundedDiagnostics = sanitizeWarningText(providerDiagnostics, MAX_RATE_LIMIT_WARNING_DIAGNOSTICS_CHARS);
+    console.warn(`[MartinLoop] Rate limit reset time could not be determined. ${boundedDiagnostics}`);
     return { sleepMs: 120_000, sleepSource: 'unknown' };
   }
 

--- a/packages/franken-orchestrator/tests/unit/skills/rate-limit-resilience.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/rate-limit-resilience.test.ts
@@ -322,6 +322,31 @@ describe('MartinLoop — Rate Limit Resilience', () => {
     console.warn = origWarn;
   });
 
+  it('redacts and bounds provider stderr in fallback sleep warnings', async () => {
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const secret = ['sk', 'providersecretvalue123456789'].join('-');
+    const longDiagnostic = `rate limit exceeded api_key=${secret} ${'x'.repeat(5_000)}`;
+
+    queueMock({ stderr: longDiagnostic, exitCode: 1 });
+    queueMock({ stderr: `429 error Authorization: Bearer ${secret}`, exitCode: 1 });
+    queueMock({ stdout: 'ok!\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    await loop.run(baseConfig({
+      maxIterations: 1,
+      providers: ['claude', 'codex'],
+      _sleepFn: sleepFn,
+    }));
+
+    const warning = warnSpy.mock.calls.flat().join(' ');
+    expect(warning).toContain('could not be determined');
+    expect(warning).toContain('<redacted>');
+    expect(warning).not.toContain(secret);
+    expect(warning.length).toBeLessThanOrEqual(1_024);
+    expect(warning).toContain('[truncated]');
+  });
+
   it('picks shortest sleep time when multiple providers have different reset times', async () => {
     const sleepFn = vi.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- redact secret-like substrings before MartinLoop logs exhausted-provider stderr
- cap each provider stderr diagnostic and the aggregate fallback warning
- add a regression covering secret-like and oversized provider stderr

## Test Plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/skills/rate-limit-resilience.test.ts` (39 passed)
- `npm run test --workspace @franken/orchestrator` (full package suite passed)
- `npm run lint --workspace @franken/orchestrator` (0 errors; existing warnings only)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`

Closes #3173
