### PR TITLE
docs(chat): define Hive Brain command center

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,6 +459,24 @@ The shipped HTTP server is integrated in `@franken/orchestrator`:
 
 The old standalone Firewall/Critique/Governor HTTP-service table describes historical/target microservice boundaries, not the current local runtime surface.
 
+### Hive Brain central-command chat (accepted design)
+
+[ADR-039](adr/039-hive-brain-command-center.md) fixes the architecture for the
+planned Hive Brain command center. A durable `BrainConversation` extends the
+existing project-scoped chat session model; it does not replace
+`/v1/chat/ws`, its `franken.chat.v1` events, or the REST reconciliation routes.
+The conversation owns transcript and resumable turn/approval state, while the
+planned `BrainRegistry` from #3685 remains the single identity/capability
+registry for one workspace `hive` brain and its `faculty` brains.
+
+This is an accepted target contract, not shipped runtime behavior yet. The
+implementation must preserve the current `franken-web` transport and route all
+Beast launches through `ChatRuntime` -> `BeastDispatchPort` ->
+`BeastDispatchService`; direct process/container execution from a brain or
+faculty is prohibited. See
+`docs/adr/039-hive-brain-command-center.md` for the entity fields, migration,
+failure rules, and the boundaries for #3701, #3702, and #3703.
+
 ## Shared Types (@franken/types)
 
 Canonical type definitions shared across all modules:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -461,7 +461,7 @@ The old standalone Firewall/Critique/Governor HTTP-service table describes histo
 
 ### Hive Brain central-command chat (accepted design)
 
-[ADR-039](adr/039-hive-brain-command-center.md) fixes the architecture for the
+[ADR-041](adr/041-hive-brain-command-center.md) fixes the architecture for the
 planned Hive Brain command center. A durable `BrainConversation` extends the
 existing project-scoped chat session model; it does not replace
 `/v1/chat/ws`, its `franken.chat.v1` events, or the REST reconciliation routes.
@@ -474,7 +474,7 @@ implementation must preserve the current `franken-web` transport and route all
 Beast launches through `ChatRuntime` -> `BeastDispatchPort` ->
 `BeastDispatchService`; direct process/container execution from a brain or
 faculty is prohibited. See
-`docs/adr/039-hive-brain-command-center.md` for the entity fields, migration,
+`docs/adr/041-hive-brain-command-center.md` for the entity fields, migration,
 failure rules, and the boundaries for #3701, #3702, and #3703.
 
 ## Shared Types (@franken/types)

