### PR TITLE
fix(observer): make SQLite worker shutdown non-blocking

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -343,11 +343,12 @@ import { SQLiteAdapter } from '@franken/observer'
 const adapter = new SQLiteAdapter('./traces.db')
 await adapter.flush(trace)
 
+await adapter.close() // await worker cleanup before reopening
+
 // Reconstruct after restart
 const adapter2  = new SQLiteAdapter('./traces.db')
 const recovered = await adapter2.queryByTraceId(trace.id)
-
-adapter.close() // release the SQLite handle
+await adapter2.close()
 ```
 
 ### `TranscriptRetentionAdapter`

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.integration.test.ts
@@ -29,13 +29,13 @@ describe('SQLiteAdapter', () => {
     adapter = new SQLiteAdapter(dbPath)
   })
 
-  afterEach(() => {
-    adapter.close()
+  afterEach(async () => {
+    await adapter.close()
     cleanup(dbPath)
   })
 
   describe('database open hardening', () => {
-    it('creates nested database directories and configures durability pragmas', () => {
+    it('creates nested database directories and configures durability pragmas', async () => {
       const root = join(tmpdir(), `franken-observer-nested-${randomUUID()}`)
       const nestedDbPath = join(root, 'missing', 'observer.db')
       const nestedAdapter = new SQLiteAdapter(nestedDbPath)
@@ -48,7 +48,7 @@ describe('SQLiteAdapter', () => {
         expect(String(handle.pragma('journal_mode', { simple: true })).toLowerCase()).toBe('wal')
         expect(handle.pragma('foreign_keys', { simple: true })).toBe(1)
       } finally {
-        nestedAdapter.close()
+        await nestedAdapter.close()
         rmSync(root, { recursive: true, force: true })
       }
     })
@@ -70,13 +70,13 @@ describe('SQLiteAdapter', () => {
         const trace = TraceContext.createTrace('stable relative path')
         TraceContext.endTrace(trace)
         await relativeAdapter.flush(trace)
-        relativeAdapter.close()
+        await relativeAdapter.close()
 
         expect(existsSync(join(firstCwd, 'relative.db'))).toBe(true)
         expect(existsSync(join(secondCwd, 'relative.db'))).toBe(false)
       } finally {
         process.chdir(originalCwd)
-        relativeAdapter?.close()
+        await relativeAdapter?.close()
         rmSync(root, { recursive: true, force: true })
       }
     })
@@ -97,7 +97,7 @@ describe('SQLiteAdapter', () => {
           })
           expect((transientAdapter as unknown as { workerClient?: unknown }).workerClient).toBeUndefined()
         } finally {
-          transientAdapter.close()
+          await transientAdapter.close()
         }
       },
     )
@@ -278,11 +278,52 @@ describe('SQLiteAdapter', () => {
       expect(worker).toBeDefined()
       await worker!.terminate()
 
-      expect(() => adapter.close()).not.toThrow()
+      await expect(adapter.close()).resolves.toBeUndefined()
     })
 
-    it('waits for the worker to release its database handle before close returns', () => {
-      adapter.close()
+    it('keeps the event loop responsive while worker shutdown is delayed', async () => {
+      await adapter.close()
+      adapter = new SQLiteAdapter(dbPath, { busyTimeoutMs: 100 })
+      await adapter.listTraceIds()
+
+      const blocker = new Database(dbPath)
+      blocker.exec('BEGIN EXCLUSIVE')
+      try {
+        const worker = (adapter as unknown as {
+          workerClient: { worker: { postMessage: (message: unknown) => void } }
+        }).workerClient.worker
+        worker.postMessage({
+          id: -1,
+          operation: 'flush',
+          payload: {
+            traces: [{
+              id: 'delayed-close',
+              goal: 'hold worker before close',
+              status: 'completed',
+              startedAt: Date.now(),
+              spans: [],
+            }],
+          },
+        })
+
+        const timer = new Promise<'timer'>(resolve => setTimeout(() => resolve('timer'), 0))
+        const close = adapter.close()
+        const firstSettled = await Promise.race([
+          Promise.resolve(close).then(() => 'close' as const),
+          timer,
+        ])
+
+        expect(firstSettled).toBe('timer')
+        await close
+      } finally {
+        blocker.exec('ROLLBACK')
+        blocker.close()
+        await adapter.close()
+      }
+    })
+
+    it('releases the worker database handle before awaited close resolves', async () => {
+      await adapter.close()
 
       const reopened = new Database(dbPath)
       try {
@@ -302,12 +343,12 @@ describe('SQLiteAdapter', () => {
       TraceContext.endTrace(trace)
 
       await adapter.flush(trace)
-      adapter.close()
+      await adapter.close()
 
       // Simulate restart: new adapter instance, same file
       const restarted = new SQLiteAdapter(dbPath)
       const result = await restarted.queryByTraceId(trace.id)
-      restarted.close()
+      await restarted.close()
 
       expect(result).not.toBeNull()
       expect(result!.spans).toHaveLength(10)
@@ -377,8 +418,8 @@ describe('SQLiteAdapter', () => {
       raw.close()
     })
 
-    it('adds the ordered trace index when opening an existing database', () => {
-      adapter.close()
+    it('adds the ordered trace index when opening an existing database', async () => {
+      await adapter.close()
       const raw = new Database(dbPath)
       raw.exec('DROP INDEX IF EXISTS idx_traces_startedAt')
       raw.close()
@@ -403,9 +444,9 @@ describe('SQLiteAdapter', () => {
 
   describe('concurrent sequential writes', () => {
     it('does not poison the worker when startup overlaps a transient write lock', async () => {
-      adapter.close()
+      await adapter.close()
       const bootstrap = new SQLiteAdapter(dbPath, { useWorkerThread: false })
-      bootstrap.close()
+      await bootstrap.close()
       const blocker = new Database(dbPath)
       blocker.exec('BEGIN IMMEDIATE')
 
@@ -436,7 +477,7 @@ describe('SQLiteAdapter', () => {
     })
 
     it('does not let a read overtake an earlier queued write', async () => {
-      adapter.close()
+      await adapter.close()
       adapter = new SQLiteAdapter(dbPath, {
         busyTimeoutMs: 500,
         maxLockRetries: 0,
@@ -470,7 +511,7 @@ describe('SQLiteAdapter', () => {
     })
 
     it('keeps the event loop responsive while SQLite waits for a write lock', async () => {
-      adapter.close()
+      await adapter.close()
       adapter = new SQLiteAdapter(dbPath, {
         busyTimeoutMs: 500,
         maxLockRetries: 0,

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -415,11 +415,11 @@ describe('SQLiteAdapter', () => {
     TraceContext.endSpan(span)
 
     const flush = adapter.flush(trace)
-    adapter.close()
+    const close = adapter.close()
 
     expect(closeMock).not.toHaveBeenCalled()
     await flush
-    await Promise.resolve()
+    await close
 
     expect(upsertTraceRun).toHaveBeenCalledWith(expect.objectContaining({ id: trace.id }))
     expect(closeMock).toHaveBeenCalledTimes(1)

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -199,14 +199,19 @@ function execute(operation, payload) {
 
 parentPort.on('message', ({ id, operation, payload }) => {
   if (operation === 'close') {
-    const closeSignal = new Int32Array(payload.closeSignal)
     try {
       db.close()
-      parentPort.close()
-    } finally {
-      Atomics.store(closeSignal, 0, 1)
-      Atomics.notify(closeSignal, 0)
+      parentPort.postMessage({ id })
+    } catch (error) {
+      parentPort.postMessage({
+        id,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          ...(typeof error?.code === 'string' ? { code: error.code } : {}),
+        },
+      })
     }
+    parentPort.close()
     return
   }
   try {
@@ -234,6 +239,11 @@ class SQLiteWorkerClient {
   private closed = false
   private failure: Error | undefined
   private readonly closeTimeoutMs: number
+  private closePromise: Promise<void> | undefined
+  private closeRequestId: number | undefined
+  private closeTimer: ReturnType<typeof setTimeout> | undefined
+  private resolveClose: (() => void) | undefined
+  private rejectClose: ((error: Error) => void) | undefined
 
   constructor(filePath: string, busyTimeoutMs: number) {
     const require = createRequire(import.meta.url)
@@ -259,14 +269,10 @@ class SQLiteWorkerClient {
       },
     )
     this.worker.on('message', (response: SQLiteWorkerResponse) => this.handleResponse(response))
-    this.worker.on('error', error => this.rejectPending(
+    this.worker.on('error', error => this.handleWorkerFailure(
       error instanceof Error ? error : new Error(String(error)),
     ))
-    this.worker.on('exit', code => {
-      if (!this.closed) {
-        this.rejectPending(new Error(`SQLite worker exited with code ${code}`))
-      }
-    })
+    this.worker.on('exit', code => this.handleWorkerExit(code))
     this.worker.unref()
   }
 
@@ -290,28 +296,55 @@ class SQLiteWorkerClient {
     })
   }
 
-  close(): void {
-    if (this.closed) return
+  close(): Promise<void> {
+    if (this.closePromise !== undefined) return this.closePromise
     this.closed = true
     if (this.failure !== undefined) {
-      void this.worker.terminate()
-      return
+      this.closePromise = this.worker.terminate()
+        .then(() => undefined)
+        .finally(() => this.worker.unref())
+      return this.closePromise
     }
-    const closeSignal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
-    this.worker.postMessage({
-      id: 0,
-      operation: 'close',
-      payload: { closeSignal: closeSignal.buffer },
+    this.worker.ref()
+    this.closeRequestId = this.nextId++
+    this.closePromise = new Promise<void>((resolve, reject) => {
+      this.resolveClose = resolve
+      this.rejectClose = reject
     })
-    const result = Atomics.wait(closeSignal, 0, 0, this.closeTimeoutMs)
-    if (result === 'timed-out') {
+    this.closeTimer = setTimeout(() => {
+      const error = new Error(`Timed out closing SQLite worker after ${this.closeTimeoutMs}ms`)
+      this.rejectPending(error)
+      this.settleClose(error)
+      this.worker.unref()
       void this.worker.terminate()
-      throw new Error(`Timed out closing SQLite worker after ${this.closeTimeoutMs}ms`)
+    }, this.closeTimeoutMs)
+    try {
+      this.worker.postMessage({
+        id: this.closeRequestId,
+        operation: 'close',
+        payload: {},
+      })
+    } catch (cause) {
+      const error = cause instanceof Error ? cause : new Error(String(cause))
+      this.rejectPending(error)
+      this.settleClose(error)
+      this.worker.unref()
+      void this.worker.terminate()
     }
-    this.worker.unref()
+    return this.closePromise
   }
 
   private handleResponse(response: SQLiteWorkerResponse): void {
+    if (response.id === this.closeRequestId) {
+      if (response.error === undefined) {
+        this.settleClose()
+      } else {
+        const error = this.workerResponseError(response.error)
+        this.rejectPending(error)
+        this.settleClose(error)
+      }
+      return
+    }
     const pending = this.pending.get(response.id)
     if (pending === undefined) return
     this.pending.delete(response.id)
@@ -320,9 +353,44 @@ class SQLiteWorkerClient {
       pending.resolve(response.result)
       return
     }
-    const error = new Error(response.error.message) as Error & { code?: string }
-    if (response.error.code !== undefined) error.code = response.error.code
-    pending.reject(error)
+    pending.reject(this.workerResponseError(response.error))
+  }
+
+  private workerResponseError(response: NonNullable<SQLiteWorkerResponse['error']>): Error {
+    const error = new Error(response.message) as Error & { code?: string }
+    if (response.code !== undefined) error.code = response.code
+    return error
+  }
+
+  private handleWorkerFailure(error: Error): void {
+    this.rejectPending(error)
+    this.settleClose(error)
+  }
+
+  private handleWorkerExit(code: number): void {
+    if (this.resolveClose === undefined && this.rejectClose === undefined) {
+      if (!this.closed) this.rejectPending(new Error(`SQLite worker exited with code ${code}`))
+      return
+    }
+    const error = new Error(`SQLite worker exited with code ${code} before acknowledging close`)
+    this.rejectPending(error)
+    this.settleClose(error)
+  }
+
+  private settleClose(error?: Error): void {
+    const resolve = this.resolveClose
+    const reject = this.rejectClose
+    if (resolve === undefined || reject === undefined) return
+    this.resolveClose = undefined
+    this.rejectClose = undefined
+    this.closeRequestId = undefined
+    if (this.closeTimer !== undefined) {
+      clearTimeout(this.closeTimer)
+      this.closeTimer = undefined
+    }
+    this.worker.unref()
+    if (error === undefined) resolve()
+    else reject(error)
   }
 
   private rejectPending(error: Error): void {
@@ -505,6 +573,7 @@ export class SQLiteAdapter implements ExportAdapter {
   private operationTail: Promise<unknown> | undefined
   private closeAfterOperations = false
   private closed = false
+  private closePromise: Promise<void> | undefined
 
   constructor(filePath: string, options: SQLiteAdapterOptions = {}) {
     const lockRetry = normalizeLockRetryOptions(options)
@@ -826,22 +895,19 @@ export class SQLiteAdapter implements ExportAdapter {
     const settled = queued.catch(() => undefined).finally(() => {
       if (this.operationTail !== settled) return
       this.operationTail = undefined
-      if (this.closeAfterOperations) {
-        this.closeNow()
-      }
     })
     this.operationTail = settled
     return queued
   }
 
-  private closeNow(): void {
-    if (this.closed) return
+  private closeNow(): Promise<void> {
+    if (this.closed) return Promise.resolve()
     this.closed = true
-    try {
-      this.workerClient?.close()
-    } finally {
+    if (this.workerClient === undefined) {
       this.db.close()
+      return Promise.resolve()
     }
+    return this.workerClient.close().finally(() => this.db.close())
   }
 
   private emitLockRetryDiagnostic(diagnostic: SQLiteLockRetryDiagnostic): void {
@@ -939,12 +1005,14 @@ export class SQLiteAdapter implements ExportAdapter {
     return Math.min(base + Math.random() * this.lockRetry.baseDelayMs, this.lockRetry.maxDelayMs)
   }
 
-  /** Release the DB connection. Call when shutting down. */
-  close(): void {
+  /** Release both DB connections. Await completion before reopening the database or exiting. */
+  close(): Promise<void> {
+    if (this.closePromise !== undefined) return this.closePromise
     this.closeAfterOperations = true
-    if (this.operationTail === undefined) {
-      this.closeNow()
-    }
+    this.closePromise = this.operationTail === undefined
+      ? this.closeNow()
+      : this.operationTail.then(() => this.closeNow())
+    return this.closePromise
   }
 }
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.worker.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.worker.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+type WorkerEvent = 'message' | 'error' | 'exit'
+type WorkerListener = (...args: unknown[]) => void
+
+const workerMocks = vi.hoisted(() => {
+  const instances: Array<{
+    listeners: Map<WorkerEvent, WorkerListener[]>
+    on: ReturnType<typeof vi.fn>
+    postMessage: ReturnType<typeof vi.fn>
+    ref: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
+    terminate: ReturnType<typeof vi.fn>
+    emit: (event: WorkerEvent, ...args: unknown[]) => void
+  }> = []
+
+  return {
+    instances,
+    create() {
+      const listeners = new Map<WorkerEvent, WorkerListener[]>()
+      const worker = {
+        listeners,
+        on: vi.fn((event: WorkerEvent, listener: WorkerListener) => {
+          const registered = listeners.get(event) ?? []
+          registered.push(listener)
+          listeners.set(event, registered)
+          return worker
+        }),
+        postMessage: vi.fn(),
+        ref: vi.fn(),
+        unref: vi.fn(),
+        terminate: vi.fn().mockResolvedValue(1),
+        emit(event: WorkerEvent, ...args: unknown[]) {
+          for (const listener of listeners.get(event) ?? []) listener(...args)
+        },
+      }
+      instances.push(worker)
+      return worker
+    },
+  }
+})
+
+const databaseMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  pragma: vi.fn((statement: string) => statement === "index_list('traces')"
+    ? [{ name: 'idx_traces_startedAt' }]
+    : undefined),
+  exec: vi.fn(),
+}))
+
+vi.mock('node:worker_threads', () => ({
+  Worker: vi.fn(function MockWorker() {
+    return workerMocks.create()
+  }),
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function MockDatabase() {
+    return {
+      pragma: databaseMocks.pragma,
+      exec: databaseMocks.exec,
+      close: databaseMocks.close,
+    }
+  }),
+}))
+
+import { SQLiteAdapter } from './SQLiteAdapter.js'
+
+describe('SQLiteAdapter worker close lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    workerMocks.instances.length = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns one idempotent promise and resolves it from the close response', async () => {
+    const adapter = new SQLiteAdapter('/tmp/worker-close.db')
+    const worker = workerMocks.instances[0]!
+
+    const first = adapter.close()
+    const second = adapter.close()
+
+    expect(second).toBe(first)
+    expect(worker.ref).toHaveBeenCalledTimes(1)
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+    const request = worker.postMessage.mock.calls[0]![0] as { id: number; operation: string }
+    expect(request.operation).toBe('close')
+
+    worker.emit('message', { id: request.id })
+    await expect(first).resolves.toBeUndefined()
+
+    expect(worker.unref).toHaveBeenCalled()
+    expect(worker.terminate).not.toHaveBeenCalled()
+    expect(databaseMocks.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a bounded close timeout, terminates the worker, and unrefs it', async () => {
+    vi.useFakeTimers()
+    const adapter = new SQLiteAdapter('/tmp/worker-close-timeout.db', { busyTimeoutMs: 1 })
+    const worker = workerMocks.instances[0]!
+
+    const close = adapter.close()
+    const rejected = expect(close).rejects.toThrow('Timed out closing SQLite worker after 1001ms')
+    await vi.advanceTimersByTimeAsync(1001)
+    await rejected
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1)
+    expect(worker.unref).toHaveBeenCalled()
+    expect(databaseMocks.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles close and every pending request once on worker error', async () => {
+    const adapter = new SQLiteAdapter('/tmp/worker-close-error.db')
+    const worker = workerMocks.instances[0]!
+    const client = (adapter as unknown as {
+      workerClient: { request<T>(operation: string): Promise<T>; close(): Promise<void> }
+    }).workerClient
+    const requestRejected = vi.fn()
+    const closeRejected = vi.fn()
+    const request = client.request<string[]>('listTraceIds').catch(requestRejected)
+    const close = client.close().catch(closeRejected)
+
+    worker.emit('error', new Error('worker crashed'))
+    worker.emit('error', new Error('duplicate error'))
+    await Promise.all([request, close])
+
+    expect(requestRejected).toHaveBeenCalledTimes(1)
+    expect(requestRejected).toHaveBeenCalledWith(expect.objectContaining({ message: 'worker crashed' }))
+    expect(closeRejected).toHaveBeenCalledTimes(1)
+    expect(closeRejected).toHaveBeenCalledWith(expect.objectContaining({ message: 'worker crashed' }))
+    await expect(adapter.close()).rejects.toThrow('worker crashed')
+    expect(databaseMocks.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles close and every pending request once on unexpected worker exit', async () => {
+    const adapter = new SQLiteAdapter('/tmp/worker-close-exit.db')
+    const worker = workerMocks.instances[0]!
+    const client = (adapter as unknown as {
+      workerClient: { request<T>(operation: string): Promise<T>; close(): Promise<void> }
+    }).workerClient
+    const requestRejected = vi.fn()
+    const closeRejected = vi.fn()
+    const request = client.request<string[]>('listTraceIds').catch(requestRejected)
+    const close = client.close().catch(closeRejected)
+
+    worker.emit('exit', 2)
+    worker.emit('exit', 3)
+    await Promise.all([request, close])
+
+    expect(requestRejected).toHaveBeenCalledTimes(1)
+    expect(requestRejected).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'SQLite worker exited with code 2 before acknowledging close',
+    }))
+    expect(closeRejected).toHaveBeenCalledTimes(1)
+    expect(closeRejected).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'SQLite worker exited with code 2 before acknowledging close',
+    }))
+    await expect(adapter.close()).rejects.toThrow('SQLite worker exited with code 2 before acknowledging close')
+    expect(databaseMocks.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/franken-orchestrator/src/cli/trace-viewer.ts
+++ b/packages/franken-orchestrator/src/cli/trace-viewer.ts
@@ -37,7 +37,7 @@ export async function setupTraceViewer(
         if (stopped) return;
         stopped = true;
         await traceServer.stop();
-        sqliteAdapter.close();
+        await sqliteAdapter.close();
       },
     };
   } catch (err) {

--- a/tasks/issue-3587-sqlite-worker-shutdown-progress.md
+++ b/tasks/issue-3587-sqlite-worker-shutdown-progress.md
@@ -1,0 +1,13 @@
+# Issue #3587 SQLite worker shutdown progress
+
+- [x] Verify live issue state/labels and confirm it is not reserved as `good first issue`.
+- [x] Create isolated worktree from current `origin/main` and configure required git identity.
+- [x] Read shared lessons and inspect the worker/public close paths and existing shutdown tests.
+- [x] Add a focused regression that delays worker close and proves main-thread timers remain responsive.
+- [x] Run the focused regression red and record observed/expected behavior plus root cause on the Kanban card.
+- [x] Implement the smallest awaitable, idempotent, bounded asynchronous worker/adapter close contract.
+- [x] Cover timeout, error/exit, pending-request settlement, worker ref/unref, and existing flush/order guarantees.
+- [x] Run focused tests, observer tests, lint, typecheck, build, and relevant root verification (root tests exposed one unrelated `@franken/brain` timeout under parallel load).
+- [ ] Commit, push, open a single-issue PR with `Closes #3587`, and verify CI.
+- [ ] Complete the real GitHub `@codex review` loop on the current head and merge only when clean.
+- [ ] Append a concise durable shared lesson if useful and close the Kanban card.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -123,6 +123,10 @@
 - Preserve the one-agent-per-issue policy during doctor/PM closeout: if an existing worktree/card owns the PR, leave evidence-backed handoff comments instead of spawning a duplicate worker or parallel replacement; every PM status comment should explicitly state whether duplicate edits/workers were created.
 - DSM/docs-only closeout notes still move the PR head if committed, so after pushing them, re-check CI on the new head and report whether the push was a documentation/lesson-only change versus a code fix.
 
