### PR TITLE
fix(orchestrator): validate signed token expiry metadata

### DIFF
--- a/packages/franken-orchestrator/src/http/security/transport-security.ts
+++ b/packages/franken-orchestrator/src/http/security/transport-security.ts
@@ -68,7 +68,11 @@ export class TransportSecurityService {
     }
 
     const payload = decode(encodedPayload);
-    const [subject, scope, expiresAtRaw] = payload.split('.');
+    const payloadParts = payload.split('.');
+    if (payloadParts.length !== 4) {
+      return false;
+    }
+    const [subject, scope, expiresAtRaw] = payloadParts;
     if (scope !== options.scope) {
       return false;
     }
@@ -77,7 +81,7 @@ export class TransportSecurityService {
     }
 
     const expiresAt = Number(expiresAtRaw);
-    if (!Number.isFinite(expiresAt) || expiresAt < wallClockNow()) {
+    if (!Number.isSafeInteger(expiresAt) || expiresAt < 0 || expiresAt < wallClockNow()) {
       return false;
     }
 

--- a/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/transport-security.test.ts
@@ -1,6 +1,14 @@
+import { createHmac } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { constantTimeTokenEqual } from '../../../src/http/security/constant-time.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
+
+function signedTokenForExpiry(expiresAt: string, secret: string): string {
+  const payload = `session-1.chat:socket.${expiresAt}.nonce`;
+  const encodedPayload = Buffer.from(payload, 'utf8').toString('base64url');
+  const signature = createHmac('sha256', secret).update(payload).digest('base64url');
+  return `${encodedPayload}.${signature}`;
+}
 
 describe('TransportSecurityService', () => {
   it('uses a digest-backed constant-time token comparator for unequal length tokens', () => {
@@ -77,6 +85,28 @@ describe('TransportSecurityService', () => {
       subject: 'session-1',
       token: second,
     })).toBe(true);
+  });
+
+  it('rejects signed tokens with invalid expiry metadata', () => {
+    const security = new TransportSecurityService();
+    const secret = security.createSecret();
+    const invalidExpiries = [
+      'not-a-number',
+      'Infinity',
+      '-1',
+      `${Date.now() + 60_000}.5`,
+      `${Date.now() + 60_000}5e-1`,
+      String(Number.MAX_SAFE_INTEGER + 1),
+    ];
+
+    for (const expiresAt of invalidExpiries) {
+      expect(security.verifySignedToken({
+        secret,
+        scope: 'chat:socket',
+        subject: 'session-1',
+        token: signedTokenForExpiry(expiresAt, secret),
+      }), expiresAt).toBe(false);
+    }
   });
 
   it('rejects tokens with extra dot-separated segments', () => {


### PR DESCRIPTION
## Summary
- reject signed-token payloads with an unexpected segment count
- require expiry metadata to be a non-negative safe integer before comparing it to the current time
- cover malformed, non-finite, negative, fractional, and unsafe far-future expiry values

## Test plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/http/transport-security.test.ts`
- `npm test --workspace @franken/orchestrator` (4,417 tests)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (passes with pre-existing warnings)
- `npm run build`

Closes #3046