### PR TITLE
fix(mcp): report resumable Codex migration failures

### DIFF
--- a/packages/franken-mcp-suite/src/cli/init.test.ts
+++ b/packages/franken-mcp-suite/src/cli/init.test.ts
@@ -548,19 +548,47 @@ describe('fbeast init', () => {
     expect(calls.filter((c) => c.args[1] === 'remove').map((c) => c.args[2])).toEqual(['fbeast-memory']);
   });
 
-  it('throws when legacy Codex removal fails', () => {
+  it('reports a resumable repair path when legacy Codex removal partially fails', () => {
     const root = tmpDir();
     dirs.push(root);
     const dbPath = join(root, '.fbeast', 'beast.db');
     const mockSpawn = (_cmd: string, args: string[]) => {
-      if (args[1] === 'get' && args[2] === 'fbeast-memory') return { status: 0, stdout: Buffer.from(dbPath) };
-      if (args[1] === 'remove' && args[2] === 'fbeast-memory') return { status: 1, stderr: Buffer.from('permission denied') };
+      if (args[1] === 'get' && ['fbeast-memory', 'fbeast-planner'].includes(args[2]!)) {
+        return { status: 0, stdout: Buffer.from(dbPath) };
+      }
+      if (args[1] === 'remove' && args[2] === 'fbeast-memory') return { status: 0 };
+      if (args[1] === 'remove' && args[2] === 'fbeast-planner') {
+        return { status: 1, stderr: Buffer.from('\u001b[31mpermission denied\u001b[0m') };
+      }
       return { status: 1 };
     };
 
-    expect(() =>
-      runInit({ root, claudeDir: join(root, '.codex'), hooks: false, client: 'codex', spawn: mockSpawn }),
-    ).toThrow('failed to remove legacy Codex MCP server fbeast-memory');
+    let thrown: unknown;
+    try {
+      runInit({
+        root,
+        claudeDir: join(root, '.codex'),
+        hooks: true,
+        servers: ['memory'],
+        client: 'codex',
+        spawn: mockSpawn,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({
+      name: 'LegacyCodexMigrationError',
+      code: 'LEGACY_CODEX_MCP_MIGRATION_FAILED',
+      failedServer: 'fbeast-planner',
+      command: ['codex', 'mcp', 'remove', 'fbeast-planner'],
+      removedServers: ['fbeast-memory'],
+      stderr: 'permission denied',
+    });
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('Legacy entries already removed: fbeast-memory');
+    expect((thrown as Error).message).toContain('Repair: codex mcp remove fbeast-planner');
+    expect((thrown as Error).message).toContain('Resume: fbeast mcp init --client=codex --hooks --pick=memory');
   });
 
   it('uses project-root placeholders for Claude .mcp.json across project roots', () => {

--- a/packages/franken-mcp-suite/src/cli/init.ts
+++ b/packages/franken-mcp-suite/src/cli/init.ts
@@ -41,6 +41,42 @@ export interface InitOptions {
   spawn?: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string; stdout?: Buffer | string };
 }
 
+export class LegacyCodexMigrationError extends Error {
+  readonly code = 'LEGACY_CODEX_MCP_MIGRATION_FAILED';
+  readonly failedServer: string;
+  readonly command: readonly string[];
+  readonly removedServers: readonly string[];
+  readonly stderr: string;
+  readonly resumeCommand: readonly string[];
+
+  constructor(options: {
+    failedServer: string;
+    command: readonly string[];
+    removedServers: readonly string[];
+    stderr: string;
+    resumeCommand: readonly string[];
+  }) {
+    const command = [...options.command];
+    const removedServers = [...options.removedServers];
+    const resumeCommand = [...options.resumeCommand];
+    const commandText = command.join(' ');
+    const removedText = removedServers.length > 0 ? removedServers.join(', ') : 'none';
+    super([
+      `fbeast init: legacy Codex MCP migration failed while running: ${commandText}`,
+      `Legacy entries already removed: ${removedText}`,
+      `Codex error: ${options.stderr}`,
+      `Repair: ${commandText}`,
+      `Resume: ${resumeCommand.join(' ')}`,
+    ].join('\n'));
+    this.name = 'LegacyCodexMigrationError';
+    this.failedServer = options.failedServer;
+    this.command = command;
+    this.removedServers = removedServers;
+    this.stderr = options.stderr;
+    this.resumeCommand = resumeCommand;
+  }
+}
+
 export function runInit(options: InitOptions): void {
   const {
     root,
@@ -170,7 +206,7 @@ function initCodex(options: {
   const dbPath = join(root, '.fbeast', 'beast.db');
   const configPath = join(root, '.fbeast', 'config.json');
 
-  migrateLegacyCodexServers(root, spawnFn);
+  migrateLegacyCodexServers(root, spawnFn, codexInitResumeCommand({ servers, hooks, mode }));
   writeCodexProjectConfig(root, servers, mode, dbPath, configPath);
 
   // Drop instructions into AGENTS.md
@@ -196,9 +232,11 @@ function initCodex(options: {
 function migrateLegacyCodexServers(
   root: string,
   spawnFn: (cmd: string, args: string[]) => { status: number | null; stderr?: Buffer | string; stdout?: Buffer | string },
+  resumeCommand: readonly string[],
 ): void {
   const dbPath = join(root, '.fbeast', 'beast.db');
   const legacyNames = [...ALL_SERVERS.map((srv) => `fbeast-${srv}`), 'fbeast-proxy'];
+  const removedServers: string[] = [];
 
   for (const name of legacyNames) {
     const getResult = spawnFn('codex', ['mcp', 'get', name]);
@@ -207,11 +245,46 @@ function migrateLegacyCodexServers(
     const output = `${getResult.stdout?.toString() ?? ''}\n${getResult.stderr?.toString() ?? ''}`;
     if (!output.includes(dbPath)) continue;
 
-    const removeResult = spawnFn('codex', ['mcp', 'remove', name]);
+    const command = ['codex', 'mcp', 'remove', name] as const;
+    const removeResult = spawnFn(command[0], command.slice(1));
     if (removeResult.status !== 0) {
-      throw new Error(`fbeast init: failed to remove legacy Codex MCP server ${name}: ${removeResult.stderr?.toString().trim() ?? 'unknown error'}`);
+      throw new LegacyCodexMigrationError({
+        failedServer: name,
+        command,
+        removedServers,
+        stderr: sanitizeCodexDiagnostic(removeResult.stderr),
+        resumeCommand,
+      });
     }
+    removedServers.push(name);
   }
+}
+
+function codexInitResumeCommand(options: {
+  servers: readonly FbeastServer[];
+  hooks: boolean;
+  mode: 'standard' | 'proxy';
+}): string[] {
+  const command = ['fbeast', 'mcp', 'init', '--client=codex'];
+  if (options.hooks) command.push('--hooks');
+  if (options.mode === 'proxy') {
+    command.push('--mode=proxy');
+  } else if (
+    options.servers.length !== ALL_SERVERS.length
+    || options.servers.some((server, index) => server !== ALL_SERVERS[index])
+  ) {
+    command.push(`--pick=${options.servers.join(',')}`);
+  }
+  return command;
+}
+
+function sanitizeCodexDiagnostic(stderr: Buffer | string | undefined): string {
+  const diagnostic = stderr?.toString() ?? '';
+  const sanitized = diagnostic
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, '')
+    .trim();
+  return sanitized.slice(0, 2_000) || 'unknown error';
 }
 
 function writeCodexProjectConfig(

--- a/tasks/issue-3648-codex-migration-repair-progress.md
+++ b/tasks/issue-3648-codex-migration-repair-progress.md
@@ -1,0 +1,14 @@
+# Issue 3648 — Codex migration repair progress
+
+- [x] Confirm issue is open and not labeled `good first issue`.
+- [x] Create isolated branch/worktree from current `origin/main`.
+- [x] Read repository instructions and shared lessons.
+- [x] Reproduce the partial legacy Codex migration failure on current main.
+- [x] Record observed/expected behavior and root-cause evidence on the Kanban card.
+- [x] Add and run a focused failing regression test.
+- [x] Implement the smallest typed/actionable migration failure fix.
+- [x] Run focused tests plus package test, typecheck, build, and lint gates.
+- [x] Commit with the required Git identity and Conventional Commit subject.
+- [ ] Push and open one PR with `Closes #3648`.
+- [ ] Obtain green CI and a current-head clean GitHub Codex review.
+- [ ] Squash-merge, update shared lessons if warranted, and close the card.


### PR DESCRIPTION
## Summary
- classify legacy Codex MCP cleanup failures with structured migration state
- report the exact repair command and a resume command that preserves hooks, mode, and server selection
- sanitize and bound Codex diagnostic output before presenting it to operators

## Test Plan
- `npm test --workspace @franken/mcp-suite`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite`
- `npm run build --workspace @franken/mcp-suite`
- `npm run build -- --filter=@franken/mcp-suite`
- `git diff --check`

Closes #3648
