### PR TITLE
fix(orchestrator): validate decrypted local secrets

### DIFF
--- a/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
@@ -10,6 +10,50 @@ const KEY_LENGTH = 32;
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
 const SALT_LENGTH = 32;
+const DANGEROUS_SECRET_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function createSecretsRecord(): Record<string, string> {
+  return Object.create(null) as Record<string, string>;
+}
+
+function assertSafeSecretKey(key: string): void {
+  if (DANGEROUS_SECRET_KEYS.has(key)) {
+    throw new Error(`Unsafe local secret key: ${JSON.stringify(key)}`);
+  }
+}
+
+function parseSecretsPayload(plaintext: string): Record<string, string> {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(plaintext) as unknown;
+  } catch (error) {
+    throw new Error('Corrupt or incompatible local secrets: decrypted payload is not valid JSON', {
+      cause: error,
+    });
+  }
+
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Corrupt or incompatible local secrets: expected a plain string-to-string object');
+  }
+
+  const prototype = Object.getPrototypeOf(payload) as unknown;
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error('Corrupt or incompatible local secrets: expected a plain string-to-string object');
+  }
+
+  const secrets = createSecretsRecord();
+  for (const [key, value] of Object.entries(payload)) {
+    if (DANGEROUS_SECRET_KEYS.has(key)) {
+      throw new Error(`Corrupt or incompatible local secrets: unsafe key ${JSON.stringify(key)}`);
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`Corrupt or incompatible local secrets: value for ${JSON.stringify(key)} must be a string`);
+    }
+    secrets[key] = value;
+  }
+
+  return secrets;
+}
 
 interface SecretsMeta {
   salt: string; // hex
@@ -32,6 +76,7 @@ export class LocalEncryptedStore implements ISecretStore {
   }
 
   async store(key: string, value: string): Promise<void> {
+    assertSafeSecretKey(key);
     const secrets = await this.loadSecrets();
     secrets[key] = value;
     await this.saveSecrets(secrets);
@@ -105,7 +150,7 @@ export class LocalEncryptedStore implements ISecretStore {
       ciphertext = await readFile(this.encPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return {};
+        return createSecretsRecord();
       }
       throw error;
     }
@@ -118,7 +163,7 @@ export class LocalEncryptedStore implements ISecretStore {
     const decipher = createDecipheriv(ALGORITHM, key, iv);
     decipher.setAuthTag(authTag);
     const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return JSON.parse(decrypted.toString('utf-8')) as Record<string, string>;
+    return parseSecretsPayload(decrypted.toString('utf-8'));
   }
 
   private async saveSecrets(secrets: Record<string, string>): Promise<void> {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
@@ -42,6 +42,21 @@ describe('LocalEncryptedStore', () => {
       expect(value).toBeUndefined();
     });
 
+    it.each(['__proto__', 'prototype', 'constructor'])(
+      'does not resolve the prototype key %s as a secret',
+      async (key) => {
+        expect(await store.resolve(key)).toBeUndefined();
+      },
+    );
+
+    it.each(['__proto__', 'prototype', 'constructor'])(
+      'rejects the unsafe key %s before storing it',
+      async (key) => {
+        await expect(store.store(key, 'value')).rejects.toThrow(/unsafe local secret key/i);
+        expect(await store.keys()).toEqual([]);
+      },
+    );
+
     it('upserts existing key', async () => {
       await store.store('key', 'value1');
       await store.store('key', 'value2');
@@ -101,6 +116,23 @@ describe('LocalEncryptedStore', () => {
         passphrase: 'wrong-passphrase',
       });
       await expect(wrongStore.resolve('key')).rejects.toThrow();
+    });
+
+    it.each([
+      ['a null value', null],
+      ['a string', 'value'],
+      ['an array', ['value']],
+      ['a non-string value', { key: 42 }],
+      ['the dangerous __proto__ key', JSON.parse('{"__proto__":"value"}') as unknown],
+      ['the dangerous prototype key', { prototype: 'value' }],
+      ['the dangerous constructor key', { constructor: 'value' }],
+    ])('rejects a decrypted payload containing %s', async (_description, payload) => {
+      const unsafeStore = store as unknown as {
+        saveSecrets(secrets: Record<string, string>): Promise<void>;
+      };
+      await unsafeStore.saveSecrets(payload as Record<string, string>);
+
+      await expect(store.resolve('key')).rejects.toThrow(/corrupt or incompatible local secrets/i);
     });
   });
 });


### PR DESCRIPTION
## Summary
- validate decrypted local-secret payloads as plain string-to-string records
- reject prototype-related keys on load and store
- use null-prototype records for safely resolved secrets

## Verification
- `npm test -- --run tests/unit/network/secret-backends/local-encrypted-store.test.ts` (24 passed)
- `npm test` in `packages/franken-orchestrator` (4,416 passed)
- `npm run typecheck` in `packages/franken-orchestrator`
- `npm run lint` in `packages/franken-orchestrator` (0 errors)
- root `npm run build` (10 packages)
- root `npm run lint:security`
- independent `codex review --uncommitted` (no findings; reran focused tests and typecheck)

Closes #3009