### PR TITLE
fix(orchestrator): omit comms provider error bodies

### DIFF
--- a/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/discord/discord-adapter.ts
@@ -76,7 +76,12 @@ export class DiscordAdapter implements ChannelAdapter {
       body: JSON.stringify(body),
     }, async response => {
       if (!response.ok) {
-        throw new Error(await formatHttpErrorMessage('Discord API error', response, targetUrl));
+        throw new Error(await formatHttpErrorMessage(
+          'Discord API error',
+          response,
+          targetUrl,
+          { provider: 'discord' },
+        ));
       }
     });
   }

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -124,7 +124,15 @@ function normalizeSlackErrorCode(value: unknown): string | undefined {
     : undefined;
 }
 
-function extractProviderErrorCode(responseBody: string): string | undefined {
+export interface HttpErrorContextOptions {
+  provider?: 'slack' | 'discord' | 'telegram' | 'whatsapp';
+  redact?: (value: string) => string;
+}
+
+function extractProviderErrorCode(
+  responseBody: string,
+  provider: HttpErrorContextOptions['provider'],
+): string | undefined {
   try {
     const payload = JSON.parse(responseBody) as unknown;
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
@@ -132,16 +140,21 @@ function extractProviderErrorCode(responseBody: string): string | undefined {
     }
 
     const record = payload as Record<string, unknown>;
-    const directCode = normalizeNumericProviderCode(record['error_code'])
-      ?? normalizeNumericProviderCode(record['code'])
-      ?? normalizeSlackErrorCode(record['error']);
-    if (directCode) {
-      return directCode;
-    }
-
-    const nestedError = record['error'];
-    if (nestedError && typeof nestedError === 'object' && !Array.isArray(nestedError)) {
-      return normalizeNumericProviderCode((nestedError as Record<string, unknown>)['code']);
+    switch (provider) {
+      case 'slack':
+        return normalizeSlackErrorCode(record['error']);
+      case 'discord':
+        return normalizeNumericProviderCode(record['code']);
+      case 'telegram':
+        return normalizeNumericProviderCode(record['error_code']);
+      case 'whatsapp': {
+        const nestedError = record['error'];
+        return nestedError && typeof nestedError === 'object' && !Array.isArray(nestedError)
+          ? normalizeNumericProviderCode((nestedError as Record<string, unknown>)['code'])
+          : undefined;
+      }
+      default:
+        return undefined;
     }
   } catch {
     // Malformed or truncated provider bodies are intentionally omitted.
@@ -153,14 +166,18 @@ export async function formatHttpErrorMessage(
   prefix: string,
   response: Response,
   endpoint: string,
-  redact: (value: string) => string = redactHttpErrorSecrets,
+  options: HttpErrorContextOptions = {},
 ): Promise<string> {
+  const redact = options.redact ?? redactHttpErrorSecrets;
   const statusText = response.statusText ? ` ${response.statusText}` : '';
   const redactedEndpoint = redact(endpoint);
   let providerCode: string | undefined;
 
   try {
-    providerCode = extractProviderErrorCode(await readBoundedErrorBody(response));
+    providerCode = extractProviderErrorCode(
+      await readBoundedErrorBody(response),
+      options.provider,
+    );
   } catch {
     providerCode = undefined;
   }

--- a/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
+++ b/packages/franken-orchestrator/src/comms/channels/http-error-context.ts
@@ -112,6 +112,43 @@ async function readBoundedErrorBody(response: Response): Promise<string> {
   return truncated ? `${decoded}…` : decoded;
 }
 
+function normalizeNumericProviderCode(value: unknown): string | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? String(value)
+    : undefined;
+}
+
+function normalizeSlackErrorCode(value: unknown): string | undefined {
+  return typeof value === 'string' && /^[a-z][a-z0-9_]{0,63}$/.test(value)
+    ? value
+    : undefined;
+}
+
+function extractProviderErrorCode(responseBody: string): string | undefined {
+  try {
+    const payload = JSON.parse(responseBody) as unknown;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return undefined;
+    }
+
+    const record = payload as Record<string, unknown>;
+    const directCode = normalizeNumericProviderCode(record['error_code'])
+      ?? normalizeNumericProviderCode(record['code'])
+      ?? normalizeSlackErrorCode(record['error']);
+    if (directCode) {
+      return directCode;
+    }
+
+    const nestedError = record['error'];
+    if (nestedError && typeof nestedError === 'object' && !Array.isArray(nestedError)) {
+      return normalizeNumericProviderCode((nestedError as Record<string, unknown>)['code']);
+    }
+  } catch {
+    // Malformed or truncated provider bodies are intentionally omitted.
+  }
+  return undefined;
+}
+
 export async function formatHttpErrorMessage(
   prefix: string,
   response: Response,
@@ -120,14 +157,14 @@ export async function formatHttpErrorMessage(
 ): Promise<string> {
   const statusText = response.statusText ? ` ${response.statusText}` : '';
   const redactedEndpoint = redact(endpoint);
-  let responseBody = '';
+  let providerCode: string | undefined;
 
   try {
-    responseBody = await readBoundedErrorBody(response);
+    providerCode = extractProviderErrorCode(await readBoundedErrorBody(response));
   } catch {
-    responseBody = '';
+    providerCode = undefined;
   }
 
-  const bodySuffix = responseBody ? `: ${redact(responseBody)}` : '';
-  return `${prefix}: ${response.status}${statusText} for ${redactedEndpoint}${bodySuffix}`;
+  const codeSuffix = providerCode ? ` (provider code: ${providerCode})` : '';
+  return `${prefix}: ${response.status}${statusText} for ${redactedEndpoint}${codeSuffix}`;
 }

--- a/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/slack/slack-adapter.ts
@@ -62,7 +62,12 @@ export class SlackAdapter implements ChannelAdapter {
       }),
     }, async response => {
       if (!response.ok) {
-        throw new Error(await formatHttpErrorMessage('Slack API error', response, targetUrl));
+        throw new Error(await formatHttpErrorMessage(
+          'Slack API error',
+          response,
+          targetUrl,
+          { provider: 'slack' },
+        ));
       }
 
       const result = await response.json() as { ok: boolean; error?: string };

--- a/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/telegram/telegram-adapter.ts
@@ -80,7 +80,7 @@ export class TelegramAdapter implements ChannelAdapter {
           'Telegram API error',
           response,
           targetUrl,
-          redactTelegramBotTokenUrls,
+          { provider: 'telegram', redact: redactTelegramBotTokenUrls },
         ));
       }
     });

