### PR TITLE
fix(security): bind observability ports to localhost

### DIFF
--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -1,0 +1,16 @@
+# Explicit opt-in for exposing local infrastructure beyond this host.
+# Requires Docker Compose 2.24.4+ for the !override tag.
+services:
+  chromadb:
+    ports: !override
+      - '0.0.0.0:8000:8000'
+
+  grafana:
+    ports: !override
+      - '0.0.0.0:3000:3000'
+
+  tempo:
+    ports: !override
+      - '0.0.0.0:3200:3200' # Tempo query API
+      - '0.0.0.0:4317:4317' # OTLP gRPC
+      - '0.0.0.0:4318:4318' # OTLP HTTP

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -8,6 +8,8 @@ services:
   grafana:
     ports: !override
       - '0.0.0.0:3000:3000'
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: 'false'
 
   tempo:
     ports: !override

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   chromadb:
     image: chromadb/chroma:1.3.7
     ports:
-      - '8000:8000'
+      - '127.0.0.1:8000:8000'
     volumes:
       - chromadb-data:/data
     environment:
@@ -28,7 +28,7 @@ services:
   grafana:
     image: grafana/grafana:12.3.8
     ports:
-      - '3000:3000'
+      - '127.0.0.1:3000:3000'
     volumes:
       - grafana-data:/var/lib/grafana
     entrypoint: ['/bin/sh', '-ec']
@@ -61,9 +61,9 @@ services:
   tempo:
     image: grafana/tempo:2.9.3
     ports:
-      - '3200:3200'   # Tempo query API
-      - '4317:4317'   # OTLP gRPC
-      - '4318:4318'   # OTLP HTTP
+      - '127.0.0.1:3200:3200'   # Tempo query API
+      - '127.0.0.1:4317:4317'   # OTLP gRPC
+      - '127.0.0.1:4318:4318'   # OTLP HTTP
     command: ['-config.file=/etc/tempo.yaml']
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml:ro

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -94,6 +94,19 @@ This starts the services defined in `docker-compose.yml`:
 
 The compose stack pins image versions and mounts `tempo.yaml` into Tempo so the
 optional tracing backend does not depend on floating tags or an implicit config.
+All published ports bind to `127.0.0.1` by default, so these development services
+are not reachable from other machines.
+
+To intentionally expose ChromaDB, Grafana, and Tempo to a trusted network, use
+the explicit override with Docker Compose 2.24.4 or newer:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d
+```
+
+The override publishes unauthenticated ChromaDB and Tempo endpoints, plus the
+Grafana login surface, on every IPv4 interface. Use it only behind an appropriate
+host firewall or other network access control, and stop the stack when finished.
 
 There is no `firewall` Docker service in the current compose file.
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -94,8 +94,10 @@ This starts the services defined in `docker-compose.yml`:
 
 The compose stack pins image versions and mounts `tempo.yaml` into Tempo so the
 optional tracing backend does not depend on floating tags or an implicit config.
-All published ports bind to `127.0.0.1` by default, so these development services
-are not reachable from other machines.
+All published ports bind to `127.0.0.1` by default. With Docker Engine 28.0.0 or
+newer, these development services are not reachable from other machines. On older
+Docker Engine releases, hosts on the same layer-2 network may still reach ports
+published to loopback; upgrade the engine or enforce equivalent host-firewall rules.
 
 To intentionally expose ChromaDB, Grafana, and Tempo to a trusted network, use
 the explicit override with Docker Compose 2.24.4 or newer:
@@ -105,8 +107,9 @@ docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d
 ```
 
 The override publishes unauthenticated ChromaDB and Tempo endpoints, plus the
-Grafana login surface, on every IPv4 interface. Use it only behind an appropriate
-host firewall or other network access control, and stop the stack when finished.
+Grafana login surface with anonymous dashboard access disabled, on every IPv4
+interface. Use it only behind an appropriate host firewall or other network access
+control, and stop the stack when finished.
 
 There is no `firewall` Docker service in the current compose file.
 

--- a/tests/docker-compose-port-security.test.ts
+++ b/tests/docker-compose-port-security.test.ts
@@ -33,6 +33,7 @@ describe("docker compose published-port security", () => {
         new RegExp(`^\\s+- ["']0\\.0\\.0\\.0:${port}:${port}["']`, "mu"),
       );
     }
+    expect(override).toMatch(/GF_AUTH_ANONYMOUS_ENABLED:\s*["']false["']/u);
   });
 
   it("documents the remote-exposure security tradeoff and opt-in command", () => {
@@ -40,6 +41,8 @@ describe("docker compose published-port security", () => {
 
     expect(quickstart).toContain("docker-compose.remote.yml");
     expect(quickstart).toContain("reachable from other machines");
+    expect(quickstart).toMatch(/Docker Engine 28\.0\.0 or\s+newer/u);
+    expect(quickstart).toContain("same layer-2 network");
     expect(quickstart).toContain(
       "docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d",
     );

--- a/tests/docker-compose-port-security.test.ts
+++ b/tests/docker-compose-port-security.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const publishedPorts = ["8000", "3000", "3200", "4317", "4318"] as const;
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf8");
+}
+
+describe("docker compose published-port security", () => {
+  it("binds every default development port to IPv4 localhost", () => {
+    const compose = readRepoFile("docker-compose.yml");
+
+    for (const port of publishedPorts) {
+      expect(compose).toMatch(
+        new RegExp(`^\\s+- ["']127\\.0\\.0\\.1:${port}:${port}["']`, "mu"),
+      );
+      expect(compose).not.toMatch(
+        new RegExp(`^\\s+- ["']?${port}:${port}["']?`, "mu"),
+      );
+    }
+  });
+
+  it("requires the explicit remote override to publish on all interfaces", () => {
+    const override = readRepoFile("docker-compose.remote.yml");
+
+    expect(override.match(/ports:\s*!override/gu)).toHaveLength(3);
+    for (const port of publishedPorts) {
+      expect(override).toMatch(
+        new RegExp(`^\\s+- ["']0\\.0\\.0\\.0:${port}:${port}["']`, "mu"),
+      );
+    }
+  });
+
+  it("documents the remote-exposure security tradeoff and opt-in command", () => {
+    const quickstart = readRepoFile("docs/guides/quickstart.md");
+
+    expect(quickstart).toContain("docker-compose.remote.yml");
+    expect(quickstart).toContain("reachable from other machines");
+    expect(quickstart).toContain(
+      "docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- bind ChromaDB, Grafana, and Tempo published ports to `127.0.0.1` by default
- add an explicit Docker Compose override for intentional `0.0.0.0` exposure
- document the security tradeoff and add regression coverage

## Reproduction
The prior short-form mappings omitted a host IP, so Compose published ports 8000, 3000, 3200, 4317, and 4318 on all host interfaces.

## Validation
- `npm run test:root -- tests/docker-compose-port-security.test.ts tests/local-setup-scripts.test.ts` (34 passed)
- `npm run test:root` (759 passed, 1 skipped)
- `npm run lint` (10/10 tasks successful; pre-existing warnings only)
- Docker Compose v2.39.4 rendered defaults with `host_ip: 127.0.0.1` and the explicit override with `host_ip: 0.0.0.0`

Closes #3159