### PR TITLE
fix(orchestrator): write local secrets atomically

### DIFF
--- a/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
@@ -1,5 +1,5 @@
 import { randomBytes, createCipheriv, createDecipheriv, pbkdf2Sync } from 'node:crypto';
-import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
+import { mkdir, open, readFile, realpath, rename, rm, stat } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import type { ISecretStore, SecretStoreDetection, SecretStoreOptions } from '../secret-store.js';
 
@@ -17,19 +17,40 @@ function createSecretsRecord(): Record<string, string> {
 }
 
 async function writeFileAtomic(filePath: string, data: string | Buffer): Promise<void> {
+  let targetPath = filePath;
+  let mode = 0o600;
+  try {
+    targetPath = await realpath(filePath);
+    mode = (await stat(targetPath)).mode & 0o777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
   const tempPath = join(
-    dirname(filePath),
-    `.${basename(filePath)}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`,
+    dirname(targetPath),
+    `.${basename(targetPath)}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`,
   );
   let tempFile: Awaited<ReturnType<typeof open>> | undefined;
 
   try {
-    tempFile = await open(tempPath, 'wx', 0o600);
+    tempFile = await open(tempPath, 'wx', mode);
     await tempFile.writeFile(data);
     await tempFile.sync();
     await tempFile.close();
     tempFile = undefined;
-    await rename(tempPath, filePath);
+    await rename(tempPath, targetPath);
+
+    let parentDir: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      parentDir = await open(dirname(targetPath), 'r');
+      await parentDir.sync();
+    } catch {
+      // Some platforms/filesystems do not support syncing directory handles.
+    } finally {
+      await parentDir?.close().catch(() => undefined);
+    }
   } catch (error) {
     await tempFile?.close().catch(() => undefined);
     await rm(tempPath, { force: true }).catch(() => undefined);

--- a/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createCipheriv, createDecipheriv, pbkdf2Sync } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import type { ISecretStore, SecretStoreDetection, SecretStoreOptions } from '../secret-store.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -14,6 +14,27 @@ const DANGEROUS_SECRET_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
 
 function createSecretsRecord(): Record<string, string> {
   return Object.create(null) as Record<string, string>;
+}
+
+async function writeFileAtomic(filePath: string, data: string | Buffer): Promise<void> {
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`,
+  );
+  let tempFile: Awaited<ReturnType<typeof open>> | undefined;
+
+  try {
+    tempFile = await open(tempPath, 'wx', 0o600);
+    await tempFile.writeFile(data);
+    await tempFile.sync();
+    await tempFile.close();
+    tempFile = undefined;
+    await rename(tempPath, filePath);
+  } catch (error) {
+    await tempFile?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 function assertSafeSecretKey(key: string): void {
@@ -128,7 +149,7 @@ export class LocalEncryptedStore implements ISecretStore {
         const salt = randomBytes(SALT_LENGTH).toString('hex');
         meta = { salt, version: 1 };
         await this.ensureDir();
-        await writeFile(this.metaPath, JSON.stringify(meta, null, 2) + '\n', 'utf-8');
+        await writeFileAtomic(this.metaPath, JSON.stringify(meta, null, 2) + '\n');
       } else {
         throw error;
       }
@@ -175,6 +196,6 @@ export class LocalEncryptedStore implements ISecretStore {
     const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
     const authTag = cipher.getAuthTag();
     const combined = Buffer.concat([iv, authTag, encrypted]);
-    await writeFile(this.encPath, combined);
+    await writeFileAtomic(this.encPath, combined);
   }
 }

--- a/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
+++ b/packages/franken-orchestrator/src/network/secret-backends/local-encrypted-store.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createCipheriv, createDecipheriv, pbkdf2Sync } from 'node:crypto';
-import { mkdir, open, readFile, realpath, rename, rm, stat } from 'node:fs/promises';
-import { basename, dirname, join } from 'node:path';
+import { lstat, mkdir, open, readFile, readlink, realpath, rename, rm, stat } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
 import type { ISecretStore, SecretStoreDetection, SecretStoreOptions } from '../secret-store.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -11,16 +11,39 @@ const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
 const SALT_LENGTH = 32;
 const DANGEROUS_SECRET_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+const UNSUPPORTED_DIRECTORY_SYNC_CODES = new Set(['EBADF', 'EISDIR', 'EINVAL', 'ENOSYS', 'ENOTSUP']);
 
 function createSecretsRecord(): Record<string, string> {
   return Object.create(null) as Record<string, string>;
 }
 
+async function resolveAtomicTarget(filePath: string): Promise<string> {
+  try {
+    return await realpath(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  try {
+    if (!(await lstat(filePath)).isSymbolicLink()) {
+      return filePath;
+    }
+    const linkTarget = await readlink(filePath);
+    return resolveAtomicTarget(resolve(dirname(filePath), linkTarget));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return filePath;
+    }
+    throw error;
+  }
+}
+
 async function writeFileAtomic(filePath: string, data: string | Buffer): Promise<void> {
-  let targetPath = filePath;
+  const targetPath = await resolveAtomicTarget(filePath);
   let mode = 0o600;
   try {
-    targetPath = await realpath(filePath);
     mode = (await stat(targetPath)).mode & 0o777;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -36,6 +59,7 @@ async function writeFileAtomic(filePath: string, data: string | Buffer): Promise
 
   try {
     tempFile = await open(tempPath, 'wx', mode);
+    await tempFile.chmod(mode);
     await tempFile.writeFile(data);
     await tempFile.sync();
     await tempFile.close();
@@ -46,8 +70,11 @@ async function writeFileAtomic(filePath: string, data: string | Buffer): Promise
     try {
       parentDir = await open(dirname(targetPath), 'r');
       await parentDir.sync();
-    } catch {
-      // Some platforms/filesystems do not support syncing directory handles.
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!code || !UNSUPPORTED_DIRECTORY_SYNC_CODES.has(code)) {
+        throw error;
+      }
     } finally {
       await parentDir?.close().catch(() => undefined);
     }

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalEncryptedStore } from '../../../../src/network/secret-backends/local-encrypted-store.js';
 import { testCredential } from '../../../support/test-credentials.js';
+
+const fsMocks = vi.hoisted(() => ({
+  rename: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  fsMocks.rename.mockImplementation(actual.rename);
+  return { ...actual, rename: fsMocks.rename };
+});
 
 const TEST_SLACK_BOT_TOKEN = testCredential('TEST_SLACK_BOT_TOKEN');
 
@@ -64,6 +74,21 @@ describe('LocalEncryptedStore', () => {
       expect(value).toBe('value2');
     });
 
+    it('preserves the previous ciphertext when the atomic replacement fails', async () => {
+      await store.store('key', 'value1');
+      const secretsDir = join(tempDir, '.fbeast');
+      const encPath = join(secretsDir, 'secrets.enc');
+      const originalCiphertext = await readFile(encPath);
+      const replacementError = Object.assign(new Error('simulated rename failure'), { code: 'EIO' });
+      fsMocks.rename.mockRejectedValueOnce(replacementError);
+
+      await expect(store.store('key', 'value2')).rejects.toBe(replacementError);
+
+      expect(await readFile(encPath)).toEqual(originalCiphertext);
+      expect((await readdir(secretsDir)).filter((name) => name.includes('secrets.enc.tmp'))).toEqual([]);
+      expect(await store.resolve('key')).toBe('value1');
+    });
+
     it('handles multiple secrets', async () => {
       await store.store('key1', 'value1');
       await store.store('key2', 'value2');
@@ -101,6 +126,20 @@ describe('LocalEncryptedStore', () => {
   });
 
   describe('encryption', () => {
+    it('removes temporary metadata when its atomic replacement fails', async () => {
+      const secretsDir = join(tempDir, '.fbeast');
+      const metaPath = join(secretsDir, 'secrets.meta.json');
+      const replacementError = Object.assign(new Error('simulated metadata rename failure'), {
+        code: 'EIO',
+      });
+      fsMocks.rename.mockRejectedValueOnce(replacementError);
+
+      await expect(store.store('key', 'value')).rejects.toBe(replacementError);
+
+      expect(await readdir(secretsDir)).toEqual([]);
+      await expect(readFile(metaPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
     it('persists secrets encrypted on disk', async () => {
       await store.store('key', 'sensitive-value');
       const { readFile } = await import('node:fs/promises');

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { chmod, lstat, mkdtemp, readFile, readdir, rename, rm, stat, symlink } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalEncryptedStore } from '../../../../src/network/secret-backends/local-encrypted-store.js';
@@ -99,14 +99,28 @@ describe('LocalEncryptedStore', () => {
       expect(fsMocks.open).toHaveBeenCalledWith(secretsDir, 'r');
     });
 
+    it('reports real parent-directory fsync failures', async () => {
+      const secretsDir = join(tempDir, '.fbeast');
+      const syncError = Object.assign(new Error('simulated directory sync failure'), { code: 'EIO' });
+      const originalOpen = fsMocks.open.getMockImplementation();
+      fsMocks.open.mockImplementation(async (...args) => {
+        if (args[0] === secretsDir && args[1] === 'r') {
+          return { sync: vi.fn().mockRejectedValue(syncError), close: vi.fn().mockResolvedValue(undefined) };
+        }
+        return originalOpen!(...args);
+      });
+
+      await expect(store.store('key', 'value')).rejects.toBe(syncError);
+    });
+
     it('preserves existing ciphertext permissions when replacing it', async () => {
       await store.store('key', 'value1');
       const encPath = join(tempDir, '.fbeast', 'secrets.enc');
-      await chmod(encPath, 0o640);
+      await chmod(encPath, 0o666);
 
       await store.store('key', 'value2');
 
-      expect((await stat(encPath)).mode & 0o777).toBe(0o640);
+      expect((await stat(encPath)).mode & 0o777).toBe(0o666);
     });
 
     it('atomically replaces the target of an existing ciphertext symlink', async () => {
@@ -121,6 +135,20 @@ describe('LocalEncryptedStore', () => {
       expect((await lstat(encPath)).isSymbolicLink()).toBe(true);
       expect(await store.resolve('key')).toBe('value2');
       expect((await stat(linkedEncPath)).isFile()).toBe(true);
+    });
+
+    it('preserves a dangling ciphertext symlink when creating its target', async () => {
+      const secretsDir = join(tempDir, '.fbeast');
+      const encPath = join(secretsDir, 'secrets.enc');
+      const linkedEncPath = join(tempDir, 'new-persisted-secrets.enc');
+      await mkdir(secretsDir);
+      await symlink(linkedEncPath, encPath);
+
+      await store.store('key', 'value');
+
+      expect((await lstat(encPath)).isSymbolicLink()).toBe(true);
+      expect((await stat(linkedEncPath)).isFile()).toBe(true);
+      expect(await store.resolve('key')).toBe('value');
     });
 
     it('handles multiple secrets', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/secret-backends/local-encrypted-store.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { chmod, lstat, mkdtemp, readFile, readdir, rename, rm, stat, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalEncryptedStore } from '../../../../src/network/secret-backends/local-encrypted-store.js';
 import { testCredential } from '../../../support/test-credentials.js';
 
 const fsMocks = vi.hoisted(() => ({
+  open: vi.fn(),
   rename: vi.fn(),
 }));
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
+  fsMocks.open.mockImplementation(actual.open);
   fsMocks.rename.mockImplementation(actual.rename);
-  return { ...actual, rename: fsMocks.rename };
+  return { ...actual, open: fsMocks.open, rename: fsMocks.rename };
 });
 
 const TEST_SLACK_BOT_TOKEN = testCredential('TEST_SLACK_BOT_TOKEN');
@@ -22,6 +24,7 @@ describe('LocalEncryptedStore', () => {
   let store: LocalEncryptedStore;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     tempDir = await mkdtemp(join(tmpdir(), 'secret-test-'));
     store = new LocalEncryptedStore({
       projectRoot: tempDir,
@@ -87,6 +90,37 @@ describe('LocalEncryptedStore', () => {
       expect(await readFile(encPath)).toEqual(originalCiphertext);
       expect((await readdir(secretsDir)).filter((name) => name.includes('secrets.enc.tmp'))).toEqual([]);
       expect(await store.resolve('key')).toBe('value1');
+    });
+
+    it('fsyncs the parent directory after replacing the ciphertext', async () => {
+      await store.store('key', 'value');
+      const secretsDir = join(tempDir, '.fbeast');
+
+      expect(fsMocks.open).toHaveBeenCalledWith(secretsDir, 'r');
+    });
+
+    it('preserves existing ciphertext permissions when replacing it', async () => {
+      await store.store('key', 'value1');
+      const encPath = join(tempDir, '.fbeast', 'secrets.enc');
+      await chmod(encPath, 0o640);
+
+      await store.store('key', 'value2');
+
+      expect((await stat(encPath)).mode & 0o777).toBe(0o640);
+    });
+
+    it('atomically replaces the target of an existing ciphertext symlink', async () => {
+      await store.store('key', 'value1');
+      const encPath = join(tempDir, '.fbeast', 'secrets.enc');
+      const linkedEncPath = join(tempDir, 'persisted-secrets.enc');
+      await rename(encPath, linkedEncPath);
+      await symlink(linkedEncPath, encPath);
+
+      await store.store('key', 'value2');
+
+      expect((await lstat(encPath)).isSymbolicLink()).toBe(true);
+      expect(await store.resolve('key')).toBe('value2');
+      expect((await stat(linkedEncPath)).isFile()).toBe(true);
     });
 
     it('handles multiple secrets', async () => {


### PR DESCRIPTION
## Summary
- write encrypted secret payloads and metadata to same-directory temporary files
- fsync and atomically rename temporary files into place
- clean up temporary files after failed replacements while preserving existing ciphertext

## Reproduction
Before the fix, an injected `rename` failure during a secret update could not guarantee failure-safe replacement because the destination was written directly.

## Test plan
- `npm run test --workspace @franken/orchestrator -- tests/unit/network/secret-backends/local-encrypted-store.test.ts` (26 passed)
- `npm run test --workspace @franken/orchestrator` (4418 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator -- --quiet`
- `npm run build`

Closes #3008