+## 2026-07-22 — Doctor closeout without force-pushing a diverged issue branch
+- When a verified PR fix is stranded in a rebased local branch that is ahead/behind the live PR head, preserve the fix as a patch and switch to a temporary local branch based directly on the remote PR branch; commit the fix there and push it as a normal fast-forward to the PR branch. This avoids rewriting reviewed history or waiting on destructive-reset/force-push approval while keeping one issue and one PR.
+- When an API changes cleanup from synchronous to awaitable, search repository consumers and await the returned promise in async teardown paths; package lint can expose missed consumers as `no-floating-promises`, and a Codex inline finding may point to a consumer even when attached to the changed API declaration.
+
 ## 2026-07-17 — Architecture docs package-name consistency
 - For docs-only architecture fixes, add narrow regression tests that slice the relevant README/docs sections and assert legacy labels are absent there, rather than banning every historical MOD reference across the repository; configuration/env docs may still need legacy toggles for compatibility.
 


### PR DESCRIPTION
## Summary
- replace the main-thread blocking worker close wait with a cached asynchronous close lifecycle
- reject new operations after close begins and settle pending requests safely
- add focused unit, integration, worker lifecycle coverage and document the awaitable close contract

## Verification
- focused SQLite unit tests: 23/23
- targeted SQLite integration tests: 28/28
- observer suite: 857/857
- observer lint: 0 errors (5 pre-existing warnings)
- observer typecheck: passed
- observer build: passed
- independent read-only diff review: PASS

Closes #3587