### PR TITLE
fix(orchestrator): bound early process output buffers

### DIFF
--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -23,11 +23,46 @@ import {
 } from '../../cli/run-config-integrity.js';
 
 const STDERR_BUFFER_SIZE = 50;
+const EARLY_OUTPUT_MAX_LINES = 50;
+const EARLY_OUTPUT_MAX_BYTES = 60 * 1_024;
 const REDACTED_SECRET = '[REDACTED]';
 const MIN_CONFIGURED_SECRET_LENGTH = 6;
 const RUN_CONFIG_DIR_MODE = 0o700;
 const RUN_CONFIG_FILE_MODE = 0o600;
 const SPAWN_FAILED_CODE = 'SPAWN_FAILED';
+
+interface EarlyOutputBuffer {
+  readonly lines: string[];
+  bytes: number;
+  droppedLines: number;
+  droppedBytes: number;
+}
+
+function createEarlyOutputBuffer(): EarlyOutputBuffer {
+  return { lines: [], bytes: 0, droppedLines: 0, droppedBytes: 0 };
+}
+
+function bufferEarlyOutput(buffer: EarlyOutputBuffer, line: string): void {
+  const lineBytes = Buffer.byteLength(line, 'utf8');
+  if (
+    buffer.lines.length >= EARLY_OUTPUT_MAX_LINES
+    || buffer.bytes + lineBytes > EARLY_OUTPUT_MAX_BYTES
+  ) {
+    buffer.droppedLines += 1;
+    buffer.droppedBytes += lineBytes;
+    return;
+  }
+  buffer.lines.push(line);
+  buffer.bytes += lineBytes;
+}
+
+function earlyOutputLines(buffer: EarlyOutputBuffer): readonly string[] {
+  if (buffer.droppedLines === 0) return buffer.lines;
+  return [
+    ...buffer.lines,
+    `[early output truncated: dropped ${buffer.droppedLines} line(s) / ${buffer.droppedBytes} byte(s); retained at most ${EARLY_OUTPUT_MAX_LINES} lines / ${EARLY_OUTPUT_MAX_BYTES} bytes]`,
+  ];
+}
 const SAFE_SPAWN_ERROR_CODES = new Set([
   'EACCES',
   'EAGAIN',
@@ -455,8 +490,8 @@ export class ProcessBeastExecutor implements BeastExecutor {
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;
-    const earlyStdoutLines: string[] = [];
-    const earlyStderrLines: string[] = [];
+    const earlyStdout = createEarlyOutputBuffer();
+    const earlyStderr = createEarlyOutputBuffer();
     const stderrTail: string[] = [];
     let earlyExit: { code: number | null; signal: string | null } | undefined;
 
@@ -473,7 +508,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
               data: { runId: run.id, attemptId, stream: 'stdout', line: redactedLine, createdAt },
             });
           } else {
-            earlyStdoutLines.push(redactedLine);
+            bufferEarlyOutput(earlyStdout, redactedLine);
           }
         },
         onStderr: (line) => {
@@ -488,7 +523,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
               data: { runId: run.id, attemptId, stream: 'stderr', line: redactedLine, createdAt },
             });
           } else {
-            earlyStderrLines.push(redactedLine);
+            bufferEarlyOutput(earlyStderr, redactedLine);
           }
         },
         onExit: (code, signal) => {
@@ -524,7 +559,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       const crashClassification = classifyWorkerCrash({
         stopReason: 'spawn_failed',
         spawnErrorCode: errorCode,
-        stderrTail: earlyStderrLines,
+        stderrTail: earlyStderr.lines,
       });
       const spawnFailedEvent = {
         type: 'run.spawn_failed' as const,
@@ -662,7 +697,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
     attemptId = attempt.id;
 
     // Flush early buffered lines to logs and SSE
-    for (const line of earlyStdoutLines) {
+    for (const line of earlyOutputLines(earlyStdout)) {
       const createdAt = new Date(wallClockNow()).toISOString();
       void this.logs.append(run.id, attemptId, 'stdout', line, createdAt);
       this.options.eventBus?.publish({
@@ -670,7 +705,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
         data: { runId: run.id, attemptId, stream: 'stdout', line, createdAt },
       });
     }
-    for (const line of earlyStderrLines) {
+    for (const line of earlyOutputLines(earlyStderr)) {
       const createdAt = new Date(wallClockNow()).toISOString();
       void this.logs.append(run.id, attemptId, 'stderr', line, createdAt);
       this.options.eventBus?.publish({

--- a/packages/franken-orchestrator/test/execution/process-beast-executor-redaction.test.ts
+++ b/packages/franken-orchestrator/test/execution/process-beast-executor-redaction.test.ts
@@ -80,6 +80,48 @@ function createRepository() {
 }
 
 describe('ProcessBeastExecutor log redaction', () => {
+  it('bounds early stdout and stderr by line count and bytes and reports truncation', async () => {
+    const logs: LogEntry[] = [];
+    const repository = createRepository();
+    const logStore = {
+      async append(
+        runId: string,
+        attemptId: string,
+        stream: 'stdout' | 'stderr',
+        message: string,
+      ): Promise<void> {
+        logs.push({ runId, attemptId, stream, message });
+      },
+    } as BeastLogStore;
+    const supervisor: ProcessSupervisorLike = {
+      async spawn(_spec, callbacks: ProcessCallbacks) {
+        for (let index = 0; index < 200; index += 1) {
+          callbacks.onStdout(`stdout-${index}`);
+          callbacks.onStderr(`stderr-${index}-${'y'.repeat(2_048)}`);
+        }
+        return { pid: 4242 };
+      },
+      async stop() {},
+      async kill() {},
+    };
+    const executor = new ProcessBeastExecutor(
+      repository as unknown as SQLiteBeastRepository,
+      logStore,
+      supervisor,
+    );
+
+    await executor.start(createRun(), createDefinition());
+
+    for (const stream of ['stdout', 'stderr'] as const) {
+      const streamLogs = logs.filter((entry) => entry.stream === stream);
+      const startupLogs = streamLogs.filter((entry) => !entry.message.startsWith('started pid='));
+      expect(startupLogs.length).toBeLessThanOrEqual(51);
+      expect(Buffer.byteLength(startupLogs.map((entry) => entry.message).join('\n'), 'utf8'))
+        .toBeLessThanOrEqual(65_536);
+      expect(startupLogs.some((entry) => entry.message.includes('early output truncated'))).toBe(true);
+    }
+  });
+
   it('redacts early stdout and stderr before flushing them to durable logs and events', async () => {
     const rawStdoutSecret = `${'sk'}-${'12345678901234567890'}`;
     const rawStderrSecret = `${'ghp'}_${'abcdefghijklmnopqrstuvwxyz1234567890'}`;


### PR DESCRIPTION
## Summary
- bound process stdout/stderr emitted before attempt creation by both line count and UTF-8 byte count
- emit an explicit truncation marker with dropped-line and dropped-byte totals
- preserve existing secret redaction before buffering and durable flush

## Reproduction
Before the fix, the focused regression failed because all 200 startup lines per stream were retained. It now verifies the stdout line cap, stderr byte cap, and observable truncation.

## Validation
- `npm test` (`@franken/orchestrator`): 283 files, 4,418 tests passed
- `npx vitest run tests/unit/beasts/process-beast-executor.test.ts test/execution/process-beast-executor-redaction.test.ts`: 57 tests passed
- `npm run typecheck` (`@franken/orchestrator`): passed
- `npm run build` (`@franken/orchestrator`): passed
- `npm run lint` (`@franken/orchestrator`): passed with existing warnings only
- `git diff --check`: passed

Closes #3116
