### PR TITLE
fix(mcp-suite): fail closed on unreadable hook context

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.test.ts
@@ -50,6 +50,24 @@ describe('runHook', () => {
     expect(governorCheck).not.toHaveBeenCalled();
   });
 
+  it('continues post-tool auditing when the context file cannot be read', async () => {
+    const missingContextFile = join(tmpdir(), `fbeast-missing-post-context-${process.pid}`);
+    vi.stubEnv(TOOL_CONTEXT_FILE_ENV, missingContextFile);
+    const deps = defaultHookDeps();
+    const observerLog = vi.fn().mockResolvedValue(undefined);
+    deps.observer.log = observerLog;
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await expect(runHook([
+      'post-tool',
+      'benign-tool',
+      '{"ok":true}',
+    ], deps)).resolves.toBeUndefined();
+    expect(observerLog).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'tool_call',
+    }));
+  });
+
   it('redacts retention-report post-tool payloads before observer logging', async () => {
     const { deps, log } = hookDeps();
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);

--- a/packages/franken-mcp-suite/src/cli/hook.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.test.ts
@@ -1,5 +1,12 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { runHook, type HookDeps } from './hook.js';
+import {
+  defaultHookDeps,
+  runHook,
+  TOOL_CONTEXT_FILE_ENV,
+  type HookDeps,
+} from './hook.js';
 
 function hookDeps() {
   const log = vi.fn().mockResolvedValue(undefined);
@@ -24,7 +31,23 @@ function hookDeps() {
 describe('runHook', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     process.exitCode = undefined;
+  });
+
+  it('fails closed when the configured context file cannot be read', async () => {
+    const missingContextFile = join(tmpdir(), `fbeast-missing-context-${process.pid}`);
+    vi.stubEnv(TOOL_CONTEXT_FILE_ENV, missingContextFile);
+    const deps = defaultHookDeps();
+    const governorCheck = vi.fn().mockResolvedValue({ decision: 'approved', reason: 'ok' });
+    deps.governor.check = governorCheck;
+
+    await expect(runHook([
+      'pre-tool',
+      'benign-tool',
+      'legacy-positional-context',
+    ], deps)).rejects.toThrow('Unable to read fbeast tool context file');
+    expect(governorCheck).not.toHaveBeenCalled();
   });
 
   it('redacts retention-report post-tool payloads before observer logging', async () => {

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -444,7 +444,15 @@ export async function runHook(
       ? await (resolvedDeps.readPostToolPayload?.() ?? readStdinPayload())
       : '';
     const rawPostPayload = payload || streamedPayload;
-    const hookArgs = hookArgsFromContext(resolvedDeps.readContext(), toolName);
+    let postToolContext = '';
+    try {
+      postToolContext = resolvedDeps.readContext();
+    } catch {
+      // Post-tool context enriches audit args but is not the enforcement input.
+      // Keep logging the completed tool call even if its context transport was
+      // removed or became unreadable after pre-tool authorization.
+    }
+    const hookArgs = hookArgsFromContext(postToolContext, toolName);
     const auditToolName = effectiveHookAuditTool(toolName, hookArgs);
     const outcome = hookAuditOutcomeFromPayload(auditToolName, rawPostPayload);
     await resolvedDeps.observer.log({

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -46,7 +46,10 @@ export function defaultHookDeps(dbPath?: string, configPath?: string): HookDeps 
         try {
           return readFileSync(contextFile, 'utf8');
         } catch {
-          return '';
+          // A configured context file is an enforcement boundary, not an
+          // optional source. Throw so pre-tool callers fail closed instead of
+          // governing an empty or legacy positional fallback.
+          throw new Error('Unable to read fbeast tool context file');
         }
       }
       return process.env[TOOL_CONTEXT_ENV] ?? '';


### PR DESCRIPTION
## Summary
- Treat a configured but unreadable `FBEAST_TOOL_CONTEXT_FILE` as a hard hook failure
- Prevent pre-tool governance from falling back to empty or legacy positional context
- Add a regression proving the governor is never called when context acquisition fails

## Verification
- `npm run test --workspace @franken/mcp-suite` (614 passed)
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite` (0 errors; 26 pre-existing warnings)
- `npm run build`
- `node scripts/check-hardcoded-secrets.mjs`

Closes #3665