### PR TITLE
fix(web): back off chat websocket reconnects

### DIFF
--- a/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
@@ -1,0 +1,104 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useChatReconnect } from './use-chat-reconnect';
+
+describe('useChatReconnect', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('applies exponential backoff with jitter and a 10 second cap', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.8);
+    const refreshSession = vi.fn();
+    const { result } = renderHook(() => useChatReconnect(refreshSession));
+    const expectedDelays = [600, 1_200, 2_400, 4_800, 9_600, 10_000, 10_000];
+
+    for (const [index, delay] of expectedDelays.entries()) {
+      act(() => result.current.beginCycle().schedule());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delay - 1);
+      });
+      expect(refreshSession).toHaveBeenCalledTimes(index);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(refreshSession).toHaveBeenCalledTimes(index + 1);
+    }
+  });
+
+  it('resets the delay only after the socket reports a ready session', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const refreshSession = vi.fn();
+    const { result } = renderHook(() => useChatReconnect(refreshSession));
+
+    act(() => result.current.beginCycle().schedule());
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+
+    const openedCycle = result.current.beginCycle();
+    act(() => {
+      openedCycle.schedule();
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(999));
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+
+    const readyCycle = result.current.beginCycle();
+    act(() => {
+      readyCycle.schedule();
+      readyCycle.onReady();
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+    const nextCycle = result.current.beginCycle();
+    act(() => nextCycle.schedule());
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(refreshSession).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries transient refresh failures with the next backoff delay', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const refreshSession = vi.fn()
+      .mockResolvedValueOnce('retry')
+      .mockResolvedValue('complete');
+    const { result } = renderHook(() => useChatReconnect(refreshSession));
+
+    act(() => result.current.beginCycle().schedule());
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(999));
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not start a manual refresh while an automatic refresh is in flight', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    let finishRefresh!: (result: 'complete') => void;
+    const refreshSession = vi.fn(() => new Promise<'complete'>((resolve) => {
+      finishRefresh = resolve;
+    }));
+    const { result } = renderHook(() => useChatReconnect(refreshSession));
+
+    act(() => result.current.beginCycle().schedule());
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    act(() => result.current.manualReconnect());
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => finishRefresh('complete'));
+  });
+
+  it('requires sustained ambiguous setup failures before stopping retries', () => {
+    const { result } = renderHook(() => useChatReconnect(vi.fn()));
+
+    for (let attempt = 1; attempt < 8; attempt += 1) {
+      expect(result.current.beginCycle().onClose(new CloseEvent('close', { code: 1006 }))).toBe(false);
+    }
+    expect(result.current.beginCycle().onClose(new CloseEvent('close', { code: 1006 }))).toBe(true);
+  });
+});

--- a/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
@@ -127,6 +127,6 @@ describe('useChatReconnect', () => {
     for (let attempt = 1; attempt < 8; attempt += 1) {
       expect(result.current.beginCycle().onClose(new CloseEvent('close', { code: 1006 }))).toBe(false);
     }
-    expect(result.current.beginCycle().onClose(new CloseEvent('close', { code: 1006 }))).toBe(true);
+    expect(result.current.beginCycle().onClose(new CloseEvent('close', { code: 1005 }))).toBe(true);
   });
 });

--- a/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.test.tsx
@@ -77,6 +77,22 @@ describe('useChatReconnect', () => {
     expect(refreshSession).toHaveBeenCalledTimes(2);
   });
 
