### PR TITLE
fix(mcp): redact hook entrypoint failures

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook-entrypoint.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook-entrypoint.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalArgv = [...process.argv];
+
+describe('fbeast-hook entrypoint', () => {
+  afterEach(() => {
+    process.argv = [...originalArgv];
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('does not print rejected hook error payloads', async () => {
+    const secret = ['entrypoint', 'secret', 'value'].join('-');
+    const rejectedPayload = {
+      message: 'hook dependency failed',
+      details: { token: secret },
+    };
+
+    vi.doMock('../shared/is-main.js', () => ({ isMain: () => true }));
+    vi.doMock('../adapters/governor-adapter.js', () => ({
+      createGovernorAdapter: () => ({
+        check: vi.fn().mockRejectedValue(rejectedPayload),
+      }),
+    }));
+    vi.doMock('../adapters/observer-adapter.js', () => ({
+      createObserverAdapter: () => ({ log: vi.fn() }),
+    }));
+
+    process.argv = ['node', 'fbeast-hook', 'pre-tool', 'test-tool'];
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await import('./hook.js');
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+
+    const logged = JSON.stringify(error.mock.calls);
+    expect(logged).toContain('fbeast-hook failed');
+    expect(logged).not.toContain(secret);
+    expect(logged).not.toContain('hook dependency failed');
+  });
+});

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -468,8 +468,10 @@ export async function runHook(
 
 const isMain = (await import('../shared/is-main.js')).isMain(import.meta.url);
 if (isMain) {
-  runHook().catch((error) => {
-    console.error('fbeast-hook failed:', error);
+  runHook().catch(() => {
+    // Hook failures can wrap arbitrary tool/provider payloads. Keep the
+    // entrypoint diagnostic stable without serializing the rejected value.
+    console.error('fbeast-hook failed');
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
- stop serializing arbitrary rejected values from the `fbeast-hook` top-level failure handler
- retain a stable failure diagnostic and exit status
- add entrypoint regression coverage for nested secret-bearing rejection payloads

## Verification
- `npm run test --workspace @franken/mcp-suite` (613 passed)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (0 errors; 26 pre-existing warnings)
- `npm run build` (10/10 packages)

Closes #3617