### PR TITLE
fix(observer): add safe Tempo retry defaults

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -672,6 +672,12 @@ See the repository copy of [`packages/franken-observer/docs/adapters.md`](https:
 
 Posts OTEL payloads to [Grafana Tempo](https://grafana.com/oss/tempo/) over OTLP/HTTP.
 
+Exports retry transient HTTP 429/5xx and network failures twice by default. Retry
+waits use jittered exponential backoff (200 ms base, capped at 2 seconds), and
+every request attempt has a 10 second deadline. Override individual values with
+`retry`; set `retry.maxRetries` to `0` when a single attempt is required. Final
+failures reject `flush()` without including the trace payload or credentials.
+
 `GRAFANA_INSTANCE_ID` and `GRAFANA_API_KEY` are only needed when exporting traces
 to Grafana Cloud Tempo. `GRAFANA_INSTANCE_ID` is the numeric Grafana Cloud stack
 or Tempo instance ID used as the Basic auth username, and `GRAFANA_API_KEY` is a

--- a/packages/franken-observer/docs/adapters.md
+++ b/packages/franken-observer/docs/adapters.md
@@ -228,6 +228,12 @@ await cloud.flush(trace)
 | `otlpPath`  | `string`        | `'/v1/traces'`   | OTLP/HTTP path appended to `endpoint`           |
 | `basicAuth` | `TempoBasicAuth`| —                | Omit for unauthenticated local Tempo            |
 | `fetch`     | `FetchFn`       | `globalThis.fetch`| Injectable for testing                         |
+| `retry`     | `HttpRetryOptions` | 2 retries; 200 ms base/2 s max jittered backoff; 10 s per-attempt deadline | Override retry/backoff/deadline values; set `maxRetries: 0` for one attempt |
+
+The defaults retry only transient HTTP 429/5xx responses and network failures.
+Other 4xx responses fail immediately. After the bounded attempts are exhausted,
+`flush()` rejects with status/timeout context but does not include the trace
+payload or Basic auth credentials in the error.
 
 **Grafana Cloud environment variables**
 

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.test.ts
@@ -61,7 +61,7 @@ describe('TempoAdapter', () => {
         const adapter = new TempoAdapter({
           endpoint: 'http://localhost:4318',
           fetch: mockFetch,
-          retry: { attemptTimeoutMs: 25 },
+          retry: { attemptTimeoutMs: 25, maxRetries: 0 },
         })
 
         const flush = adapter.flush(makeTrace())
@@ -162,6 +162,48 @@ describe('TempoAdapter', () => {
 
   describe('retry on transient failures (issue #68)', () => {
     const sleep = () => vi.fn().mockResolvedValue(undefined)
+
+    it('uses bounded retry defaults when retry options are omitted', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+        .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
+      const adapter = new TempoAdapter({ endpoint: 'http://localhost:4318', fetch: mockFetch })
+
+      await expect(adapter.flush(makeTrace())).resolves.toBeUndefined()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('bounds the default exponential backoff and final failure', async () => {
+      const retrySleep = sleep()
+      mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
+      const adapter = new TempoAdapter({
+        endpoint: 'http://localhost:4318',
+        fetch: mockFetch,
+        retry: { jitter: false, sleep: retrySleep },
+      })
+
+      await expect(adapter.flush(makeTrace())).rejects.toThrow('Tempo export failed: 503 Service Unavailable')
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(retrySleep.mock.calls.map(call => call[0])).toEqual([200, 400])
+    })
+
+    it('applies the default request deadline to every bounded attempt', async () => {
+      vi.useFakeTimers()
+      try {
+        mockFetch.mockImplementation(() => new Promise(() => undefined))
+        const adapter = new TempoAdapter({ endpoint: 'http://localhost:4318', fetch: mockFetch })
+
+        const flush = adapter.flush(makeTrace())
+        const rejection = expect(flush).rejects.toThrow('HTTP attempt timed out after 10000ms')
+        await vi.advanceTimersByTimeAsync(31_000)
+
+        await rejection
+        expect(mockFetch).toHaveBeenCalledTimes(3)
+        for (const [, init] of mockFetch.mock.calls) expect(init.signal.aborted).toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
 
     it('retries a 5xx then succeeds', async () => {
       mockFetch

--- a/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
+++ b/packages/franken-observer/src/adapters/tempo/TempoAdapter.ts
@@ -35,8 +35,20 @@ export interface TempoAdapterOptions {
   /** Injectable for testing. Defaults to globalThis.fetch. */
   fetch?: FetchFn
 
-  /** Retry on transient (5xx/network) failures. Omit for a single attempt. */
+  /**
+   * Retry and per-attempt deadline overrides for transient (429/5xx/network)
+   * failures. Defaults to 2 retries with bounded exponential backoff, jitter,
+   * and a 10 second request deadline. Set `maxRetries: 0` to disable retries.
+   */
   retry?: HttpRetryOptions
+}
+
+const DEFAULT_TEMPO_RETRY: Readonly<HttpRetryOptions> = {
+  maxRetries: 2,
+  baseDelayMs: 200,
+  maxDelayMs: 2_000,
+  jitter: true,
+  attemptTimeoutMs: 10_000,
 }
 
 /**
@@ -50,7 +62,7 @@ export class TempoAdapter implements ExportAdapter {
   private readonly tracesUrl: string
   private readonly authHeader: string | undefined
   private readonly fetchFn: FetchFn
-  private readonly retry: HttpRetryOptions | undefined
+  private readonly retry: HttpRetryOptions
 
   constructor(options: TempoAdapterOptions) {
     const base = options.endpoint.replace(/\/$/, '')
@@ -63,7 +75,7 @@ export class TempoAdapter implements ExportAdapter {
     }
 
     this.fetchFn = options.fetch ?? (globalThis.fetch as unknown as FetchFn)
-    this.retry = options.retry
+    this.retry = { ...DEFAULT_TEMPO_RETRY, ...options.retry }
   }
 
   async flush(trace: Trace): Promise<void> {


### PR DESCRIPTION
## Summary
- give `TempoAdapter` two bounded default retries for transient 429/5xx and network failures
- retain the shared 10-second per-attempt deadline and add capped jittered exponential backoff defaults
- document override/disable behavior and cover default success, exhaustion, backoff, and timeout paths

## Verification
- `npm run test --workspace @franken/observer` (871 passed)
- `npm run typecheck --workspace @franken/observer`
- `npm run lint --workspace @franken/observer` (0 errors; 5 pre-existing warnings)
- `npm run build --workspace @franken/observer`

Closes #3644