### PR TITLE
fix(web): bind approval decisions to rendered request

### DIFF
--- a/packages/franken-orchestrator/src/chat/approval-input.ts
+++ b/packages/franken-orchestrator/src/chat/approval-input.ts
@@ -1,4 +1,4 @@
-import type { PendingApproval } from '@franken/types';
+import type { ApprovalDecisionRequest, PendingApproval } from '@franken/types';
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
 const MAX_PENDING_APPROVAL_COMMAND_LENGTH = 4_096;
@@ -43,4 +43,15 @@ export function approvalRuntimeInput(pendingApproval: PendingApproval | null | u
   }
 
   return `/run ${normalizePendingCommand(pendingApproval.command)}`;
+}
+
+export function approvalDecisionMatches(
+  sessionId: string,
+  pendingApproval: PendingApproval,
+  request: ApprovalDecisionRequest,
+): boolean {
+  return (request.sessionId === undefined || request.sessionId === sessionId)
+    && (request.requestedAt === undefined || request.requestedAt === pendingApproval.requestedAt)
+    && (request.command === undefined || request.command === pendingApproval.command)
+    && (request.approvalToken === undefined || request.approvalToken === pendingApproval.approvalToken);
 }

--- a/packages/franken-orchestrator/src/http/routes/chat-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/chat-routes.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
-import { approvalRuntimeInput, UnsafeApprovalCommandError } from '../../chat/approval-input.js';
+import { approvalDecisionMatches, approvalRuntimeInput, UnsafeApprovalCommandError } from '../../chat/approval-input.js';
 import { FileApprovalAuditLog, commandSha256, type ApprovalAuditLog } from '../../chat/approval-audit-log.js';
 import { BeastDaemonRequestError } from '../../chat/beast-daemon-dispatch-adapter.js';
 import { isValidChatSessionId, type CorruptChatSessionFile, type ISessionStore } from '../../chat/session-store.js';
@@ -18,7 +18,7 @@ import type {
   MessageResult,
   TurnOutcome,
 } from '@franken/types';
-import { isoNow, MAX_CHAT_MESSAGE_CONTENT_LENGTH } from '@franken/types';
+import { ApprovalDecisionRequestSchema, isoNow, MAX_CHAT_MESSAGE_CONTENT_LENGTH } from '@franken/types';
 import { HttpError, parseJsonBody, validateBody } from '../middleware.js';
 import { createSseHandler } from '../sse.js';
 import type { SseConnectionTicketStore } from '../../beasts/events/sse-connection-ticket.js';
