### PR TITLE
fix(security): disable anonymous Grafana by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ CHROMA_URL=http://localhost:8000
 # The compose startup guard resets the persisted admin password for existing local Grafana volumes.
 # GRAFANA_USER=admin
 # GRAFANA_PASSWORD=change-me-random-grafana-password
+# Anonymous dashboard access is disabled by default. For a short-lived,
+# loopback-only local demo, explicitly opt in with GRAFANA_ANONYMOUS_ENABLED=true.
+# Never enable it when exposing the compose stack to another machine.
 # Optional Grafana Cloud Tempo export for @franken/observer TempoAdapter examples.
 # Omit both for the local Tempo service; keep API keys in CI secret stores, not git.
 # GRAFANA_INSTANCE_ID=123456

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-}
-      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ENABLED=${GRAFANA_ANONYMOUS_ENABLED:-false}
     depends_on:
       - tempo
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -99,6 +99,17 @@ newer, these development services are not reachable from other machines. On olde
 Docker Engine releases, hosts on the same layer-2 network may still reach ports
 published to loopback; upgrade the engine or enforce equivalent host-firewall rules.
 
+Grafana anonymous dashboard access is disabled by default. If a short-lived local
+demo specifically needs anonymous access, opt in for that invocation only:
+
+```bash
+GRAFANA_ANONYMOUS_ENABLED=true docker compose up -d grafana
+```
+
+This opt-in still requires the explicit admin credentials described above, and
+Grafana remains bound to `127.0.0.1`. Do not combine this opt-in with
+`docker-compose.remote.yml` or otherwise expose the service to another machine.
+
 To intentionally expose ChromaDB, Grafana, and Tempo to a trusted network, use
 the explicit override with Docker Compose 2.24.4 or newer:
 

--- a/tests/docker-compose-port-security.test.ts
+++ b/tests/docker-compose-port-security.test.ts
@@ -11,6 +11,23 @@ function readRepoFile(path: string): string {
 }
 
 describe("docker compose published-port security", () => {
+  it("disables anonymous Grafana access by default with an explicit local opt-in", () => {
+    const compose = readRepoFile("docker-compose.yml");
+    const envExample = readRepoFile(".env.example");
+    const quickstart = readRepoFile("docs/guides/quickstart.md");
+
+    expect(compose).toContain(
+      "GF_AUTH_ANONYMOUS_ENABLED=${GRAFANA_ANONYMOUS_ENABLED:-false}",
+    );
+    expect(compose).not.toMatch(/GF_AUTH_ANONYMOUS_ENABLED=true/u);
+    expect(envExample).toContain("GRAFANA_ANONYMOUS_ENABLED=true");
+    expect(quickstart).toContain(
+      "GRAFANA_ANONYMOUS_ENABLED=true docker compose up -d grafana",
+    );
+    expect(quickstart).toContain("remains bound to `127.0.0.1`");
+    expect(quickstart).toContain("Do not combine this opt-in");
+  });
+
   it("binds every default development port to IPv4 localhost", () => {
     const compose = readRepoFile("docker-compose.yml");
 


### PR DESCRIPTION
## Summary
- disable Grafana anonymous dashboard access unless explicitly opted in
- document the loopback-only opt-in and prohibit combining it with remote exposure
- add regression coverage for the secure default and opt-in guidance

## Verification
- `npm run test:root -- tests/docker-compose-port-security.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run lint:security`
- `git diff --check`

Closes #3156