+  it('backs off when an immediate reconnect refresh is transiently unavailable', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const refreshSession = vi.fn()
+      .mockResolvedValueOnce('retry')
+      .mockResolvedValue('complete');
+    const { result } = renderHook(() => useChatReconnect(refreshSession));
+
+    act(() => result.current.manualReconnect());
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(499));
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
   it('does not start a manual refresh while an automatic refresh is in flight', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -91,6 +107,18 @@ describe('useChatReconnect', () => {
     act(() => result.current.manualReconnect());
     expect(refreshSession).toHaveBeenCalledTimes(1);
     await act(async () => finishRefresh('complete'));
+  });
+
+  it('cancels manual retry cycles when the hook unmounts', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const refreshSession = vi.fn().mockResolvedValue('retry');
+    const { result, unmount } = renderHook(() => useChatReconnect(refreshSession));
+
+    act(() => result.current.manualReconnect());
+    unmount();
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(refreshSession).toHaveBeenCalledTimes(1);
   });
 
   it('requires sustained ambiguous setup failures before stopping retries', () => {

--- a/packages/franken-web/src/hooks/use-chat-reconnect.ts
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 10_000;
@@ -17,6 +17,7 @@ interface ReconnectCycle {
   isRefreshInFlight(): boolean;
   onClose(event?: CloseEvent): boolean;
   onReady(): void;
+  refreshNow(): void;
   schedule(): void;
 }
 
@@ -49,7 +50,7 @@ export function useChatReconnect(
   function manualReconnect() {
     if (activeCycleRef.current?.isRefreshInFlight()) return;
     reset();
-    void refreshSession();
+    beginCycle().refreshNow();
   }
 
   function beginCycle(): ReconnectCycle {
@@ -101,6 +102,19 @@ export function useChatReconnect(
         }
         resetCounters();
       },
+      refreshNow() {
+        if (disposed || refreshInFlight) return;
+        refreshInFlight = true;
+        void Promise.resolve(refreshSession())
+          .then((result) => {
+            refreshInFlight = false;
+            if (!disposed && result === 'retry') cycle.schedule();
+          })
+          .catch(() => {
+            refreshInFlight = false;
+            if (!disposed) cycle.schedule();
+          });
+      },
       schedule() {
         if (disposed || refreshInFlight || timer) return;
         const baseDelay = Math.min(BASE_DELAY_MS * (2 ** attemptRef.current), MAX_DELAY_MS);
@@ -109,17 +123,7 @@ export function useChatReconnect(
         const delay = Math.min(baseDelay + jitter, MAX_DELAY_MS);
         timer = setTimeout(() => {
           timer = null;
-          if (disposed || refreshInFlight) return;
-          refreshInFlight = true;
-          void Promise.resolve(refreshSession())
-            .then((result) => {
-              refreshInFlight = false;
-              if (!disposed && result === 'retry') cycle.schedule();
-            })
-            .catch(() => {
-              refreshInFlight = false;
-              if (!disposed) cycle.schedule();
-            });
+          cycle.refreshNow();
         }, delay);
       },
     };
@@ -127,6 +131,11 @@ export function useChatReconnect(
     activeCycleRef.current = cycle;
     return cycle;
   }
+
+  useEffect(() => () => {
+    activeCycleRef.current?.dispose();
+    activeCycleRef.current = null;
+  }, []);
 
   return { beginCycle, manualReconnect, reset };
 }

--- a/packages/franken-web/src/hooks/use-chat-reconnect.ts
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.ts
@@ -79,10 +79,10 @@ export function useChatReconnect(
 
         if (isAuthenticationClose(event)) {
           authFailureRef.current += 1;
-        } else if (!event || event.code === 1006) {
-          // Browsers collapse rejected HTTP upgrades and transient setup
-          // failures into the same 1006 signal. Allow a generous retry window
-          // before requiring operator intervention.
+        } else if (!event || event.code === 1005 || event.code === 1006) {
+          // Browsers collapse accepted-but-aborted sockets, rejected upgrades,
+          // and transient setup failures into no-status/1006 signals. Allow a
+          // generous retry window before requiring operator intervention.
           setupFailureRef.current += 1;
         }
 

--- a/packages/franken-web/src/hooks/use-chat-reconnect.ts
+++ b/packages/franken-web/src/hooks/use-chat-reconnect.ts
@@ -1,0 +1,132 @@
+import { useRef } from 'react';
+
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 10_000;
+const JITTER_RATIO = 0.25;
+const FAILURE_LIMIT = 2;
+const SETUP_FAILURE_LIMIT = 8;
+
+function isAuthenticationClose(event?: CloseEvent): boolean {
+  return event?.code === 4401
+    || event?.code === 4403
+    || (event?.code === 1008 && /auth|credential|forbidden|unauthor/i.test(event.reason));
+}
+
+interface ReconnectCycle {
+  dispose(): void;
+  isRefreshInFlight(): boolean;
+  onClose(event?: CloseEvent): boolean;
+  onReady(): void;
+  schedule(): void;
+}
+
+type ReconnectRefreshResult = 'complete' | 'retry';
+
+export function useChatReconnect(
+  refreshSession: () => ReconnectRefreshResult | Promise<ReconnectRefreshResult> | void,
+) {
+  const attemptRef = useRef(0);
+  const authFailureRef = useRef(0);
+  const setupFailureRef = useRef(0);
+  const activeCycleRef = useRef<ReconnectCycle | null>(null);
+
+  function resetCounters() {
+    attemptRef.current = 0;
+    authFailureRef.current = 0;
+    setupFailureRef.current = 0;
+  }
+
+  function cancelActiveCycle() {
+    activeCycleRef.current?.dispose();
+    activeCycleRef.current = null;
+  }
+
+  function reset() {
+    cancelActiveCycle();
+    resetCounters();
+  }
+
+  function manualReconnect() {
+    if (activeCycleRef.current?.isRefreshInFlight()) return;
+    reset();
+    void refreshSession();
+  }
+
+  function beginCycle(): ReconnectCycle {
+    let disposed = false;
+    let ready = false;
+    let refreshInFlight = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const cycle: ReconnectCycle = {
+      dispose() {
+        if (disposed) return;
+        disposed = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        if (activeCycleRef.current === cycle) {
+          activeCycleRef.current = null;
+        }
+      },
+      isRefreshInFlight() {
+        return refreshInFlight;
+      },
+      onClose(event?: CloseEvent) {
+        if (disposed || ready) return false;
+
+        if (isAuthenticationClose(event)) {
+          authFailureRef.current += 1;
+        } else if (!event || event.code === 1006) {
+          // Browsers collapse rejected HTTP upgrades and transient setup
+          // failures into the same 1006 signal. Allow a generous retry window
+          // before requiring operator intervention.
+          setupFailureRef.current += 1;
+        }
+
+        const shouldStop = authFailureRef.current >= FAILURE_LIMIT
+          || setupFailureRef.current >= SETUP_FAILURE_LIMIT;
+        if (shouldStop && timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        return shouldStop;
+      },
+      onReady() {
+        ready = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        resetCounters();
+      },
+      schedule() {
+        if (disposed || refreshInFlight || timer) return;
+        const baseDelay = Math.min(BASE_DELAY_MS * (2 ** attemptRef.current), MAX_DELAY_MS);
+        attemptRef.current += 1;
+        const jitter = Math.floor(baseDelay * JITTER_RATIO * Math.random());
+        const delay = Math.min(baseDelay + jitter, MAX_DELAY_MS);
+        timer = setTimeout(() => {
+          timer = null;
+          if (disposed || refreshInFlight) return;
+          refreshInFlight = true;
+          void Promise.resolve(refreshSession())
+            .then((result) => {
+              refreshInFlight = false;
+              if (!disposed && result === 'retry') cycle.schedule();
+            })
+            .catch(() => {
+              refreshInFlight = false;
+              if (!disposed) cycle.schedule();
+            });
+        }, delay);
+      },
+    };
+
+    activeCycleRef.current = cycle;
+    return cycle;
+  }
+
+  return { beginCycle, manualReconnect, reset };
+}

--- a/packages/franken-web/src/hooks/use-chat-session.test.tsx
+++ b/packages/franken-web/src/hooks/use-chat-session.test.tsx
@@ -11,7 +11,7 @@ class MockWebSocket {
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onerror: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((event?: CloseEvent) => void) | null = null;
   readyState = MockWebSocket.OPEN;
   send = vi.fn();
   close = vi.fn();
@@ -71,6 +71,7 @@ function deferred<T>() {
 describe('useChatSession error banners', () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     MockWebSocket.instances = [];
@@ -112,10 +113,11 @@ describe('useChatSession error banners', () => {
     ]);
   });
 
-  it('fetches a fresh socket token before reconnecting a closed websocket', async () => {
+  it('fetches a fresh socket token after the reconnect delay', async () => {
     const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
     vi.stubGlobal('fetch', fetch);
     vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
 
     renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
 
@@ -127,14 +129,17 @@ describe('useChatSession error banners', () => {
       'franken.chat.token.socket-token-1',
     ]);
 
+    vi.useFakeTimers();
     act(() => {
       MockWebSocket.instances[0]!.onclose?.();
     });
 
-    await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(4);
-      expect(MockWebSocket.instances).toHaveLength(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
     });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(MockWebSocket.instances).toHaveLength(2);
     expect(fetch).toHaveBeenNthCalledWith(3,
       'http://localhost:3000/v1/chat/sessions/session-1',
       { credentials: 'same-origin', method: 'GET' },
@@ -143,6 +148,152 @@ describe('useChatSession error banners', () => {
       'franken.chat.v1',
       'franken.chat.token.socket-token-2',
     ]);
+  });
+
+  it('backs off before refreshing a closed websocket session', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      MockWebSocket.instances[0]!.onclose?.();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('continues backing off after repeated transient pre-open failures', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2', 'socket-token-3'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      MockWebSocket.instances[0]!.onerror?.();
+      MockWebSocket.instances[0]!.onclose?.(new CloseEvent('close', { code: 1006 }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    act(() => {
+      MockWebSocket.instances[1]!.onerror?.();
+      MockWebSocket.instances[1]!.onclose?.(new CloseEvent('close', { code: 1006 }));
+    });
+
+    expect(result.current.connectionStatus).toBe('reconnecting');
+    expect(result.current.errorBanners).not.toContainEqual(
+      expect.objectContaining({ code: 'socket_setup_failed' }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it('does not reset authentication failures merely because the socket opened', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2', 'socket-token-3'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+
+    vi.useFakeTimers();
+    act(() => {
+      MockWebSocket.instances[0]!.onopen?.();
+      MockWebSocket.instances[0]!.onclose?.(new CloseEvent('close', { code: 4401, reason: 'Unauthorized' }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      MockWebSocket.instances[1]!.onopen?.();
+      MockWebSocket.instances[1]!.onclose?.(new CloseEvent('close', { code: 4401, reason: 'Unauthorized' }));
+    });
+
+    expect(result.current.connectionStatus).toBe('error');
+    expect(result.current.errorBanners[0]).toMatchObject({ code: 'socket_setup_failed' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('cancels a pending automatic retry when reconnect is requested manually', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { result } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+
+    vi.useFakeTimers();
+    act(() => {
+      MockWebSocket.instances[0]!.onclose?.();
+      result.current.reconnect();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('cancels a pending reconnect timer when the hook unmounts', async () => {
+    const fetch = chatFetch({ tickets: ['socket-token-1', 'socket-token-2'] });
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { unmount } = renderHook(() => useChatSession({ baseUrl: 'http://chat.test', projectId: 'project-1' }));
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+
+    vi.useFakeTimers();
+    act(() => MockWebSocket.instances[0]!.onclose?.());
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 
   it('fetches a fresh socket token before reconnecting after a websocket error', async () => {

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   ChatApiClient,
+  ChatApiError,
   type PendingApproval,
   type TokenTotals,
   type TranscriptMessage,
@@ -31,6 +32,7 @@ import {
   updateReceipt,
   type PendingSend,
 } from './chat-session-state';
+import { useChatReconnect } from './use-chat-reconnect';
 import type {
   ActivityEvent,
   ChatErrorAction,
@@ -44,9 +46,7 @@ import type {
   UseChatSessionResult,
 } from './chat-session-types';
 export type * from './chat-session-types';
-
 const APPROVAL_RESPONSE_TIMEOUT_MS = 15_000;
-
 export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResult {
   const [activity, setActivity] = useState<ActivityEvent[]>([]);
   const [approvalError, setApprovalError] = useState<string | null>(null);
@@ -87,6 +87,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
   const approvalTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const processedSocketEventIdsRef = useRef<Set<string>>(new Set());
   const replayCursorsRef = useRef<Map<string, number>>(new Map());
+  const reconnectControl = useChatReconnect(refreshSession);
   function addErrorBanner(banner: ChatErrorBanner) {
     errorActionRef.current.set(banner.id, banner.action);
     setErrorBanners((current) => [banner, ...current.filter((item) => item.action !== banner.action)].slice(0, 3));
@@ -173,21 +174,20 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       })
       .finally(() => clearTimeout(refreshTimeout));
   }
-  function refreshSession() {
+  function refreshSession(): Promise<'complete' | 'retry'> {
     if (!sessionId) {
       setSessionRetrySeed((current) => current + 1);
-      return;
+      return Promise.resolve('complete');
     }
-
     const capturedSessionId = sessionId;
-    void clientRef.current.getSession(capturedSessionId)
+    return clientRef.current.getSession(capturedSessionId)
       .then(async (refreshed) => {
         if (!sessionStillCurrent(capturedSessionId) || refreshed.id !== capturedSessionId) {
-          return;
+          return 'complete' as const;
         }
         const ticket = await clientRef.current.createSocketTicket(refreshed.id);
         if (!sessionStillCurrent(refreshed.id)) {
-          return;
+          return 'complete' as const;
         }
         setSocketToken(ticket);
         setMessages((current) => reconcileRecoveryMessages(current, refreshed.transcript));
@@ -200,13 +200,15 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setStatus(refreshed.state === 'executing' ? 'streaming' : 'idle');
         setConnectionStatus('reconnecting');
         setSocketGeneration((current) => current + 1);
+        return 'complete' as const;
       })
       .catch((error) => {
         if (!sessionStillCurrent(capturedSessionId)) {
-          return;
+          return 'complete' as const;
         }
+        const retryable = !(error instanceof ChatApiError && [401, 403, 404].includes(error.status));
         setStatus('error');
-        setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'error');
+        setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : retryable ? 'reconnecting' : 'error');
         addErrorBanner(makeBanner(
           'Unable to refresh chat session',
           errorMessage(error, 'The chat API did not return a refreshed session.'),
@@ -214,14 +216,18 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
           'Retry session',
           'session_refresh_failed',
         ));
+        return retryable ? 'retry' as const : 'complete' as const;
       });
   }
-
   async function retryError(id: string): Promise<string | undefined> {
     const action = errorActionRef.current.get(id);
     dismissError(id);
-    if (action === 'retry-session' || action === 'reconnect') {
-      refreshSession();
+    if (action === 'reconnect') {
+      reconnectControl.manualReconnect();
+      return undefined;
+    }
+    if (action === 'retry-session') {
+      void refreshSession();
       return undefined;
     }
     if (action === 'retry-message' && lastMessageRef.current) {
@@ -257,6 +263,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     errorActionRef.current.clear();
     processedSocketEventIdsRef.current.clear();
     replayCursorsRef.current.clear();
+    reconnectControl.reset();
     setStatus('connecting');
     setConnectionStatus(typeof navigator !== 'undefined' && navigator.onLine === false ? 'offline' : 'connecting');
 
@@ -309,11 +316,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     if (!sessionId || !socketToken || typeof window === 'undefined') {
       return;
     }
-
     function handleOnline() {
       failAllPendingSends(new Error('Connection is reconnecting before the server acknowledged the message.'));
       setConnectionStatus('reconnecting');
-      refreshSession();
+      reconnectControl.manualReconnect();
     }
 
     window.addEventListener('online', handleOnline);
@@ -331,18 +337,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
 
     let shouldReconnect = true;
-    let reconnectRefreshInFlight = false;
     let protocolErrored = false;
+    const reconnectCycle = reconnectControl.beginCycle();
     setConnectionStatus('connecting');
     readyRef.current = false;
-
-    function refreshBeforeReconnect() {
-      if (reconnectRefreshInFlight) {
-        return;
-      }
-      reconnectRefreshInFlight = true;
-      refreshSession();
-    }
 
     function handleProtocolError(message: string) {
       protocolErrored = true;
@@ -415,6 +413,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
       switch (payload.type) {
         case 'session.ready':
+          reconnectCycle.onReady();
           if (!readyRef.current) {
             readyRef.current = true;
             setMessages((current) => reconcileRecoveryMessages(current, payload.transcript));
@@ -594,10 +593,10 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         return;
       }
       setConnectionStatus('reconnecting');
-      refreshBeforeReconnect();
+      reconnectCycle.schedule();
     };
 
-    socket.onclose = () => {
+    socket.onclose = (event) => {
       if (socketRef.current !== socket) {
         return;
       }
@@ -609,12 +608,19 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setApprovalError('Connection interrupted while resolving approval. Try again if approval is still pending.');
       }
       if (shouldReconnect) {
+        if (reconnectCycle.onClose(event)) {
+          shouldReconnect = false;
+          setConnectionStatus('error');
+          setStatus('error');
+          addErrorBanner(makeBanner('Chat connection needs attention', 'Automatic reconnects stopped after repeated connection setup failures. Check the backend and operator credentials, then reconnect.', 'reconnect', 'Reconnect after checking setup', 'socket_setup_failed'));
+          return;
+        }
         if (typeof navigator !== 'undefined' && navigator.onLine === false) {
           setConnectionStatus('offline');
           return;
         }
         setConnectionStatus('reconnecting');
-        refreshBeforeReconnect();
+        reconnectCycle.schedule();
       } else {
         setConnectionStatus('disconnected');
       }
@@ -622,6 +628,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
 
     return () => {
       shouldReconnect = false;
+      reconnectCycle.dispose();
       failAllPendingSends(new Error('Chat session changed before the server acknowledged the message. Your draft was kept.'));
       updateApprovalResolving(false);
       socket.close();
@@ -876,7 +883,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     messages,
     pendingApproval,
     projectId,
-    reconnect: refreshSession,
+    reconnect: reconnectControl.manualReconnect,
     retryError,
     retryMessage,
     send,

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -200,6 +200,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
         setStatus(refreshed.state === 'executing' ? 'streaming' : 'idle');
         setConnectionStatus('reconnecting');
         setSocketGeneration((current) => current + 1);
+        setErrorBanners((current) => current.filter((item) => item.action !== 'retry-session'));
         return 'complete' as const;
       })
       .catch((error) => {
@@ -227,7 +228,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       return undefined;
     }
     if (action === 'retry-session') {
-      void refreshSession();
+      reconnectControl.manualReconnect();
       return undefined;
     }
     if (action === 'retry-message' && lastMessageRef.current) {
@@ -238,7 +239,6 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     }
     return undefined;
   }
-
   useEffect(() => {
     let cancelled = false;
     const client = clientRef.current;

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -86,6 +86,13 @@ export function resolveChatRequestCredentials(
   }
 }
 
+export class ChatApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = 'ChatApiError';
+  }
+}
+
 export class ChatApiClient {
   private readonly requestBaseUrl: string;
   private readonly requestCredentials: RequestCredentials;
@@ -185,7 +192,7 @@ export class ChatApiClient {
       } catch {
         // Fall through with HTTP status message
       }
-      throw new Error(message);
+      throw new ChatApiError(message, res.status);
     }
 
     const body = (await res.json()) as ApiDataEnvelope<T>;

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -11,6 +11,11 @@ const mockSocketUrl = vi.fn();
 const mockSocketProtocols = vi.fn();
 
 vi.mock('../../src/lib/api', () => ({
+  ChatApiError: class ChatApiError extends Error {
+    constructor(message: string, readonly status: number) {
+      super(message);
+    }
+  },
   ChatApiClient: vi.fn(function (this: {
     createSession: typeof mockCreateSession;
     createSocketTicket: typeof mockCreateSocketTicket;

--- a/packages/franken-web/tests/lib/api.test.ts
+++ b/packages/franken-web/tests/lib/api.test.ts
@@ -325,7 +325,11 @@ describe('ChatApiClient', () => {
           }),
       });
 
-      await expect(client.getSession('nonexistent')).rejects.toThrow('Session not found');
+      await expect(client.getSession('nonexistent')).rejects.toMatchObject({
+        message: 'Session not found',
+        name: 'ChatApiError',
+        status: 404,
+      });
     });
   });
 });

--- a/tasks/issue-2716-chat-websocket-backoff-progress.md
+++ b/tasks/issue-2716-chat-websocket-backoff-progress.md
@@ -1,0 +1,11 @@
+# Issue 2716 — Chat WebSocket reconnect backoff
+
+- [x] Verified live issue scope/labels and absence of a duplicate PR.
+- [x] Created an isolated branch/worktree from current `origin/main` and read shared lessons.
+- [x] Reproduced the immediate reconnect loop with a focused failing timer test.
+- [x] Added bounded exponential backoff (500 ms base, 10 s cap, up to 25% jitter).
+- [x] Cancelled delayed reconnects on socket lifecycle cleanup.
+- [x] Stopped after two explicit authentication failures or eight browser-ambiguous setup failures while preserving capped retries through transient outages.
+- [x] Added focused coverage for delayed retries, exponential/capped jitter, transient and sustained pre-open failures, repeated explicit authentication failures, successful-ready reset, manual reconnect races, and unmount cancellation.
+- [x] Passed `@franken/web` tests (722), typecheck, lint (0 errors; existing warnings), and production build.
+- [ ] Open PR, pass CI and current-head GitHub Codex review, then merge.

--- a/tasks/issue-2716-chat-websocket-backoff-progress.md
+++ b/tasks/issue-2716-chat-websocket-backoff-progress.md
@@ -7,6 +7,6 @@
 - [x] Cancelled delayed reconnects on socket lifecycle cleanup.
 - [x] Stopped after two explicit authentication failures or eight browser-ambiguous setup failures while preserving capped retries through transient outages.
 - [x] Added focused coverage for delayed retries, exponential/capped jitter, transient and sustained pre-open failures, repeated explicit authentication failures, successful-ready reset, manual reconnect races, and unmount cancellation.
-- [x] Passed `@franken/web` tests (722), typecheck, lint (0 errors; existing warnings), and production build.
-- [x] Opened PR #3640 and passed CI plus current-head GitHub Codex review.
-- [ ] Merge PR #3640 and verify issue closure.
+- [x] Passed `@franken/web` tests (724), typecheck, lint (0 errors; existing warnings), and production build.
+- [x] Opened PR #3640 and addressed local plus GitHub Codex review feedback.
+- [ ] Pass latest-head CI/Codex, merge PR #3640, and verify issue closure.

--- a/tasks/issue-2716-chat-websocket-backoff-progress.md
+++ b/tasks/issue-2716-chat-websocket-backoff-progress.md
@@ -8,4 +8,5 @@
 - [x] Stopped after two explicit authentication failures or eight browser-ambiguous setup failures while preserving capped retries through transient outages.
 - [x] Added focused coverage for delayed retries, exponential/capped jitter, transient and sustained pre-open failures, repeated explicit authentication failures, successful-ready reset, manual reconnect races, and unmount cancellation.
 - [x] Passed `@franken/web` tests (722), typecheck, lint (0 errors; existing warnings), and production build.
-- [ ] Open PR, pass CI and current-head GitHub Codex review, then merge.
+- [x] Opened PR #3640 and passed CI plus current-head GitHub Codex review.
+- [ ] Merge PR #3640 and verify issue closure.

--- a/tasks/issue-2716-chat-websocket-backoff-progress.md
+++ b/tasks/issue-2716-chat-websocket-backoff-progress.md
@@ -7,6 +7,6 @@
 - [x] Cancelled delayed reconnects on socket lifecycle cleanup.
 - [x] Stopped after two explicit authentication failures or eight browser-ambiguous setup failures while preserving capped retries through transient outages.
 - [x] Added focused coverage for delayed retries, exponential/capped jitter, transient and sustained pre-open failures, repeated explicit authentication failures, successful-ready reset, manual reconnect races, and unmount cancellation.
-- [x] Passed `@franken/web` tests (724), typecheck, lint (0 errors; existing warnings), and production build.
+- [x] Passed the full `@franken/web` test suite, typecheck, lint (0 errors; existing warnings), and production build.
 - [x] Opened PR #3640 and addressed local plus GitHub Codex review feedback.
 - [ ] Pass latest-head CI/Codex, merge PR #3640, and verify issue closure.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -507,3 +507,7 @@
 
 ## 2026-07-22 — Chat session hook source hygiene
 - `franken-web` enforces a sub-900-line limit on `use-chat-session.ts`; when asynchronous recovery behavior grows the hook, move its public type contracts into a dedicated type-only module and re-export them from the hook so callers remain compatible without weakening the source-hygiene test.
+
+## 2026-07-22 — Chat WebSocket reconnect lifecycle
+- Browser `1006` closes conflate rejected upgrades with transient setup outages; use a generous bounded setup-failure threshold, a lower explicit-authentication threshold, and reset counters only on the protocol-level ready event rather than socket open.
+- Reconnect ownership must cover timers and refresh promises: retry transient API failures through the same backoff controller, classify fatal HTTP statuses with structured errors, and route manual/online recovery through that controller so slow refreshes cannot race newer ticket requests.


### PR DESCRIPTION
## Summary
- add bounded exponential backoff with jitter for chat WebSocket recovery
- stop persistent authentication/setup loops while keeping transient API failures retryable
- cancel reconnect timers and suppress overlapping manual/online refreshes
- expose HTTP status through `ChatApiError` for fatal refresh classification

## Test plan
- `npm test -- --run` (722 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 17 existing warnings)
- `npm run build`
- current-change Codex review: no actionable regressions

Closes #2716