### PR TITLE
fix(observer): expose unknown model cost attribution

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -203,6 +203,13 @@ const records = counter.allModels().map((model) => ({
 }))
 calc.totalCost(records)
 
+// Governance and dashboards can opt into structured attribution instead of
+// conflating an unpriced model with a legitimately free model.
+const attributed = calc.totalCostWithAttribution(records)
+if (attributed.unknownModelCount > 0) {
+  console.warn(`Missing pricing for: ${attributed.unknownModels.join(', ')}`)
+}
+
 // Extend the pricing table
 const myPricing = { ...DEFAULT_PRICING, 'my-local-model': { promptPerMillion: 0, completionPerMillion: 0 } }
 const customCalc = new CostCalculator(myPricing)

--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -43,16 +43,33 @@ describe('CostCalculator', () => {
       expect(cost).toBe((1 * 15) / 1_000_000)
     })
 
-    it('returns 0 for an unknown model', () => {
-      const quietCalc = new CostCalculator(DEFAULT_PRICING, {
-        onUnknownModel: () => {},
-      })
-      const cost = quietCalc.calculate({
+    it('distinguishes an unknown model from a legitimately free model', () => {
+      const quietCalc = new CostCalculator(
+        { free: { promptPerMillion: 0, completionPerMillion: 0 } },
+        { onUnknownModel: () => {} },
+      )
+
+      expect(quietCalc.calculateWithAttribution({
+        model: 'free',
+        promptTokens: 1000,
+        completionTokens: 500,
+      })).toEqual({ costUsd: 0, unknownModel: false })
+      expect(quietCalc.calculateWithAttribution({
         model: 'unknown-model-xyz',
         promptTokens: 1000,
         completionTokens: 500,
+      })).toEqual({ costUsd: 0, unknownModel: true })
+    })
+
+    it('preserves the legacy numeric result for an unknown model', () => {
+      const quietCalc = new CostCalculator(DEFAULT_PRICING, {
+        onUnknownModel: () => {},
       })
-      expect(cost).toBe(0)
+      expect(quietCalc.calculate({
+        model: 'unknown-model-xyz',
+        promptTokens: 1000,
+        completionTokens: 500,
+      })).toBe(0)
     })
 
     it.each([
@@ -156,6 +173,24 @@ describe('CostCalculator', () => {
       ]
 
       expect(calc.totalCost(entries)).toBe(10_000_000_000_000_002)
+    })
+
+    it('reports distinct unknown models without conflating them with a zero-cost total', () => {
+      const calc = new CostCalculator(
+        { free: { promptPerMillion: 0, completionPerMillion: 0 } },
+        { onUnknownModel: () => {} },
+      )
+
+      expect(calc.totalCostWithAttribution([
+        { model: 'free', promptTokens: 100, completionTokens: 50 },
+        { model: 'unknown-a', promptTokens: 100, completionTokens: 50 },
+        { model: 'unknown-a', promptTokens: 200, completionTokens: 100 },
+        { model: 'unknown-b', promptTokens: 100, completionTokens: 50 },
+      ])).toEqual({
+        costUsd: 0,
+        unknownModelCount: 2,
+        unknownModels: ['unknown-a', 'unknown-b'],
+      })
     })
 
     it('returns 0 for an empty list', () => {

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -5,6 +5,19 @@ export interface CostCalculatorOptions {
   onUnknownModel?: (model: string) => void
 }
 
+/** Structured result for callers that must distinguish unpriced usage from a priced zero. */
+export interface CostCalculation {
+  costUsd: number
+  unknownModel: boolean
+}
+
+/** Structured aggregate with distinct unknown model labels in first-seen order. */
+export interface TotalCostCalculation {
+  costUsd: number
+  unknownModelCount: number
+  unknownModels: string[]
+}
+
 export class CostCalculator {
   private readonly warnedModels = new Set<string>()
   private readonly onUnknownModel: (model: string) => void
@@ -27,6 +40,10 @@ export class CostCalculator {
   }
 
   calculate(entry: TokenRecord): number {
+    return this.calculateWithAttribution(entry).costUsd
+  }
+
+  calculateWithAttribution(entry: TokenRecord): CostCalculation {
     CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
     CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
 
@@ -36,20 +53,31 @@ export class CostCalculator {
         this.warnedModels.add(entry.model)
         this.onUnknownModel(entry.model)
       }
-      return 0
+      return { costUsd: 0, unknownModel: true }
     }
-    return (
-      (entry.promptTokens * model.promptPerMillion) / 1_000_000 +
-      (entry.completionTokens * model.completionPerMillion) / 1_000_000
-    )
+    return {
+      costUsd:
+        (entry.promptTokens * model.promptPerMillion) / 1_000_000 +
+        (entry.completionTokens * model.completionPerMillion) / 1_000_000,
+      unknownModel: false,
+    }
   }
 
   totalCost(entries: TokenRecord[]): number {
+    return this.totalCostWithAttribution(entries).costUsd
+  }
+
+  totalCostWithAttribution(entries: TokenRecord[]): TotalCostCalculation {
     let sum = 0
     let compensation = 0
+    const unknownModels = new Set<string>()
 
     for (const entry of entries) {
-      const cost = this.calculate(entry)
+      const result = this.calculateWithAttribution(entry)
+      const cost = result.costUsd
+      if (result.unknownModel) {
+        unknownModels.add(entry.model)
+      }
       const next = sum + cost
 
       // Neumaier summation preserves low-order costs that direct addition loses
@@ -62,6 +90,10 @@ export class CostCalculator {
       sum = next
     }
 
-    return sum + compensation
+    return {
+      costUsd: sum + compensation,
+      unknownModelCount: unknownModels.size,
+      unknownModels: Array.from(unknownModels),
+    }
   }
 }

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -121,7 +121,11 @@ export type {
 } from './core/types.js'
 export type { TokenUsage } from './core/SpanLifecycle.js'
 export type { TokenRecord, TokenTotals, TokenCounterOptions } from './cost/TokenCounter.js'
-export type { CostCalculatorOptions } from './cost/CostCalculator.js'
+export type {
+  CostCalculation,
+  CostCalculatorOptions,
+  TotalCostCalculation,
+} from './cost/CostCalculator.js'
 export type { CircuitBreakerOptions, CircuitBreakerResult } from './cost/CircuitBreaker.js'
 export type {
   AttributionEntry,

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-22 — Isolated monorepo worktree dependencies
+- Do not symlink a fresh worktree's root `node_modules` to another checkout when npm workspace packages are symlinked within it: internal imports can resolve that other checkout's stale build outputs and produce misleading missing-export errors. Run a local `npm ci`, then build prerequisite workspace packages before package-level typecheck/build gates.
+
 ## 2026-07-22 — Post-tool authorization and nested-string redaction
 - Use separate redaction modes for executable pre-tool shell context and inert post-tool output: shell assignments must stop at the first token so governance still sees the command, while post-tool output can consume known structured multi-token authorization values.
 - Authorization redaction must treat quoted header values and structured multi-token schemes (including AWS `Credential`/`SignedHeaders`/`Signature` parameters) as one secret-bearing value while stopping before shell control/substitution boundaries.


### PR DESCRIPTION
## Summary
- add structured per-entry cost results that distinguish missing pricing from legitimate zero-rate models
- add structured aggregate results with distinct unknown model names and a count while preserving legacy numeric methods
- export the result types and document governance/dashboard usage

## Test Plan
- `npm test --workspace @franken/observer -- src/cost/CostCalculator.test.ts` (24 passed)
- `npm run build --workspace @franken/types`
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors, 5 pre-existing warnings)
- `npm test --workspace @franken/observer` (864 passed)

Closes #3002