--- a/docs/adr/039-hive-brain-command-center.md
+++ b/docs/adr/039-hive-brain-command-center.md
@@ -1,0 +1,262 @@
+# ADR-039: Hive Brain command center
+
+- **Date:** 2026-07-24
+- **Status:** Accepted
+- **Deciders:** Frankenbeast maintainers
+- **Supersedes:** none
+- **Related:** ADR-014, issues #3685, #3690, #3700, #3701, #3702, and #3703
+
+## Context
+
+Frankenbeast already exposes project-scoped chat sessions through REST and the
+`franken.chat.v1` WebSocket protocol. A `ChatSession` persists the transcript,
+turn state, pending approval, provider context, token totals, and an optional
+in-progress Beast interview. Both REST and WebSocket input enter the shared
+`ChatRuntime`; Beast launch requests then use the existing chat dispatch adapter
+and Beast control plane.
+
+The Hive Brain epic adds a workspace-scoped command center above individual
+agent-type brains. Before implementing it, four choices must be fixed: whether
+central-command chat replaces the existing transport, what a
+`BrainConversation` owns, how it relates to the planned `BrainRegistry`, and
+where Beast dispatch crosses the safety boundary.
+
+## Decision
+
+### 1. Extend the existing chat transport
+
+The command center has exactly one persistent brain conversation per
+`(workspaceId, subjectId)`. A newly created chat session with no explicit
+lower-level agent/run attachment binds to that existing conversation (creating
+it only when none exists). The conversation does **not** replace `/v1/chat/ws`
+and does not add a parallel socket protocol. Existing clients continue to use:
+
+- `POST /v1/chat/sessions` and `GET /v1/chat/sessions/:id` for creation and
+  reconciliation;
+- `POST /v1/chat/sessions/:id/socket-ticket` followed by `/v1/chat/ws` with the
+  `franken.chat.v1` subprotocol for live turns; and
+- the current strict `ClientSocketEventSchema` and `ServerSocketEventSchema`,
+  including opt-in feature extensions.
+
+`ChatSession` remains a transport/view binding with its own `id` and a durable
+`conversationId`. Existing sessions explicitly attached to one agent/run remain
+supported lower-level debug/attach views and are not silently reinterpreted as
+the command center. The server resolves the binding, conversation, and brain
+before calling `ChatRuntime`. Transport handlers remain adapters: they
+authenticate, enforce admission/rate limits, load state, invoke the runtime
+once, persist the result, and project it back into the v1 response/event shapes.
+Business routing does not move into `franken-web` or the WebSocket controller.
+
+Additive identifiers may be exposed in REST and WebSocket snapshots only after
+the shared `@franken/types` schemas support them. Strict v1 socket events must
+not receive unnegotiated fields. No existing URL, event name, receipt sequence,
+approval event, or reconnect behavior changes as part of the Hive Brain work.
+
+### 2. `BrainConversation` is durable conversation state, not a brain
+
+`BrainConversation` is a workspace-scoped aggregate with this minimum canonical
+shape:
+
+| Field | Contract |
+| --- | --- |
+| `id` | Stable command-center conversation identifier, independent of transport session ids. |
+| `workspaceId` | Stable workspace/project namespace; initially derived from `projectId`. |
+| `subjectId` | Stable authenticated user/operator principal. Local single-operator mode uses the explicit `local-operator` principal. |
+| `brainKey` | Required namespaced key for one workspace-scoped Hive Brain in `BrainRegistry`. |
+| `facultyId` | Optional selected faculty/agent-type brain; `null` means the Hive Brain command center handles the turn. |
+| `transcript` | Ordered user/assistant/system messages, preserving message ids and timestamps. |
+| `state` | Current turn/approval lifecycle state. |
+| `pendingApproval` | Durable, redacted-on-read approval state; secret execution metadata remains server-side. |
+| `beastContext` | Optional in-progress Beast interview binding. |
+| `supervisedAgents` | Durable associations to tracked agents/runs known to this conversation, including type, status, and last-observed timestamp. |
+| `crossAgentSummary` | Compact recent summary derived from hive-mind data; it is refreshable state, not the authoritative run record. |
+| `providerContext`, `routingMetadata` | Last provider result and auditable brain/faculty routing facts. |
+| `tokenTotals`, `costUsd` | Durable accounting values. |
+| `createdAt`, `updatedAt` | Persistence timestamps. |
+
+`subjectId` is derived server-side from the authenticated principal; the
+browser cannot choose another subject in `CreateSessionBody` or socket events.
+Until multi-user identity exists, authenticated local operation deliberately
+maps to the single `local-operator` principal rather than using an unstable
+token, IP address, or browser-generated id.
+
+A conversation owns conversational history, resumable turn state, supervised
+agent associations, and the recent cross-agent summary. Its repository is
+backed by the workspace Hive Brain's durable namespace, through a dedicated
+conversation repository/port; callers must not encode this aggregate as ad-hoc
+working-memory keys. It does not own faculty definitions, instantiate a second
+registry, or duplicate authoritative run/hive-mind records. The selected Hive
+Brain/faculty reads memory through the brain package's existing ports, while the
+conversation repository gives the aggregate explicit schema/version and atomic
+write semantics.
+
+All writes are atomic at the aggregate boundary. The existing mutation-admission
+mechanism is reused but keyed by canonical `conversationId` for command-center
+bindings (and by session id only for an unbound legacy view). This prevents two
+browser sessions bound to the same user/workspace conversation from mutating it
+concurrently. Corrupt or missing conversation records fail closed and surface
+through the existing reconciliation/diagnostic path; the server must not
+silently create a replacement and lose approval or transcript state.
+
+### 3. Use the same `BrainRegistry` with separate key namespaces
+
+Issue #3685's `BrainRegistry` remains the sole in-process registry. Its required
+`forAgentType(agentTypeId)` API and stable per-agent-type instances remain
+unchanged. Hive work extends that class additively with
+`forWorkspaceHive(workspaceId)`; both methods share the registry lifecycle but
+use disjoint canonical keys (`agent-type:<id>` and `workspace-hive:<id>`) so a
+workspace cannot collide with an agent type. No second Hive registry is added.
+
+The registry owns stable brain instance lookup. Faculty/capability metadata and
+health come from the faculty/hive-mind work that consumes those instances; this
+ADR does not retrofit unrequested metadata fields into #3685. The conversation
+stores its `workspace-hive:<id>` brain key and the faculty selected for each turn
+in `routingMetadata`. This keeps central-command chat one level above faculties
+without inventing a separate "conversation brain" lifecycle.
+
+If a requested faculty is missing or unhealthy, routing fails as a typed,
+visible turn error or falls back to the Hive Brain only when policy explicitly
+allows that fallback. It never dispatches to an unregistered implementation.
+
+### 4. Migrate without breaking `franken-web`
+
+Existing `ChatSession` JSON records remain valid lower-level sessions. Migration
+does not collapse their unrelated transcripts into one command-center history.
+On the first default command-center session for a `(workspaceId, subjectId)`, the
+server atomically resolves or creates the one `BrainConversation`, then persists
+`chatSession.conversationId`. It may import existing tracked-agent associations
+for that workspace from hive-mind/run data, but legacy transcripts remain with
+their original sessions unless an explicit import is designed later.
+
+The migration is additive and restart-safe. A compatibility adapter presents
+the existing `ISessionStore` contract: for command-center bindings it projects
+the canonical conversation state into current session responses; for explicit
+legacy agent/run bindings it serves the unchanged session record. One
+transaction (or recoverable journal when the stores cannot share a transaction)
+must persist conversation state plus binding metadata per turn; independent
+dual writes are forbidden because they can split approval state from transcript
+state. Schema/version markers distinguish bindings and canonical records.
+Rollback keeps serving legacy records without deleting canonical conversation
+data.
+
+`franken-web` remains compatible throughout: it creates/resumes sessions as it
+does today, receives `session.ready`, sends `message.send` and
+`approval.respond`, and reconciles with `GET /v1/chat/sessions/:id`. Hive/faculty
+controls are later additive UI work; absence of those controls means
+`facultyId = null`, not a legacy or ungated execution path.
+
+### 5. Reuse the governed Beast dispatch seam
+
+A routed turn that requests a Beast follows this invariant:
+
+```text
+franken-web / REST / comms
+  -> ChatRuntime
+  -> BeastDispatchPort (local ChatBeastDispatchAdapter or daemon adapter)
+  -> tracked-agent interview/init
+  -> BeastDispatchService.createRun
+  -> normal Beast executor and governor/HITL policy
+```
+
+The Hive Brain may choose a registered faculty or propose a Beast definition and
+configuration. It may not start a process/container, write a run directly to the
+repository, synthesize an approval, or call an executor outside this path.
+Existing authentication, mutation admission, maintenance mode, capacity
+reservation, role/tool manifest checks, approval audit/replay protection, and
+governor/HITL decisions remain authoritative. A denial, unavailable dependency,
+unsafe approval payload, or policy error fails closed and is persisted/emitted
+using the current chat and Beast failure contracts.
+
+The current code proves the shared structural seam but does not expose a direct
+`IGovernorModule` call inside `BeastDispatchService.createRun`. Therefore #3703
+must first characterize the old per-session path with the required denied/
+unapproved integration test. If that test exposes a missing governor decision,
+the fix belongs once in this shared adapter/service/execution seam so both old
+and brain-conversation callers fail identically; adding a brain-only gate or
+claiming the service is already gated without evidence is not acceptable.
+
+`dispatchedBy = "chat"`, the conversation/session correlation ids, selected
+`brainKey`/`facultyId`, and routing reason must be retained as audit metadata.
+The browser receives redacted approval state only; privileged approval tokens,
+requester/workdir details, and Beast operator credentials never enter bundled
+client state.
+
+## Turn sequence
+
+1. Authenticate the REST request or one-shot WebSocket ticket.
+2. Resolve the session binding; load the unique `BrainConversation` and resolve
+   `brainKey` plus optional `facultyId`
+   through `BrainRegistry`.
+3. Acquire the existing mutation admission lock keyed by `conversationId` (or
+   the legacy session id for an unbound lower-level session).
+4. Invoke `ChatRuntime` with the persisted transcript, approval, provider,
+   routing, and Beast-interview state.
+5. For conversational work, route to the Hive Brain or selected registered
+   faculty. For Beast work, use `BeastDispatchPort` and the existing control
+   plane exactly as described above.
+6. Atomically persist the resulting aggregate before emitting completion.
+7. Emit only v1-compatible events; after reconnect, `session.ready` and the REST
+   session projection are the source of truth.
+
+## Failure and recovery rules
+
+- Registry lookup failure, invalid brain/faculty ownership, or conversation
+  corruption is explicit and fail-closed.
+- A socket disconnect does not cancel or duplicate an accepted turn. Clients
+  reconcile through the existing session GET and fresh one-shot socket ticket.
+- At most one turn mutates a conversation at a time.
+- Approval remains durable across restart and cannot be replayed.
+- A post-dispatch persistence failure reports an error and is repaired from the
+  Beast run/audit correlation; it must not create a second run on retry.
+- Telemetry and routing metadata must not contain prompts, credentials, or
+  unredacted approval secrets.
+
+## Implementation boundaries
+
+This ADR is documentation only. Runtime work remains split as follows:
+
+- **#3701 — entity and persistence:** add versioned `BrainConversation` schemas,
+  uniqueness for `(workspaceId, subjectId)`, Hive-Brain-backed repository,
+  supervised-agent/summary state, compatibility projection/binding migration,
+  atomicity, corruption, and restart tests.
+- **#3702 — hive-aware query/routing:** resolve the workspace Hive Brain and
+  optional faculty from `BrainRegistry`, record routing metadata, and expose
+  additive typed API fields without changing v1 transport behavior.
+- **#3703 — dispatch integration:** feed routed Beast requests through
+  `BeastDispatchPort`/`BeastDispatchService`, preserving governor/HITL, auth,
+  admission, audit, capacity, and idempotency behavior.
+
+Those issues remain blocked until this decision is merged. Issue #3685 must
+provide the registry contract before #3701 or #3702 can bind persisted foreign
+keys to it.
+
+## Consequences
+
+### Positive
+
+- Existing CLI and browser chat clients continue to work unchanged.
+- One durable aggregate becomes the source of truth for transcript, routing,
+  approval, and resumable Beast interview state.
+- One registry governs Hive and faculty identities.
+- Central-command dispatch cannot bypass the established safety/control plane.
+- The three implementation issues have explicit, non-overlapping contracts.
+
+### Negative
+
+- A compatibility projection/migration is required before `ChatSession` can be
+  retired as the persisted name.
+- The registry dependency makes #3685 a hard prerequisite.
+- Strict v1 WebSocket schemas require deliberate feature negotiation for future
+  additive fields.
+
+## Alternatives rejected
+
+- **Replace `/v1/chat/ws`:** unnecessary client breakage and duplicate reconnect,
+  receipt, auth, and approval semantics.
+- **Add `/v1/brain/ws`:** creates two live-turn protocols that will drift.
+- **Treat each conversation as a brain:** conflates memory/identity lifecycle
+  with transcript lifecycle and multiplies registry entries.
+- **Create a separate Hive registry:** duplicates health, capability, and
+  ownership rules from `BrainRegistry`.
+- **Dispatch directly from the Hive Brain:** bypasses existing policy, audit,
+  capacity, and execution safeguards.

