### PR TITLE
fix(observer): reject unsafe webhook retry counts

### DIFF
--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -1246,6 +1246,16 @@ describe('WebhookNotifier', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
+    it('rejects unsafe integer maxRetries during retry configuration validation', () => {
+      expect(
+        () =>
+          createNotifier({
+            retry: { maxRetries: Number.MAX_SAFE_INTEGER + 1 },
+          }),
+      ).toThrow('retry.maxRetries must be a non-negative safe integer')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     it('rejects invalid retry delay bounds during retry configuration validation', () => {
       const invalidOptions = [
         { retry: { maxRetries: 1, baseDelayMs: -1 } },

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -221,6 +221,9 @@ function validateNonNegativeInteger(value: number, fieldName: string): number {
   if (!Number.isInteger(value) || value < 0) {
     throw new RangeError(`${fieldName} must be a non-negative integer`)
   }
+  if (!Number.isSafeInteger(value)) {
+    throw new RangeError(`${fieldName} must be a non-negative safe integer`)
+  }
   return value
 }
 


### PR DESCRIPTION
## Summary
- reject unsafe integer `WebhookNotifier` retry counts during configuration
- preserve existing validation errors for negative, fractional, and non-finite values
- add regression coverage for the `Number.MAX_SAFE_INTEGER` boundary

## Test plan
- `npm run test --workspace @franken/observer -- WebhookNotifier.test.ts -t "rejects unsafe integer maxRetries"`
- `npm run test --workspace @franken/observer -- WebhookNotifier.test.ts`
- `npm run test --workspace @franken/observer` (869 tests)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)
- `git diff --check`

Closes #2996