### PR TITLE
fix(critique): accept unknown error causes

### DIFF
--- a/packages/franken-critique/src/errors/index.ts
+++ b/packages/franken-critique/src/errors/index.ts
@@ -1,6 +1,6 @@
 export interface CritiqueErrorOptions {
   readonly context?: Readonly<Record<string, unknown>>;
-  readonly cause?: Error;
+  readonly cause?: unknown;
 }
 
 export class CritiqueError extends Error {

--- a/packages/franken-critique/tests/types/error-cause.type-test.ts
+++ b/packages/franken-critique/tests/types/error-cause.type-test.ts
@@ -1,0 +1,27 @@
+import {
+  CircuitBreakerError,
+  ConfigurationError,
+  CritiqueError,
+  EscalationError,
+  EvaluationError,
+  IntegrationError,
+} from '../../src/errors/index.js';
+import type { CritiqueErrorOptions } from '../../src/errors/index.js';
+
+const causes: readonly unknown[] = [
+  new Error('failure'),
+  'string failure',
+  { reason: 'object failure' },
+  undefined,
+];
+
+for (const cause of causes) {
+  const options: CritiqueErrorOptions = { cause };
+
+  void new CritiqueError('failed', 'TEST_FAILED', options);
+  void new EvaluationError('failed', options);
+  void new CircuitBreakerError('failed', options);
+  void new EscalationError('failed', options);
+  void new IntegrationError('failed', options);
+  void new ConfigurationError('failed', options);
+}

--- a/packages/franken-critique/tests/unit/errors/error-cause.test.ts
+++ b/packages/franken-critique/tests/unit/errors/error-cause.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CircuitBreakerError,
+  ConfigurationError,
+  CritiqueError,
+  EscalationError,
+  EvaluationError,
+  IntegrationError,
+} from '../../../src/errors/index.js';
+
+const errorFactories = [
+  (cause: unknown): CritiqueError =>
+    new CritiqueError('failed', 'TEST_FAILED', { cause }),
+  (cause: unknown): CritiqueError => new EvaluationError('failed', { cause }),
+  (cause: unknown): CritiqueError =>
+    new CircuitBreakerError('failed', { cause }),
+  (cause: unknown): CritiqueError => new EscalationError('failed', { cause }),
+  (cause: unknown): CritiqueError => new IntegrationError('failed', { cause }),
+  (cause: unknown): CritiqueError =>
+    new ConfigurationError('failed', { cause }),
+] as const;
+
+const causes: readonly unknown[] = [
+  new Error('failure'),
+  'string failure',
+  { reason: 'object failure' },
+  undefined,
+];
+
+describe('critique error causes', () => {
+  it.each(errorFactories)(
+    'preserves arbitrary thrown values',
+    (createError) => {
+      for (const cause of causes) {
+        expect(createError(cause).cause).toBe(cause);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- widen `CritiqueErrorOptions.cause` from `Error` to `unknown` to match JavaScript `ErrorOptions`
- add a compile-time contract test for arbitrary caught values across the exported error hierarchy
- verify runtime cause identity for `Error`, string, object, and `undefined` causes

## Test plan
- `npm --workspace @franken/types run build`
- `npm --workspace @franken/critique run typecheck`
- `npm --workspace @franken/critique test -- --run`
- `npm --workspace @franken/critique run lint`
- `npm --workspace @franken/critique run build`
- `npx prettier --check src/errors/index.ts tests/types/error-cause.type-test.ts tests/unit/errors/error-cause.test.ts`

Closes #3639
