### PR TITLE
fix(observer): validate total cost token aggregates

### DIFF
--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -193,6 +193,51 @@ describe('CostCalculator', () => {
       })
     })
 
+    it.each([
+      [
+        'prompt token aggregate',
+        [
+          { model: 'gpt-4o', promptTokens: Number.MAX_SAFE_INTEGER, completionTokens: 0 },
+          { model: 'gpt-4o', promptTokens: 1, completionTokens: 0 },
+        ],
+      ],
+      [
+        'completion token aggregate',
+        [
+          { model: 'gpt-4o', promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER },
+          { model: 'gpt-4o', promptTokens: 0, completionTokens: 1 },
+        ],
+      ],
+      [
+        'combined prompt and completion aggregate',
+        [
+          {
+            model: 'gpt-4o',
+            promptTokens: Number.MAX_SAFE_INTEGER,
+            completionTokens: 1,
+          },
+        ],
+      ],
+    ])('rejects an unsafe %s', (_name, entries) => {
+      const calc = new CostCalculator(DEFAULT_PRICING)
+
+      expect(() => calc.totalCost(entries)).toThrow(RangeError)
+    })
+
+    it('validates token aggregates before reporting unknown models', () => {
+      const onUnknownModel = vi.fn()
+      const calc = new CostCalculator(DEFAULT_PRICING, { onUnknownModel })
+
+      expect(() => calc.totalCost([
+        {
+          model: 'unknown-model',
+          promptTokens: Number.MAX_SAFE_INTEGER,
+          completionTokens: 1,
+        },
+      ])).toThrow(RangeError)
+      expect(onUnknownModel).not.toHaveBeenCalled()
+    })
+
     it('returns 0 for an empty list', () => {
       const calc = new CostCalculator(DEFAULT_PRICING)
       expect(calc.totalCost([])).toBe(0)

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -39,6 +39,29 @@ export class CostCalculator {
     }
   }
 
+  private static safeAddTokenCounts(a: number, b: number): number {
+    const sum = a + b
+    if (!Number.isSafeInteger(sum)) {
+      throw new RangeError(
+        `CostCalculator: token total ${sum} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+      )
+    }
+    return sum
+  }
+
+  private static assertValidTokenAggregates(entries: TokenRecord[]): void {
+    let promptTokens = 0
+    let completionTokens = 0
+
+    for (const entry of entries) {
+      CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
+      CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
+      promptTokens = CostCalculator.safeAddTokenCounts(promptTokens, entry.promptTokens)
+      completionTokens = CostCalculator.safeAddTokenCounts(completionTokens, entry.completionTokens)
+      CostCalculator.safeAddTokenCounts(promptTokens, completionTokens)
+    }
+  }
+
   calculate(entry: TokenRecord): number {
     return this.calculateWithAttribution(entry).costUsd
   }
@@ -68,6 +91,10 @@ export class CostCalculator {
   }
 
   totalCostWithAttribution(entries: TokenRecord[]): TotalCostCalculation {
+    // Validate the full snapshot before calculating costs so no invalid aggregate
+    // can produce a partial result or unknown-model warning side effect.
+    CostCalculator.assertValidTokenAggregates(entries)
+
     let sum = 0
     let compensation = 0
     const unknownModels = new Set<string>()


### PR DESCRIPTION
## Summary
- validate prompt and completion token aggregates before total-cost calculation
- reject combined token totals outside JavaScript's safe-integer range
- avoid unknown-model warning side effects for invalid aggregate snapshots

## Verification
- `npm test -- --run src/cost/CostCalculator.test.ts` (28 passed)
- `npm test` (868 passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 5 pre-existing warnings)

Closes #3001