--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -1,4 +1,4 @@
-# ADR-039: Hive Brain command center
+# ADR-041: Hive Brain command center
 
 - **Date:** 2026-07-24
 - **Status:** Accepted

--- a/docs/onboarding/RAMP_UP.md
+++ b/docs/onboarding/RAMP_UP.md
@@ -127,8 +127,8 @@ packages/franken-orchestrator/src/
   - `ChatSocketController` handles WebSocket connections with chunk-based content delivery and turn event streaming
   - Shares the same `ChatRuntime` as the CLI REPL
 - **Hive Brain central-command chat is an accepted design, not implemented runtime behavior.**
-  [ADR-039](../adr/039-hive-brain-command-center.md)
-  (`docs/adr/039-hive-brain-command-center.md`) keeps the existing REST and
+  [ADR-041](../adr/041-hive-brain-command-center.md)
+  (`docs/adr/041-hive-brain-command-center.md`) keeps the existing REST and
   `/v1/chat/ws` browser contract, defines `BrainConversation` as durable
   transcript/routing/approval state bound to the planned `BrainRegistry`, and
   requires every Beast launch to reuse the existing governed dispatch path.

--- a/docs/onboarding/RAMP_UP.md
+++ b/docs/onboarding/RAMP_UP.md
@@ -126,6 +126,13 @@ packages/franken-orchestrator/src/
   - In managed/default dashboard flows it is a chat/control gateway client of `beasts-daemon`; it proxies `/v1/beasts/*` only after operator auth.
   - `ChatSocketController` handles WebSocket connections with chunk-based content delivery and turn event streaming
   - Shares the same `ChatRuntime` as the CLI REPL