--- a/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
+++ b/packages/franken-orchestrator/src/comms/channels/whatsapp/whatsapp-adapter.ts
@@ -57,7 +57,12 @@ export class WhatsAppAdapter implements ChannelAdapter {
       body: JSON.stringify(body),
     }, async response => {
       if (!response.ok) {
-        throw new Error(await formatHttpErrorMessage('WhatsApp API error', response, targetUrl));
+        throw new Error(await formatHttpErrorMessage(
+          'WhatsApp API error',
+          response,
+          targetUrl,
+          { provider: 'whatsapp' },
+        ));
       }
     });
   }

--- a/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/discord-adapter.test.ts
@@ -96,21 +96,28 @@ describe('DiscordAdapter', () => {
     expect(body.components[0].components[0].style).toBe(1); // Primary
   });
 
-  it('includes endpoint and response body when Discord rejects a message', async () => {
+  it('omits raw Discord error bodies while preserving status and provider code', async () => {
     const adapter = new DiscordAdapter({ token: 'bot-token' });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue(new Response('{"message":"rate limited"}', {
-      status: 429,
-      statusText: 'Too Many Requests',
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({
+      code: 50035,
+      message: 'private request data',
+    }), {
+      status: 400,
+      statusText: 'Bad Request',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello from discord',
       status: 'reply',
       metadata: { channelId: 'C1' },
-    })).rejects.toThrow(
-      'Discord API error: 429 Too Many Requests for https://discord.com/api/v10/channels/C1/messages: {"message":"rate limited"}',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Discord API error: 400 Bad Request for https://discord.com/api/v10/channels/C1/messages (provider code: 50035)',
     );
+    expect((error as Error).message).not.toContain('private request data');
   });
 
   it('redacts echoed auth headers from Discord error bodies by default', async () => {
@@ -121,13 +128,18 @@ describe('DiscordAdapter', () => {
       statusText: 'Bad Gateway',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello from discord',
       status: 'reply',
       metadata: { channelId: 'C1' },
-    })).rejects.toThrow(
-      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":"[REDACTED]","x-api-key":"[REDACTED]"}',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages',
     );
+    expect((error as Error).message).not.toContain('bot-token');
+    expect((error as Error).message).not.toContain('proxy-key');
   });
 
   it('redacts unterminated echoed auth fields from Discord error bodies', async () => {
@@ -138,13 +150,17 @@ describe('DiscordAdapter', () => {
       statusText: 'Bad Gateway',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello from discord',
       status: 'reply',
       metadata: { channelId: 'C1' },
-    })).rejects.toThrow(
-      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: {"Authorization":"[REDACTED]"',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages',
     );
+    expect((error as Error).message).not.toContain('bot-token');
   });
 
   it('bounds streamed Discord error bodies before formatting diagnostics', async () => {
@@ -160,13 +176,17 @@ describe('DiscordAdapter', () => {
       statusText: 'Bad Gateway',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello from discord',
       status: 'reply',
       metadata: { channelId: 'C1' },
-    })).rejects.toThrow(
-      `Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages: ${'x'.repeat(2048)}…`,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Discord API error: 502 Bad Gateway for https://discord.com/api/v10/channels/C1/messages',
     );
+    expect((error as Error).message).not.toContain('x'.repeat(32));
   });
 
   it('times out a never-resolving outbound request with a redacted error', async () => {

--- a/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
@@ -9,14 +9,14 @@ const responseBody = (value: string) => new ReadableStream<Uint8Array>({
 });
 
 describe('http error context', () => {
-  it('bounds streamed response bodies before formatting provider errors', async () => {
+  it('omits unstructured provider response bodies from formatted errors', async () => {
     const message = await formatHttpErrorMessage('Provider failed', {
       status: 502,
       statusText: 'Bad Gateway',
       body: responseBody('x'.repeat(3000)),
     } as Response, 'https://discord.example.test/webhook');
 
-    expect(message).toBe(`Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: ${'x'.repeat(2048)}…`);
+    expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook');
   });
 
   it('does not fall back to unbounded text() reads when a body stream is unavailable', async () => {
@@ -47,14 +47,14 @@ describe('http error context', () => {
       .toBe('proxy echoed https://api.telegram.org/[REDACTED]/sendMessage');
   });
 
-  it('does not mark exact-limit provider bodies as truncated', async () => {
+  it('omits exact-limit provider bodies', async () => {
     const message = await formatHttpErrorMessage('Provider failed', {
       status: 502,
       statusText: 'Bad Gateway',
       body: responseBody('x'.repeat(2048)),
     } as Response, 'https://discord.example.test/webhook');
 
-    expect(message).toBe(`Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: ${'x'.repeat(2048)}`);
+    expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook');
   });
 
   it('stops waiting on stalled provider error bodies', async () => {
@@ -72,6 +72,6 @@ describe('http error context', () => {
     } as Response, 'https://discord.example.test/webhook');
 
     expect(Date.now() - startedAt).toBeLessThan(750);
-    expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook: partial…');
+    expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook');
   });
 });

--- a/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/http-error-context.test.ts
@@ -19,6 +19,17 @@ describe('http error context', () => {
     expect(message).toBe('Provider failed: 502 Bad Gateway for https://discord.example.test/webhook');
   });
 
+  it('does not treat non-Slack error strings as provider codes', async () => {
+    const message = await formatHttpErrorMessage('Discord failed', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: responseBody(JSON.stringify({ error: 'private_request_data' })),
+    } as Response, 'https://discord.example.test/webhook', { provider: 'discord' });
+
+    expect(message).toBe('Discord failed: 502 Bad Gateway for https://discord.example.test/webhook');
+    expect(message).not.toContain('private_request_data');
+  });
+
   it('does not fall back to unbounded text() reads when a body stream is unavailable', async () => {
     const text = vi.fn().mockResolvedValue('unbounded body');
     const message = await formatHttpErrorMessage('Provider failed', {

--- a/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/slack-adapter.test.ts
@@ -164,20 +164,27 @@ describe('SlackAdapter', () => {
     expect(body.blocks.find((b) => b.type === 'context')).toBeUndefined();
   });
 
-  it('includes endpoint and response body when Slack returns HTTP errors', async () => {
+  it('omits raw Slack error bodies while preserving status and provider code', async () => {
     const adapter = new SlackAdapter({ token: TEST_SLACK_BOT_TOKEN });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue(new Response('temporarily unavailable', {
-      status: 503,
-      statusText: 'Service Unavailable',
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({
+      error: 'invalid_auth',
+      request_echo: 'private request data',
+    }), {
+      status: 401,
+      statusText: 'Unauthorized',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'result',
       metadata: { channelId: 'C1' },
-    })).rejects.toThrow(
-      'Slack API error: 503 Service Unavailable for https://slack.com/api/chat.postMessage: temporarily unavailable',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Slack API error: 401 Unauthorized for https://slack.com/api/chat.postMessage (provider code: invalid_auth)',
     );
+    expect((error as Error).message).not.toContain('private request data');
   });
 
   it('times out a never-resolving outbound request with a redacted error', async () => {

--- a/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/telegram-adapter.test.ts
@@ -83,22 +83,30 @@ describe('TelegramAdapter', () => {
     })).rejects.not.toThrow(token);
   });
 
-  it('includes redacted endpoint and response body when Telegram returns HTTP errors', async () => {
+  it('omits raw Telegram error bodies while preserving status and provider code', async () => {
     const token = '123456789:abcdefghijklmnopqrstuvwxyz';
     const adapter = new TelegramAdapter({ token });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue(new Response('{"description":"chat not found"}', {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({
+      error_code: 400,
+      description: 'private request data',
+    }), {
       status: 400,
       statusText: 'Bad Request',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello telegram',
       status: 'reply',
       metadata: { chatId: '12345' },
-    })).rejects.toThrow(
-      'Telegram API error: 400 Bad Request for https://api.telegram.org/bot[REDACTED]/sendMessage: {"description":"chat not found"}',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Telegram API error: 400 Bad Request for https://api.telegram.org/bot[REDACTED]/sendMessage (provider code: 400)',
     );
+    expect((error as Error).message).not.toContain('private request data');
+    expect((error as Error).message).not.toContain(token);
   });
 
   it('times out a never-resolving outbound request without exposing the bot token', async () => {

--- a/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/comms/whatsapp-adapter.test.ts
@@ -79,24 +79,33 @@ describe('WhatsAppAdapter', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('includes endpoint and response body when WhatsApp returns HTTP errors', async () => {
+  it('omits raw WhatsApp error bodies while preserving status and provider code', async () => {
     const adapter = new WhatsAppAdapter({
       accessToken: 'token',
       phoneNumberId: '123',
     });
     const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValue(new Response('{"error":"invalid token"}', {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({
+      error: {
+        code: 190,
+        message: 'private request data',
+      },
+    }), {
       status: 401,
       statusText: 'Unauthorized',
     }));
 
-    await expect(adapter.send('session-123', {
+    const error = await adapter.send('session-123', {
       text: 'hello whatsapp',
       status: 'reply',
       metadata: { phoneNumber: '123456789' },
-    })).rejects.toThrow(
-      'WhatsApp API error: 401 Unauthorized for https://graph.facebook.com/v21.0/123/messages: {"error":"invalid token"}',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'WhatsApp API error: 401 Unauthorized for https://graph.facebook.com/v21.0/123/messages (provider code: 190)',
     );
+    expect((error as Error).message).not.toContain('private request data');
   });
 
   it('times out a never-resolving outbound request with a redacted error', async () => {

--- a/tasks/issue-3145-progress.md
+++ b/tasks/issue-3145-progress.md
@@ -1,0 +1,11 @@
+# Issue #3145 progress
+
+- [x] Verify live issue scope, labels, duplicate PR/branch state, and current `origin/main`.
+- [x] Read shared lessons and inspect all four comms adapters plus error-context tests.
+- [x] Add focused regression coverage proving raw provider bodies are omitted while HTTP status and provider codes remain.
+- [x] Run the focused tests red and record reproduction evidence on the Kanban card.
+- [x] Implement the smallest shared error-context fix.
+- [x] Run focused tests, orchestrator typecheck/build/lint, and relevant broader tests.
+- [ ] Commit, push, open the issue-scoped PR, and run the current-head Codex review loop.
+- [ ] Merge only after green CI, current-head Codex clean, and zero unresolved Codex threads.
+- [ ] Update durable shared lessons if useful and close out the Kanban card.


### PR DESCRIPTION
## Summary
- stop appending raw communications-provider response bodies to thrown HTTP errors
- retain HTTP status, sanitized endpoint, and narrowly validated provider error codes
- cover Slack, Discord, Telegram, WhatsApp, malformed, streamed, and stalled response bodies

## Security impact
Provider response bodies can contain request echoes, identifiers, credentials, or operational metadata. This change makes omission the default boundary and extracts only numeric provider codes or Slack-style lowercase error codes.

## Test plan
- `npm test --workspace @franken/orchestrator -- --run tests/unit/comms/http-error-context.test.ts tests/unit/comms/slack-adapter.test.ts tests/unit/comms/discord-adapter.test.ts tests/unit/comms/telegram-adapter.test.ts tests/unit/comms/whatsapp-adapter.test.ts` (51 passed)
- `npm test --workspace @franken/orchestrator -- --run tests/unit/comms` (142 passed)
- `npm test --workspace @franken/orchestrator` (4,425 passed)
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings only)
- `npm run build`
- `npm run lint:security`

Closes #3145