### PR TITLE
fix(observer): bound HTTP exporter attempts

### DIFF
--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.test.ts
@@ -98,6 +98,29 @@ describe('LangfuseAdapter', () => {
       const [, init] = mockFetch.mock.calls[0]
       expect(init.method).toBe('POST')
     })
+
+    it('aborts and rejects a stalled export within the configured attempt deadline', async () => {
+      vi.useFakeTimers()
+      try {
+        mockFetch.mockImplementation(() => new Promise(() => undefined))
+        const adapter = new LangfuseAdapter({
+          publicKey: LANGFUSE_PUBLIC_KEY,
+          secretKey: LANGFUSE_SECRET_KEY,
+          fetch: mockFetch,
+          retry: { attemptTimeoutMs: 25 },
+        })
+
+        const flush = adapter.flush(makeTrace())
+        const rejection = expect(flush).rejects.toThrow('HTTP attempt timed out after 25ms')
+        await vi.advanceTimersByTimeAsync(25)
+
+        await rejection
+        expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+        expect(mockFetch.mock.calls[0][1].signal.aborted).toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('retry on transient failures (issue #68)', () => {

--- a/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
+++ b/packages/franken-observer/src/adapters/langfuse/LangfuseAdapter.ts
@@ -5,7 +5,13 @@ import { fetchWithRetry, type HttpRetryOptions } from '../../export/httpRetry.js
 
 export type FetchFn = (
   url: string,
-  init?: { method?: string; headers?: Record<string, string>; body?: string; redirect?: 'error' | 'follow' | 'manual' },
+  init?: {
+    method?: string
+    headers?: Record<string, string>
+    body?: string
+    redirect?: 'error' | 'follow' | 'manual'
+    signal?: AbortSignal
+  },
 ) => Promise<{ ok: boolean; status: number; statusText?: string }>
 
 export interface LangfuseAdapterOptions {
@@ -42,7 +48,7 @@ export class LangfuseAdapter implements ExportAdapter {
     const payload = OTELSerializer.serializeTrace(trace)
     const url = `${this.baseUrl}/api/public/otel/v1/traces`
     const response = await fetchWithRetry(
-      () =>
+      signal =>
         this.fetchFn(url, {
           method: 'POST',
           headers: {
@@ -50,6 +56,7 @@ export class LangfuseAdapter implements ExportAdapter {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
+          signal,
         }),
       this.retry,
     )

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
@@ -53,6 +53,28 @@ describe('TempoAdapter', () => {
       const [, init] = mockFetch.mock.calls[0]
       expect(init.method).toBe('POST')
     })
+
+    it('aborts and rejects a stalled export within the configured attempt deadline', async () => {
+      vi.useFakeTimers()
+      try {
+        mockFetch.mockImplementation(() => new Promise(() => undefined))
+        const adapter = new TempoAdapter({
+          endpoint: 'http://localhost:4318',
+          fetch: mockFetch,
+          retry: { attemptTimeoutMs: 25 },
+        })
+
+        const flush = adapter.flush(makeTrace())
+        const rejection = expect(flush).rejects.toThrow('HTTP attempt timed out after 25ms')
+        await vi.advanceTimersByTimeAsync(25)
+
+        await rejection
+        expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+        expect(mockFetch.mock.calls[0][1].signal.aborted).toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('flush() — headers', () => {

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
@@ -72,11 +72,12 @@ export class TempoAdapter implements ExportAdapter {
     if (this.authHeader) headers['Authorization'] = this.authHeader
 
     const response = await fetchWithRetry(
-      () =>
+      signal =>
         this.fetchFn(this.tracesUrl, {
           method: 'POST',
           headers,
           body: JSON.stringify(payload),
+          signal,
         }),
       this.retry,
     )

--- a/packages/franken-observer/src/export/httpRetry.test.ts
+++ b/packages/franken-observer/src/export/httpRetry.test.ts
@@ -43,6 +43,49 @@ describe('fetchWithRetry (issue #68)', () => {
     expect(attempt).toHaveBeenCalledTimes(3)
   })
 
+  it('aborts and rejects an attempt that never settles within its deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      let receivedSignal: AbortSignal | undefined
+      const attempt = vi.fn((signal: AbortSignal) => {
+        receivedSignal = signal
+        return new Promise<typeof ok>(() => undefined)
+      })
+
+      const result = fetchWithRetry(attempt, { attemptTimeoutMs: 25 })
+      const rejection = expect(result).rejects.toThrow('HTTP attempt timed out after 25ms')
+      await vi.advanceTimersByTimeAsync(25)
+
+      await rejection
+      expect(receivedSignal?.aborted).toBe(true)
+      expect(attempt).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a timed-out attempt and succeeds within the next deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempt = vi.fn()
+        .mockImplementationOnce(() => new Promise<typeof ok>(() => undefined))
+        .mockResolvedValueOnce(ok)
+      const result = fetchWithRetry(attempt, {
+        attemptTimeoutMs: 25,
+        maxRetries: 1,
+        jitter: false,
+        sleep: noSleep(),
+      })
+
+      await vi.advanceTimersByTimeAsync(25)
+
+      await expect(result).resolves.toEqual(ok)
+      expect(attempt).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('retries a 429 rate-limit response then succeeds', async () => {
     const sleep = noSleep()
     const attempt = vi.fn().mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(ok)
@@ -105,6 +148,17 @@ describe('fetchWithRetry (issue #68)', () => {
       )
       expect(attempt).not.toHaveBeenCalled()
       expect(sleep).not.toHaveBeenCalled()
+    }
+  })
+
+  it('rejects invalid attempt deadlines before making an attempt', async () => {
+    for (const attemptTimeoutMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const attempt = vi.fn().mockResolvedValue(ok)
+
+      await expect(fetchWithRetry(attempt, { attemptTimeoutMs })).rejects.toThrow(
+        'attemptTimeoutMs must be a finite positive number',
+      )
+      expect(attempt).not.toHaveBeenCalled()
     }
   })
 

--- a/packages/franken-observer/src/export/httpRetry.ts
+++ b/packages/franken-observer/src/export/httpRetry.ts
@@ -17,9 +17,22 @@ export interface HttpRetryOptions {
   jitter?: boolean
   /** Injectable sleep for testing without real timers. Default: setTimeout wrapper. */
   sleep?: (ms: number) => Promise<void>
+  /** Per-attempt request deadline in ms. Default: 10000. */
+  attemptTimeoutMs?: number
 }
 
 const MAX_HTTP_RETRIES = 10
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 10_000
+
+export class HttpAttemptTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`HTTP attempt timed out after ${timeoutMs}ms`)
+    this.name = 'HttpAttemptTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
 
 /**
  * A response is transient and worth retrying when it is a 5xx server error or a
@@ -46,19 +59,51 @@ function requireFiniteNonNegative(name: 'baseDelayMs' | 'maxDelayMs', value: num
   return normalized
 }
 
+function normalizeAttemptTimeoutMs(value: number | undefined): number {
+  const timeoutMs = value ?? DEFAULT_ATTEMPT_TIMEOUT_MS
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('attemptTimeoutMs must be a finite positive number')
+  }
+  return timeoutMs
+}
+
+async function runWithDeadline(
+  attempt: (signal: AbortSignal) => Promise<FetchResponse>,
+  timeoutMs: number,
+): Promise<FetchResponse> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeoutError = new HttpAttemptTimeoutError(timeoutMs)
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort(timeoutError)
+      reject(timeoutError)
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([attempt(controller.signal), deadline])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
 /**
- * Invoke `attempt` with bounded exponential backoff. Retries only transient
- * failures: thrown errors (network), 5xx responses, and 429 rate-limit
- * responses. Other 4xx responses are returned immediately to the caller with no
- * retry. The caller is responsible for turning a non-ok response into an error.
+ * Invoke `attempt` with a bounded per-attempt deadline and exponential backoff.
+ * Each attempt receives an AbortSignal that is aborted when its deadline expires.
+ * Retries only transient failures: thrown errors (including timeouts), 5xx
+ * responses, and 429 rate-limit responses. Other 4xx responses are returned
+ * immediately to the caller with no retry. The caller is responsible for
+ * turning a non-ok response into an error.
  * On exhaustion, the last transient response is returned (so the caller throws
  * its own formatted error) and the last network error is rethrown.
  */
 export async function fetchWithRetry(
-  attempt: () => Promise<FetchResponse>,
+  attempt: (signal: AbortSignal) => Promise<FetchResponse>,
   options: HttpRetryOptions = {},
 ): Promise<FetchResponse> {
   const maxRetries = normalizeMaxRetries(options.maxRetries)
+  const attemptTimeoutMs = normalizeAttemptTimeoutMs(options.attemptTimeoutMs)
   const jitter = options.jitter ?? true
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
 
@@ -76,7 +121,7 @@ export async function fetchWithRetry(
       await sleep(delay)
     }
     try {
-      const response = await attempt()
+      const response = await runWithDeadline(attempt, attemptTimeoutMs)
       // Success or a non-transient (non-429 4xx) response → return; the caller decides.
       if (response.ok || !isTransientStatus(response.status)) return response
       lastError = new Error(`transient HTTP ${response.status}`)


### PR DESCRIPTION
## Summary
- add a validated 10-second per-attempt deadline to observer HTTP retries
- abort timed-out fetch attempts and retry timeout failures under the existing policy
- pass deadline signals through Langfuse and Tempo exporters with deterministic regressions

## Test plan
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (passes with 5 pre-existing warnings)
- `npm run build --workspace @franken/observer`
- `npm run test --workspace @franken/observer` (862 tests)

Closes #3532