+- **Hive Brain central-command chat is an accepted design, not implemented runtime behavior.**
+  [ADR-039](../adr/039-hive-brain-command-center.md)
+  (`docs/adr/039-hive-brain-command-center.md`) keeps the existing REST and
+  `/v1/chat/ws` browser contract, defines `BrainConversation` as durable
+  transcript/routing/approval state bound to the planned `BrainRegistry`, and
+  requires every Beast launch to reuse the existing governed dispatch path.
+  Do not add a second socket protocol or dispatch directly from a brain/faculty.
 - Beast control catalog currently exposes three operator flows: `design-interview`, `chunk-plan` (labeled `Design Doc -> Chunk Creation` and using a `file` prompt for `designDocPath`), and `martin-loop` (now requiring `chunkDirectory` with a `directory` prompt)
 - Tracked-agent domain types, HTTP routes, and dashboard wiring now sit below the beast control layer so init lifecycle state can exist before a Beast run is dispatched
 - **Beast daemon execution pipeline**: `ProcessBeastExecutor` manages spawned agent processes with config file passthrough (`FRANKENBEAST_RUN_CONFIG` env var), `ProcessSupervisor` three-way exit gate, early stdout/stderr buffering, and stop/kill escalation (SIGTERM → timeout → SIGKILL). `BeastEventBus` publishes real-time `run.status`, `run.log`, and `agent.status` events to SSE subscribers. `SseConnectionTicketStore` authenticates EventSource connections via single-use tickets (ADR-030). Config files are written to `.fbeast/.build/run-configs/` and cleaned up on terminal state.

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -286,7 +286,7 @@ The package creates the required SQLite schema in its constructor and enables WA
 ## Planned Hive Brain registry relationship
 
 The accepted central-command design is documented in
