### PR TITLE
fix(observer): bound webhook delivery attempts

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -814,12 +814,14 @@ detector.on('loop-detected', result => {
 
 When `send(payload, { idempotencyKey, target })` receives an idempotency key, `WebhookNotifier` records a delivery receipt with `pending`, `sent`, `skipped`, or `failed`, an ISO timestamp, the logical target, and a SHA-256 content hash. A later call with the same key, target, and content hash is skipped after a successful receipt or a non-stale pending reservation; changed content, a different target, a stale pending reservation, or a prior failed receipt is delivered again. Receipt stores must implement atomic `reserve()` plus content-hash lookup so overlapping cron/status runs cannot both POST the same logical notification. The in-memory receipt store is useful for one process, while status, approval, and doctor/loop notification runners should pass a durable `WebhookDeliveryReceiptStore` so repeated cron/status runs do not duplicate Discord or webhook messages across restarts. If no logical target is provided, the notifier stores a redacted endpoint plus a short SHA-256 URL discriminator rather than the raw webhook URL.
 
-Retries are opt-in through `retry`. When enabled, `WebhookNotifier` retries only transient failures: network errors, HTTP 429, and HTTP 5xx responses. Non-transient 4xx responses fail immediately so invalid payloads or credentials do not create retry storms. Retry delays use exponential backoff (`baseDelayMs * 2^attempt`), jitter is enabled by default to spread concurrent webhook traffic, and the final delay is always capped by `maxDelayMs` even after jitter is applied.
+Retries are opt-in through `retry`. Every delivery attempt has a 10-second deadline by default; set `deliveryTimeoutMs` to a positive millisecond value no greater than `2147483647` to tune it. A timed-out attempt is aborted and follows the normal network-error retry policy. Callers can also pass `send(payload, { signal })`; caller cancellation aborts the active request and stops pending DNS/backoff work and further retries. When enabled, `WebhookNotifier` retries only transient failures: network errors, HTTP 429, and HTTP 5xx responses. Non-transient 4xx responses fail immediately so invalid payloads or credentials do not create retry storms. Retry delays use exponential backoff (`baseDelayMs * 2^attempt`), jitter is enabled by default to spread concurrent webhook traffic, and the final delay is always capped by `maxDelayMs` even after jitter is applied.
 
 ```ts
 const notifier = new WebhookNotifier({
   url: process.env.SLACK_WEBHOOK_URL!,
   allowedTargetOrigins: ['https://hooks.slack.com'],
+  // Abort each individual delivery attempt after this deadline (default: 10 seconds).
+  deliveryTimeoutMs: 5_000,
   retry: {
     maxRetries: 3,      // initial request + up to 3 retries
     baseDelayMs: 200,  // first retry waits about 200ms before jitter

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -638,6 +638,25 @@ describe('WebhookNotifier', () => {
       expect(Date.now() - startedAt).toBeLessThan(750)
     })
 
+    it('does not wait for stalled stream cancellation after the body-read deadline', async () => {
+      const cancel = vi.fn(() => new Promise<void>(() => undefined))
+      const stream = new ReadableStream<Uint8Array>({ cancel })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: stream,
+      })
+      const notifier = createNotifier({ deliveryTimeoutMs: 1_000 })
+      const startedAt = Date.now()
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery failed: 500 Internal Server Error',
+      )
+      expect(Date.now() - startedAt).toBeLessThan(750)
+      expect(cancel).toHaveBeenCalledTimes(1)
+    })
+
     it('keeps the delivery deadline active while reading an error body', async () => {
       const cancel = vi.fn()
       const stream = new ReadableStream<Uint8Array>({ cancel })
@@ -1470,6 +1489,29 @@ describe('WebhookNotifier', () => {
       })
 
       await expect(notifier.send({ type: 'test' })).rejects.toThrow('401')
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(sleepFn).not.toHaveBeenCalled()
+    })
+
+    it('does not retry non-transient 4xx responses when body collection times out', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        cancel: vi.fn(),
+      })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        body: stream,
+      })
+      const sleepFn = vi.fn().mockResolvedValue(undefined)
+      const notifier = createNotifier({
+        deliveryTimeoutMs: 10,
+        retry: { maxRetries: 2 },
+        sleep: sleepFn,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow('401 Unauthorized')
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(sleepFn).not.toHaveBeenCalled()

--- a/packages/franken-observer/src/notify/WebhookNotifier.test.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.test.ts
@@ -152,6 +152,7 @@ describe('WebhookNotifier', () => {
       const payload = { type: 'status', runId: 'run-concurrent', state: 'green' }
 
       const first = notifier.send(payload, { idempotencyKey: 'status:run-concurrent' })
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
       const secondReceipt = await notifier.send(payload, { idempotencyKey: 'status:run-concurrent' })
       releaseFetch()
       const firstReceipt = await first
@@ -637,6 +638,273 @@ describe('WebhookNotifier', () => {
       expect(Date.now() - startedAt).toBeLessThan(750)
     })
 
+    it('keeps the delivery deadline active while reading an error body', async () => {
+      const cancel = vi.fn()
+      const stream = new ReadableStream<Uint8Array>({ cancel })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: stream,
+      })
+      const notifier = createNotifier({ deliveryTimeoutMs: 10 })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery timed out after 10ms',
+      )
+      expect(cancel).toHaveBeenCalled()
+    })
+
+    it('cancels a stalled error-body read when the caller aborts', async () => {
+      const controller = new AbortController()
+      const pull = vi.fn()
+      const cancel = vi.fn()
+      const stream = new ReadableStream<Uint8Array>({ pull, cancel })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: stream,
+      })
+      const notifier = createNotifier({ deliveryTimeoutMs: 1_000 })
+      const delivery = notifier.send({ type: 'test' }, { signal: controller.signal })
+      await vi.waitFor(() => expect(pull).toHaveBeenCalled())
+
+      controller.abort(new Error('cancelled during response body'))
+
+      await expect(delivery).rejects.toThrow('cancelled during response body')
+      expect(cancel).toHaveBeenCalled()
+    })
+
+    it('passes a delivery deadline signal to fetch', async () => {
+      const notifier = createNotifier()
+
+      await notifier.send({ type: 'test' })
+
+      const [, init] = mockFetch.mock.calls[0]
+      expect(init.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('cleans up the delivery timeout after delivery', async () => {
+      let receivedSignal: AbortSignal | undefined
+      mockFetch.mockImplementation(async (_url, init) => {
+        receivedSignal = init?.signal
+        return { ok: true, status: 200, statusText: 'OK' }
+      })
+      const notifier = createNotifier({ deliveryTimeoutMs: 10 })
+
+      await notifier.send({ type: 'test' })
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(receivedSignal?.aborted).toBe(false)
+    })
+
+    it('cleans up caller-signal listeners after delivery', async () => {
+      const controller = new AbortController()
+      const addSpy = vi.spyOn(controller.signal, 'addEventListener')
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener')
+      const notifier = createNotifier()
+
+      await notifier.send({ type: 'test' }, { signal: controller.signal })
+
+      const abortListeners = addSpy.mock.calls
+        .filter(([type]) => type === 'abort')
+        .map(([, listener]) => listener)
+      expect(abortListeners.length).toBeGreaterThan(0)
+      for (const listener of abortListeners) {
+        expect(removeSpy).toHaveBeenCalledWith('abort', listener)
+      }
+    })
+
+    it('aborts and rejects a hung delivery after the configured timeout', async () => {
+      let receivedSignal: AbortSignal | undefined
+      mockFetch.mockImplementation((_url, init) => {
+        receivedSignal = init?.signal
+        return new Promise(() => undefined)
+      })
+      const notifier = createNotifier({ deliveryTimeoutMs: 10 })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery timed out after 10ms',
+      )
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+
+    it('retries a timed-out delivery with a fresh signal', async () => {
+      const signals: AbortSignal[] = []
+      mockFetch
+        .mockImplementationOnce((_url, init) => {
+          signals.push(init?.signal as AbortSignal)
+          return new Promise(() => undefined)
+        })
+        .mockImplementationOnce(async (_url, init) => {
+          signals.push(init?.signal as AbortSignal)
+          return { ok: true, status: 200, statusText: 'OK' }
+        })
+      const notifier = createNotifier({
+        deliveryTimeoutMs: 10,
+        retry: { maxRetries: 1, jitter: false },
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+
+      await expect(notifier.send({ type: 'test' })).resolves.toMatchObject({ status: 'sent' })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(signals[0]?.aborted).toBe(true)
+      expect(signals[1]?.aborted).toBe(false)
+      expect(signals[1]).not.toBe(signals[0])
+    })
+
+    it('honours caller cancellation without retrying', async () => {
+      const controller = new AbortController()
+      let receivedSignal: AbortSignal | undefined
+      mockFetch.mockImplementation((_url, init) => {
+        receivedSignal = init?.signal
+        return new Promise(() => undefined)
+      })
+      const notifier = createNotifier({
+        deliveryTimeoutMs: 1_000,
+        retry: { maxRetries: 2 },
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+      const delivery = notifier.send({ type: 'test' }, { signal: controller.signal })
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+
+      controller.abort(new Error('delivery cancelled'))
+
+      await expect(delivery).rejects.toThrow('delivery cancelled')
+      expect(receivedSignal?.aborted).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects a pre-cancelled delivery before starting fetch', async () => {
+      const controller = new AbortController()
+      controller.abort(new Error('already cancelled'))
+      const notifier = createNotifier({ retry: { maxRetries: 2 } })
+
+      await expect(notifier.send({ type: 'test' }, { signal: controller.signal })).rejects.toThrow(
+        'already cancelled',
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('stops a retry while waiting in backoff after caller cancellation', async () => {
+      const controller = new AbortController()
+      let resolveSleep!: () => void
+      const sleep = vi.fn(() => new Promise<void>(resolve => { resolveSleep = resolve }))
+      mockFetch.mockRejectedValueOnce(new Error('ECONNRESET'))
+      const notifier = createNotifier({
+        retry: { maxRetries: 1, jitter: false },
+        sleep,
+      })
+      let settled: 'cancelled' | 'resolved' | undefined
+      const delivery = notifier.send({ type: 'test' }, { signal: controller.signal })
+        .then(() => { settled = 'resolved' }, error => {
+          if ((error as Error).message === 'cancelled during backoff') settled = 'cancelled'
+        })
+      await vi.waitFor(() => expect(sleep).toHaveBeenCalledTimes(1))
+
+      controller.abort(new Error('cancelled during backoff'))
+      await vi.waitFor(() => expect(settled).toBe('cancelled'))
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      resolveSleep()
+      await delivery
+    })
+
+    it('clears the default backoff timer after caller cancellation', async () => {
+      const controller = new AbortController()
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+      mockFetch.mockRejectedValueOnce(new Error('ECONNRESET'))
+      const notifier = createNotifier({
+        retry: {
+          maxRetries: 1,
+          baseDelayMs: 30_000,
+          maxDelayMs: 30_000,
+          jitter: false,
+        },
+      })
+      const delivery = notifier.send({ type: 'test' }, { signal: controller.signal })
+      await vi.waitFor(() => {
+        expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 30_000)).toBe(true)
+      })
+      const backoffCallIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 30_000)
+      const backoffTimer = setTimeoutSpy.mock.results[backoffCallIndex]?.value
+
+      controller.abort(new Error('cancelled during default backoff'))
+
+      await expect(delivery).rejects.toThrow('cancelled during default backoff')
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(backoffTimer)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops a stalled DNS lookup after caller cancellation without starting HTTPS', async () => {
+      const controller = new AbortController()
+      let resolveDns!: (addresses: string[]) => void
+      const dnsLookup = vi.fn(() => new Promise<string[]>(resolve => { resolveDns = resolve }))
+      const notifier = new WebhookNotifier({
+        url: 'https://webhooks.example.com/api/webhooks/123/secret',
+        allowedTargets: ['https://webhooks.example.com/api/webhooks/'],
+        dnsLookup,
+      })
+      let settled: 'cancelled' | 'resolved' | undefined
+      const delivery = notifier.send({ type: 'test' }, { signal: controller.signal })
+        .then(() => { settled = 'resolved' }, error => {
+          if ((error as Error).message === 'cancelled during DNS') settled = 'cancelled'
+        })
+      await vi.waitFor(() => expect(dnsLookup).toHaveBeenCalledTimes(1))
+
+      controller.abort(new Error('cancelled during DNS'))
+      await vi.waitFor(() => expect(settled).toBe('cancelled'))
+
+      expect(httpsRequest).not.toHaveBeenCalled()
+      resolveDns(['203.0.113.10'])
+      await delivery
+    })
+
+    it('times out a stalled DNS lookup before starting HTTPS', async () => {
+      const dnsLookup = vi.fn(() => new Promise<string[]>(() => undefined))
+      const notifier = new WebhookNotifier({
+        url: 'https://webhooks.example.com/api/webhooks/123/secret',
+        allowedTargets: ['https://webhooks.example.com/api/webhooks/'],
+        dnsLookup,
+        deliveryTimeoutMs: 10,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery timed out after 10ms',
+      )
+      expect(httpsRequest).not.toHaveBeenCalled()
+    })
+
+    it('retries a DNS lookup that exceeds the per-attempt delivery deadline', async () => {
+      mockPinnedHttpsResponse()
+      const dnsLookup = vi.fn()
+        .mockImplementationOnce(() => new Promise<string[]>(() => undefined))
+        .mockResolvedValueOnce(['203.0.113.10'])
+      const notifier = new WebhookNotifier({
+        url: 'https://webhooks.example.com/api/webhooks/123/secret',
+        allowedTargets: ['https://webhooks.example.com/api/webhooks/'],
+        dnsLookup,
+        deliveryTimeoutMs: 10,
+        retry: { maxRetries: 1, jitter: false },
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+
+      await expect(notifier.send({ type: 'test' })).resolves.toMatchObject({ status: 'sent' })
+      expect(dnsLookup).toHaveBeenCalledTimes(2)
+      expect(httpsRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_VALUE])(
+      'rejects invalid deliveryTimeoutMs value %s',
+      deliveryTimeoutMs => {
+        expect(() => createNotifier({ deliveryTimeoutMs })).toThrow(
+          'deliveryTimeoutMs must be a finite positive number no greater than 2147483647',
+        )
+      },
+    )
+
     it('rethrows if fetch itself rejects (network error)', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
       const notifier = createNotifier()
@@ -830,6 +1098,47 @@ describe('WebhookNotifier', () => {
         'Injected fetch cannot safely pin DNS-validated webhook addresses',
       )
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('aborts a stalled default pinned HTTPS request at the delivery deadline', async () => {
+      const request = new EventEmitter() as EventEmitter & {
+        write: ReturnType<typeof vi.fn>
+        end: ReturnType<typeof vi.fn>
+        destroy: ReturnType<typeof vi.fn>
+      }
+      request.write = vi.fn()
+      request.end = vi.fn()
+      request.destroy = vi.fn()
+      vi.mocked(httpsRequest).mockReturnValue(request as never)
+      const dnsLookup = vi.fn(async () => ['203.0.113.10'])
+      const notifier = new WebhookNotifier({
+        url: 'https://webhooks.example.com/api/webhooks/123/secret',
+        allowedTargets: ['https://webhooks.example.com/api/webhooks/'],
+        dnsLookup,
+        deliveryTimeoutMs: 10,
+      })
+
+      await expect(notifier.send({ type: 'test' })).rejects.toThrow(
+        'Webhook delivery timed out after 10ms',
+      )
+      expect(request.destroy).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'WebhookDeliveryTimeoutError',
+      }))
+    })
+
+    it('removes the deadline abort listener after a pinned HTTPS response', async () => {
+      mockPinnedHttpsResponse()
+      const removeEventListener = vi.spyOn(AbortSignal.prototype, 'removeEventListener')
+      const dnsLookup = vi.fn(async () => ['203.0.113.10'])
+      const notifier = new WebhookNotifier({
+        url: 'https://webhooks.example.com/api/webhooks/123/secret',
+        allowedTargets: ['https://webhooks.example.com/api/webhooks/'],
+        dnsLookup,
+      })
+
+      await notifier.send({ type: 'test' })
+
+      expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function))
     })
 
     it('preserves response bodies from the default pinned HTTPS transport', async () => {

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -682,7 +682,7 @@ export class WebhookNotifier {
         }
 
         let dnsFailure = false
-        let response: WebhookFetchResponse
+        let response: WebhookFetchResponse | undefined
         let responseBody = ''
         try {
           const attemptResult = await this.runWithDeliveryDeadline(async deadlineSignal => {
@@ -706,6 +706,7 @@ export class WebhookNotifier {
               body: requestBody,
               signal: deadlineSignal,
             })
+            response = attemptResponse
             const shouldReadBody = !attemptResponse.ok
               && (!this.retry
                 || !isTransientStatus(attemptResponse.status)
@@ -722,12 +723,21 @@ export class WebhookNotifier {
           if (options.signal?.aborted) {
             throw err
           }
+          if (response && !response.ok && !isTransientStatus(response.status)) {
+            const bodySuffix = responseBody ? `: ${responseBody}` : ''
+            throw new Error(
+              `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''} for ${sanitizeWebhookEndpoint(this.url)}${bodySuffix}`,
+            )
+          }
           if (dnsFailure && (!this.retry || !isTransientDnsError(err) || attempt === maxAttempts - 1)) {
             throw err
           }
           continue
         }
 
+        if (!response) {
+          continue
+        }
         if (!response.ok) {
           const bodySuffix = responseBody ? `: ${responseBody}` : ''
           lastError = new Error(
@@ -851,9 +861,21 @@ export class WebhookNotifier {
       }
     } finally {
       if (truncated || timedOut || signal?.aborted) {
-        await reader.cancel().catch(() => undefined)
+        const releaseLock = () => {
+          try {
+            reader.releaseLock()
+          } catch {
+            // A pending read retains the lock until cancellation settles.
+          }
+        }
+        try {
+          void reader.cancel().catch(() => undefined).finally(releaseLock)
+        } catch {
+          releaseLock()
+        }
+      } else {
+        reader.releaseLock()
       }
-      reader.releaseLock()
     }
 
     const decoded = new TextDecoder().decode(Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS)).trim()

--- a/packages/franken-observer/src/notify/WebhookNotifier.ts
+++ b/packages/franken-observer/src/notify/WebhookNotifier.ts
@@ -45,6 +45,8 @@ export interface WebhookSendOptions {
   idempotencyKey?: string
   /** Optional logical target override when one notifier fronts multiple channels. */
   target?: string
+  /** Optional caller cancellation signal. Cancellation stops all delivery phases without retrying. */
+  signal?: AbortSignal
 }
 
 export interface WebhookDeliveryReceiptStore {
@@ -172,6 +174,8 @@ export interface WebhookNotifierOptions {
   dnsLookup?: WebhookDnsLookup
   /** Retry configuration. Omit to send exactly once (backwards-compatible). */
   retry?: WebhookRetryOptions
+  /** Per-attempt delivery deadline in milliseconds. Default: 10000. */
+  deliveryTimeoutMs?: number
   /**
    * Injectable sleep function for testing retry delays without real timers.
    * Defaults to a Promise-based `setTimeout` wrapper.
@@ -230,6 +234,17 @@ function validateNonNegativeInteger(value: number, fieldName: string): number {
 function validateFiniteNonNegativeNumber(value: number, fieldName: string): number {
   if (!Number.isFinite(value) || value < 0) {
     throw new RangeError(`${fieldName} must be a finite non-negative number`)
+  }
+  return value
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+
+function validateTimerDelay(value: number, fieldName: string): number {
+  if (!Number.isFinite(value) || value <= 0 || value > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(
+      `${fieldName} must be a finite positive number no greater than ${MAX_TIMER_DELAY_MS}`,
+    )
   }
   return value
 }
@@ -456,6 +471,65 @@ function normalizeAllowedTargets(
 
 const MAX_ERROR_BODY_CHARS = 2048
 const ERROR_BODY_READ_TIMEOUT_MS = 250
+const DEFAULT_DELIVERY_TIMEOUT_MS = 10_000
+
+class WebhookDeliveryTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Webhook delivery timed out after ${timeoutMs}ms`)
+    this.name = 'WebhookDeliveryTimeoutError'
+  }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('Webhook delivery aborted', 'AbortError')
+}
+
+async function awaitWithSignal<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return operation
+  }
+  if (signal.aborted) {
+    throw abortReason(signal)
+  }
+
+  let onAbort: (() => void) | undefined
+  const interrupted = new Promise<never>((_, reject) => {
+    onAbort = () => reject(abortReason(signal))
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+  try {
+    return await Promise.race([operation, interrupted])
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+}
+
+function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(abortReason(signal))
+  }
+
+  return new Promise((resolve, reject) => {
+    let onAbort: (() => void) | undefined
+    const timeoutId = setTimeout(() => {
+      if (signal && onAbort) {
+        signal.removeEventListener('abort', onAbort)
+      }
+      resolve()
+    }, ms)
+    if (signal) {
+      const handleAbort = () => {
+        clearTimeout(timeoutId)
+        signal.removeEventListener('abort', handleAbort)
+        reject(abortReason(signal))
+      }
+      onAbort = handleAbort
+      signal.addEventListener('abort', handleAbort, { once: true })
+    }
+  })
+}
 
 function redactWebhookSecrets(value: string): string {
   return value
@@ -504,7 +578,8 @@ export class WebhookNotifier {
   private readonly usePinnedDefaultFetch: boolean
   private readonly dnsLookupFn: WebhookDnsLookup | null
   private readonly retry: Required<WebhookRetryOptions> | null
-  private readonly sleepFn: (ms: number) => Promise<void>
+  private readonly deliveryTimeoutMs: number
+  private readonly sleepFn: (ms: number, signal?: AbortSignal) => Promise<void>
   private readonly receiptStore: WebhookDeliveryReceiptStore
 
   constructor(options: WebhookNotifierOptions) {
@@ -529,8 +604,15 @@ export class WebhookNotifier {
     this.dnsLookupFn = options.dnsLookup ?? (options.fetch
       ? null
       : async hostname => (await dnsLookup(hostname, { all: true })).map(result => result.address))
-    this.sleepFn = options.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)))
+    const sleep = options.sleep
+    this.sleepFn = sleep
+      ? (ms: number) => sleep(ms)
+      : sleepWithSignal
     this.receiptStore = options.deliveryReceiptStore ?? new InMemoryWebhookDeliveryReceiptStore()
+    this.deliveryTimeoutMs = validateTimerDelay(
+      options.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS,
+      'deliveryTimeoutMs',
+    )
     this.retry = options.retry
       ? {
           maxRetries: validateNonNegativeInteger(options.retry.maxRetries, 'retry.maxRetries'),
@@ -542,6 +624,9 @@ export class WebhookNotifier {
   }
 
   async send(payload: unknown, options: WebhookSendOptions = {}): Promise<WebhookDeliveryReceipt> {
+    if (options.signal?.aborted) {
+      throw abortReason(options.signal)
+    }
     this.assertTargetAllowed()
 
     const receiptTarget = options.target ?? `${sanitizeWebhookEndpoint(this.url)}#${createHash('sha256').update(this.url).digest('hex').slice(0, 12)}`
@@ -584,45 +669,66 @@ export class WebhookNotifier {
 
     try {
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (options.signal?.aborted) {
+          throw abortReason(options.signal)
+        }
         if (attempt > 0 && this.retry) {
           const { baseDelayMs, maxDelayMs, jitter } = this.retry
           const base = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs)
           const jittered = jitter ? base + seededRandom.random() * baseDelayMs : base
           // Clamp after adding jitter so maxDelayMs remains a true upper bound.
           const delay = Math.min(jittered, maxDelayMs)
-          await this.sleepFn(delay)
+          await awaitWithSignal(this.sleepFn(delay, options.signal), options.signal)
         }
 
-        let resolvedAddresses: readonly string[] = []
-        try {
-          resolvedAddresses = await this.resolveAllowedTargetAddresses()
-        } catch (err) {
-          lastError = err
-          if (this.retry && isTransientDnsError(err) && attempt < maxAttempts - 1) {
-            continue
-          }
-          throw err
-        }
-
+        let dnsFailure = false
         let response: WebhookFetchResponse
+        let responseBody = ''
         try {
-          response = await this.fetchWebhook(resolvedAddresses, {
-            method: 'POST',
-            redirect: 'manual',
-            headers: {
-              'Content-Type': 'application/json',
-              ...this.extraHeaders,
-            },
-            body: requestBody,
-          })
+          const attemptResult = await this.runWithDeliveryDeadline(async deadlineSignal => {
+            let resolvedAddresses: readonly string[] = []
+            try {
+              resolvedAddresses = await awaitWithSignal(
+                this.resolveAllowedTargetAddresses(),
+                deadlineSignal,
+              )
+            } catch (err) {
+              dnsFailure = !deadlineSignal.aborted
+              throw err
+            }
+            const attemptResponse = await this.fetchWebhook(resolvedAddresses, {
+              method: 'POST',
+              redirect: 'manual',
+              headers: {
+                'Content-Type': 'application/json',
+                ...this.extraHeaders,
+              },
+              body: requestBody,
+              signal: deadlineSignal,
+            })
+            const shouldReadBody = !attemptResponse.ok
+              && (!this.retry
+                || !isTransientStatus(attemptResponse.status)
+                || attempt === maxAttempts - 1)
+            const attemptResponseBody = shouldReadBody
+              ? await this.readResponseBody(attemptResponse, deadlineSignal)
+              : ''
+            return { response: attemptResponse, responseBody: attemptResponseBody }
+          }, options.signal)
+          response = attemptResult.response
+          responseBody = attemptResult.responseBody
         } catch (err) {
           lastError = err
+          if (options.signal?.aborted) {
+            throw err
+          }
+          if (dnsFailure && (!this.retry || !isTransientDnsError(err) || attempt === maxAttempts - 1)) {
+            throw err
+          }
           continue
         }
 
         if (!response.ok) {
-          const shouldReadBody = !this.retry || !isTransientStatus(response.status) || attempt === maxAttempts - 1
-          const responseBody = shouldReadBody ? await this.readResponseBody(response) : ''
           const bodySuffix = responseBody ? `: ${responseBody}` : ''
           lastError = new Error(
             `Webhook delivery failed: ${response.status}${response.statusText ? ` ${response.statusText}` : ''} for ${sanitizeWebhookEndpoint(this.url)}${bodySuffix}`,
@@ -669,7 +775,10 @@ export class WebhookNotifier {
     }
   }
 
-  private async readResponseBody(response: WebhookFetchResponse): Promise<string> {
+  private async readResponseBody(
+    response: WebhookFetchResponse,
+    signal?: AbortSignal,
+  ): Promise<string> {
     try {
       const readable = response as {
         body?: ({ getReader?: () => ReadableStreamDefaultReader<Uint8Array> } & Partial<AsyncIterable<Uint8Array | Buffer | string>>) | null
@@ -677,19 +786,25 @@ export class WebhookNotifier {
       }
       const body = readable.body
         ? typeof readable.body.getReader === 'function'
-          ? await this.readBoundedStream(readable.body as ReadableStream<Uint8Array>)
-          : await this.readBoundedAsyncIterable(readable.body)
+          ? await this.readBoundedStream(readable.body as ReadableStream<Uint8Array>, signal)
+          : await this.readBoundedAsyncIterable(readable.body, signal)
         : ''
       const redactedBody = redactWebhookSecrets(body)
       return redactedBody.length > MAX_ERROR_BODY_CHARS
         ? `${redactedBody.slice(0, MAX_ERROR_BODY_CHARS)}…`
         : redactedBody
     } catch {
+      if (signal?.aborted) {
+        throw abortReason(signal)
+      }
       return ''
     }
   }
 
-  private async readBoundedStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  private async readBoundedStream(
+    stream: ReadableStream<Uint8Array>,
+    signal?: AbortSignal,
+  ): Promise<string> {
     const reader = stream.getReader()
     const chunks: Uint8Array[] = []
     let totalBytes = 0
@@ -708,14 +823,14 @@ export class WebhookNotifier {
         const timeout = new Promise<{ done: true; value?: undefined; timedOut: true }>(resolve => {
           timeoutId = setTimeout(() => resolve({ done: true, timedOut: true }), remainingMs)
         })
-        const result = await Promise.race([
+        const result = await awaitWithSignal(Promise.race([
           reader.read().then(read => ({ ...read, timedOut: false as const })),
           timeout,
         ]).finally(() => {
           if (timeoutId) {
             clearTimeout(timeoutId)
           }
-        })
+        }), signal)
         if (result.timedOut) {
           timedOut = true
           break
@@ -734,10 +849,10 @@ export class WebhookNotifier {
           break
         }
       }
-      if (truncated || timedOut) {
-        await reader.cancel()
-      }
     } finally {
+      if (truncated || timedOut || signal?.aborted) {
+        await reader.cancel().catch(() => undefined)
+      }
       reader.releaseLock()
     }
 
@@ -745,7 +860,7 @@ export class WebhookNotifier {
     return truncated || timedOut ? `${decoded}…` : decoded
   }
 
-  private async readBoundedAsyncIterable(body: unknown): Promise<string> {
+  private async readBoundedAsyncIterable(body: unknown, signal?: AbortSignal): Promise<string> {
     const iterable = body && typeof body === 'object'
       ? body as AsyncIterable<Uint8Array | Buffer | string>
       : undefined
@@ -761,49 +876,56 @@ export class WebhookNotifier {
     let timedOut = false
     const deadlineMs = Date.now() + ERROR_BODY_READ_TIMEOUT_MS
 
-    while (totalBytes < MAX_ERROR_BODY_CHARS) {
-      const remainingMs = deadlineMs - Date.now()
-      if (remainingMs <= 0) {
-        timedOut = true
-        break
+    try {
+      while (totalBytes < MAX_ERROR_BODY_CHARS) {
+        const remainingMs = deadlineMs - Date.now()
+        if (remainingMs <= 0) {
+          timedOut = true
+          break
+        }
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        const pendingRead = Promise.race<IteratorResult<Uint8Array | Buffer | string> | 'timeout'>([
+          iterator.next(),
+          new Promise<'timeout'>(resolve => {
+            timeoutId = setTimeout(() => resolve('timeout'), remainingMs)
+          }),
+        ]).finally(() => {
+          if (timeoutId) clearTimeout(timeoutId)
+        })
+        const result = await awaitWithSignal(pendingRead, signal)
+        if (result === 'timeout') {
+          timedOut = true
+          break
+        }
+        if (result.done || result.value === undefined) {
+          break
+        }
+        const bytes = typeof result.value === 'string'
+          ? Buffer.from(result.value)
+          : Buffer.from(result.value)
+        const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes
+        if (bytes.byteLength > remainingBytes) {
+          chunks.push(bytes.subarray(0, remainingBytes))
+          totalBytes += remainingBytes
+          truncated = true
+          break
+        }
+        chunks.push(bytes)
+        totalBytes += bytes.byteLength
       }
-      let timeoutId: ReturnType<typeof setTimeout> | undefined
-      const result = await Promise.race<IteratorResult<Uint8Array | Buffer | string> | 'timeout'>([
-        iterator.next(),
-        new Promise<'timeout'>(resolve => {
-          timeoutId = setTimeout(() => resolve('timeout'), remainingMs)
-        }),
-      ]).finally(() => {
-        if (timeoutId) clearTimeout(timeoutId)
-      })
-      if (result === 'timeout') {
-        timedOut = true
-        break
+    } finally {
+      if (truncated || timedOut || signal?.aborted) {
+        ;(body as { destroy?: () => void })?.destroy?.()
+        const cleanup = iterator.return?.(undefined)
+        if (cleanup && typeof (cleanup as Promise<IteratorResult<Uint8Array | Buffer | string>>).catch === 'function') {
+          void (cleanup as Promise<IteratorResult<Uint8Array | Buffer | string>>).catch(() => undefined)
+        }
       }
-      if (result.done || result.value === undefined) {
-        break
-      }
-      const bytes = typeof result.value === 'string' ? Buffer.from(result.value) : Buffer.from(result.value)
-      const remainingBytes = MAX_ERROR_BODY_CHARS - totalBytes
-      if (bytes.byteLength > remainingBytes) {
-        chunks.push(bytes.subarray(0, remainingBytes))
-        totalBytes += remainingBytes
-        truncated = true
-        break
-      }
-      chunks.push(bytes)
-      totalBytes += bytes.byteLength
     }
 
-    if (truncated || timedOut) {
-      ;(body as { destroy?: () => void })?.destroy?.()
-      const cleanup = iterator.return?.(undefined)
-      if (cleanup && typeof (cleanup as Promise<IteratorResult<Uint8Array | Buffer | string>>).catch === 'function') {
-        void (cleanup as Promise<IteratorResult<Uint8Array | Buffer | string>>).catch(() => undefined)
-      }
-    }
-
-    const decoded = new TextDecoder().decode(Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS)).trim()
+    const decoded = new TextDecoder().decode(
+      Buffer.concat(chunks).subarray(0, MAX_ERROR_BODY_CHARS),
+    ).trim()
     return truncated || timedOut ? `${decoded}…` : decoded
   }
 
@@ -845,6 +967,48 @@ export class WebhookNotifier {
     throw lastError
   }
 
+  private async runWithDeliveryDeadline<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
+    callerSignal?: AbortSignal,
+  ): Promise<T> {
+    if (callerSignal?.aborted) {
+      throw abortReason(callerSignal)
+    }
+
+    const controller = new AbortController()
+    const timeoutError = new WebhookDeliveryTimeoutError(this.deliveryTimeoutMs)
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let onCallerAbort: (() => void) | undefined
+    const interrupted = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        controller.abort(timeoutError)
+        reject(timeoutError)
+      }, this.deliveryTimeoutMs)
+      if (callerSignal) {
+        onCallerAbort = () => {
+          const reason = abortReason(callerSignal)
+          controller.abort(reason)
+          reject(reason)
+        }
+        callerSignal.addEventListener('abort', onCallerAbort, { once: true })
+      }
+    })
+
+    try {
+      return await Promise.race([
+        operation(controller.signal),
+        interrupted,
+      ])
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+      }
+      if (callerSignal && onCallerAbort) {
+        callerSignal.removeEventListener('abort', onCallerAbort)
+      }
+    }
+  }
+
   private async fetchWithPinnedAddress(address: string, init: WebhookFetchInit): Promise<WebhookFetchResponse> {
     const originalHostname = normalizeHostnameForValidation(this.parsedUrl.hostname)
     const body = typeof init.body === 'string' ? init.body : init.body ? String(init.body) : undefined
@@ -861,6 +1025,7 @@ export class WebhookNotifier {
           ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
         },
       }, response => {
+        init.signal?.removeEventListener('abort', onAbort)
         resolve({
           ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
           status: response.statusCode ?? 0,
@@ -868,7 +1033,20 @@ export class WebhookNotifier {
           body: response as unknown as NonNullable<WebhookFetchResponse['body']>,
         })
       })
-      request.on('error', reject)
+      const onAbort = () => {
+        const reason = abortReason(init.signal!)
+        request.destroy(reason instanceof Error ? reason : undefined)
+        reject(reason)
+      }
+      request.on('error', error => {
+        init.signal?.removeEventListener('abort', onAbort)
+        reject(error)
+      })
+      if (init.signal?.aborted) {
+        onAbort()
+        return
+      }
+      init.signal?.addEventListener('abort', onAbort, { once: true })
       if (body) {
         request.write(body)
       }

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -514,3 +514,6 @@
 ## 2026-07-22 — Chat WebSocket reconnect lifecycle
 - Browser `1006` closes conflate rejected upgrades with transient setup outages; use a generous bounded setup-failure threshold, a lower explicit-authentication threshold, and reset counters only on the protocol-level ready event rather than socket open.
 - Reconnect ownership must cover timers and refresh promises: retry transient API failures through the same backoff controller, classify fatal HTTP statuses with structured errors, and route manual/online recovery through that controller so slow refreshes cannot race newer ticket requests.
+
+## 2026-07-22 — Webhook delivery deadlines and cancellation
+- A per-attempt webhook deadline must cover DNS resolution, transport, and bounded error-body reads—not stop at response headers. Caller cancellation must also interrupt DNS, active requests, response-body reads, and retry backoff, with owned timers and abort listeners removed on every terminal path.


### PR DESCRIPTION
## Summary
- add a configurable 10-second per-attempt deadline for webhook delivery
- propagate timeout and caller cancellation through DNS resolution, transport, response-body reads, and retry backoff
- validate timer bounds and clean up abort listeners/timers across terminal paths
- document the timeout option and add targeted regression coverage

## Test plan
- `npm test` (35 files, 897 tests)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 5 pre-existing warnings)
- `git diff --check`

Closes #2999