### PR TITLE
perf(critique): bound ConcisenessEvaluator input memory and processing (#3657)

### DIFF
--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -34,6 +34,60 @@ interface UnresolvedMarkerOccurrence {
   readonly index: number;
 }
 
+/**
+ * Truncates `content` to at most `maxBytes` UTF-8 bytes. `String.length` and
+ * `String.slice` operate on UTF-16 code units, not bytes, so a naive
+ * character-count cap under-enforces the intended memory bound for
+ * non-ASCII content (e.g. CJK text is ~3 bytes/char in UTF-8 but 1 code
+ * unit in UTF-16 -- a 500,000-unit cap would let through ~1.5MB). This
+ * truncates on the actual encoded byte size and backs off from the cut
+ * point while it lands inside a multi-byte sequence, so a character is
+ * never split and the result is always valid UTF-8.
+ */
+function truncateToByteLimit(
+  content: string,
+  maxBytes: number,
+): { content: string; truncated: boolean } {
+  const encoded = Buffer.from(content, 'utf8');
+  if (encoded.length <= maxBytes) {
+    return { content, truncated: false };
+  }
+
+  let end = maxBytes;
+  // Continuation bytes match the 10xxxxxx bit pattern; back off until we
+  // land right after a complete character.
+  while (end > 0 && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+    end -= 1;
+  }
+
+  return {
+    content: encoded.subarray(0, end).toString('utf8'),
+    truncated: true,
+  };
+}
+
+/**
+ * If truncation cut through an open block comment (its `/*` appeared
+ * before the cutoff but its closing `*\/` would have appeared after it),
+ * the naive `BLOCK_COMMENT_PATTERN` regex used for comment-ratio scoring
+ * requires a literal closing delimiter and so silently counts none of
+ * that comment's lines. Closing the dangling comment keeps the ratio
+ * calculation honest about the content that was actually scanned.
+ */
+function closeUnterminatedBlockComment(content: string): string {
+  const lastOpen = content.lastIndexOf('/*');
+  if (lastOpen === -1) {
+    return content;
+  }
+
+  const lastClose = content.lastIndexOf('*/');
+  if (lastClose > lastOpen) {
+    return content;
+  }
+
+  return `${content}*/`;
+}
+
 function skipQuotedLiteral(content: string, start: number): number {
   const quote = content[start];
   let index = start + 1;
@@ -244,33 +298,57 @@ function isPostfixOperatorBefore(content: string, index: number): boolean {
   return false;
 }
 
-function findMatchingOpeningParen(content: string, closeIndex: number): number {
-  const openParens: number[] = [];
-  let cursor = 0;
+interface ParenScanState {
+  readonly stack: number[];
+  readonly closeToOpen: Map<number, number>;
+  cursor: number;
+}
 
-  while (cursor <= closeIndex && cursor < content.length) {
+function createParenScanState(): ParenScanState {
+  return { stack: [], closeToOpen: new Map(), cursor: 0 };
+}
+
+/**
+ * Incrementally extends a shared paren-matching scan up to (and including)
+ * `target`, recording every closing paren's matching opening paren as it
+ * goes. `state.cursor` only ever moves forward and is shared across every
+ * call for a given `content` string, so the *total* work performed by all
+ * calls combined is bounded by `content.length` -- unlike a from-scratch
+ * rescan on every call, which is O(n) work per call and O(n^2) overall
+ * when many candidate regex literals follow closing parens (e.g. repeated
+ * `if (x) /a/;` lines).
+ */
+function advanceParenScan(
+  content: string,
+  state: ParenScanState,
+  target: number,
+): void {
+  const openParens = state.stack;
+
+  while (state.cursor <= target && state.cursor < content.length) {
+    const cursor = state.cursor;
     const current = content[cursor];
     const next = content[cursor + 1];
 
     if (current === '"' || current === "'" || current === '`') {
-      cursor = skipQuotedLiteral(content, cursor);
+      state.cursor = skipQuotedLiteral(content, cursor);
       continue;
     }
 
     if (current === '/' && next === '/') {
       const lineEnd = content.indexOf('\n', cursor + 2);
-      cursor = lineEnd === -1 ? content.length : lineEnd + 1;
+      state.cursor = lineEnd === -1 ? content.length : lineEnd + 1;
       continue;
     }
 
     if (current === '/' && next === '*') {
       const commentEnd = content.indexOf('*/', cursor + 2);
-      cursor = commentEnd === -1 ? content.length : commentEnd + 2;
+      state.cursor = commentEnd === -1 ? content.length : commentEnd + 2;
       continue;
     }
 
     if (current === '/' && canStartRegexLiteralWhileMatchingParens(content, cursor)) {
-      cursor = skipRegexLiteral(content, cursor);
+      state.cursor = skipRegexLiteral(content, cursor);
       continue;
     }
 
@@ -278,24 +356,38 @@ function findMatchingOpeningParen(content: string, closeIndex: number): number {
       openParens.push(cursor);
     } else if (current === ')') {
       const openIndex = openParens.pop();
-      if (cursor === closeIndex) {
-        return openIndex ?? -1;
+      if (openIndex !== undefined) {
+        state.closeToOpen.set(cursor, openIndex);
       }
     }
 
-    cursor += 1;
+    state.cursor = cursor + 1;
   }
-
-  return -1;
 }
 
-function followsControlCondition(content: string, index: number): boolean {
+function findMatchingOpeningParen(
+  content: string,
+  closeIndex: number,
+  state: ParenScanState,
+): number {
+  if (closeIndex < 0) return -1;
+  if (state.cursor <= closeIndex) {
+    advanceParenScan(content, state, closeIndex);
+  }
+  return state.closeToOpen.get(closeIndex) ?? -1;
+}
+
+function followsControlCondition(
+  content: string,
+  index: number,
+  state: ParenScanState,
+): boolean {
   const previousIndex = previousSignificantIndex(content, index);
   if (content[previousIndex] !== ')') {
     return false;
   }
 
-  const openIndex = findMatchingOpeningParen(content, previousIndex);
+  const openIndex = findMatchingOpeningParen(content, previousIndex, state);
   if (openIndex === -1) {
     return false;
   }
@@ -328,7 +420,11 @@ function canStartRegexLiteralWhileMatchingParens(
   );
 }
 
-function canStartRegexLiteral(content: string, index: number): boolean {
+function canStartRegexLiteral(
+  content: string,
+  index: number,
+  state: ParenScanState,
+): boolean {
   const previous = previousSignificantCharacter(content, index);
   const previousToken = previousSignificantToken(content, index);
   if (isPostfixOperatorBefore(content, index)) {
@@ -362,7 +458,7 @@ function canStartRegexLiteral(content: string, index: number): boolean {
   return (
     isRegexPrefixToken(previousToken) ||
     followsForIterationKeywordOnLine(content, index) ||
-    followsControlCondition(content, index) ||
+    followsControlCondition(content, index, state) ||
     previous === '' ||
     '([{=,:;!&|?+-*~^<>/'.includes(previous)
   );
@@ -513,6 +609,7 @@ function collectJsxTagExpressionMarkers(
   content: string,
   start: number,
   end: number,
+  state: ParenScanState,
 ): UnresolvedMarkerOccurrence[] {
   const markers: UnresolvedMarkerOccurrence[] = [];
   let index = start + 1;
@@ -537,6 +634,7 @@ function collectJsxTagExpressionMarkers(
         content,
         index + 1,
         '}',
+        state,
       );
       markers.push(...expressionMarkers);
       index = expressionEnd;
@@ -838,6 +936,7 @@ function isJsxTextBlockComment(content: string, start: number, end: number): boo
 function collectTemplateLiteralMarkers(
   content: string,
   start: number,
+  state: ParenScanState,
 ): [UnresolvedMarkerOccurrence[], number] {
   const markers: UnresolvedMarkerOccurrence[] = [];
   let index = start + 1;
@@ -857,6 +956,7 @@ function collectTemplateLiteralMarkers(
         content,
         index + 2,
         '}',
+        state,
       );
       markers.push(...expressionMarkers);
       index = expressionEnd;
@@ -870,8 +970,9 @@ function collectTemplateLiteralMarkers(
 
 function collectCodeMarkers(
   content: string,
-  start = 0,
-  endCharacter?: string,
+  start: number,
+  endCharacter: string | undefined,
+  state: ParenScanState,
 ): [UnresolvedMarkerOccurrence[], number] {
   const markers: UnresolvedMarkerOccurrence[] = [];
   let index = start;
@@ -926,6 +1027,7 @@ function collectCodeMarkers(
       const [templateMarkers, templateEnd] = collectTemplateLiteralMarkers(
         content,
         index,
+        state,
       );
       markers.push(...templateMarkers);
       index = templateEnd;
@@ -957,13 +1059,15 @@ function collectCodeMarkers(
     if (current === '<' && isLikelyJsxTagStart(content, index)) {
       const tagEnd = skipJsxTag(content, index);
       if (tagEnd !== -1 && !isLikelyTypeArgumentTag(content, index, tagEnd)) {
-        markers.push(...collectJsxTagExpressionMarkers(content, index, tagEnd));
+        markers.push(
+          ...collectJsxTagExpressionMarkers(content, index, tagEnd, state),
+        );
         index = tagEnd;
         continue;
       }
     }
 
-    if (current === '/' && canStartRegexLiteral(content, index)) {
+    if (current === '/' && canStartRegexLiteral(content, index, state)) {
       index = skipRegexLiteral(content, index);
       continue;
     }
@@ -977,7 +1081,7 @@ function collectCodeMarkers(
 function collectUnresolvedCommentMarkers(
   content: string,
 ): UnresolvedMarkerOccurrence[] {
-  return collectCodeMarkers(content)[0];
+  return collectCodeMarkers(content, 0, undefined, createParenScanState())[0];
 }
 
 function lineNumberAt(content: string, index: number): number {
@@ -1006,9 +1110,13 @@ export class ConcisenessEvaluator implements Evaluator {
   readonly category = 'heuristic' as const;
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
-    const content = input.content.length > MAX_INPUT_BYTES
-      ? input.content.slice(0, MAX_INPUT_BYTES)
-      : input.content;
+    const { content: truncated, truncated: wasTruncated } = truncateToByteLimit(
+      input.content,
+      MAX_INPUT_BYTES,
+    );
+    const content = wasTruncated
+      ? closeUnterminatedBlockComment(truncated)
+      : truncated;
 
     if (!content.trim()) {
       return {

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -27,6 +27,7 @@ const UNRESOLVED_COMMENT_LINE_PATTERN = new RegExp(
   'i',
 );
 const MAX_COMMENT_RATIO = 0.5;
+const MAX_INPUT_BYTES = 500_000;
 
 interface UnresolvedMarkerOccurrence {
   readonly label: string;
@@ -1014,10 +1015,15 @@ export class ConcisenessEvaluator implements Evaluator {
       };
     }
 
+    const content = input.content.length > MAX_INPUT_BYTES
+      ? input.content.slice(0, MAX_INPUT_BYTES)
+      : input.content;
+
     const findings: EvaluationFinding[] = [];
 
-    this.checkCommentRatio(input.content, findings);
-    this.checkTodoComments(input.content, findings);
+    this.checkCommentRatio(content, findings);
+    this.checkTodoComments(content, findings);
+
 
     const score = createScore(Math.max(0, 1 - findings.length * 0.2));
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -1006,7 +1006,11 @@ export class ConcisenessEvaluator implements Evaluator {
   readonly category = 'heuristic' as const;
 
   async evaluate(input: EvaluationInput): Promise<EvaluationResult> {
-    if (!input.content.trim()) {
+    const content = input.content.length > MAX_INPUT_BYTES
+      ? input.content.slice(0, MAX_INPUT_BYTES)
+      : input.content;
+
+    if (!content.trim()) {
       return {
         evaluatorName: this.name,
         verdict: 'pass',
@@ -1015,15 +1019,10 @@ export class ConcisenessEvaluator implements Evaluator {
       };
     }
 
-    const content = input.content.length > MAX_INPUT_BYTES
-      ? input.content.slice(0, MAX_INPUT_BYTES)
-      : input.content;
-
     const findings: EvaluationFinding[] = [];
 
     this.checkCommentRatio(content, findings);
     this.checkTodoComments(content, findings);
-
 
     const score = createScore(Math.max(0, 1 - findings.length * 0.2));
 

--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -43,17 +43,28 @@ interface UnresolvedMarkerOccurrence {
  * truncates on the actual encoded byte size and backs off from the cut
  * point while it lands inside a multi-byte sequence, so a character is
  * never split and the result is always valid UTF-8.
+ *
+ * Every UTF-16 code unit encodes to at least 1 UTF-8 byte, so a
+ * `maxBytes`-code-unit prefix of `content` is always long enough (in
+ * bytes) to reach `maxBytes` if the full content would. We take that
+ * bounded prefix *before* encoding, so `Buffer.from` never has to
+ * materialize or scan an arbitrarily large uncapped input just to
+ * discover it needs truncating -- encode/scan work is bounded by
+ * `maxBytes`, not by `content.length`.
  */
 function truncateToByteLimit(
   content: string,
   maxBytes: number,
 ): { content: string; truncated: boolean } {
-  const encoded = Buffer.from(content, 'utf8');
-  if (encoded.length <= maxBytes) {
+  const isEntireContent = content.length <= maxBytes;
+  const candidate = isEntireContent ? content : content.slice(0, maxBytes);
+  const encoded = Buffer.from(candidate, 'utf8');
+
+  if (isEntireContent && encoded.length <= maxBytes) {
     return { content, truncated: false };
   }
 
-  let end = maxBytes;
+  let end = Math.min(encoded.length, maxBytes);
   // Continuation bytes match the 10xxxxxx bit pattern; back off until we
   // land right after a complete character.
   while (end > 0 && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
@@ -67,6 +78,55 @@ function truncateToByteLimit(
 }
 
 /**
+ * Determines whether scanning `content` to its end leaves us inside an
+ * unterminated block comment. This mirrors the same quote/comment/regex
+ * skip logic `collectCodeMarkers` uses (reusing `skipQuotedLiteral`,
+ * `canStartRegexLiteral`, and `skipRegexLiteral`) so a `/*`-looking
+ * substring inside a string or regex literal -- e.g. `const sentinel =
+ * "/*";` -- is never mistaken for a real comment opener. It is a single
+ * forward O(n) pass over `content`, which is already bounded to at most
+ * `maxBytes` by `truncateToByteLimit`.
+ */
+function isInsideOpenBlockComment(content: string): boolean {
+  const state = createParenScanState();
+  let index = 0;
+
+  while (index < content.length) {
+    const current = content[index];
+    const next = content[index + 1];
+
+    if (current === '"' || current === "'" || current === '`') {
+      index = skipQuotedLiteral(content, index);
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? content.length : lineEnd + 1;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', index + 2);
+      if (commentEnd === -1) {
+        return true;
+      }
+      index = commentEnd + 2;
+      continue;
+    }
+
+    if (current === '/' && canStartRegexLiteral(content, index, state)) {
+      index = skipRegexLiteral(content, index);
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return false;
+}
+
+/**
  * If truncation cut through an open block comment (its `/*` appeared
  * before the cutoff but its closing `*\/` would have appeared after it),
  * the naive `BLOCK_COMMENT_PATTERN` regex used for comment-ratio scoring
@@ -75,17 +135,7 @@ function truncateToByteLimit(
  * calculation honest about the content that was actually scanned.
  */
 function closeUnterminatedBlockComment(content: string): string {
-  const lastOpen = content.lastIndexOf('/*');
-  if (lastOpen === -1) {
-    return content;
-  }
-
-  const lastClose = content.lastIndexOf('*/');
-  if (lastClose > lastOpen) {
-    return content;
-  }
-
-  return `${content}*/`;
+  return isInsideOpenBlockComment(content) ? `${content}*/` : content;
 }
 
 function skipQuotedLiteral(content: string, start: number): number {

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -609,4 +609,20 @@ const x = 1;
     expect(result.verdict).toBe('pass');
     expect(result.score).toBe(1);
   });
+
+  it('bounds execution and memory on oversized inputs (>500KB)', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    // Generate an input larger than 500KB (600,000 chars)
+    const largeLine = 'const x = 42; // some code comment\n';
+    const oversizedContent = largeLine.repeat(20_000); // ~700KB
+    expect(oversizedContent.length).toBeGreaterThan(500_000);
+
+    const start = Date.now();
+    const result = await evaluator.evaluate(createInput(oversizedContent));
+    const duration = Date.now() - start;
+
+    expect(result.evaluatorName).toBe('conciseness');
+    expect(duration).toBeLessThan(1000); // Execution should complete very quickly
+  });
 });
+

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -641,5 +641,116 @@ const x = 1;
     expect(result.verdict).toBe('pass');
     expect(duration).toBeLessThan(1000);
   });
+
+  describe('resource-bounding regressions after rebase', () => {
+    it('bounds work on inputs with many regex literals after control-condition parens', async () => {
+      // Regression test for a quadratic path in collectCodeMarkers():
+      // findMatchingOpeningParen() previously rescanned the entire
+      // preceding prefix from scratch every time a `/` immediately
+      // followed a `)`, so many `if (x) /a/;`-shaped lines degrade to
+      // O(n^2). A crafted ~24KB input of this shape was clocked at ~7s
+      // pre-fix; a correctly linear scan should stay well under a second
+      // even for a substantially larger input.
+      const evaluator = new ConcisenessEvaluator();
+      const pathologicalLine = 'if (x) /a/;\n';
+      const pathologicalContent = pathologicalLine.repeat(5_000); // ~65KB
+
+      const start = Date.now();
+      const result = await evaluator.evaluate(createInput(pathologicalContent));
+      const duration = Date.now() - start;
+
+      expect(result.evaluatorName).toBe('conciseness');
+      expect(duration).toBeLessThan(1000);
+    });
+
+    it('scales roughly linearly (not quadratically) as pathological input grows', async () => {
+      // Complexity-based check that avoids relying on a single fragile
+      // wall-clock threshold: quadratic behavior means an 8x larger input
+      // takes ~64x longer, while linear behavior takes ~8x longer. Assert
+      // a generous bound that a quadratic regression would blow through
+      // but ordinary CI timing jitter should not.
+      const evaluator = new ConcisenessEvaluator();
+      const pathologicalLine = 'if (x) /a/;\n';
+      const small = pathologicalLine.repeat(1_000);
+      const large = pathologicalLine.repeat(8_000);
+
+      const smallStart = Date.now();
+      await evaluator.evaluate(createInput(small));
+      const smallDuration = Math.max(Date.now() - smallStart, 1);
+
+      const largeStart = Date.now();
+      await evaluator.evaluate(createInput(large));
+      const largeDuration = Date.now() - largeStart;
+
+      expect(largeDuration).toBeLessThan(smallDuration * 20);
+    });
+
+    it('preserves an open block comment that spans the truncation boundary', async () => {
+      // Regression test: if truncation cuts through a block comment before
+      // its closing `*/`, the naive BLOCK_COMMENT_PATTERN regex used for
+      // comment-ratio scoring requires a literal closing delimiter and so
+      // silently drops the entire (truncated) comment from the ratio,
+      // making an almost-all-comment payload score as if it had ~0%
+      // comments instead of the ~99%+ it should.
+      const evaluator = new ConcisenessEvaluator();
+      const commentLine = 'x'.repeat(78);
+      const linesNeeded = Math.ceil(600_000 / (commentLine.length + 1));
+      const body = `${commentLine}\n`.repeat(linesNeeded);
+      // The closing `*/` sits well past the 500,000-byte cutoff, so the
+      // truncated content ends mid-comment with no closing delimiter.
+      const content = `/*\n${body}*/\n`;
+      expect(Buffer.byteLength(content, 'utf8')).toBeGreaterThan(500_000);
+
+      const result = await evaluator.evaluate(createInput(content));
+
+      const ratioFinding = result.findings.find((f) =>
+        f.message.startsWith('Excessive comment ratio:'),
+      );
+      expect(ratioFinding).toBeTruthy();
+      const percentage = Number(
+        ratioFinding?.message.match(/Excessive comment ratio: (\d+)%/)?.[1],
+      );
+      expect(percentage).toBeGreaterThan(90);
+    });
+
+    it('truncates at a UTF-8 byte boundary, not a UTF-16 code-unit boundary', async () => {
+      // Regression test: MAX_INPUT_BYTES is measured against
+      // `String.length`, which counts UTF-16 code units, not bytes. Each
+      // '中' character is 1 UTF-16 code unit but 3 UTF-8 bytes, so 170,000
+      // of them is only ~170K by `.length` (nowhere near the old
+      // character-count cap) yet ~510KB by actual byte size -- past the
+      // intended 500,000-byte memory bound.
+      const evaluator = new ConcisenessEvaluator();
+      const marker = ['TO', 'DO'].join('');
+      const filler = '中'.repeat(170_000);
+      const content = `${filler}\n// ${marker}: filler marker\n`;
+      expect(content.length).toBeLessThan(500_000);
+      expect(Buffer.byteLength(content, 'utf8')).toBeGreaterThan(500_000);
+
+      const result = await evaluator.evaluate(createInput(content));
+
+      // The marker sits after the true 500,000-byte cutoff, so a
+      // byte-accurate truncation must drop it entirely.
+      expect(
+        result.findings.some((f) =>
+          f.message.includes('unresolved marker comment'),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not corrupt output when the byte cutoff lands mid-character', async () => {
+      // 500,000 is not a multiple of 3, so a naive byte slice at exactly
+      // MAX_INPUT_BYTES would split the last multi-byte character in half,
+      // producing invalid UTF-8 / mojibake. The evaluator should still
+      // resolve cleanly.
+      const evaluator = new ConcisenessEvaluator();
+      const filler = '中'.repeat(200_000); // 600,000 bytes
+
+      const result = await evaluator.evaluate(createInput(filler));
+
+      expect(result.evaluatorName).toBe('conciseness');
+      expect(result.verdict).toBe('pass');
+    });
+  });
 });
 

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -751,6 +751,72 @@ const x = 1;
       expect(result.evaluatorName).toBe('conciseness');
       expect(result.verdict).toBe('pass');
     });
+
+    it('bounds encoding work instead of encoding the entire uncapped input', async () => {
+      // Regression test: truncateToByteLimit() previously called
+      // `Buffer.from(content, 'utf8')` on the *full* input before checking
+      // its length, so a review far larger than 500KB still incurred an
+      // allocation and encode pass proportional to the whole payload --
+      // the byte-boundary fix for the UTF-16-vs-byte finding didn't
+      // actually bound memory/CPU, it just moved where the check happened.
+      // A multi-megabyte pathological input should still resolve quickly.
+      const evaluator = new ConcisenessEvaluator();
+      const veryLargeContent = 'x'.repeat(20_000_000); // 20MB, ASCII
+
+      const start = Date.now();
+      const result = await evaluator.evaluate(createInput(veryLargeContent));
+      const duration = Date.now() - start;
+
+      expect(result.evaluatorName).toBe('conciseness');
+      expect(duration).toBeLessThan(1000);
+    });
+
+    it('does not treat a "/*"-shaped string literal near the truncation tail as an open comment', async () => {
+      // Regression test: closeUnterminatedBlockComment() previously used a
+      // raw lastIndexOf('/*') / lastIndexOf('*/') comparison with no
+      // lexical awareness, so a `/*`-looking substring inside a string
+      // literal (not a real comment opener) was misidentified as an open
+      // block comment, and the synthetic closing `*/` made
+      // BLOCK_COMMENT_PATTERN match from that string literal all the way
+      // to the truncation boundary -- scoring ordinary code as ~100%
+      // comments.
+      const evaluator = new ConcisenessEvaluator();
+      const sentinel = 'const sentinel = "/*";\n';
+      const ordinaryLine = 'const value = 1;\n';
+      const body = ordinaryLine.repeat(
+        Math.ceil(600_000 / ordinaryLine.length),
+      );
+      const content = `${sentinel}${body}`;
+      expect(Buffer.byteLength(content, 'utf8')).toBeGreaterThan(500_000);
+
+      const result = await evaluator.evaluate(createInput(content));
+
+      expect(
+        result.findings.some((f) =>
+          f.message.startsWith('Excessive comment ratio:'),
+        ),
+      ).toBe(false);
+    });
+
+    it('still closes a genuinely open block comment that spans the truncation boundary', async () => {
+      // Companion to the lexical-awareness test above: a *real* unterminated
+      // block comment at the truncation boundary must still be detected
+      // and accounted for (this is finding #2 from the prior round,
+      // re-verified against the lexical-scanner-based implementation).
+      const evaluator = new ConcisenessEvaluator();
+      const commentLine = 'x'.repeat(78);
+      const linesNeeded = Math.ceil(600_000 / (commentLine.length + 1));
+      const body = `${commentLine}\n`.repeat(linesNeeded);
+      const content = `/*\n${body}*/\n`;
+      expect(Buffer.byteLength(content, 'utf8')).toBeGreaterThan(500_000);
+
+      const result = await evaluator.evaluate(createInput(content));
+
+      const ratioFinding = result.findings.find((f) =>
+        f.message.startsWith('Excessive comment ratio:'),
+      );
+      expect(ratioFinding).toBeTruthy();
+    });
   });
 });
 

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -624,5 +624,22 @@ const x = 1;
     expect(result.evaluatorName).toBe('conciseness');
     expect(duration).toBeLessThan(1000); // Execution should complete very quickly
   });
+
+  it('bounds execution on oversized all-whitespace inputs (>500KB)', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    // Regression test: the empty-content short-circuit must run on the
+    // truncated content, not the raw input, or an oversized whitespace-only
+    // payload would still be scanned in full by `.trim()` before the
+    // MAX_INPUT_BYTES cap is ever applied — defeating the resource bound.
+    const oversizedWhitespace = ' '.repeat(600_000);
+    expect(oversizedWhitespace.length).toBeGreaterThan(500_000);
+
+    const start = Date.now();
+    const result = await evaluator.evaluate(createInput(oversizedWhitespace));
+    const duration = Date.now() - start;
+
+    expect(result.verdict).toBe('pass');
+    expect(duration).toBeLessThan(1000);
+  });
 });
 

--- a/tasks/issue-3657-conciseness-bounds-progress.md
+++ b/tasks/issue-3657-conciseness-bounds-progress.md
@@ -1,0 +1,21 @@
+# Issue #3657: ConcisenessEvaluator Input Bounds - Progress Checklist
+
+Implementation checklist for resolving Issue #3657 (Bounding `ConcisenessEvaluator` scans for large inputs).
+
+## Acceptance Criteria
+
+- [x] Define `MAX_INPUT_BYTES = 500_000` (500 KB) constant in `packages/franken-critique/src/evaluators/conciseness.ts`.
+- [x] If `input.content.length > MAX_INPUT_BYTES`, truncate the content to `MAX_INPUT_BYTES` before line splitting and comment checks, ensuring predictable memory and CPU usage.
+- [x] Unit tests in `packages/franken-critique/tests/unit/evaluators/conciseness.test.ts` verify early truncation and correct behavior under oversized inputs (>500KB).
+- [x] All package tests in `packages/franken-critique` pass cleanly.
+
+## Checklist
+
+- [x] Create progress document at `tasks/issue-3657-conciseness-bounds-progress.md` <!-- id: 0 -->
+- [x] Add unit tests for oversized input (>500KB) handling in `packages/franken-critique/tests/unit/evaluators/conciseness.test.ts` <!-- id: 1 -->
+- [x] Implement `MAX_INPUT_BYTES` bound and truncation in `packages/franken-critique/src/evaluators/conciseness.ts` <!-- id: 2 -->
+- [x] Run vitest suite for `packages/franken-critique` to confirm all 17 test files pass <!-- id: 3 -->
+- [x] Run `npx tsc --noEmit` to verify type safety <!-- id: 4 -->
+- [x] Commit changes, push branch, open PR, and run task-end review loop <!-- id: 5 -->
+- [x] Mark progress checklist complete <!-- id: 6 -->
+


### PR DESCRIPTION
Fixes #3657.

## Description
`ConcisenessEvaluator` performed full string splits and regex scans on review payloads without a size limit, causing potential CPU and memory spikes on large inputs (>500KB).

## Changes
- Defined `MAX_INPUT_BYTES = 500_000` (500 KB) in `ConcisenessEvaluator`.
- Truncates `input.content` to `MAX_INPUT_BYTES` before line splitting and comment ratio scans.
- Added unit tests in `conciseness.test.ts` verifying fast execution on oversized payloads (>500KB).