-[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md).
+[`docs/adr/041-hive-brain-command-center.md`](../../docs/adr/041-hive-brain-command-center.md).
 Issue #3685's planned `BrainRegistry.forAgentType(id)` remains the agent-type
 lookup. Hive work extends the same registry additively with a disjoint
 `forWorkspaceHive(workspaceId)` key namespace. One `BrainConversation` per

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -283,6 +283,21 @@ SqliteBrain
 
 The package creates the required SQLite schema in its constructor and enables WAL mode. Use `:memory:` for tests or pass a file path for persistent state.
 
+## Planned Hive Brain registry relationship
+
+The accepted central-command design is documented in
+[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md).
+Issue #3685's planned `BrainRegistry.forAgentType(id)` remains the agent-type
+lookup. Hive work extends the same registry additively with a disjoint
+`forWorkspaceHive(workspaceId)` key namespace. One `BrainConversation` per
+user/workspace is persisted through that workspace Hive Brain and owns
+transcript, routing, approval, supervised-agent associations, and resumable turn
+state; it is not a second registry entry per browser session.
+
+This section describes a target contract, not a current export. Do not add
+`BrainRegistry` or `BrainConversation` to examples until their implementation
+issues land with public exports and tests.
+
 ## Memory schema versioning and migrations
 
 Durable memory stores are explicitly versioned. `working_memory`, `episodic_events`, and `checkpoints` rows include a `schema_version` column, and the `memory_schema_versions` table records the current schema version for each store. `SqliteBrain#getMemorySchemaMetadata()` returns the active store versions and record counts so callers can audit what is on disk.

