### PR TITLE
fix(release): target repository for latest-tag repair

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,6 +65,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 

--- a/tests/unit/ci-workflow.test.ts
+++ b/tests/unit/ci-workflow.test.ts
@@ -559,6 +559,9 @@ jobs:
       (step) => step.name === 'Ensure only root release is marked latest',
     );
     expect(releaseLatestStep).toBeTruthy();
+    expect(expectRecord(releaseLatestStep?.env, 'latest-release repair environment').GH_REPO).toBe(
+      '${{ github.repository }}',
+    );
     const releaseLatestRun = String(releaseLatestStep?.run ?? '');
     const firstCommand = releaseLatestRun
       .split('\n')


### PR DESCRIPTION
## Summary
- set `GH_REPO` for the latest-release repair step so `gh release` commands work without a repository checkout
- preserve the existing post-promotion latest-tag verification
- add regression coverage that pins the repository context

## Root cause
The `release-please` job does not check out the repository. Live run 29951186445 failed on the first `gh release list` call with `fatal: not a git repository`, leaving the component release marked latest and making the existing verification unreachable.

## Test plan
- `npm run test:root -- tests/workspaces.test.ts tests/unit/release-please-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/web-dev-server-dependency-policy.test.ts` (113 passed)
- `actionlint .github/workflows/release-please.yml`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `GH_REPO=djm204/frankenbeast gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName,isLatest` from `/tmp`

Closes #3027