@@ -37,6 +37,7 @@ const SubmitMessageBody = z.object({
 
 const ApproveBody = z.object({
   approved: z.boolean(),
+  request: ApprovalDecisionRequestSchema.optional(),
 }).strict();
 
 export interface ChatRoutesDeps {
@@ -461,8 +462,17 @@ export function chatRoutes(deps: ChatRoutesDeps): Hono {
   app.post('/v1/chat/sessions/:id/approve', async (c) => {
     const id = validateChatSessionId(c.req.param('id'));
     const body = await parseJsonBody(c);
-    const { approved } = validateBody(ApproveBody, body);
+    const { approved, request } = validateBody(ApproveBody, body);
     return withChatMutationAdmission(c, id, async (session) => {
+      if (session.pendingApproval && request && !approvalDecisionMatches(session.id, session.pendingApproval, request)) {
+        return c.json({
+          error: {
+            code: 'APPROVAL_REQUEST_CHANGED',
+            message: 'The pending approval changed before this decision was submitted. Review the current request and try again.',
+          },
+        }, 409);
+      }
+
       if (!session.pendingApproval) {
         if (session.state === 'approved' || session.state === 'rejected') {
           return c.json({

--- a/packages/franken-orchestrator/src/http/ws-chat-server.ts
+++ b/packages/franken-orchestrator/src/http/ws-chat-server.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, Server as HttpServer } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { WebSocketServer, type RawData, type WebSocket } from 'ws';
-import { approvalRuntimeInput, UnsafeApprovalCommandError } from '../chat/approval-input.js';
+import { approvalDecisionMatches, approvalRuntimeInput, UnsafeApprovalCommandError } from '../chat/approval-input.js';
 import {
   FileApprovalAuditLog,
   commandSha256,
@@ -17,7 +17,7 @@ import {
   ChatSocketSessionTicketStore,
   verifyChatSocketRequest,
 } from './ws-chat-auth.js';
-import { ClientSocketEventSchema, type ChatSessionResponse, type ProviderContext, type TokenUsage, deterministicUuid, isoNow } from '@franken/types';
+import { ClientSocketEventSchema, type ApprovalDecisionRequest, type ClientSocketEvent, type ChatSessionResponse, type ProviderContext, type TokenUsage, deterministicUuid, isoNow } from '@franken/types';
 import { InMemoryRateLimiter } from '../beasts/http/beast-rate-limit.js';
 import { ChatMutationAdmission, chatClientKey, createChatRateLimiter, DEFAULT_CHAT_RATE_LIMIT, type ChatRateLimitOptions } from './chat-rate-limit.js';
 
@@ -35,12 +35,6 @@ interface ConnectionState {
   /** Client opted in (via ?features=usage-stats) to `usage`/`truncated` on completions. */
   supportsUsageStats: boolean;
 }
-
-type ClientSocketEvent =
-  | { type: 'message.send'; clientMessageId: string; content: string; executionMode?: 'process' | 'container' | undefined }
-  | { type: 'approval.respond'; approved: boolean }
-  | { type: 'message.read'; messageId: string }
-  | { type: 'ping' };
 
 type ServerSocketEvent = {
   eventId?: string | undefined;
@@ -396,7 +390,7 @@ export class ChatSocketController {
         if ((session.pendingApproval || session.state === 'pending_approval') && !this.takeChatRateLimit(peer, connection)) {
           return;
         }
-        await this.runWithSessionTurn(peer, session, () => this.handleApproval(peer, session, event.approved));
+        await this.runWithSessionTurn(peer, session, () => this.handleApproval(peer, session, event.approved, event.request));
         return;
       case 'message.read':
         this.emit(peer, {
@@ -599,6 +593,7 @@ export class ChatSocketController {
     peer: ChatSocketPeer,
     session: ChatSession,
     approved: boolean,
+    request?: ApprovalDecisionRequest,
   ): Promise<void> {
     if (!session.pendingApproval) {
       if (session.state === 'pending_approval') {
@@ -633,6 +628,16 @@ export class ChatSocketController {
       this.emit(peer, {
         type: 'turn.approval.resolved',
         approved: session.state !== 'rejected',
+        timestamp: nowIso(),
+      });
+      return;
+    }
+
+    if (request && !approvalDecisionMatches(session.id, session.pendingApproval, request)) {
+      this.emit(peer, {
+        type: 'turn.error',
+        code: 'APPROVAL_REQUEST_CHANGED',
+        message: 'The pending approval changed before this decision was submitted. Review the current request and try again.',
         timestamp: nowIso(),
       });
       return;

--- a/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
+++ b/packages/franken-orchestrator/tests/integration/chat/ws-chat-server.test.ts
@@ -1233,6 +1233,58 @@ describe('ws chat server', () => {
     rmSync(TMP, { recursive: true, force: true });
   });
 
+  it('rejects a WebSocket decision captured for an older approval request', async () => {
+    mkdirSync(TMP, { recursive: true });
+    const store = new FileSessionStore(TMP);
+    const session = store.create('proj');
+    session.state = 'pending_approval';
+    session.pendingApproval = {
+      description: 'deploy staging',
+      requestedAt: '2026-03-09T00:00:00Z',
+      command: 'deploy staging',
+      sessionId: session.id,
+    };
+    store.save(session);
+    const secret = createSessionTokenSecret();
+    const token = issueSessionToken({ expiresInMs: CHAT_SOCKET_TOKEN_TTL_MS, secret, sessionId: session.id });
+    const execute = vi.fn();
+    const controller = new ChatSocketController({
+      runtime: new ChatRuntime({
+        engine: { processTurn: vi.fn() } as unknown as ConversationEngine,
+        turnRunner: new TurnRunner({ execute }),
+      }),
+      sessionStore: store,
+      tokenSecret: secret,
+    });
+    const { peer, sent } = createPeer();
+    expect(controller.connect(peer, {
+      origin: null,
+      sessionId: session.id,
+      token,
+    }).ok).toBe(true);
+
+    await controller.receive(peer, JSON.stringify({
+      type: 'approval.respond',
+      approved: true,
+      request: {
+        sessionId: session.id,
+        requestedAt: '2026-03-08T23:59:00Z',
+        command: 'deploy staging',
+      },
+    }));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(store.get(session.id)?.pendingApproval).toEqual(session.pendingApproval);
+    expect(sent.map((raw) => JSON.parse(raw) as Record<string, unknown>)).toContainEqual(
+      expect.objectContaining({
+        type: 'turn.error',
+        code: 'APPROVAL_REQUEST_CHANGED',
+      }),
+    );
+
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
   it('does not execute the same approved action twice for duplicate approval frames', async () => {
     mkdirSync(TMP, { recursive: true });
     const store = new FileSessionStore(TMP);

--- a/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/chat-routes-approval.test.ts
@@ -58,6 +58,43 @@ describe('chat approval route persistence', () => {
     expect(stored?.pendingApproval).toBeUndefined();
   });
 
+  it('rejects an HTTP decision captured for an older approval request', async () => {
+    const runtime = { run: vi.fn() };
+    const app = createChatApp({
+      sessionStore,
+      engine: {} as never,
+      runtime: runtime as never,
+      turnRunner: {} as never,
+    });
+    const session = pendingApprovalSession(sessionStore.create('project-1'));
+    session.pendingApproval = {
+      ...session.pendingApproval!,
+      command: 'npm run deploy',
+      approvalToken: 'approval-token-current',
+    };
+    sessionStore.save(session);
+
+    const response = await app.request(`/v1/chat/sessions/${session.id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        approved: true,
+        request: {
+          requestedAt: '2026-07-07T15:23:06.000Z',
+          command: 'npm run deploy',
+          approvalToken: 'approval-token-stale',
+        },
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { error: { code: string } };
+    expect(body.error.code).toBe('APPROVAL_REQUEST_CHANGED');
+    expect(runtime.run).not.toHaveBeenCalled();
+    expect(sessionStore.get(session.id)?.pendingApproval?.requestedAt)
+      .toBe('2026-07-07T15:23:06.000Z');
+  });
+
   it('rejects stale state-only HTTP approval responses without changing session state', async () => {
     const app = createChatApp({
       sessionStore,

--- a/packages/franken-types/src/api-contracts.ts
+++ b/packages/franken-types/src/api-contracts.ts
@@ -24,6 +24,17 @@ export type PendingApproval = z.infer<typeof PendingApprovalSchema> & {
   workdir?: string | undefined;
 };
 
+export const ApprovalDecisionRequestSchema = z.object({
+  sessionId: z.string().min(1).optional(),
+  requestedAt: z.string().min(1).optional(),
+  command: z.string().optional(),
+  approvalToken: z.string().min(1).optional(),
+}).strict().refine(
+  (request) => Object.values(request).some((value) => value !== undefined),
+  { message: 'Approval request identity must include at least one field.' },
+);
+export type ApprovalDecisionRequest = z.infer<typeof ApprovalDecisionRequestSchema>;
+
 export const TranscriptMessageSchema = z.object({
   id: z.string().optional(),
   role: z.enum(['user', 'assistant', 'system']),

--- a/packages/franken-types/src/comms.ts
+++ b/packages/franken-types/src/comms.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { TokenUsageSchema } from './provider.js';
-import { ProviderContextSchema } from './api-contracts.js';
+import { ApprovalDecisionRequestSchema, ProviderContextSchema } from './api-contracts.js';
 
 // Keep below the default 16 KiB HTTP body cap so the JSON envelope has
 // headroom while REST and WebSocket enforce one shared content limit.
@@ -16,6 +16,7 @@ export const ClientSocketEventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('approval.respond'),
     approved: z.boolean(),
+    request: ApprovalDecisionRequestSchema.optional(),
   }).strict(),
   z.object({
     type: z.literal('message.read'),

--- a/packages/franken-web/src/components/approval-card.tsx
+++ b/packages/franken-web/src/components/approval-card.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { PendingApproval } from '../lib/api';
-
-export interface ApprovalDecisionScope {
-  sessionId?: string;
-  requestedAt?: string;
-  command?: string;
-}
+import type { ApprovalDecisionRequest, PendingApproval } from '../lib/api';
 
 export interface ApprovalCardProps {
   pending: boolean;
@@ -14,8 +8,8 @@ export interface ApprovalCardProps {
   resolving?: boolean;
   error?: string | null;
   sessionId?: string | null;
-  onApprove: (scope: ApprovalDecisionScope) => void;
-  onReject: (scope: ApprovalDecisionScope) => void;
+  onApprove: (scope: ApprovalDecisionRequest) => void;
+  onReject: (scope: ApprovalDecisionRequest) => void;
 }
 
 function formatRequestedAt(value: string): string {
@@ -70,10 +64,11 @@ export function ApprovalCard({
     approval?.requestedAt ?? null,
     approval?.command ?? null,
   ]);
-  const decisionScope: ApprovalDecisionScope = {
+  const decisionScope: ApprovalDecisionRequest = {
     ...(effectiveSessionId ? { sessionId: effectiveSessionId } : {}),
     ...(approval?.requestedAt ? { requestedAt: approval.requestedAt } : {}),
     ...(approval?.command ? { command: approval.command } : {}),
+    ...(approval?.approvalToken ? { approvalToken: approval.approvalToken } : {}),
   };
   const submittedRequestKeyRef = useRef<string | null>(null);
   const [submittedRequestKey, setSubmittedRequestKey] = useState<string | null>(null);
@@ -87,7 +82,7 @@ export function ApprovalCard({
     }
   }, [error, requestKey]);
 
-  function submitDecision(callback: (scope: ApprovalDecisionScope) => void) {
+  function submitDecision(callback: (scope: ApprovalDecisionRequest) => void) {
     if (resolving || submittedRequestKeyRef.current === requestKey) {
       return;
     }

--- a/packages/franken-web/src/components/approval-card.tsx
+++ b/packages/franken-web/src/components/approval-card.tsx
@@ -1,4 +1,11 @@
+import { useEffect, useRef, useState } from 'react';
 import type { PendingApproval } from '../lib/api';
+
+export interface ApprovalDecisionScope {
+  sessionId?: string;
+  requestedAt?: string;
+  command?: string;
+}
 
 export interface ApprovalCardProps {
   pending: boolean;
@@ -7,8 +14,8 @@ export interface ApprovalCardProps {
   resolving?: boolean;
   error?: string | null;
   sessionId?: string | null;
-  onApprove: () => void;
-  onReject: () => void;
+  onApprove: (scope: ApprovalDecisionScope) => void;
+  onReject: (scope: ApprovalDecisionScope) => void;
 }
 
 function formatRequestedAt(value: string): string {
@@ -58,6 +65,43 @@ export function ApprovalCard({
 }: ApprovalCardProps) {
   const approvalDescription = approval?.description ?? description ?? '';
   const effectiveSessionId = approval?.sessionId ?? sessionId ?? undefined;
+  const requestKey = approval?.approvalToken ?? JSON.stringify([
+    effectiveSessionId ?? null,
+    approval?.requestedAt ?? null,
+    approval?.command ?? null,
+  ]);
+  const decisionScope: ApprovalDecisionScope = {
+    ...(effectiveSessionId ? { sessionId: effectiveSessionId } : {}),
+    ...(approval?.requestedAt ? { requestedAt: approval.requestedAt } : {}),
+    ...(approval?.command ? { command: approval.command } : {}),
+  };
+  const submittedRequestKeyRef = useRef<string | null>(null);
+  const [submittedRequestKey, setSubmittedRequestKey] = useState<string | null>(null);
+  const locallySubmitting = submittedRequestKey === requestKey;
+  const isSubmitting = resolving || locallySubmitting;
+
+  useEffect(() => {
+    if (error && submittedRequestKeyRef.current === requestKey) {
+      submittedRequestKeyRef.current = null;
+      setSubmittedRequestKey(null);
+    }
+  }, [error, requestKey]);
+
+  function submitDecision(callback: (scope: ApprovalDecisionScope) => void) {
+    if (resolving || submittedRequestKeyRef.current === requestKey) {
+      return;
+    }
+
+    submittedRequestKeyRef.current = requestKey;
+    setSubmittedRequestKey(requestKey);
+    try {
+      callback(decisionScope);
+    } catch (error) {
+      submittedRequestKeyRef.current = null;
+      setSubmittedRequestKey(null);
+      throw error;
+    }
+  }
 
   return (
     <section
@@ -77,7 +121,7 @@ export function ApprovalCard({
       {!pending ? (
         <p className="rail-card__empty">No approval required.</p>
       ) : (
-        <div aria-busy={resolving}>
+        <div aria-busy={isSubmitting}>
           <p className="approval-card__description">{approvalDescription}</p>
           <dl className="approval-card__details" aria-label="Approval context">
             <DetailRow label="Tool" children={approval?.tool} />
@@ -87,7 +131,7 @@ export function ApprovalCard({
             <DetailRow label="Affected files" children={approval?.affectedFiles} />
             <DetailRow label="Session" children={effectiveSessionId} />
           </dl>
-          {resolving ? (
+          {isSubmitting ? (
             <p className="approval-card__status" role="status">
               Waiting for approval response…
             </p>
@@ -98,10 +142,10 @@ export function ApprovalCard({
             </p>
           ) : null}
           <div className="approval-card__actions">
-            <button className="button button--primary" disabled={resolving} onClick={onApprove}>
-              {resolving ? 'Submitting…' : 'Approve'}
+            <button className="button button--primary" disabled={isSubmitting} onClick={() => submitDecision(onApprove)}>
+              {isSubmitting ? 'Submitting…' : 'Approve'}
             </button>
-            <button className="button button--secondary" disabled={resolving} onClick={onReject}>Reject</button>
+            <button className="button button--secondary" disabled={isSubmitting} onClick={() => submitDecision(onReject)}>Reject</button>
           </div>
         </div>
       )}

--- a/packages/franken-web/src/components/chat-shell.tsx
+++ b/packages/franken-web/src/components/chat-shell.tsx
@@ -995,11 +995,11 @@ export function ChatShell({ baseUrl, projectId, sessionId, version }: ChatShellP
                 resolving={approvalResolving}
                 error={approvalError}
                 sessionId={activeSessionId}
-                onApprove={() => {
-                  void approve(true);
+                onApprove={(request) => {
+                  void approve(true, request);
                 }}
-                onReject={() => {
-                  void approve(false);
+                onReject={(request) => {
+                  void approve(false, request);
                 }}
               />
             </aside>

--- a/packages/franken-web/src/hooks/chat-session-types.ts
+++ b/packages/franken-web/src/hooks/chat-session-types.ts
@@ -1,4 +1,4 @@
-import type { PendingApproval, TokenTotals } from '@franken/types';
+import type { ApprovalDecisionRequest, PendingApproval, TokenTotals } from '@franken/types';
 
 export type SessionStatus = 'idle' | 'connecting' | 'sending' | 'streaming' | 'error';
 export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'offline' | 'error';
@@ -43,7 +43,7 @@ export interface UseChatSessionOptions {
 
 export interface UseChatSessionResult {
   activity: ActivityEvent[];
-  approve: (approved: boolean) => Promise<void>;
+  approve: (approved: boolean, request?: ApprovalDecisionRequest) => Promise<void>;
   approvalError: string | null;
   approvalResolving: boolean;
   connectionStatus: ConnectionStatus;

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   ChatApiClient,
   ChatApiError,
+  type ApprovalDecisionRequest,
   type PendingApproval,
   type TokenTotals,
   type TranscriptMessage,
@@ -799,7 +800,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     await send(message.content);
   }
 
-  async function approve(approved: boolean): Promise<void> {
+  async function approve(approved: boolean, request?: ApprovalDecisionRequest): Promise<void> {
     const socket = socketRef.current;
     if (!sessionId || approvalResolvingRef.current) {
       return;
@@ -812,7 +813,9 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     setStatus('sending');
     if (!socket || socket.readyState !== 1) {
       try {
-        const approvalResult = await clientRef.current.approve(sessionId, approved);
+        const approvalResult = request
+          ? await clientRef.current.approve(sessionId, approved, request)
+          : await clientRef.current.approve(sessionId, approved);
         const refreshed = await clientRef.current.getSession(sessionId);
         readyRef.current = true;
         setMessages((current) => {
@@ -862,6 +865,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
     socket.send(JSON.stringify({
       type: 'approval.respond',
       approved,
+      ...(request ? { request } : {}),
     }));
     approvalTimeoutRef.current = setTimeout(() => {
       approvalTimeoutRef.current = null;

--- a/packages/franken-web/src/hooks/use-chat-session.ts
+++ b/packages/franken-web/src/hooks/use-chat-session.ts
@@ -862,11 +862,7 @@ export function useChatSession(opts: UseChatSessionOptions): UseChatSessionResul
       return;
     }
 
-    socket.send(JSON.stringify({
-      type: 'approval.respond',
-      approved,
-      ...(request ? { request } : {}),
-    }));
+    socket.send(JSON.stringify({ type: 'approval.respond', approved, ...(request ? { request } : {}) }));
     approvalTimeoutRef.current = setTimeout(() => {
       approvalTimeoutRef.current = null;
       reconcileApprovalResponse(sessionId, approvalAttempt, approved);

--- a/packages/franken-web/src/lib/api.ts
+++ b/packages/franken-web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   ApiDataEnvelope,
   ApiErrorEnvelope,
+  ApprovalDecisionRequest,
   ApproveResult,
   ChatSocketTicketResponse,
   ChatSessionResponse as ChatSession,
@@ -13,6 +14,7 @@ import type {
 } from '@franken/types';
 
 export type {
+  ApprovalDecisionRequest,
   ApproveResult,
   ChatSessionSummary,
   MessageResult,
@@ -153,13 +155,17 @@ export class ChatApiClient {
     );
   }
 
-  async approve(sessionId: string, approved: boolean): Promise<ApproveResult> {
+  async approve(
+    sessionId: string,
+    approved: boolean,
+    request?: ApprovalDecisionRequest,
+  ): Promise<ApproveResult> {
     return this.request<ApproveResult>(
       `/v1/chat/sessions/${encodeURIComponent(sessionId)}/approve`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ approved }),
+        body: JSON.stringify({ approved, ...(request ? { request } : {}) }),
       },
     );
   }

--- a/packages/franken-web/tests/components/approval-card.test.tsx
+++ b/packages/franken-web/tests/components/approval-card.test.tsx
@@ -83,6 +83,40 @@ describe('ApprovalCard', () => {
     expect(screen.getByRole('button', { name: /reject/i })).toBeTruthy();
   });
 
+  it('binds the first decision to the rendered approval and suppresses replay', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+
+    render(
+      <ApprovalCard
+        pending
+        approval={{
+          description: 'Approve deploy',
+          requestedAt: '2026-07-23T20:00:00Z',
+          command: 'npm run deploy',
+          sessionId: 'sess-approval-1',
+        }}
+        onApprove={onApprove}
+        onReject={onReject}
+      />,
+    );
+
+    const approveButton = screen.getByRole('button', { name: /approve/i });
+    fireEvent.click(approveButton);
+    fireEvent.click(approveButton);
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onApprove).toHaveBeenCalledWith({
+      command: 'npm run deploy',
+      requestedAt: '2026-07-23T20:00:00Z',
+      sessionId: 'sess-approval-1',
+    });
+    expect(onReject).not.toHaveBeenCalled();
+    expect(approveButton.hasAttribute('disabled')).toBe(true);
+    expect(screen.getByRole('button', { name: /reject/i }).hasAttribute('disabled')).toBe(true);
+  });
+
   it('disables actions while resolving and exposes inline errors for retry', () => {
     const onApprove = vi.fn();
     const onReject = vi.fn();

--- a/packages/franken-web/tests/components/approval-card.test.tsx
+++ b/packages/franken-web/tests/components/approval-card.test.tsx
@@ -95,6 +95,7 @@ describe('ApprovalCard', () => {
           requestedAt: '2026-07-23T20:00:00Z',
           command: 'npm run deploy',
           sessionId: 'sess-approval-1',
+          approvalToken: 'approval-token-1',
         }}
         onApprove={onApprove}
         onReject={onReject}
@@ -108,6 +109,7 @@ describe('ApprovalCard', () => {
 
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith({
+      approvalToken: 'approval-token-1',
       command: 'npm run deploy',
       requestedAt: '2026-07-23T20:00:00Z',
       sessionId: 'sess-approval-1',

--- a/packages/franken-web/tests/hooks/use-chat-session.test.ts
+++ b/packages/franken-web/tests/hooks/use-chat-session.test.ts
@@ -1055,6 +1055,7 @@ describe('useChatSession', () => {
       socket.message({
         type: 'turn.approval.requested',
         description: 'Deploy the generated fix',
+        command: 'npm run deploy',
         timestamp: '2026-03-09T00:00:06Z',
       });
     });
@@ -1063,12 +1064,19 @@ describe('useChatSession', () => {
     expect(result.current.sessionState).toBe('pending_approval');
 
     await act(async () => {
-      await result.current.approve(true);
+      await result.current.approve(true, {
+        requestedAt: '2026-03-09T00:00:06Z',
+        command: 'npm run deploy',
+      });
     });
 
     expect(JSON.parse(socket.sent[0] ?? '{}')).toMatchObject({
       type: 'approval.respond',
       approved: true,
+      request: {
+        requestedAt: '2026-03-09T00:00:06Z',
+        command: 'npm run deploy',
+      },
     });
 
     act(() => {

--- a/packages/franken-web/tests/lib/api.test.ts
+++ b/packages/franken-web/tests/lib/api.test.ts
@@ -246,7 +246,7 @@ describe('ChatApiClient', () => {
   });
 
   describe('approve', () => {
-    it('sends POST to /v1/chat/sessions/:id/approve with approved flag', async () => {
+    it('sends POST to /v1/chat/sessions/:id/approve with the rendered request scope', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -255,7 +255,10 @@ describe('ChatApiClient', () => {
           }),
       });
 
-      const result = await client.approve('sess-1', true);
+      const result = await client.approve('sess-1', true, {
+        requestedAt: '2026-07-23T20:00:00Z',
+        command: 'npm run deploy',
+      });
       expect(result.approved).toBe(true);
       expect(result.state).toBe('approved');
       expect(mockFetch).toHaveBeenCalledWith(
@@ -263,7 +266,13 @@ describe('ChatApiClient', () => {
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ approved: true }),
+          body: JSON.stringify({
+            approved: true,
+            request: {
+              requestedAt: '2026-07-23T20:00:00Z',
+              command: 'npm run deploy',
+            },
+          }),
         }),
       );
     });

--- a/tasks/issue-3663-approval-request-binding-progress.md
+++ b/tasks/issue-3663-approval-request-binding-progress.md
@@ -1,0 +1,13 @@
+# Issue #3663 Approval Request Binding Progress
+
+- [x] Reconfirm live PR #3712 head, CI state, and exact Codex finding.
+- [x] Preserve and run the prior worker's focused red-capable tests.
+- [x] Trace approval scope through ApprovalCard, ChatShell, useChatSession, REST, WebSocket, and server handlers.
+- [x] Thread the rendered approval request identity through browser REST/WebSocket clients.
+- [x] Validate captured request identity against the current pending approval before server-side resolution.
+- [x] Add focused REST, WebSocket, client, hook, and component regression coverage.
+- [x] Run targeted tests plus relevant package typecheck/lint/build.
+- [ ] Commit and push the review fix through the approved issue branch.
+- [ ] Reply to and resolve the Codex thread; trigger and obtain current-head Codex clean.
+- [ ] Verify exact-head CI green and squash-merge PR #3712.
+- [ ] Record reusable lessons and complete Kanban task t_bd13f736.


### PR DESCRIPTION
## Summary
- bind approval callbacks to the rendered session/request timestamp/command/token scope
- lock both approval controls synchronously after the first decision
- carry approval identity over REST and WebSocket and reject stale decisions server-side
- preserve retry behavior after an inline approval error
- add component, hook, API, REST, and WebSocket regression coverage

## Test plan
- `npm test --workspace @franken/web -- --run tests/components/approval-card.test.tsx tests/hooks/use-chat-session.test.ts tests/lib/api.test.ts` (77 passed)
- `npm test --workspace @franken/orchestrator -- --run tests/unit/http/chat-routes-approval.test.ts tests/integration/chat/ws-chat-server.test.ts` (55 passed)
- `npm run typecheck --workspace @franken/types`
- `npm run typecheck --workspace @franken/web`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/web` (0 errors; pre-existing warnings)
- `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)
- `npm run build --workspace @franken/web`
- `npm run build --workspace @franken/orchestrator`

Closes #3663