--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -131,6 +131,21 @@ The rubric checks six criteria:
 
 Each criterion reports `pass` only when matching evidence is present in working memory, recent events, or checkpoint context; sparse handoffs report `needs-attention` with guidance instead of inventing missing evidence. Structured tooling can import `assessPmHandoffQuality` from `@franken/orchestrator` when it needs the rubric score without parsing handoff prose.
 
+## Hive Brain central-command chat contract
+
+[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md)
+defines the accepted, not-yet-implemented Hive Brain chat architecture. The
+existing REST session routes and `/v1/chat/ws` remain the browser transport. A
+future `BrainConversation` compatibility repository will provide the current
+`ISessionStore` projection while binding browser sessions to the unique
+user/workspace command-center conversation, workspace Hive Brain, and optional
+registered faculty. Explicit legacy agent/run sessions remain supported.
+
+The dispatch invariant is unchanged: transport -> `ChatRuntime` ->
+`BeastDispatchPort` -> `BeastDispatchService` -> the normal Beast executor and
+governor/HITL policy. Brain/faculty code must not create runs in storage or
+start process/container executors directly.
+
 ## Package areas
 
 | Area | Paths | Responsibility |

--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -133,7 +133,7 @@ Each criterion reports `pass` only when matching evidence is present in working 
 
 ## Hive Brain central-command chat contract
 
-[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md)
+[`docs/adr/041-hive-brain-command-center.md`](../../docs/adr/041-hive-brain-command-center.md)
 defines the accepted, not-yet-implemented Hive Brain chat architecture. The
 existing REST session routes and `/v1/chat/ws` remain the browser transport. A
 future `BrainConversation` compatibility repository will provide the current

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -53,6 +53,16 @@ The frontend uses same-origin API paths at runtime:
 
 Open the Vite URL, usually `http://127.0.0.1:5173/`. The `dev:chat` script proxies `/api` and `/v1` requests to the local plain-HTTP chat server on `http://127.0.0.1:3737`; production deployments should use TLS-terminated `https://`/`wss://` endpoints.
 
