### PR TITLE
fix(web): describe analytics event drawer

### DIFF
--- a/packages/franken-web/src/pages/analytics-page.test.tsx
+++ b/packages/franken-web/src/pages/analytics-page.test.tsx
@@ -585,6 +585,12 @@ describe('AnalyticsPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'View details for Denied destructive command' }));
 
     expect(await screen.findByText('Partial row data')).toBeTruthy();
+    const dialog = screen.getByRole('dialog', { name: 'Denied destructive command' });
+    const partialDescriptionId = dialog.getAttribute('aria-describedby');
+    expect(partialDescriptionId).toBeTruthy();
+    expect(document.getElementById(partialDescriptionId!)?.textContent).toBe(
+      'Analytics event details. Loading full event detail; the fields below are from the selected table row.',
+    );
     expect(screen.getByText('Loading full event detail; the fields below are from the selected table row.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy JSON' })).toHaveProperty('disabled', true);
     expect(screen.getByText('Copy JSON is available after full event detail loads.')).toBeTruthy();
@@ -604,6 +610,11 @@ describe('AnalyticsPage', () => {
     });
 
     expect(await screen.findByText('Full event detail')).toBeTruthy();
+    const fullDescriptionId = dialog.getAttribute('aria-describedby');
+    expect(fullDescriptionId).toBeTruthy();
+    expect(document.getElementById(fullDescriptionId!)?.textContent).toBe(
+      'Analytics event details. This drawer is showing the full analytics event detail.',
+    );
     expect(screen.getByText('This drawer is showing the full analytics event detail.')).toBeTruthy();
     expect(screen.getByText('"full": true')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy JSON' })).toHaveProperty('disabled', false);

--- a/packages/franken-web/src/pages/analytics-page.tsx
+++ b/packages/franken-web/src/pages/analytics-page.tsx
@@ -529,6 +529,11 @@ function DetailDrawer({
     tone: 'success' | 'error';
   } | null>(null);
   const detailStateLabel = hasFullDetail ? 'Full event detail' : 'Partial row data';
+  const detailStateDescription = hasFullDetail
+    ? 'This drawer is showing the full analytics event detail.'
+    : isLoading
+      ? 'Loading full event detail; the fields below are from the selected table row.'
+      : 'Full event detail is not loaded; the fields below are only from the selected table row.';
   const copyDisabled = !hasFullDetail;
 
   useEffect(() => {
@@ -572,7 +577,6 @@ function DetailDrawer({
       <Dialog.Portal>
         <Dialog.Overlay className="analytics-drawer-overlay" />
         <Dialog.Content
-          aria-describedby={undefined}
           aria-modal="true"
           asChild
           onOpenAutoFocus={(event) => {
@@ -587,6 +591,9 @@ function DetailDrawer({
                 <Dialog.Title asChild>
                   <h3><SafeMarkdownText text={detail.summary} /></h3>
                 </Dialog.Title>
+                <Dialog.Description className="sr-only">
+                  Analytics event details. {detailStateDescription}
+                </Dialog.Description>
               </div>
               <Dialog.Close asChild>
                 <button ref={closeButtonRef} className="button button--secondary button--small" type="button">Close</button>
@@ -597,13 +604,7 @@ function DetailDrawer({
 
             <div className="analytics-detail-status" aria-live="polite">
               <strong>{detailStateLabel}</strong>
-              <span>
-                {hasFullDetail
-                  ? 'This drawer is showing the full analytics event detail.'
-                  : isLoading
-                    ? 'Loading full event detail; the fields below are from the selected table row.'
-                    : 'Full event detail is not loaded; the fields below are only from the selected table row.'}
-              </span>
+              <span>{detailStateDescription}</span>
             </div>
 
             <dl className="analytics-detail-list">


### PR DESCRIPTION
## Summary
- add a Radix dialog description for the Analytics event-detail drawer
- announce whether the drawer contains loading/partial row data or full event detail
- preserve the existing live status while sharing one state-description source
- cover the `aria-describedby` relationship and its state update

## Test plan
- `npm test -- --run src/pages/analytics-page.test.tsx`
- `npm test` (712 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build` (repository root)

Closes #3589