### PR TITLE
fix(deps): upgrade js-yaml past GHSA-pm4m-ph32-ghv5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "better-sqlite3": "^12.11.1",
         "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
-        "js-yaml": "^5.2.1",
+        "js-yaml": "^5.2.2",
         "jsdom": "^29.1.1",
         "tsx": "^4.23.1",
         "turbo": "^2.10.6",
@@ -4741,9 +4741,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "better-sqlite3": "^12.11.1",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
-    "js-yaml": "^5.2.1",
+    "js-yaml": "^5.2.2",
     "jsdom": "^29.1.1",
     "tsx": "^4.23.1",
     "turbo": "^2.10.6",


### PR DESCRIPTION
## Summary
- upgrade the direct root `js-yaml` devDependency from `^5.2.1` to `^5.2.2`
- refresh the lockfile to resolve `js-yaml@5.2.2`, the first non-vulnerable release for GHSA-pm4m-ph32-ghv5
- keep the security unblock isolated from PR #3745

## Verification
- `npm ci`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm run audit:dependencies` (0 vulnerabilities)
- `npm run deps:vulnerability-sla` (0 findings)
- `npm run build`
- `npm run typecheck`
- `npm run test:ci`
- `npm ls js-yaml --all` (`js-yaml@5.2.2`)

## Notes
A preliminary plain `npm run test` before building dependencies exposed unrelated ordering/flakiness failures; the repository CI-equivalent `npm run test:ci` passed after the required build step.