+### Hive Brain compatibility contract
+
+The accepted central-command design in
+[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md)
+keeps this package's existing session and WebSocket behavior. The dashboard
+continues to create or resume `/v1/chat/sessions`, mint one-shot socket tickets,
+connect to `/v1/chat/ws` with `franken.chat.v1`, and reconcile from
+`session.ready`/the session GET route. Hive/faculty selection will be additive;
+no second brain-chat socket or browser-side Beast dispatch path is permitted.
+
 If you use a non-default backend port in local development, keep `VITE_API_URL` unset and set `VITE_API_PROXY_TARGET` so the Vite `/v1/chat` proxy keeps chat auth server-side. Beast routes (`/v1/beasts/*`) reuse that same target by default. Set `VITE_BEAST_API_PROXY_TARGET` only when Beast controls run on a different backend, for example a separate local orchestrator or daemon port:
 
 | Local workflow | Backend topology | Vite env vars to set |

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -56,7 +56,7 @@ Open the Vite URL, usually `http://127.0.0.1:5173/`. The `dev:chat` script proxi
 ### Hive Brain compatibility contract
 
 The accepted central-command design in
-[`docs/adr/039-hive-brain-command-center.md`](../../docs/adr/039-hive-brain-command-center.md)
+[`docs/adr/041-hive-brain-command-center.md`](../../docs/adr/041-hive-brain-command-center.md)
 keeps this package's existing session and WebSocket behavior. The dashboard
 continues to create or resume `/v1/chat/sessions`, mint one-shot socket tickets,
 connect to `/v1/chat/ws` with `franken.chat.v1`, and reconcile from

