### PR TITLE
fix(observer): redact credentials from OTEL exports

### DIFF
--- a/packages/franken-observer/docs/adapters.md
+++ b/packages/franken-observer/docs/adapters.md
@@ -68,6 +68,11 @@ const adapter = new LangfuseAdapter({
 await adapter.flush(trace) // throws on non-2xx response
 ```
 
+Before export, credential-bearing OTEL attributes and secret-shaped text are
+masked with `[REDACTED]`. This applies to trace content only; the Basic
+Authorization header still carries the configured Langfuse credentials and
+must not be logged by callers.
+
 **Options**
 
 | Option      | Type      | Default                      | Description                       |
@@ -219,6 +224,11 @@ const cloud = new TempoAdapter({
 })
 await cloud.flush(trace)
 ```
+
+Before export, credential-bearing OTEL attributes and secret-shaped text are
+masked with `[REDACTED]`. This applies to trace content only; the Basic
+Authorization header still carries the configured Grafana credentials and
+must not be logged by callers.
 
 **Options**
 

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
@@ -86,6 +86,42 @@ describe('LangfuseAdapter', () => {
       expect(idAttr?.value.stringValue).toBe(trace.id)
     })
 
+    it('redacts credentials from trace payloads while preserving request authentication', async () => {
+      const rawSecret = ['sk', 'observer', 'raw', 'credential'].join('-')
+      const jsonSecret = ['plain', 'json', 'credential', 'value'].join('-')
+      const colonSecret = ['plain', 'colon', 'credential', 'value'].join('-')
+      const authSecret = ['plain', 'bearer', 'credential', 'value'].join('-')
+      const trace = makeTrace()
+      trace.goal = `inspect api_key=${rawSecret}`
+      trace.spans[0]!.metadata = {
+        api_key: rawSecret,
+        authorization: `Bearer ${rawSecret}`,
+        diagnostic: `Authorization: Bearer ${authSecret}`,
+        jsonDiagnostic: JSON.stringify({ password: jsonSecret }),
+        colonDiagnostic: `password: ${colonSecret}`,
+        safe: 'retained',
+      }
+      const adapter = new LangfuseAdapter({
+        publicKey: LANGFUSE_PUBLIC_KEY,
+        secretKey: LANGFUSE_SECRET_KEY,
+        fetch: mockFetch,
+      })
+
+      await adapter.flush(trace)
+
+      const [, init] = mockFetch.mock.calls[0]
+      const body = init.body as string
+      expect(body).not.toContain(rawSecret)
+      expect(body).not.toContain(jsonSecret)
+      expect(body).not.toContain(colonSecret)
+      expect(body).not.toContain(authSecret)
+      expect(body).toContain('[REDACTED]')
+      expect(body).toContain('retained')
+      expect(init.headers['Authorization']).toBe(
+        `Basic ${Buffer.from(`${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}`).toString('base64')}`,
+      )
+    })
+
     it('throws if the HTTP response is not ok', async () => {
       mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
       const adapter = new LangfuseAdapter({ publicKey: 'bad', secretKey: 'bad', fetch: mockFetch })

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
@@ -1,6 +1,7 @@
 import type { ExportAdapter } from '../../export/ExportAdapter.js'
 import type { Trace } from '../../core/types.js'
 import { OTELSerializer } from '../../export/OTELSerializer.js'
+import { redactOTELPayloadSecrets } from '../../export/redactOTELPayloadSecrets.js'
 import { fetchWithRetry, type HttpRetryOptions } from '../../export/httpRetry.js'
 
 export type FetchFn = (
@@ -39,7 +40,7 @@ export class LangfuseAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
-    const payload = OTELSerializer.serializeTrace(trace)
+    const payload = redactOTELPayloadSecrets(OTELSerializer.serializeTrace(trace))
     const url = `${this.baseUrl}/api/public/otel/v1/traces`
     const response = await fetchWithRetry(
       () =>

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
@@ -122,6 +122,42 @@ describe('TempoAdapter', () => {
       const idAttr = resourceAttrs.find(a => a.key === 'frankenbeast.trace.id')
       expect(idAttr?.value.stringValue).toBe(trace.id)
     })
+
+    it('redacts credentials from trace payloads while preserving request authentication', async () => {
+      const rawSecret = ['glc', 'observer', 'raw', 'credential'].join('_')
+      const jsonSecret = ['plain', 'json', 'credential', 'value'].join('-')
+      const colonSecret = ['plain', 'colon', 'credential', 'value'].join('-')
+      const authSecret = ['plain', 'bearer', 'credential', 'value'].join('-')
+      const trace = makeTrace()
+      trace.goal = `inspect api_key=${rawSecret}`
+      trace.spans[0]!.metadata = {
+        apiKey: rawSecret,
+        authorization: `Bearer ${rawSecret}`,
+        diagnostic: `Authorization: Bearer ${authSecret}`,
+        jsonDiagnostic: JSON.stringify({ password: jsonSecret }),
+        colonDiagnostic: `password: ${colonSecret}`,
+        safe: 'retained',
+      }
+      const adapter = new TempoAdapter({
+        endpoint: 'https://otlp-gateway-prod-us-central-0.grafana.net',
+        basicAuth: { user: '123456', password: rawSecret },
+        fetch: mockFetch,
+      })
+
+      await adapter.flush(trace)
+
+      const [, init] = mockFetch.mock.calls[0]
+      const body = init.body as string
+      expect(body).not.toContain(rawSecret)
+      expect(body).not.toContain(jsonSecret)
+      expect(body).not.toContain(colonSecret)
+      expect(body).not.toContain(authSecret)
+      expect(body).toContain('[REDACTED]')
+      expect(body).toContain('retained')
+      expect(init.headers['Authorization']).toBe(
+        `Basic ${Buffer.from(`123456:${rawSecret}`).toString('base64')}`,
+      )
+    })
   })
 
   describe('flush() — error handling', () => {

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
@@ -2,6 +2,7 @@ import type { ExportAdapter } from '../../export/ExportAdapter.js'
 import type { Trace } from '../../core/types.js'
 import type { FetchFn } from '../langfuse/LangfuseAdapter.js'
 import { OTELSerializer } from '../../export/OTELSerializer.js'
+import { redactOTELPayloadSecrets } from '../../export/redactOTELPayloadSecrets.js'
 import { fetchWithRetry, type HttpRetryOptions } from '../../export/httpRetry.js'
 
 export interface TempoBasicAuth {
@@ -67,7 +68,7 @@ export class TempoAdapter implements ExportAdapter {
   }
 
   async flush(trace: Trace): Promise<void> {
-    const payload = OTELSerializer.serializeTrace(trace)
+    const payload = redactOTELPayloadSecrets(OTELSerializer.serializeTrace(trace))
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     if (this.authHeader) headers['Authorization'] = this.authHeader
 

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { OTELPayload } from './OTELSerializer.js'
+import { redactOTELPayloadSecrets } from './redactOTELPayloadSecrets.js'
+
+function payloadWith(...values: string[]): OTELPayload {
+  return {
+    resourceSpans: [{
+      resource: {
+        attributes: values.map((value, index) => ({
+          key: `diagnostic.${index}`,
+          value: { stringValue: value },
+        })),
+      },
+      scopeSpans: [{ scope: { name: '@franken/observer' }, spans: [] }],
+    }],
+  }
+}
+
+describe('redactOTELPayloadSecrets', () => {
+  it('redacts shared credential families from OTEL text attributes', () => {
+    const cookieSecret = ['cookie', 'session', 'credential'].join('-')
+    const csrfSecret = ['cookie', 'csrf', 'credential'].join('-')
+    const basicSecret = ['dXNl', 'cjpw', 'YXNz'].join('')
+    const databaseSecret = ['database', 'credential', 'value'].join('-')
+    const webhookSecret = ['discord', 'webhook', 'credential'].join('-')
+    const tokenSecrets = [
+      ['github', 'pat', 'a'.repeat(24)].join('_'),
+      `ghs_${'b'.repeat(24)}`,
+      `ghr_${'c'.repeat(24)}`,
+      `npm_${'d'.repeat(24)}`,
+    ]
+
+    const redacted = redactOTELPayloadSecrets(payloadWith(
+      `Cookie: session=${cookieSecret}; csrf=${csrfSecret}`,
+      `authorization=Basic ${basicSecret}`,
+      `postgres://user:${databaseSecret}@db.example.test/app`,
+      `https://discord.com/api/webhooks/123/${webhookSecret}`,
+      ...tokenSecrets,
+      'safe diagnostic value',
+    ))
+    const output = JSON.stringify(redacted)
+
+    for (const secret of [
+      cookieSecret,
+      csrfSecret,
+      basicSecret,
+      databaseSecret,
+      webhookSecret,
+      ...tokenSecrets,
+    ]) {
+      expect(output).not.toContain(secret)
+    }
+    expect(output).toContain('[REDACTED]')
+    expect(output).toContain('safe diagnostic value')
+  })
+})

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -27,8 +27,14 @@ describe('redactOTELPayloadSecrets', () => {
       ['aggregate', 'credential', 'two'].join('-'),
     ]
     const keySecret = ['dynamic', 'key', 'credential'].join('-')
+    const pluralKeySecret = ['plural', 'key', 'credential'].join('-')
     const databaseSecret = ['database', 'credential', 'value'].join('-')
     const redisSecret = ['redis', 'tls', 'credential'].join('-')
+    const genericUrlSecret = ['generic', 'url', 'credential'].join('-')
+    const flagSecret = ['command', 'flag', 'credential'].join('-')
+    const geminiSecret = `AIza${'e'.repeat(35)}`
+    const slackSecret = ['slack', 'webhook', 'credential'].join('-')
+    const jwtSecret = `eyJ${'a'.repeat(16)}.${'b'.repeat(16)}.${'c'.repeat(16)}`
     const webhookSecret = ['discord', 'webhook', 'credential'].join('-')
     const tokenSecrets = [
       ['github', 'pat', 'a'.repeat(24)].join('_'),
@@ -42,8 +48,14 @@ describe('redactOTELPayloadSecrets', () => {
       `authorization=Basic ${basicSecret}`,
       `Authorization: Token ${tokenAuthSecret}`,
       JSON.stringify({ password: aggregateSecrets }),
+      `debug ${JSON.stringify({ secrets: aggregateSecrets })}`,
       `postgres://user:${databaseSecret}@db.example.test/app`,
       `rediss://:${redisSecret}@cache.example.test:6380/0`,
+      `https://user:${genericUrlSecret}@example.test/path`,
+      `--api-key ${flagSecret}`,
+      geminiSecret,
+      `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
+      jwtSecret,
       `https://discord.com/api/webhooks/123/${webhookSecret}`,
       ...tokenSecrets,
       'safe diagnostic value',
@@ -51,6 +63,9 @@ describe('redactOTELPayloadSecrets', () => {
     input.resourceSpans[0]!.resource.attributes.push({
       key: `api_key=${keySecret}`,
       value: { boolValue: true },
+    }, {
+      key: 'credentials',
+      value: { stringValue: pluralKeySecret },
     })
 
     const redacted = redactOTELPayloadSecrets(input)
@@ -63,8 +78,14 @@ describe('redactOTELPayloadSecrets', () => {
       tokenAuthSecret,
       ...aggregateSecrets,
       keySecret,
+      pluralKeySecret,
       databaseSecret,
       redisSecret,
+      genericUrlSecret,
+      flagSecret,
+      geminiSecret,
+      slackSecret,
+      jwtSecret,
       webhookSecret,
       ...tokenSecrets,
     ]) {

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -37,6 +37,11 @@ describe('redactOTELPayloadSecrets', () => {
     const tupleAuthSecret = ['tuple', 'auth', 'credential'].join('-')
     const tupleApiKeySecret = ['tuple', 'api', 'credential'].join('-')
     const truncatedAuthSecret = ['truncated', 'auth', 'credential'].join('-')
+    const escapedJsonSecret = ['escaped', 'json', 'credential'].join('-')
+    const digestSecret = ['digest', 'auth', 'credential'].join('-')
+    const headerObjectSecret = ['header', 'object', 'credential'].join('-')
+    const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
+      .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
     const slackSecret = ['slack', 'webhook', 'credential'].join('-')
     const jwtSecret = `eyJ${'a'.repeat(16)}.${'b'.repeat(16)}.${'c'.repeat(16)}`
@@ -62,6 +67,10 @@ describe('redactOTELPayloadSecrets', () => {
       `--auth Basic ${basicAuthSecret}`,
       JSON.stringify([['Authorization', `Basic ${tupleAuthSecret}`], ['x-api-key', tupleApiKeySecret]]),
       `{"Authorization":"Token ${truncatedAuthSecret}`,
+      `body={\\"password\\":\\"${escapedJsonSecret}\\"}`,
+      `--auth Digest ${digestSecret}`,
+      JSON.stringify([{ key: 'x-api-key', value: headerObjectSecret }]),
+      ...aliasSecrets.map(([key, secret]) => JSON.stringify({ [key]: secret })),
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
       jwtSecret,
@@ -97,6 +106,10 @@ describe('redactOTELPayloadSecrets', () => {
       tupleAuthSecret,
       tupleApiKeySecret,
       truncatedAuthSecret,
+      escapedJsonSecret,
+      digestSecret,
+      headerObjectSecret,
+      ...aliasSecrets.map(([, secret]) => secret),
       geminiSecret,
       slackSecret,
       jwtSecret,

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -21,7 +21,14 @@ describe('redactOTELPayloadSecrets', () => {
     const cookieSecret = ['cookie', 'session', 'credential'].join('-')
     const csrfSecret = ['cookie', 'csrf', 'credential'].join('-')
     const basicSecret = ['dXNl', 'cjpw', 'YXNz'].join('')
+    const tokenAuthSecret = ['token', 'authorization', 'credential'].join('-')
+    const aggregateSecrets = [
+      ['aggregate', 'credential', 'one'].join('-'),
+      ['aggregate', 'credential', 'two'].join('-'),
+    ]
+    const keySecret = ['dynamic', 'key', 'credential'].join('-')
     const databaseSecret = ['database', 'credential', 'value'].join('-')
+    const redisSecret = ['redis', 'tls', 'credential'].join('-')
     const webhookSecret = ['discord', 'webhook', 'credential'].join('-')
     const tokenSecrets = [
       ['github', 'pat', 'a'.repeat(24)].join('_'),
@@ -30,21 +37,34 @@ describe('redactOTELPayloadSecrets', () => {
       `npm_${'d'.repeat(24)}`,
     ]
 
-    const redacted = redactOTELPayloadSecrets(payloadWith(
+    const input = payloadWith(
       `Cookie: session=${cookieSecret}; csrf=${csrfSecret}`,
       `authorization=Basic ${basicSecret}`,
+      `Authorization: Token ${tokenAuthSecret}`,
+      JSON.stringify({ password: aggregateSecrets }),
       `postgres://user:${databaseSecret}@db.example.test/app`,
+      `rediss://:${redisSecret}@cache.example.test:6380/0`,
       `https://discord.com/api/webhooks/123/${webhookSecret}`,
       ...tokenSecrets,
       'safe diagnostic value',
-    ))
+    )
+    input.resourceSpans[0]!.resource.attributes.push({
+      key: `api_key=${keySecret}`,
+      value: { boolValue: true },
+    })
+
+    const redacted = redactOTELPayloadSecrets(input)
     const output = JSON.stringify(redacted)
 
     for (const secret of [
       cookieSecret,
       csrfSecret,
       basicSecret,
+      tokenAuthSecret,
+      ...aggregateSecrets,
+      keySecret,
       databaseSecret,
+      redisSecret,
       webhookSecret,
       ...tokenSecrets,
     ]) {

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -44,6 +44,8 @@ describe('redactOTELPayloadSecrets', () => {
     const multiwordSecret = ['correct', 'horse', 'battery', 'staple'].join(' ')
     const multiValueHeaderSecret = ['multi', 'value', 'header', 'credential'].join('-')
     const unmatchedTupleSecret = ['unmatched', 'tuple', 'credential'].join('-')
+    const unmatchedArraySecrets = ['alpha one', 'beta two']
+    const escapedArraySecrets = ['escaped alpha', 'escaped beta']
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -79,6 +81,9 @@ describe('redactOTELPayloadSecrets', () => {
       `passphrase=${multiwordSecret}`,
       JSON.stringify({ name: 'x-api-key', values: [multiValueHeaderSecret] }),
       `prefix { ... ${JSON.stringify([['x-api-key', unmatchedTupleSecret]])}`,
+      `prefix { ... ${JSON.stringify({ safe: 'x', password: unmatchedArraySecrets })}`,
+      `body={\\"password\\":[\\"${escapedArraySecrets[0]}\\",\\"${escapedArraySecrets[1]}\\"]}`,
+      `user: alice password: ${multiwordSecret}`,
       ...aliasSecrets.map(([key, secret]) => JSON.stringify({ [key]: secret })),
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
@@ -122,6 +127,8 @@ describe('redactOTELPayloadSecrets', () => {
       multiwordSecret,
       multiValueHeaderSecret,
       unmatchedTupleSecret,
+      ...unmatchedArraySecrets,
+      ...escapedArraySecrets,
       ...aliasSecrets.map(([, secret]) => secret),
       geminiSecret,
       slackSecret,

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -56,6 +56,10 @@ describe('redactOTELPayloadSecrets', () => {
     const truncatedHeaderSecret = ['truncated', 'header', 'credential'].join('-')
     const singleTupleSecret = ['single', 'tuple', 'credential'].join('-')
     const singleFieldSecret = ['single', 'field', 'credential'].join('-')
+    const queryApiKeySecret = ['query', 'api', 'credential'].join('-')
+    const queryTokenSecret = ['query', 'token', 'credential'].join('-')
+    const pgPasswordSecret = ['pg', 'password', 'credential'].join('-')
+    const clientSecret = ['client', 'secret', 'credential'].join('-')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -109,6 +113,11 @@ describe('redactOTELPayloadSecrets', () => {
       `[['x-api-key','${singleTupleSecret}']]`,
       `{'password': '${singleFieldSecret}'}`,
       'tool:execute tokens=504',
+      'usage={"input_tokens":30,"output_tokens":8}',
+      `url=https://example.test/cb?api_key=${queryApiKeySecret}&safe=value`,
+      `https://example.test/cb?safe=value&token=${queryTokenSecret}`,
+      `PGPASSWORD=${pgPasswordSecret}`,
+      `clientsecret=${clientSecret}`,
       'safe diagnostic value',
     )
     input.resourceSpans[0]!.resource.attributes.push({
@@ -166,12 +175,18 @@ describe('redactOTELPayloadSecrets', () => {
       truncatedHeaderSecret,
       singleTupleSecret,
       singleFieldSecret,
+      queryApiKeySecret,
+      queryTokenSecret,
+      pgPasswordSecret,
+      clientSecret,
     ]) {
       expect(output).not.toContain(secret)
     }
     expect(output).toContain('[REDACTED]')
     expect(output).toContain('safe diagnostic value')
     expect(output).toContain('tool:execute tokens=504')
+    expect(output).toContain('\\"input_tokens\\":30')
+    expect(output).toContain('\\"output_tokens\\":8')
 
     for (const key of ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']) {
       input.resourceSpans[0]!.resource.attributes.push({ key, value: { intValue: 42 } })

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -46,6 +46,10 @@ describe('redactOTELPayloadSecrets', () => {
     const unmatchedTupleSecret = ['unmatched', 'tuple', 'credential'].join('-')
     const unmatchedArraySecrets = ['alpha one', 'beta two']
     const escapedArraySecrets = ['escaped alpha', 'escaped beta']
+    const truncatedArraySecrets = ['truncated alpha', 'truncated beta']
+    const dottedSecret = ['dotted', 'api', 'credential'].join('-')
+    const claudeSessionSecret = ['claude', 'session', 'credential'].join('-')
+    const stringMetricTokenSecret = ['input', 'token', 'credential'].join('-')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -84,6 +88,9 @@ describe('redactOTELPayloadSecrets', () => {
       `prefix { ... ${JSON.stringify({ safe: 'x', password: unmatchedArraySecrets })}`,
       `body={\\"password\\":[\\"${escapedArraySecrets[0]}\\",\\"${escapedArraySecrets[1]}\\"]}`,
       `user: alice password: ${multiwordSecret}`,
+      `{"password":["${truncatedArraySecrets[0]}","${truncatedArraySecrets[1]}"`,
+      `openai.api.key=${dottedSecret}`,
+      JSON.stringify({ CLAUDE_SESSION: claudeSessionSecret }),
       ...aliasSecrets.map(([key, secret]) => JSON.stringify({ [key]: secret })),
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
@@ -129,6 +136,9 @@ describe('redactOTELPayloadSecrets', () => {
       unmatchedTupleSecret,
       ...unmatchedArraySecrets,
       ...escapedArraySecrets,
+      ...truncatedArraySecrets,
+      dottedSecret,
+      claudeSessionSecret,
       ...aliasSecrets.map(([, secret]) => secret),
       geminiSecret,
       slackSecret,
@@ -144,11 +154,16 @@ describe('redactOTELPayloadSecrets', () => {
     for (const key of ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']) {
       input.resourceSpans[0]!.resource.attributes.push({ key, value: { intValue: 42 } })
     }
+    input.resourceSpans[0]!.resource.attributes.push({
+      key: 'inputToken',
+      value: { stringValue: stringMetricTokenSecret },
+    })
     const withMetrics = redactOTELPayloadSecrets(input)
-    expect(withMetrics.resourceSpans[0]!.resource.attributes.slice(-4)).toEqual(
+    expect(withMetrics.resourceSpans[0]!.resource.attributes.slice(-5, -1)).toEqual(
       ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']
         .map(key => ({ key, value: { intValue: 42 } })),
     )
+    expect(JSON.stringify(withMetrics)).not.toContain(stringMetricTokenSecret)
   })
 
   it('handles unmatched JSON openers without repeatedly rescanning the suffix', () => {

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -50,6 +50,10 @@ describe('redactOTELPayloadSecrets', () => {
     const dottedSecret = ['dotted', 'api', 'credential'].join('-')
     const claudeSessionSecret = ['claude', 'session', 'credential'].join('-')
     const stringMetricTokenSecret = ['input', 'token', 'credential'].join('-')
+    const capitalizedHeaderSecret = ['capitalized', 'header', 'credential'].join('-')
+    const acronymApiKeySecret = ['acronym', 'api', 'credential'].join('-')
+    const sigV4Secret = ['sigv4', 'signature', 'credential'].join('-')
+    const truncatedHeaderSecret = ['truncated', 'header', 'credential'].join('-')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -97,6 +101,9 @@ describe('redactOTELPayloadSecrets', () => {
       jwtSecret,
       `https://discord.com/api/webhooks/123/${webhookSecret}`,
       ...tokenSecrets,
+      JSON.stringify({ Name: 'Authorization', Value: `Basic ${capitalizedHeaderSecret}` }),
+      `--auth AWS4-HMAC-SHA256 Credential=scope, SignedHeaders=host, Signature=${sigV4Secret}`,
+      `{"name":"x-api-key","value":"${truncatedHeaderSecret}"`,
       'safe diagnostic value',
     )
     input.resourceSpans[0]!.resource.attributes.push({
@@ -105,6 +112,9 @@ describe('redactOTELPayloadSecrets', () => {
     }, {
       key: 'credentials',
       value: { stringValue: pluralKeySecret },
+    }, {
+      key: 'OpenAIAPIKey',
+      value: { stringValue: acronymApiKeySecret },
     })
 
     const redacted = redactOTELPayloadSecrets(input)
@@ -145,6 +155,10 @@ describe('redactOTELPayloadSecrets', () => {
       jwtSecret,
       webhookSecret,
       ...tokenSecrets,
+      capitalizedHeaderSecret,
+      acronymApiKeySecret,
+      sigV4Secret,
+      truncatedHeaderSecret,
     ]) {
       expect(output).not.toContain(secret)
     }

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -42,6 +42,8 @@ describe('redactOTELPayloadSecrets', () => {
     const headerObjectSecret = ['header', 'object', 'credential'].join('-')
     const passphraseSecret = ['vault', 'passphrase', 'credential'].join('-')
     const multiwordSecret = ['correct', 'horse', 'battery', 'staple'].join(' ')
+    const multiValueHeaderSecret = ['multi', 'value', 'header', 'credential'].join('-')
+    const unmatchedTupleSecret = ['unmatched', 'tuple', 'credential'].join('-')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -74,6 +76,9 @@ describe('redactOTELPayloadSecrets', () => {
       JSON.stringify([{ key: 'x-api-key', value: headerObjectSecret }]),
       `FRANKENBEAST_PASSPHRASE=${passphraseSecret}`,
       `password: ${multiwordSecret}`,
+      `passphrase=${multiwordSecret}`,
+      JSON.stringify({ name: 'x-api-key', values: [multiValueHeaderSecret] }),
+      `prefix { ... ${JSON.stringify([['x-api-key', unmatchedTupleSecret]])}`,
       ...aliasSecrets.map(([key, secret]) => JSON.stringify({ [key]: secret })),
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
@@ -115,6 +120,8 @@ describe('redactOTELPayloadSecrets', () => {
       headerObjectSecret,
       passphraseSecret,
       multiwordSecret,
+      multiValueHeaderSecret,
+      unmatchedTupleSecret,
       ...aliasSecrets.map(([, secret]) => secret),
       geminiSecret,
       slackSecret,
@@ -127,15 +134,14 @@ describe('redactOTELPayloadSecrets', () => {
     expect(output).toContain('[REDACTED]')
     expect(output).toContain('safe diagnostic value')
 
-    input.resourceSpans[0]!.resource.attributes.push({
-      key: 'promptTokens',
-      value: { intValue: 42 },
-    })
+    for (const key of ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']) {
+      input.resourceSpans[0]!.resource.attributes.push({ key, value: { intValue: 42 } })
+    }
     const withMetrics = redactOTELPayloadSecrets(input)
-    expect(withMetrics.resourceSpans[0]!.resource.attributes.at(-1)).toEqual({
-      key: 'promptTokens',
-      value: { intValue: 42 },
-    })
+    expect(withMetrics.resourceSpans[0]!.resource.attributes.slice(-4)).toEqual(
+      ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']
+        .map(key => ({ key, value: { intValue: 42 } })),
+    )
   })
 
   it('handles unmatched JSON openers without repeatedly rescanning the suffix', () => {

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -54,6 +54,8 @@ describe('redactOTELPayloadSecrets', () => {
     const acronymApiKeySecret = ['acronym', 'api', 'credential'].join('-')
     const sigV4Secret = ['sigv4', 'signature', 'credential'].join('-')
     const truncatedHeaderSecret = ['truncated', 'header', 'credential'].join('-')
+    const singleTupleSecret = ['single', 'tuple', 'credential'].join('-')
+    const singleFieldSecret = ['single', 'field', 'credential'].join('-')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -104,6 +106,9 @@ describe('redactOTELPayloadSecrets', () => {
       JSON.stringify({ Name: 'Authorization', Value: `Basic ${capitalizedHeaderSecret}` }),
       `--auth AWS4-HMAC-SHA256 Credential=scope, SignedHeaders=host, Signature=${sigV4Secret}`,
       `{"name":"x-api-key","value":"${truncatedHeaderSecret}"`,
+      `[['x-api-key','${singleTupleSecret}']]`,
+      `{'password': '${singleFieldSecret}'}`,
+      'tool:execute tokens=504',
       'safe diagnostic value',
     )
     input.resourceSpans[0]!.resource.attributes.push({
@@ -159,11 +164,14 @@ describe('redactOTELPayloadSecrets', () => {
       acronymApiKeySecret,
       sigV4Secret,
       truncatedHeaderSecret,
+      singleTupleSecret,
+      singleFieldSecret,
     ]) {
       expect(output).not.toContain(secret)
     }
     expect(output).toContain('[REDACTED]')
     expect(output).toContain('safe diagnostic value')
+    expect(output).toContain('tool:execute tokens=504')
 
     for (const key of ['promptTokens', 'inputTokens', 'outputTokens', 'cached_tokens']) {
       input.resourceSpans[0]!.resource.attributes.push({ key, value: { intValue: 42 } })

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -40,6 +40,8 @@ describe('redactOTELPayloadSecrets', () => {
     const escapedJsonSecret = ['escaped', 'json', 'credential'].join('-')
     const digestSecret = ['digest', 'auth', 'credential'].join('-')
     const headerObjectSecret = ['header', 'object', 'credential'].join('-')
+    const passphraseSecret = ['vault', 'passphrase', 'credential'].join('-')
+    const multiwordSecret = ['correct', 'horse', 'battery', 'staple'].join(' ')
     const aliasSecrets = ['sshKey', 'signing_key', 'gpg_key', 'PAT', 'webhookUrl']
       .map(key => [key, `${key}-credential`] as const)
     const geminiSecret = `AIza${'e'.repeat(35)}`
@@ -70,6 +72,8 @@ describe('redactOTELPayloadSecrets', () => {
       `body={\\"password\\":\\"${escapedJsonSecret}\\"}`,
       `--auth Digest ${digestSecret}`,
       JSON.stringify([{ key: 'x-api-key', value: headerObjectSecret }]),
+      `FRANKENBEAST_PASSPHRASE=${passphraseSecret}`,
+      `password: ${multiwordSecret}`,
       ...aliasSecrets.map(([key, secret]) => JSON.stringify({ [key]: secret })),
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
@@ -109,6 +113,8 @@ describe('redactOTELPayloadSecrets', () => {
       escapedJsonSecret,
       digestSecret,
       headerObjectSecret,
+      passphraseSecret,
+      multiwordSecret,
       ...aliasSecrets.map(([, secret]) => secret),
       geminiSecret,
       slackSecret,
@@ -120,6 +126,16 @@ describe('redactOTELPayloadSecrets', () => {
     }
     expect(output).toContain('[REDACTED]')
     expect(output).toContain('safe diagnostic value')
+
+    input.resourceSpans[0]!.resource.attributes.push({
+      key: 'promptTokens',
+      value: { intValue: 42 },
+    })
+    const withMetrics = redactOTELPayloadSecrets(input)
+    expect(withMetrics.resourceSpans[0]!.resource.attributes.at(-1)).toEqual({
+      key: 'promptTokens',
+      value: { intValue: 42 },
+    })
   })
 
   it('handles unmatched JSON openers without repeatedly rescanning the suffix', () => {

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.test.ts
@@ -32,6 +32,11 @@ describe('redactOTELPayloadSecrets', () => {
     const redisSecret = ['redis', 'tls', 'credential'].join('-')
     const genericUrlSecret = ['generic', 'url', 'credential'].join('-')
     const flagSecret = ['command', 'flag', 'credential'].join('-')
+    const proxyAuthSecret = ['proxy', 'auth', 'credential'].join('-')
+    const basicAuthSecret = ['basic', 'auth', 'credential'].join('-')
+    const tupleAuthSecret = ['tuple', 'auth', 'credential'].join('-')
+    const tupleApiKeySecret = ['tuple', 'api', 'credential'].join('-')
+    const truncatedAuthSecret = ['truncated', 'auth', 'credential'].join('-')
     const geminiSecret = `AIza${'e'.repeat(35)}`
     const slackSecret = ['slack', 'webhook', 'credential'].join('-')
     const jwtSecret = `eyJ${'a'.repeat(16)}.${'b'.repeat(16)}.${'c'.repeat(16)}`
@@ -53,6 +58,10 @@ describe('redactOTELPayloadSecrets', () => {
       `rediss://:${redisSecret}@cache.example.test:6380/0`,
       `https://user:${genericUrlSecret}@example.test/path`,
       `--api-key ${flagSecret}`,
+      `proxyAuthorization=Bearer ${proxyAuthSecret}`,
+      `--auth Basic ${basicAuthSecret}`,
+      JSON.stringify([['Authorization', `Basic ${tupleAuthSecret}`], ['x-api-key', tupleApiKeySecret]]),
+      `{"Authorization":"Token ${truncatedAuthSecret}`,
       geminiSecret,
       `https://hooks.slack.com/services/T000/B000/${slackSecret}`,
       jwtSecret,
@@ -83,6 +92,11 @@ describe('redactOTELPayloadSecrets', () => {
       redisSecret,
       genericUrlSecret,
       flagSecret,
+      proxyAuthSecret,
+      basicAuthSecret,
+      tupleAuthSecret,
+      tupleApiKeySecret,
+      truncatedAuthSecret,
       geminiSecret,
       slackSecret,
       jwtSecret,
@@ -93,5 +107,15 @@ describe('redactOTELPayloadSecrets', () => {
     }
     expect(output).toContain('[REDACTED]')
     expect(output).toContain('safe diagnostic value')
+  })
+
+  it('handles unmatched JSON openers without repeatedly rescanning the suffix', () => {
+    const secret = ['unmatched', 'brace', 'credential'].join('-')
+    const input = payloadWith(`${'{'.repeat(20_000)} password=${secret}`)
+
+    const output = JSON.stringify(redactOTELPayloadSecrets(input))
+
+    expect(output).not.toContain(secret)
+    expect(output).toContain('[REDACTED]')
   })
 })

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -2,7 +2,7 @@ import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSeria
 
 const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?)(?:$|_)/iu
-const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total)_tokens?(?:$|_)/iu
+const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total|input|output|cached|reasoning)_tokens?(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
   String.raw`\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
@@ -14,7 +14,8 @@ const SENSITIVE_FLAG_RE = new RegExp(
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
-const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*:\s*)[^\r\n]+/gu
+const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)[^\r\n]+/gu
+const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -101,6 +102,9 @@ function redactPlainText(value: string): string {
     .replace(SENSITIVE_LINE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
       isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
     )
+    .replace(SENSITIVE_HEADER_TUPLE_RE, (match, prefix: string, key: string, suffix: string) =>
+      isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
+    )
     .replace(AUTHORIZATION_ASSIGNMENT_RE, `$1${REDACTED}`)
     .replace(AUTHORIZATION_RE, `$1${REDACTED}`)
     .replace(DISCORD_WEBHOOK_RE, REDACTED)
@@ -138,7 +142,9 @@ function redactJsonValue(value: unknown): unknown {
   )
   return Object.fromEntries(entries.map(([key, child]) => [
     redactPlainText(key),
-    isSensitiveKey(key) || (headerName !== undefined && key === 'value') ? REDACTED : redactJsonValue(child),
+    isSensitiveKey(key) || (headerName !== undefined && (key === 'value' || key === 'values'))
+      ? REDACTED
+      : redactJsonValue(child),
   ]))
 }
 

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -2,7 +2,7 @@ import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSeria
 
 const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|signatures?|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?|claude_?sessions?)(?:$|_)/iu
-const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total|input|output|cached|reasoning)_tokens?(?:$|_)/iu
+const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:(?:prompt|completion|total|input|output|cached|reasoning)_tokens?|tokens?)(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
   String.raw`\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
@@ -13,11 +13,13 @@ const SENSITIVE_FLAG_RE = new RegExp(
   'giu',
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
+const SENSITIVE_SINGLE_QUOTED_FIELD_RE = /('([^'\\]*(?:\\.[^'\\]*)*)'\s*:\s*)('(?:\\.|[^'\\])*'|'(?:\\.|[^'\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
 const SENSITIVE_JSON_COLLECTION_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)(\[[^\]\r\n]*(?:\]|$)|\{[^}\r\n]*(?:\}|$))/gu
 const ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*)(\[[^\]\r\n]*(?:\]|$)|\{[^}\r\n]*(?:\}|$))/gu
-const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)[^\r\n]*?(?=\s+[A-Za-z_][A-Za-z0-9_.-]*\s*[=:]|$)/gu
+const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)([^\r\n]*?)(?=\s+[A-Za-z_][A-Za-z0-9_.-]*\s*[=:]|$)/gu
 const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
+const SENSITIVE_SINGLE_QUOTED_HEADER_TUPLE_RE = /(\[\s*'([^'\\]*(?:\\.[^'\\]*)*)'\s*,\s*')[^'\r\n]*('\s*\])/gu
 const SENSITIVE_HEADER_OBJECT_RE = /("(?:key|name)"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*"(?:value|values)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/giu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
@@ -45,6 +47,11 @@ function isSensitiveKey(key: string): boolean {
 function isNumericTokenMetric(key: string, value: OTELAttributeValue): boolean {
   return TOKEN_METRIC_KEY_RE.test(normalizeSensitiveKey(key))
     && (value.intValue !== undefined || value.doubleValue !== undefined)
+}
+
+function isNumericTokenMetricText(key: string, value: string): boolean {
+  return TOKEN_METRIC_KEY_RE.test(normalizeSensitiveKey(key))
+    && /^\s*\d+(?:\.\d+)?\s*$/u.test(value)
 }
 
 function redactEmbeddedJson(value: string): string {
@@ -115,10 +122,15 @@ function redactPlainText(value: string): string {
   return redactEmbeddedJson(value)
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(COOKIE_HEADER_RE, REDACTED)
-    .replace(SENSITIVE_LINE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
-      isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
+    .replace(SENSITIVE_LINE_ASSIGNMENT_RE, (match, key: string, separator: string, child: string) =>
+      isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
+        ? `${key}${separator}${REDACTED}`
+        : match,
     )
     .replace(SENSITIVE_HEADER_TUPLE_RE, (match, prefix: string, key: string, suffix: string) =>
+      isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
+    )
+    .replace(SENSITIVE_SINGLE_QUOTED_HEADER_TUPLE_RE, (match, prefix: string, key: string, suffix: string) =>
       isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
     )
     .replace(SENSITIVE_HEADER_OBJECT_RE, (match, prefix: string, key: string) =>
@@ -139,11 +151,18 @@ function redactPlainText(value: string): string {
     .replace(SENSITIVE_FLAG_RE, (match, leading: string, flag: string, key: string, separator: string) =>
       isSensitiveKey(key) ? `${leading}${flag}${separator}${REDACTED}` : match,
     )
-    .replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
-      isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
+    .replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string, separator: string, child: string) =>
+      isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
+        ? `${key}${separator}${REDACTED}`
+        : match,
     )
     .replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) =>
       isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
+    )
+    .replace(SENSITIVE_SINGLE_QUOTED_FIELD_RE, (match, prefix: string, key: string, child: string) =>
+      isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
+        ? `${prefix}'${REDACTED}'`
+        : match,
     )
     .replace(ESCAPED_SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string, suffix: string) =>
       isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,17 +1,19 @@
 import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
 
 const REDACTED = '[REDACTED]'
-const SENSITIVE_KEY_RE = /(?:^|_)(?:secret|token|password|passwd|pwd|credential|cookie|bearer|auth|authorization|api_?key|private_?key|access_?key)(?:$|_)/iu
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?)(?:$|_)/iu
 const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
+const SENSITIVE_FLAG_RE = /(^|\s)(--([A-Za-z][A-Za-z0-9_-]*))(\s+)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
 const AUTHORIZATION_RE = /\b((?:Proxy-)?Authorization\s*:\s*)[^\r\n]+/giu
 const DISCORD_WEBHOOK_RE = /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+/giu
-const CREDENTIAL_URL_RE = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu
+const SLACK_WEBHOOK_RE = /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9_/-]+/giu
+const CREDENTIAL_URL_RE = /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s:/@"']*:[^\s@"']+@[^\s"'<>]+/gu
 const BEARER_RE = /\bBearer\s+[^\s,;]+/giu
-const TOKEN_RE = /\b(?:(?:sk|gh[oprsu]|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{12,})\b/gu
+const TOKEN_RE = /\b(?:(?:sk|gh[oprsu]|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{12,}|AIza[0-9A-Za-z_-]{35}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/gu
 
 function normalizeSensitiveKey(key: string): string {
   return key
@@ -24,15 +26,70 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_RE.test(normalizeSensitiveKey(key))
 }
 
+function redactEmbeddedJson(value: string): string {
+  let output = ''
+  let cursor = 0
+
+  while (cursor < value.length) {
+    const start = value.slice(cursor).search(/[\[{]/u)
+    if (start < 0) return output + value.slice(cursor)
+
+    const absoluteStart = cursor + start
+    output += value.slice(cursor, absoluteStart)
+    const stack: string[] = []
+    let quoted = false
+    let escaped = false
+    let end = absoluteStart
+
+    for (; end < value.length; end += 1) {
+      const character = value[end]!
+      if (quoted) {
+        if (escaped) escaped = false
+        else if (character === '\\') escaped = true
+        else if (character === '"') quoted = false
+        continue
+      }
+      if (character === '"') {
+        quoted = true
+      } else if (character === '{' || character === '[') {
+        stack.push(character)
+      } else if (character === '}' || character === ']') {
+        const opening = stack.at(-1)
+        if ((opening === '{' && character !== '}') || (opening === '[' && character !== ']')) break
+        stack.pop()
+        if (stack.length === 0) {
+          end += 1
+          break
+        }
+      }
+    }
+
+    const candidate = value.slice(absoluteStart, end)
+    try {
+      output += JSON.stringify(redactJsonValue(JSON.parse(candidate)))
+      cursor = end
+    } catch {
+      output += value[absoluteStart]
+      cursor = absoluteStart + 1
+    }
+  }
+
+  return output
+}
+
 function redactPlainText(value: string): string {
-  return value
+  return redactEmbeddedJson(value)
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(COOKIE_HEADER_RE, REDACTED)
     .replace(AUTHORIZATION_ASSIGNMENT_RE, `$1${REDACTED}`)
     .replace(AUTHORIZATION_RE, `$1${REDACTED}`)
     .replace(DISCORD_WEBHOOK_RE, REDACTED)
+    .replace(SLACK_WEBHOOK_RE, REDACTED)
     .replace(CREDENTIAL_URL_RE, REDACTED)
     .replace(BEARER_RE, REDACTED)
+    .replace(SENSITIVE_FLAG_RE, (match, leading: string, flag: string, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${leading}${flag}${separator}${REDACTED}` : match,
+    )
     .replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
       isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
     )

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,11 +1,11 @@
 import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
 
 const REDACTED = '[REDACTED]'
-const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?)(?:$|_)/iu
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?|claude_?sessions?)(?:$|_)/iu
 const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total|input|output|cached|reasoning)_tokens?(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
-  String.raw`\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
+  String.raw`\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
   'giu',
 )
 const SENSITIVE_FLAG_RE = new RegExp(
@@ -14,9 +14,9 @@ const SENSITIVE_FLAG_RE = new RegExp(
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
-const SENSITIVE_JSON_COLLECTION_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)(\[[^\]\r\n]*\]|\{[^}\r\n]*\})/gu
-const ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*)(\[[^\]\r\n]*\]|\{[^}\r\n]*\})/gu
-const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)[^\r\n]*?(?=\s+[A-Za-z_][A-Za-z0-9_-]*\s*[=:]|$)/gu
+const SENSITIVE_JSON_COLLECTION_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)(\[[^\]\r\n]*(?:\]|$)|\{[^}\r\n]*(?:\}|$))/gu
+const ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*)(\[[^\]\r\n]*(?:\]|$)|\{[^}\r\n]*(?:\}|$))/gu
+const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)[^\r\n]*?(?=\s+[A-Za-z_][A-Za-z0-9_.-]*\s*[=:]|$)/gu
 const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
@@ -37,7 +37,12 @@ function normalizeSensitiveKey(key: string): string {
 
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizeSensitiveKey(key)
-  return !TOKEN_METRIC_KEY_RE.test(normalized) && SENSITIVE_KEY_RE.test(normalized)
+  return SENSITIVE_KEY_RE.test(normalized)
+}
+
+function isNumericTokenMetric(key: string, value: OTELAttributeValue): boolean {
+  return TOKEN_METRIC_KEY_RE.test(normalizeSensitiveKey(key))
+    && (value.intValue !== undefined || value.doubleValue !== undefined)
 }
 
 function redactEmbeddedJson(value: string): string {
@@ -183,7 +188,7 @@ function redactAttributeValue(value: OTELAttributeValue): OTELAttributeValue {
 
 function redactAttribute(attribute: OTELAttribute): OTELAttribute {
   const key = redactPlainText(attribute.key)
-  if (isSensitiveKey(attribute.key)) {
+  if (isSensitiveKey(attribute.key) && !isNumericTokenMetric(attribute.key, attribute.value)) {
     return { ...attribute, key, value: { stringValue: REDACTED } }
   }
   return { ...attribute, key, value: redactAttributeValue(attribute.value) }

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -2,6 +2,7 @@ import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSeria
 
 const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|signatures?|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?|claude_?sessions?)(?:$|_)/iu
+const UNSEPARATED_SENSITIVE_SUFFIX_RE = /(?:password|secret|token)$/iu
 const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:(?:prompt|completion|total|input|output|cached|reasoning)_tokens?|tokens?)(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
@@ -21,6 +22,7 @@ const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)([
 const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
 const SENSITIVE_SINGLE_QUOTED_HEADER_TUPLE_RE = /(\[\s*'([^'\\]*(?:\\.[^'\\]*)*)'\s*,\s*')[^'\r\n]*('\s*\])/gu
 const SENSITIVE_HEADER_OBJECT_RE = /("(?:key|name)"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*"(?:value|values)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/giu
+const SENSITIVE_QUERY_PARAMETER_RE = /([?&])([A-Za-z_][A-Za-z0-9_.-]*)(=)([^&#\s"']*)/giu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -41,7 +43,7 @@ function normalizeSensitiveKey(key: string): string {
 
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizeSensitiveKey(key)
-  return SENSITIVE_KEY_RE.test(normalized)
+  return SENSITIVE_KEY_RE.test(normalized) || UNSEPARATED_SENSITIVE_SUFFIX_RE.test(normalized)
 }
 
 function isNumericTokenMetric(key: string, value: OTELAttributeValue): boolean {
@@ -122,6 +124,9 @@ function redactPlainText(value: string): string {
   return redactEmbeddedJson(value)
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(COOKIE_HEADER_RE, REDACTED)
+    .replace(SENSITIVE_QUERY_PARAMETER_RE, (match, leading: string, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${leading}${key}${separator}${REDACTED}` : match,
+    )
     .replace(SENSITIVE_LINE_ASSIGNMENT_RE, (match, key: string, separator: string, child: string) =>
       isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
         ? `${key}${separator}${REDACTED}`
@@ -156,8 +161,10 @@ function redactPlainText(value: string): string {
         ? `${key}${separator}${REDACTED}`
         : match,
     )
-    .replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) =>
-      isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
+    .replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string, child: string) =>
+      isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
+        ? `${prefix}"${REDACTED}"`
+        : match,
     )
     .replace(SENSITIVE_SINGLE_QUOTED_FIELD_RE, (match, prefix: string, key: string, child: string) =>
       isSensitiveKey(key) && !isNumericTokenMetricText(key, child)
@@ -187,7 +194,7 @@ function redactJsonValue(value: unknown): unknown {
   )
   return Object.fromEntries(entries.map(([key, child]) => [
     redactPlainText(key),
-    isSensitiveKey(key)
+    (isSensitiveKey(key) && !(TOKEN_METRIC_KEY_RE.test(normalizeSensitiveKey(key)) && typeof child === 'number'))
       || (headerName !== undefined && (key.toLowerCase() === 'value' || key.toLowerCase() === 'values'))
       ? REDACTED
       : redactJsonValue(child),

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -4,9 +4,14 @@ const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_RE = /(?:^|_)(?:secret|token|password|passwd|pwd|credential|cookie|bearer|auth|authorization|api_?key|private_?key|access_?key)(?:$|_)/iu
 const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
+const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
+const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
+const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)(?:Basic|Bearer)\s+[^\s,;]+/giu
 const AUTHORIZATION_RE = /\b((?:Proxy-)?Authorization\s*:\s*)(?:Basic|Bearer)\s+[^\s,;]+/giu
+const DISCORD_WEBHOOK_RE = /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+/giu
+const CREDENTIAL_URL_RE = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu
 const BEARER_RE = /\bBearer\s+[^\s,;]+/giu
-const TOKEN_RE = /\b(?:sk|gho|ghp|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}\b/gu
+const TOKEN_RE = /\b(?:(?:sk|gh[oprsu]|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{12,})\b/gu
 
 function normalizeSensitiveKey(key: string): string {
   return key
@@ -21,7 +26,12 @@ function isSensitiveKey(key: string): boolean {
 
 function redactText(value: string): string {
   return value
+    .replace(PRIVATE_KEY_RE, REDACTED)
+    .replace(COOKIE_HEADER_RE, REDACTED)
+    .replace(AUTHORIZATION_ASSIGNMENT_RE, `$1${REDACTED}`)
     .replace(AUTHORIZATION_RE, `$1${REDACTED}`)
+    .replace(DISCORD_WEBHOOK_RE, REDACTED)
+    .replace(CREDENTIAL_URL_RE, REDACTED)
     .replace(BEARER_RE, REDACTED)
     .replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
       isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,7 +1,7 @@
 import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
 
 const REDACTED = '[REDACTED]'
-const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?|claude_?sessions?)(?:$|_)/iu
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|signatures?|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?|claude_?sessions?)(?:$|_)/iu
 const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total|input|output|cached|reasoning)_tokens?(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
@@ -18,6 +18,7 @@ const SENSITIVE_JSON_COLLECTION_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)(
 const ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*)(\[[^\]\r\n]*(?:\]|$)|\{[^}\r\n]*(?:\}|$))/gu
 const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*[=:]\s*)[^\r\n]*?(?=\s+[A-Za-z_][A-Za-z0-9_.-]*\s*[=:]|$)/gu
 const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
+const SENSITIVE_HEADER_OBJECT_RE = /("(?:key|name)"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*"(?:value|values)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/giu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -30,6 +31,7 @@ const TOKEN_RE = /\b(?:(?:sk|gh[oprsu]|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12
 
 function normalizeSensitiveKey(key: string): string {
   return key
+    .replace(/api_?key/giu, '_api_key')
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
     .replace(/[^a-z0-9]+/giu, '_')
@@ -119,6 +121,9 @@ function redactPlainText(value: string): string {
     .replace(SENSITIVE_HEADER_TUPLE_RE, (match, prefix: string, key: string, suffix: string) =>
       isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
     )
+    .replace(SENSITIVE_HEADER_OBJECT_RE, (match, prefix: string, key: string) =>
+      isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
+    )
     .replace(SENSITIVE_JSON_COLLECTION_FIELD_RE, (match, prefix: string, key: string) =>
       isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
     )
@@ -158,11 +163,13 @@ function redactJsonValue(value: unknown): unknown {
 
   const entries = Object.entries(value)
   const headerName = entries.find(([key, child]) =>
-    (key === 'key' || key === 'name') && typeof child === 'string' && isSensitiveKey(child),
+    (key.toLowerCase() === 'key' || key.toLowerCase() === 'name')
+      && typeof child === 'string' && isSensitiveKey(child),
   )
   return Object.fromEntries(entries.map(([key, child]) => [
     redactPlainText(key),
-    isSensitiveKey(key) || (headerName !== undefined && (key === 'value' || key === 'values'))
+    isSensitiveKey(key)
+      || (headerName !== undefined && (key.toLowerCase() === 'value' || key.toLowerCase() === 'values'))
       ? REDACTED
       : redactJsonValue(child),
   ]))

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,0 +1,72 @@
+import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
+
+const REDACTED = '[REDACTED]'
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secret|token|password|passwd|pwd|credential|cookie|bearer|auth|authorization|api_?key|private_?key|access_?key)(?:$|_)/iu
+const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
+const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
+const AUTHORIZATION_RE = /\b((?:Proxy-)?Authorization\s*:\s*)(?:Basic|Bearer)\s+[^\s,;]+/giu
+const BEARER_RE = /\bBearer\s+[^\s,;]+/giu
+const TOKEN_RE = /\b(?:sk|gho|ghp|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}\b/gu
+
+function normalizeSensitiveKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^a-z0-9]+/giu, '_')
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_RE.test(normalizeSensitiveKey(key))
+}
+
+function redactText(value: string): string {
+  return value
+    .replace(AUTHORIZATION_RE, `$1${REDACTED}`)
+    .replace(BEARER_RE, REDACTED)
+    .replace(SENSITIVE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
+    )
+    .replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) =>
+      isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
+    )
+    .replace(TOKEN_RE, REDACTED)
+}
+
+function redactAttributeValue(value: OTELAttributeValue): OTELAttributeValue {
+  if (value.stringValue === undefined) return { ...value }
+  return { ...value, stringValue: redactText(value.stringValue) }
+}
+
+function redactAttribute(attribute: OTELAttribute): OTELAttribute {
+  if (isSensitiveKey(attribute.key)) {
+    return { ...attribute, value: { stringValue: REDACTED } }
+  }
+  return { ...attribute, value: redactAttributeValue(attribute.value) }
+}
+
+/**
+ * Clone an OTEL export payload while masking credential-bearing attributes and
+ * secret-shaped text. This protects external observability egress without
+ * modifying the caller's trace or the HTTP Authorization header used to send it.
+ */
+export function redactOTELPayloadSecrets(payload: OTELPayload): OTELPayload {
+  return {
+    resourceSpans: payload.resourceSpans.map(resourceSpan => ({
+      resource: {
+        attributes: resourceSpan.resource.attributes.map(redactAttribute),
+      },
+      scopeSpans: resourceSpan.scopeSpans.map(scopeSpans => ({
+        scope: { ...scopeSpans.scope },
+        spans: scopeSpans.spans.map(span => ({
+          ...span,
+          name: redactText(span.name),
+          attributes: span.attributes.map(redactAttribute),
+          status: {
+            ...span.status,
+            ...(span.status.message === undefined ? {} : { message: redactText(span.status.message) }),
+          },
+        })),
+      })),
+    })),
+  }
+}

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -2,9 +2,16 @@ import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSeria
 
 const REDACTED = '[REDACTED]'
 const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?)(?:$|_)/iu
-const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
-const SENSITIVE_FLAG_RE = /(^|\s)(--([A-Za-z][A-Za-z0-9_-]*))(\s+)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;]+)/gu
-const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
+const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token)\s+[^\s,;]+`
+const SENSITIVE_ASSIGNMENT_RE = new RegExp(
+  String.raw`\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
+  'giu',
+)
+const SENSITIVE_FLAG_RE = new RegExp(
+  String.raw`(^|\s)(--([A-Za-z][A-Za-z0-9_-]*))(\s+)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
+  'giu',
+)
+const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -64,6 +71,12 @@ function redactEmbeddedJson(value: string): string {
       }
     }
 
+    if (stack.length > 0 || quoted) {
+      // No balanced JSON candidate starts here. Preserve the remaining text for
+      // the linear regex passes below instead of rescanning every later opener.
+      return output + value.slice(absoluteStart)
+    }
+
     const candidate = value.slice(absoluteStart, end)
     try {
       output += JSON.stringify(redactJsonValue(JSON.parse(candidate)))
@@ -101,7 +114,12 @@ function redactPlainText(value: string): string {
 
 function redactJsonValue(value: unknown): unknown {
   if (typeof value === 'string') return redactPlainText(value)
-  if (Array.isArray(value)) return value.map(redactJsonValue)
+  if (Array.isArray(value)) {
+    if (value.length >= 2 && typeof value[0] === 'string' && isSensitiveKey(value[0])) {
+      return [redactPlainText(value[0]), REDACTED, ...value.slice(2).map(redactJsonValue)]
+    }
+    return value.map(redactJsonValue)
+  }
   if (value === null || typeof value !== 'object') return value
 
   return Object.fromEntries(Object.entries(value).map(([key, child]) => [

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -6,10 +6,10 @@ const SENSITIVE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\s]+)/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
-const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)(?:Basic|Bearer)\s+[^\s,;]+/giu
-const AUTHORIZATION_RE = /\b((?:Proxy-)?Authorization\s*:\s*)(?:Basic|Bearer)\s+[^\s,;]+/giu
+const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
+const AUTHORIZATION_RE = /\b((?:Proxy-)?Authorization\s*:\s*)[^\r\n]+/giu
 const DISCORD_WEBHOOK_RE = /https:\/\/(?:discord(?:app)?\.com|canary\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+/giu
-const CREDENTIAL_URL_RE = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu
+const CREDENTIAL_URL_RE = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?):\/\/[^\s:@/]*:[^\s@/]+@[^\s]+/giu
 const BEARER_RE = /\bBearer\s+[^\s,;]+/giu
 const TOKEN_RE = /\b(?:(?:sk|gh[oprsu]|glpat|glc|xox[baprs])[-_][A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9_-]{12,})\b/gu
 
@@ -24,7 +24,7 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_RE.test(normalizeSensitiveKey(key))
 }
 
-function redactText(value: string): string {
+function redactPlainText(value: string): string {
   return value
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(COOKIE_HEADER_RE, REDACTED)
@@ -42,16 +42,41 @@ function redactText(value: string): string {
     .replace(TOKEN_RE, REDACTED)
 }
 
+function redactJsonValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactPlainText(value)
+  if (Array.isArray(value)) return value.map(redactJsonValue)
+  if (value === null || typeof value !== 'object') return value
+
+  return Object.fromEntries(Object.entries(value).map(([key, child]) => [
+    redactPlainText(key),
+    isSensitiveKey(key) ? REDACTED : redactJsonValue(child),
+  ]))
+}
+
+function redactText(value: string): string {
+  const trimmed = value.trim()
+  if ((trimmed.startsWith('{') && trimmed.endsWith('}'))
+    || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+    try {
+      return JSON.stringify(redactJsonValue(JSON.parse(value)))
+    } catch {
+      // Fall through to best-effort text redaction for malformed JSON.
+    }
+  }
+  return redactPlainText(value)
+}
+
 function redactAttributeValue(value: OTELAttributeValue): OTELAttributeValue {
   if (value.stringValue === undefined) return { ...value }
   return { ...value, stringValue: redactText(value.stringValue) }
 }
 
 function redactAttribute(attribute: OTELAttribute): OTELAttribute {
+  const key = redactPlainText(attribute.key)
   if (isSensitiveKey(attribute.key)) {
-    return { ...attribute, value: { stringValue: REDACTED } }
+    return { ...attribute, key, value: { stringValue: REDACTED } }
   }
-  return { ...attribute, value: redactAttributeValue(attribute.value) }
+  return { ...attribute, key, value: redactAttributeValue(attribute.value) }
 }
 
 /**

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -14,7 +14,9 @@ const SENSITIVE_FLAG_RE = new RegExp(
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
-const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)[^\r\n]+/gu
+const SENSITIVE_JSON_COLLECTION_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)(\[[^\]\r\n]*\]|\{[^}\r\n]*\})/gu
+const ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*)(\[[^\]\r\n]*\]|\{[^}\r\n]*\})/gu
+const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)[^\r\n]*?(?=\s+[A-Za-z_][A-Za-z0-9_-]*\s*[=:]|$)/gu
 const SENSITIVE_HEADER_TUPLE_RE = /(\[\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*,\s*")[^"\r\n]*("\s*\])/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
@@ -39,60 +41,67 @@ function isSensitiveKey(key: string): boolean {
 }
 
 function redactEmbeddedJson(value: string): string {
-  let output = ''
-  let cursor = 0
+  const firstStart = value.search(/[\[{]/u)
+  if (firstStart < 0) return value
 
-  while (cursor < value.length) {
-    const start = value.slice(cursor).search(/[\[{]/u)
-    if (start < 0) return output + value.slice(cursor)
+  const stack: Array<{ opening: string, start: number }> = []
+  const candidates: Array<{ start: number, end: number, redacted: string }> = []
+  let quoted = false
+  let escaped = false
 
-    const absoluteStart = cursor + start
-    output += value.slice(cursor, absoluteStart)
-    const stack: string[] = []
-    let quoted = false
-    let escaped = false
-    let end = absoluteStart
-
-    for (; end < value.length; end += 1) {
-      const character = value[end]!
-      if (quoted) {
-        if (escaped) escaped = false
-        else if (character === '\\') escaped = true
-        else if (character === '"') quoted = false
+  for (let index = firstStart; index < value.length; index += 1) {
+    const character = value[index]!
+    if (quoted) {
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"' && value[index - 1] !== '\\') {
+      quoted = true
+    } else if (character === '{' || character === '[') {
+      stack.push({ opening: character, start: index })
+    } else if (character === '}' || character === ']') {
+      const frame = stack.at(-1)
+      if (frame === undefined
+        || (frame.opening === '{' && character !== '}')
+        || (frame.opening === '[' && character !== ']')) {
+        stack.length = 0
         continue
       }
-      if (character === '"') {
-        quoted = true
-      } else if (character === '{' || character === '[') {
-        stack.push(character)
-      } else if (character === '}' || character === ']') {
-        const opening = stack.at(-1)
-        if ((opening === '{' && character !== '}') || (opening === '[' && character !== ']')) break
-        stack.pop()
-        if (stack.length === 0) {
-          end += 1
-          break
+      stack.pop()
+      const candidate = value.slice(frame.start, index + 1)
+      let redacted: string | undefined
+      try {
+        redacted = JSON.stringify(redactJsonValue(JSON.parse(candidate)))
+      } catch {
+        const unescaped = candidate.replace(/\\+"/gu, '"')
+        if (unescaped !== candidate) {
+          try {
+            redacted = JSON.stringify(redactJsonValue(JSON.parse(unescaped))).replace(/"/gu, '\\"')
+          } catch {
+            // Keep scanning for a later valid embedded candidate.
+          }
         }
       }
-    }
-
-    if (stack.length > 0 || quoted) {
-      // No balanced JSON candidate starts here. Preserve the remaining text for
-      // the linear regex passes below instead of rescanning every later opener.
-      return output + value.slice(absoluteStart)
-    }
-
-    const candidate = value.slice(absoluteStart, end)
-    try {
-      output += JSON.stringify(redactJsonValue(JSON.parse(candidate)))
-      cursor = end
-    } catch {
-      output += value[absoluteStart]
-      cursor = absoluteStart + 1
+      if (redacted !== undefined) {
+        for (let candidateIndex = candidates.length - 1; candidateIndex >= 0; candidateIndex -= 1) {
+          if (candidates[candidateIndex]!.start >= frame.start) candidates.splice(candidateIndex, 1)
+        }
+        candidates.push({ start: frame.start, end: index + 1, redacted })
+      }
     }
   }
 
-  return output
+  if (candidates.length === 0) return value
+  candidates.sort((left, right) => left.start - right.start)
+  let output = ''
+  let cursor = 0
+  for (const candidate of candidates) {
+    output += value.slice(cursor, candidate.start) + candidate.redacted
+    cursor = candidate.end
+  }
+  return output + value.slice(cursor)
 }
 
 function redactPlainText(value: string): string {
@@ -104,6 +113,12 @@ function redactPlainText(value: string): string {
     )
     .replace(SENSITIVE_HEADER_TUPLE_RE, (match, prefix: string, key: string, suffix: string) =>
       isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
+    )
+    .replace(SENSITIVE_JSON_COLLECTION_FIELD_RE, (match, prefix: string, key: string) =>
+      isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
+    )
+    .replace(ESCAPED_SENSITIVE_JSON_COLLECTION_FIELD_RE, (match, prefix: string, key: string) =>
+      isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
     )
     .replace(AUTHORIZATION_ASSIGNMENT_RE, `$1${REDACTED}`)
     .replace(AUTHORIZATION_RE, `$1${REDACTED}`)

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,8 +1,8 @@
 import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
 
 const REDACTED = '[REDACTED]'
-const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?)(?:$|_)/iu
-const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token)\s+[^\s,;]+`
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?)(?:$|_)/iu
+const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
   String.raw`\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
   'giu',
@@ -12,6 +12,7 @@ const SENSITIVE_FLAG_RE = new RegExp(
   'giu',
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
+const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -109,6 +110,9 @@ function redactPlainText(value: string): string {
     .replace(SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string) =>
       isSensitiveKey(key) ? `${prefix}"${REDACTED}"` : match,
     )
+    .replace(ESCAPED_SENSITIVE_JSON_FIELD_RE, (match, prefix: string, key: string, suffix: string) =>
+      isSensitiveKey(key) ? `${prefix}${REDACTED}${suffix}` : match,
+    )
     .replace(TOKEN_RE, REDACTED)
 }
 
@@ -122,9 +126,13 @@ function redactJsonValue(value: unknown): unknown {
   }
   if (value === null || typeof value !== 'object') return value
 
-  return Object.fromEntries(Object.entries(value).map(([key, child]) => [
+  const entries = Object.entries(value)
+  const headerName = entries.find(([key, child]) =>
+    (key === 'key' || key === 'name') && typeof child === 'string' && isSensitiveKey(child),
+  )
+  return Object.fromEntries(entries.map(([key, child]) => [
     redactPlainText(key),
-    isSensitiveKey(key) ? REDACTED : redactJsonValue(child),
+    isSensitiveKey(key) || (headerName !== undefined && key === 'value') ? REDACTED : redactJsonValue(child),
   ]))
 }
 

--- a/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
+++ b/packages/franken-observer/src/export/redactOTELPayloadSecrets.ts
@@ -1,7 +1,8 @@
 import type { OTELAttribute, OTELAttributeValue, OTELPayload } from './OTELSerializer.js'
 
 const REDACTED = '[REDACTED]'
-const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?)(?:$|_)/iu
+const SENSITIVE_KEY_RE = /(?:^|_)(?:secrets?|tokens?|passwords?|passphrases?|passwd|pwd|credentials?|cookies?|bearers?|auth|authorization|api_?keys?|private_?keys?|access_?keys?|ssh_?keys?|signing_?keys?|gpg_?keys?|pats?|personal_?access_?tokens?|webhook_?urls?)(?:$|_)/iu
+const TOKEN_METRIC_KEY_RE = /(?:^|_)(?:prompt|completion|total)_tokens?(?:$|_)/iu
 const AUTH_SCHEME_VALUE = String.raw`(?:Basic|Bearer|Token|ApiKey|Digest|Negotiate|NTLM|AWS4-HMAC-SHA256)\s+[^\s,;]+`
 const SENSITIVE_ASSIGNMENT_RE = new RegExp(
   String.raw`\b([A-Za-z_][A-Za-z0-9_-]*)(\s*[=:]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|${AUTH_SCHEME_VALUE}|[^\s,;]+)`,
@@ -13,6 +14,7 @@ const SENSITIVE_FLAG_RE = new RegExp(
 )
 const SENSITIVE_JSON_FIELD_RE = /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)("(?:\\.|[^"\\])*"|"(?:\\.|[^"\\])*(?=$|[\r\n])|[^,}\]\r\n]+)/gu
 const ESCAPED_SENSITIVE_JSON_FIELD_RE = /(\\+"([^"\\]*(?:\\.[^"\\]*)*)\\+"\s*:\s*\\+")[^"\r\n]*?(\\+")/gu
+const SENSITIVE_LINE_ASSIGNMENT_RE = /\b([A-Za-z_][A-Za-z0-9_-]*)(\s*:\s*)[^\r\n]+/gu
 const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu
 const COOKIE_HEADER_RE = /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu
 const AUTHORIZATION_ASSIGNMENT_RE = /\b((?:proxy[-_])?authorization\s*[=:]\s*)[^\r\n]+/giu
@@ -31,7 +33,8 @@ function normalizeSensitiveKey(key: string): string {
 }
 
 function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEY_RE.test(normalizeSensitiveKey(key))
+  const normalized = normalizeSensitiveKey(key)
+  return !TOKEN_METRIC_KEY_RE.test(normalized) && SENSITIVE_KEY_RE.test(normalized)
 }
 
 function redactEmbeddedJson(value: string): string {
@@ -95,6 +98,9 @@ function redactPlainText(value: string): string {
   return redactEmbeddedJson(value)
     .replace(PRIVATE_KEY_RE, REDACTED)
     .replace(COOKIE_HEADER_RE, REDACTED)
+    .replace(SENSITIVE_LINE_ASSIGNMENT_RE, (match, key: string, separator: string) =>
+      isSensitiveKey(key) ? `${key}${separator}${REDACTED}` : match,
+    )
     .replace(AUTHORIZATION_ASSIGNMENT_RE, `$1${REDACTED}`)
     .replace(AUTHORIZATION_RE, `$1${REDACTED}`)
     .replace(DISCORD_WEBHOOK_RE, REDACTED)


### PR DESCRIPTION
## Summary
- redact secret-bearing OTEL attributes and trace text before Langfuse and Tempo exports
- preserve adapter transport authentication headers so requests continue to authenticate
- cover sensitive keys, assignments, JSON fields, authorization headers, bearer values, and provider-token shapes
- document default outbound payload redaction behavior

## Test plan
- `npm --workspace @franken/types run build`
- `npm --workspace @franken/observer test -- --run` (33 files, 855 tests)
- `npm --workspace @franken/observer run typecheck`
- `npm --workspace @franken/observer run lint` (0 errors; 5 pre-existing warnings)
- `npm --workspace @franken/observer run build`
- local Codex pre-commit review: no actionable regression identified after two review-fix rounds

Closes #3621
