### PR TITLE
fix(web): back off Beast event stream reconnects

### DIFF
--- a/packages/franken-web/src/lib/beast-api.ts
+++ b/packages/franken-web/src/lib/beast-api.ts
@@ -1,4 +1,4 @@
-import { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
+import { MODULE_CONFIG_KEYS, seededRandom, TRACKED_AGENT_STATUSES } from '@franken/types';
 import type {
   ApiDataEnvelope,
   BeastCatalogEntry,
@@ -23,6 +23,9 @@ import type {
   TrackedAgentSummary,
 } from '@franken/types';
 import { toError } from './http-error';
+
+const BEAST_EVENT_RECONNECT_BASE_DELAY_MS = 1_000;
+const BEAST_EVENT_RECONNECT_MAX_DELAY_MS = 30_000;
 
 export { MODULE_CONFIG_KEYS, TRACKED_AGENT_STATUSES } from '@franken/types';
 export type {
@@ -244,6 +247,7 @@ export class BeastApiClient {
     let closed = false;
     let eventSource: EventSource | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let reconnectAttempt = 0;
     let lastEventId: string | undefined;
     let failedEventId: string | undefined;
     class MalformedSsePayloadError extends Error {
@@ -272,6 +276,7 @@ export class BeastApiClient {
       handler: ((payload: T) => void) | undefined,
     ): void => {
       if (!handler) {
+        reconnectAttempt = 0;
         rememberProcessedEventId(event);
         return;
       }
@@ -283,26 +288,39 @@ export class BeastApiClient {
         rememberFailedEventId(event);
         throw new MalformedSsePayloadError(error);
       }
+      reconnectAttempt = 0;
       rememberProcessedEventId(event);
       handler(payload);
     };
-    const scheduleReconnect = () => {
+    const scheduleReconnect = (reason: Error) => {
       if (closed || reconnectTimer) return;
+      reconnectAttempt += 1;
+      const exponentialDelay = Math.min(
+        BEAST_EVENT_RECONNECT_BASE_DELAY_MS * 2 ** (reconnectAttempt - 1),
+        BEAST_EVENT_RECONNECT_MAX_DELAY_MS,
+      );
+      const reconnectDelay = Math.min(
+        exponentialDelay + seededRandom.random() * BEAST_EVENT_RECONNECT_BASE_DELAY_MS,
+        BEAST_EVENT_RECONNECT_MAX_DELAY_MS,
+      );
+      const retrySeconds = Math.ceil(reconnectDelay / 1_000);
+      handlers.error?.(new Error(
+        `${reason.message}; reconnecting in ${retrySeconds}s (attempt ${reconnectAttempt})`,
+      ));
       reconnectTimer = setTimeout(() => {
         reconnectTimer = undefined;
         void connect().catch((error: unknown) => {
           if (!closed) {
-            handlers.error?.(toError(error));
-            scheduleReconnect();
+            scheduleReconnect(toError(error));
           }
         });
-      }, 1_000);
+      }, reconnectDelay);
     };
     const reconnectAfterMalformedPayload = (source: EventSource): void => {
       if (closed || eventSource !== source) return;
       eventSource = undefined;
       source.close();
-      scheduleReconnect();
+      scheduleReconnect(new Error('Beast event stream received malformed data'));
     };
     const reportEventError = (error: unknown, source: EventSource): void => {
       if (error instanceof MalformedSsePayloadError) {
@@ -380,16 +398,15 @@ export class BeastApiClient {
       });
       nextSource.addEventListener('error', () => {
         if (closed || eventSource !== nextSource) return;
+        eventSource = undefined;
         nextSource.close();
-        handlers.error?.(new Error('Beast event stream disconnected; reconnecting'));
-        scheduleReconnect();
+        scheduleReconnect(new Error('Beast event stream disconnected'));
       });
     };
 
     await connect().catch((error: unknown) => {
       if (!closed) {
-        handlers.error?.(toError(error));
-        scheduleReconnect();
+        scheduleReconnect(toError(error));
       }
     });
 

--- a/packages/franken-web/tests/lib/beast-api.test.ts
+++ b/packages/franken-web/tests/lib/beast-api.test.ts
@@ -1,8 +1,10 @@
+import { seededRandom } from '@franken/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BeastApiClient, BeastApiError } from '../../src/lib/beast-api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
+const seededRandomSpy = vi.spyOn(seededRandom, 'random').mockReturnValue(0);
 
 describe('BeastApiClient', () => {
   const client = new BeastApiClient('http://localhost:3000');
@@ -538,6 +540,155 @@ describe('BeastApiClient', () => {
     }
   });
 
+  it('backs off consecutive Beast event stream reconnects and reports the retry attempt', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-1' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-2' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-3' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket-4' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ error: onError });
+
+      listeners[0]?.error?.({ data: '' });
+      expect(onError).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: expect.stringContaining('attempt 1'),
+      }));
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      listeners[1]?.error?.({ data: '' });
+      expect(onError).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: expect.stringContaining('attempt 2'),
+      }));
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1_001);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      listeners[2]?.snapshot?.({ data: JSON.stringify({ agents: [] }) });
+      listeners[2]?.error?.({ data: '' });
+      expect(onError).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: expect.stringContaining('attempt 1'),
+      }));
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('jitters Beast event stream reconnect delays', async () => {
+    vi.useFakeTimers();
+    seededRandomSpy.mockReturnValueOnce(0.5);
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket' }) });
+
+    try {
+      const unsubscribe = await client.subscribeToEvents({ error: vi.fn() });
+      listeners[0]?.error?.({ data: '' });
+
+      await vi.advanceTimersByTimeAsync(1_499);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
+  it('caps Beast event stream reconnect delays at thirty seconds', async () => {
+    vi.useFakeTimers();
+    const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
+    const MockEventSource = vi.fn(function (this: { addEventListener?: unknown; close?: unknown }) {
+      const instanceListeners: Record<string, (event: { data: string }) => void> = {};
+      listeners.push(instanceListeners);
+      Object.assign(this, {
+        addEventListener: vi.fn((type: string, handler: (event: { data: string }) => void) => {
+          instanceListeners[type] = handler;
+        }),
+        close: vi.fn(),
+      });
+    });
+    const originalEventSource = globalThis.EventSource;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).EventSource = MockEventSource;
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ connectionId: 'ticket' }) });
+
+    try {
+      const onError = vi.fn();
+      const unsubscribe = await client.subscribeToEvents({ error: onError });
+      const uncappedDelays = [1_000, 2_000, 4_000, 8_000, 16_000];
+      for (const [index, delay] of uncappedDelays.entries()) {
+        listeners[index]?.error?.({ data: '' });
+        await vi.advanceTimersByTimeAsync(delay);
+      }
+
+      listeners[5]?.error?.({ data: '' });
+      expect(onError).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: expect.stringContaining('reconnecting in 30s (attempt 6)'),
+      }));
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(mockFetch).toHaveBeenCalledTimes(6);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockFetch).toHaveBeenCalledTimes(7);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+      if (originalEventSource) {
+        globalThis.EventSource = originalEventSource;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (globalThis as any).EventSource;
+      }
+    }
+  });
+
   it('notifies handlers when the Beast event stream reconnects successfully', async () => {
     vi.useFakeTimers();
     const listeners: Array<Record<string, (event: { data: string }) => void>> = [];
@@ -845,8 +996,10 @@ describe('BeastApiClient', () => {
 
       listeners[0]?.error?.({ data: '' });
       await vi.advanceTimersByTimeAsync(1_000);
-      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'HTTP 500' }));
-      await vi.advanceTimersByTimeAsync(1_000);
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'HTTP 500; reconnecting in 2s (attempt 2)',
+      }));
+      await vi.advanceTimersByTimeAsync(2_000);
 
       expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(MockEventSource).toHaveBeenNthCalledWith(
@@ -887,7 +1040,9 @@ describe('BeastApiClient', () => {
       const onError = vi.fn();
       const unsubscribe = await client.subscribeToEvents({ error: onError });
 
-      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'HTTP 503' }));
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'HTTP 503; reconnecting in 1s (attempt 1)',
+      }));
       expect(MockEventSource).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1_000);


### PR DESCRIPTION
## Summary
- replace fixed one-second Beast SSE reconnects with capped exponential backoff and seeded jitter
- reset retry state after a healthy SSE event and ignore stale closed sources
- surface reconnect delay and attempt number so the UI shows degraded stream state clearly
- cover consecutive failures, jitter, cap, reset, and ticket-request failures

## Test plan
- `npm test` (`packages/franken-web`: 78 files, 715 tests)
- `npm run typecheck` (`packages/franken-web`)
- `npm run lint` (`packages/franken-web`; 0 errors, 17 pre-existing warnings)
- `npm run build` (`packages/franken-web`)

Closes #2714