--- a/tasks/issue-3700-hive-brain-chat-design-progress.md
+++ b/tasks/issue-3700-hive-brain-chat-design-progress.md
@@ -1,0 +1,17 @@
+# Issue #3700 Hive Brain chat design progress
+
+- [x] Read the live issue and confirm no open PR owns #3700.
+- [x] Sync the isolated issue branch to current `origin/main`.
+- [x] Read PM/root handoffs, epic progress, and shared lessons.
+- [x] Locate ADR-039 or establish its live source/status without guessing.
+- [x] Trace the existing chat runtime, session persistence, WebSocket/REST contracts, web client, BrainRegistry dependency, and governor-gated dispatch path.
+- [x] Write concrete transport, entity/namespace, migration, persistence/API, and dispatch decisions with implementation-child acceptance mapping.
+- [x] Address independent review findings: enforce one conversation per
+  user/workspace, persist supervised-agent/summary state, use the planned
+  registry API additively, and lock on canonical conversation id.
+- [x] Synchronize architecture, ramp-up, and relevant package documentation.
+- [x] Add narrow documentation/contract regression coverage supported by repository convention.
+- [x] Run focused tests plus applicable typecheck/build/docs checks. (`docs-issue-3700`: 3/3 pass; all newly added relative links resolve. Root typecheck/build were attempted but the worktree resolves `@franken/types` through the primary checkout's shared `node_modules`, producing unrelated missing-export errors in brain/observer.)
+- [ ] Commit with the required identity, push, and open one PR that closes #3700.
+- [ ] Resolve real current-head Codex feedback, verify CI/threads, and merge.
+- [ ] Append reusable lessons and publish terminal Kanban/blackboard evidence.

--- a/tasks/issue-3700-hive-brain-chat-design-progress.md
+++ b/tasks/issue-3700-hive-brain-chat-design-progress.md
@@ -3,7 +3,8 @@
 - [x] Read the live issue and confirm no open PR owns #3700.
 - [x] Sync the isolated issue branch to current `origin/main`.
 - [x] Read PM/root handoffs, epic progress, and shared lessons.
-- [x] Locate ADR-039 or establish its live source/status without guessing.
+- [x] Locate the referenced ADR, resolve the live ADR-039 collision by assigning
+  this decision the next unused identifier (ADR-041), and update all links.
 - [x] Trace the existing chat runtime, session persistence, WebSocket/REST contracts, web client, BrainRegistry dependency, and governor-gated dispatch path.
 - [x] Write concrete transport, entity/namespace, migration, persistence/API, and dispatch decisions with implementation-child acceptance mapping.
 - [x] Address independent review findings: enforce one conversation per

--- a/tests/docs-issue-3700.test.ts
+++ b/tests/docs-issue-3700.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
-const ADR_PATH = 'docs/adr/039-hive-brain-command-center.md';
+const ADR_PATH = 'docs/adr/041-hive-brain-command-center.md';
 
 describe('issue #3700 Hive Brain central-command chat decision', () => {
   it('answers the transport, entity, registry, compatibility, and dispatch questions', () => {

--- a/tests/docs-issue-3700.test.ts
+++ b/tests/docs-issue-3700.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const readDoc = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+const ADR_PATH = 'docs/adr/039-hive-brain-command-center.md';
+
+describe('issue #3700 Hive Brain central-command chat decision', () => {
+  it('answers the transport, entity, registry, compatibility, and dispatch questions', () => {
+    const adr = readDoc(ADR_PATH);
+
+    for (const decision of [
+      '### 1. Extend the existing chat transport',
+      '### 2. `BrainConversation` is durable conversation state, not a brain',
+      '### 3. Use the same `BrainRegistry` with separate key namespaces',
+      '### 4. Migrate without breaking `franken-web`',
+      '### 5. Reuse the governed Beast dispatch seam',
+      '/v1/chat/ws',
+      'forWorkspaceHive(workspaceId)',
+      'BeastDispatchService.createRun',
+    ]) {
+      expect(adr).toContain(decision);
+    }
+  });
+
+  it('keeps the decision discoverable from architecture, onboarding, and package docs', () => {
+    for (const path of [
+      'docs/ARCHITECTURE.md',
+      'docs/onboarding/RAMP_UP.md',
+      'packages/franken-brain/README.md',
+      'packages/franken-orchestrator/README.md',
+      'packages/franken-web/README.md',
+    ]) {
+      expect(readDoc(path), `${path} must link the Hive Brain ADR`).toContain(ADR_PATH);
+    }
+  });
+
+  it('preserves the existing transport and governed-dispatch invariants', () => {
+    const adr = readDoc(ADR_PATH);
+
+    expect(adr).toContain('does **not** replace `/v1/chat/ws`');
+    expect(adr).toContain('one persistent brain conversation per');
+    expect(adr).toContain('`supervisedAgents`');
+    expect(adr).toContain('`crossAgentSummary`');
+    expect(adr).toContain('keyed by canonical `conversationId`');
+    expect(adr).toContain('does not expose a direct');
+    expect(adr.replaceAll('\n', ' ')).toContain('independent dual writes are forbidden');
+    expect(adr).toContain('It may not start a process/container');
+    expect(adr).toContain('Those issues remain blocked until this decision is merged.');
+  });
+});


### PR DESCRIPTION
## Summary
- defines the accepted Hive Brain central-command chat architecture and its one-conversation-per-user/workspace entity model
- preserves the existing REST/WebSocket browser contract while binding sessions to a canonical conversation
- documents BrainRegistry namespace, migration/atomicity, supervised-agent state, and fail-closed dispatch invariants
- synchronizes architecture, onboarding, and affected package documentation with a focused contract test

## API compatibility
No existing chat API contract changes in this PR. `/v1/chat/ws`, `franken.chat.v1`, current event names, REST routes, receipt order, approval flow, and reconnect behavior remain unchanged. Future identifiers require additive shared schemas and negotiated socket features.

## Test plan
- [x] `npx vitest run tests/docs-issue-3700.test.ts` (3 tests passed)
- [x] `git diff --check`
- [x] newly added relative documentation links resolve
- [ ] `npm run typecheck` / `npm run build` attempted; local worktree resolution uses the primary checkout's shared `node_modules/@franken/types`, producing unrelated missing-export errors in `@franken/brain` and `@franken/observer`. CI is the clean-workspace authority.

Closes #3700
