### PR TITLE
fix(brain): harden persisted brain inspection

### DIFF
--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -4,11 +4,7 @@
 - **Status:** Accepted
 - **Deciders:** Frankenbeast maintainers
 - **Supersedes:** none
-<<<<<<< HEAD
-- **Related:** ADR-014, issues #3685, #3690, #3695, #3700, #3701, #3702, #3703, and #3704
-=======
-- **Related:** ADR-014, issues #3685, #3690, #3695, #3696, #3700, #3701, #3702, and #3703
->>>>>>> origin/main
+- **Related:** ADR-014, issues #3685, #3690, #3695, #3696, #3700, #3701, #3702, #3703, and #3704
 
 ## Context
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3210,16 +3210,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {

--- a/packages/franken-brain/src/brain-registry.ts
+++ b/packages/franken-brain/src/brain-registry.ts
@@ -36,15 +36,20 @@ function assertSafeAgentTypeId(agentTypeId: string): void {
  * including `:memory:`, when they intentionally need different persistence.
  */
 export class BrainRegistry {
-  private readonly brains = new Map<string, { brain: SqliteBrain; dbPath: string }>();
+  private readonly brains = new Map<string, Map<string, SqliteBrain>>();
+  private readonly preferredDbPaths = new Map<string, string>();
 
   constructor(private readonly brainsDir = join('.fbeast', 'brains')) {}
 
   forAgentType(agentTypeId: string, dbPath?: string): SqliteBrain {
     assertSafeAgentTypeId(agentTypeId);
 
-    const existing = this.brains.get(agentTypeId);
-    if (dbPath === undefined && existing) return existing.brain;
+    const agentBrains = this.brains.get(agentTypeId);
+    const preferredDbPath = this.preferredDbPaths.get(agentTypeId);
+    if (dbPath === undefined && preferredDbPath) {
+      const preferred = agentBrains?.get(preferredDbPath);
+      if (preferred) return preferred;
+    }
 
     if (
       dbPath === undefined
@@ -57,16 +62,16 @@ export class BrainRegistry {
 
     const requestedDbPath = dbPath ?? join(this.brainsDir, `${agentTypeId}.db`);
     const resolvedDbPath = requestedDbPath === ':memory:' ? requestedDbPath : resolve(requestedDbPath);
-    if (existing?.dbPath === resolvedDbPath) return existing.brain;
-    if (existing) {
-      existing.brain.close();
-      this.brains.delete(agentTypeId);
-    }
+    const existing = agentBrains?.get(resolvedDbPath);
+    if (existing) return existing;
     if (dbPath === undefined) {
       mkdirSync(this.brainsDir, { recursive: true });
     }
     const brain = new SqliteBrain(resolvedDbPath);
-    this.brains.set(agentTypeId, { brain, dbPath: resolvedDbPath });
+    const paths = agentBrains ?? new Map<string, SqliteBrain>();
+    paths.set(resolvedDbPath, brain);
+    this.brains.set(agentTypeId, paths);
+    this.preferredDbPaths.set(agentTypeId, resolvedDbPath);
     return brain;
   }
 
@@ -74,12 +79,17 @@ export class BrainRegistry {
   getAgentType(agentTypeId: string, dbPath?: string): SqliteBrain | undefined {
     assertSafeAgentTypeId(agentTypeId);
 
-    const existing = this.brains.get(agentTypeId);
-    if (dbPath === undefined && existing) return existing.brain;
+    const agentBrains = this.brains.get(agentTypeId);
+    const preferredDbPath = this.preferredDbPaths.get(agentTypeId);
+    if (dbPath === undefined && preferredDbPath) {
+      const preferred = agentBrains?.get(preferredDbPath);
+      if (preferred) return preferred;
+    }
 
     if (dbPath !== undefined) {
       const resolvedDbPath = dbPath === ':memory:' ? dbPath : resolve(dbPath);
-      if (existing?.dbPath === resolvedDbPath) return existing.brain;
+      const existing = agentBrains?.get(resolvedDbPath);
+      if (existing) return existing;
       if (dbPath === ':memory:' || !existsSync(resolvedDbPath)) return undefined;
       return this.forAgentType(agentTypeId, resolvedDbPath);
     }
@@ -96,7 +106,10 @@ export class BrainRegistry {
 
   /** Close every brain owned by this registry and release its process-local keys. */
   close(): void {
-    for (const { brain } of this.brains.values()) brain.close();
+    for (const paths of this.brains.values()) {
+      for (const brain of paths.values()) brain.close();
+    }
     this.brains.clear();
+    this.preferredDbPaths.clear();
   }
 }

--- a/packages/franken-brain/src/brain-registry.ts
+++ b/packages/franken-brain/src/brain-registry.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { existsSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { SqliteBrain } from './sqlite-brain.js';
 
@@ -36,7 +36,7 @@ function assertSafeAgentTypeId(agentTypeId: string): void {
  * including `:memory:`, when they intentionally need different persistence.
  */
 export class BrainRegistry {
-  private readonly brains = new Map<string, SqliteBrain>();
+  private readonly brains = new Map<string, { brain: SqliteBrain; dbPath: string }>();
 
   constructor(private readonly brainsDir = join('.fbeast', 'brains')) {}
 
@@ -44,7 +44,7 @@ export class BrainRegistry {
     assertSafeAgentTypeId(agentTypeId);
 
     const existing = this.brains.get(agentTypeId);
-    if (existing) return existing;
+    if (dbPath === undefined && existing) return existing.brain;
 
     if (
       dbPath === undefined
@@ -55,21 +55,34 @@ export class BrainRegistry {
       );
     }
 
-    const resolvedDbPath = dbPath ?? join(this.brainsDir, `${agentTypeId}.db`);
+    const requestedDbPath = dbPath ?? join(this.brainsDir, `${agentTypeId}.db`);
+    const resolvedDbPath = requestedDbPath === ':memory:' ? requestedDbPath : resolve(requestedDbPath);
+    if (existing?.dbPath === resolvedDbPath) return existing.brain;
+    if (existing) {
+      existing.brain.close();
+      this.brains.delete(agentTypeId);
+    }
     if (dbPath === undefined) {
       mkdirSync(this.brainsDir, { recursive: true });
     }
     const brain = new SqliteBrain(resolvedDbPath);
-    this.brains.set(agentTypeId, brain);
+    this.brains.set(agentTypeId, { brain, dbPath: resolvedDbPath });
     return brain;
   }
 
-  /** Return an existing default agent brain without creating an unknown database. */
-  getAgentType(agentTypeId: string): SqliteBrain | undefined {
+  /** Return an existing agent brain without creating an unknown database. */
+  getAgentType(agentTypeId: string, dbPath?: string): SqliteBrain | undefined {
     assertSafeAgentTypeId(agentTypeId);
 
     const existing = this.brains.get(agentTypeId);
-    if (existing) return existing;
+    if (dbPath === undefined && existing) return existing.brain;
+
+    if (dbPath !== undefined) {
+      const resolvedDbPath = dbPath === ':memory:' ? dbPath : resolve(dbPath);
+      if (existing?.dbPath === resolvedDbPath) return existing.brain;
+      if (dbPath === ':memory:' || !existsSync(resolvedDbPath)) return undefined;
+      return this.forAgentType(agentTypeId, resolvedDbPath);
+    }
 
     if (Buffer.byteLength(agentTypeId, 'utf8') > MAX_DEFAULT_BRAIN_FILENAME_AGENT_TYPE_ID_BYTES) {
       throw new RangeError(
@@ -83,7 +96,7 @@ export class BrainRegistry {
 
   /** Close every brain owned by this registry and release its process-local keys. */
   close(): void {
-    for (const brain of this.brains.values()) brain.close();
+    for (const { brain } of this.brains.values()) brain.close();
     this.brains.clear();
   }
 }

--- a/packages/franken-brain/src/brain-registry.ts
+++ b/packages/franken-brain/src/brain-registry.ts
@@ -63,7 +63,10 @@ export class BrainRegistry {
     const requestedDbPath = dbPath ?? join(this.brainsDir, `${agentTypeId}.db`);
     const resolvedDbPath = requestedDbPath === ':memory:' ? requestedDbPath : resolve(requestedDbPath);
     const existing = agentBrains?.get(resolvedDbPath);
-    if (existing) return existing;
+    if (existing) {
+      if (dbPath !== undefined) this.preferredDbPaths.set(agentTypeId, resolvedDbPath);
+      return existing;
+    }
     if (dbPath === undefined) {
       mkdirSync(this.brainsDir, { recursive: true });
     }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -562,6 +562,7 @@ export type MemoryAccessAuditOperation =
   | 'episodic.recordLearning'
   | 'episodic.recall'
   | 'episodic.recent'
+  | 'episodic.readBoundedPage'
   | 'episodic.recentFailures'
   | 'episodic.count'
   | 'recovery.checkpoint'
@@ -2447,6 +2448,27 @@ class SqliteWorkingMemory implements IWorkingMemory {
     return keys;
   }
 
+  /** Read the current durable key set without trusting this process's cached map. */
+  persistedKeys(): string[] {
+    const rows = this.db
+      .prepare(`SELECT key, value FROM working_memory ORDER BY key ASC`)
+      .all() as Array<{ key: string; value: string }>;
+    const keys = rows.flatMap((row) => {
+      const serialized = this.encryption?.decrypt(row.value) ?? row.value;
+      validateWorkingMemoryKey(row.key);
+      return isExpiredWorkingMemoryValue(parseHydratedWorkingMemoryValue(row.key, serialized))
+        ? []
+        : [row.key];
+    });
+    this.audit?.({
+      operation: 'working.keys',
+      store: 'working',
+      outcome: 'success',
+      details: { count: keys.length, source: 'persisted' },
+    });
+    return keys;
+  }
+
   private snapshotEntries(options: { expireGuardedEntries?: boolean } = {}): Record<string, unknown> {
     if (options.expireGuardedEntries ?? true) {
       this.expireRuntimeKeysMatchingCurrentGuards();
@@ -3147,6 +3169,149 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       });
       throw error;
     }
+  }
+
+  /**
+   * Read an HTTP-safe page while dropping oversized details in SQLite, before
+   * JSON parsing can materialize an unbounded payload in the Node process.
+   */
+  readBoundedPage(options: {
+    limit: number;
+    offset: number;
+    query?: string;
+    maxDetailsBytes: number;
+  }): Array<EpisodicEvent & { detailsTruncated?: true }> {
+    try {
+      const result = this.readBoundedPageUnchecked(options);
+      this.audit?.({
+        operation: 'episodic.readBoundedPage',
+        store: 'episodic',
+        ...(options.query === undefined ? {} : { query: options.query }),
+        outcome: 'success',
+        details: { limit: options.limit, offset: options.offset, count: result.length },
+      });
+      return result;
+    } catch (error) {
+      this.audit?.({
+        operation: 'episodic.readBoundedPage',
+        store: 'episodic',
+        ...(options.query === undefined ? {} : { query: options.query }),
+        outcome: 'error',
+        details: {
+          limit: options.limit,
+          offset: options.offset,
+          errorName: error instanceof Error ? error.name : 'Error',
+        },
+      });
+      throw error;
+    }
+  }
+
+  private readBoundedPageUnchecked(options: {
+    limit: number;
+    offset: number;
+    query?: string;
+    maxDetailsBytes: number;
+  }): Array<EpisodicEvent & { detailsTruncated?: true }> {
+    const { limit, offset, query, maxDetailsBytes } = options;
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+      throw new RangeError('limit must be a positive safe integer');
+    }
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new RangeError('offset must be a non-negative safe integer');
+    }
+    if (!Number.isSafeInteger(maxDetailsBytes) || maxDetailsBytes < 0) {
+      throw new RangeError('maxDetailsBytes must be a non-negative safe integer');
+    }
+    const normalizedQuery = query?.trim();
+    const keywords = normalizedQuery ? normalizeRecallKeywords(normalizedQuery) : [];
+    const detailsProjection = `CASE
+      WHEN details IS NOT NULL AND length(CAST(details AS BLOB)) > ? THEN NULL
+      ELSE details
+    END AS details`;
+    const truncatedProjection = `CASE
+      WHEN details IS NOT NULL AND length(CAST(details AS BLOB)) > ? THEN 1
+      ELSE 0
+    END AS details_truncated`;
+    const projectedColumns = `id, type, step, summary, ${detailsProjection}, created_at, schema_version,
+                              ${truncatedProjection}`;
+    const mapRows = (rows: Array<EpisodicRow & { details_truncated: 0 | 1 }>) => rows.flatMap((row) => {
+      const event = rowToEvent(row, this.encryption);
+      if (!event) return [];
+      return [{
+        ...event,
+        ...(row.details_truncated === 1 ? { detailsTruncated: true as const } : {}),
+      }];
+    });
+
+    if (keywords.length === 0) {
+      const rows = this.db.prepare(
+        `SELECT ${projectedColumns}
+           FROM episodic_events
+          ORDER BY created_at DESC, id DESC
+          LIMIT ? OFFSET ?`,
+      ).all(maxDetailsBytes, maxDetailsBytes, limit, offset) as Array<
+        EpisodicRow & { details_truncated: 0 | 1 }
+      >;
+      return mapRows(rows);
+    }
+
+    if (this.encryption) {
+      const batchSize = 128;
+      const matches: Array<{ event: EpisodicEvent & { detailsTruncated?: true }; score: number }> = [];
+      let rowOffset = 0;
+      while (true) {
+        const rows = this.db.prepare(
+          `SELECT ${projectedColumns}
+             FROM episodic_events
+            ORDER BY created_at DESC, id DESC
+            LIMIT ? OFFSET ?`,
+        ).all(maxDetailsBytes, maxDetailsBytes, batchSize, rowOffset) as Array<
+          EpisodicRow & { details_truncated: 0 | 1 }
+        >;
+        for (const event of mapRows(rows)) {
+          const score = recallEventScore(event, keywords);
+          if (score > 0) matches.push({ event, score });
+        }
+        if (rows.length < batchSize) break;
+        rowOffset += rows.length;
+      }
+      return matches
+        .sort((a, b) =>
+          b.score - a.score
+          || b.event.createdAt.localeCompare(a.event.createdAt)
+          || Number(b.event.id ?? 0) - Number(a.event.id ?? 0))
+        .slice(offset, offset + limit)
+        .map(({ event }) => event);
+    }
+
+    const searchableDetails = `CASE WHEN json_valid(details) THEN details ELSE '' END`;
+    const scoringCases = keywords.map(() =>
+      `(CASE WHEN lower(summary) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END
+        + CASE WHEN lower(${searchableDetails}) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END)`,
+    ).join(' + ');
+    const whereClauses = keywords.map(() =>
+      `(lower(summary) LIKE ? ESCAPE '\\' OR lower(${searchableDetails}) LIKE ? ESCAPE '\\')`,
+    ).join(' OR ');
+    const likeParams = keywords.flatMap((keyword) => {
+      const escaped = `%${escapeLike(keyword)}%`;
+      return [escaped, escaped];
+    });
+    const rows = this.db.prepare(
+      `SELECT ${projectedColumns}, (${scoringCases}) AS relevance_score
+         FROM episodic_events
+        WHERE ${whereClauses}
+        ORDER BY relevance_score DESC, created_at DESC, id DESC
+        LIMIT ? OFFSET ?`,
+    ).all(
+      maxDetailsBytes,
+      maxDetailsBytes,
+      ...likeParams,
+      ...likeParams,
+      limit,
+      offset,
+    ) as Array<EpisodicRow & { details_truncated: 0 | 1; relevance_score: number }>;
+    return mapRows(rows);
   }
 
   snapshotForHandoff(n = 100, nowMs = Date.now()): EpisodicEvent[] {

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3277,17 +3277,34 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       const matches: Array<{ event: EpisodicEvent & { detailsTruncated?: true }; score: number }> = [];
       let rowOffset = 0;
       while (true) {
+        // Search a separately bounded ciphertext projection so details modestly
+        // larger than the response budget remain searchable without allowing a
+        // corrupted database row to allocate unbounded memory during decrypt.
+        const searchableDetailsByteLimit = encryptedPayloadByteLimit(1024 * 1024);
         const rows = this.db.prepare(
-          `SELECT ${projectedColumns}
+          `SELECT ${projectedColumns},
+                  CASE WHEN details IS NOT NULL AND length(CAST(details AS BLOB)) <= ?
+                    THEN details ELSE NULL END AS search_details
              FROM episodic_events
             ORDER BY created_at DESC, id DESC
             LIMIT ? OFFSET ?`,
-        ).all(storedDetailsByteLimit, storedDetailsByteLimit, batchSize, rowOffset) as Array<
-          EpisodicRow & { details_truncated: 0 | 1 }
+        ).all(storedDetailsByteLimit, storedDetailsByteLimit, searchableDetailsByteLimit, batchSize, rowOffset) as Array<
+          EpisodicRow & { details_truncated: 0 | 1; search_details: string | null }
         >;
-        for (const event of mapRows(rows)) {
-          const score = recallEventScore(event, keywords);
-          if (score > 0) matches.push({ event, score });
+        for (const row of rows) {
+          const searchableEvent = rowToEvent({ ...row, details: row.search_details }, this.encryption);
+          const boundedEvent = rowToEvent(row, this.encryption);
+          if (!searchableEvent || !boundedEvent) continue;
+          const score = recallEventScore(searchableEvent, keywords);
+          if (score > 0) {
+            matches.push({
+              event: {
+                ...boundedEvent,
+                ...(row.details_truncated === 1 ? { detailsTruncated: true as const } : {}),
+              },
+              score,
+            });
+          }
         }
         if (rows.length < batchSize) break;
         rowOffset += rows.length;

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -725,6 +725,16 @@ export class MemoryEncryptionWrongKeyError extends Error {
 const MEMORY_ENCRYPTION_ALGORITHM = 'aes-256-gcm' as const;
 const MEMORY_ENCRYPTION_PREFIX = 'enc:v1:';
 const MEMORY_ENCRYPTION_VERIFIER = 'franken-memory-encryption-verifier:v1';
+
+function encryptedPayloadByteLimit(plaintextBytes: number): number {
+  const base64UrlLength = (bytes: number) => Math.ceil(bytes * 4 / 3);
+  return Buffer.byteLength(MEMORY_ENCRYPTION_PREFIX)
+    + base64UrlLength(12)
+    + 1
+    + base64UrlLength(16)
+    + 1
+    + base64UrlLength(plaintextBytes);
+}
 const MEMORY_STORES = [
   'working_memory',
   'episodic_events',
@@ -3225,6 +3235,12 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
     const normalizedQuery = query?.trim();
     const keywords = normalizedQuery ? normalizeRecallKeywords(normalizedQuery) : [];
+    // AES-GCM envelopes are larger than their plaintext. Bound the envelope at
+    // the exact maximum size for an allowed plaintext instead of comparing
+    // base64 ciphertext bytes to the public JSON response limit.
+    const storedDetailsByteLimit = this.encryption
+      ? encryptedPayloadByteLimit(maxDetailsBytes)
+      : maxDetailsBytes;
     const detailsProjection = `CASE
       WHEN details IS NOT NULL AND length(CAST(details AS BLOB)) > ? THEN NULL
       ELSE details
@@ -3250,7 +3266,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
            FROM episodic_events
           ORDER BY created_at DESC, id DESC
           LIMIT ? OFFSET ?`,
-      ).all(maxDetailsBytes, maxDetailsBytes, limit, offset) as Array<
+      ).all(storedDetailsByteLimit, storedDetailsByteLimit, limit, offset) as Array<
         EpisodicRow & { details_truncated: 0 | 1 }
       >;
       return mapRows(rows);
@@ -3266,7 +3282,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
              FROM episodic_events
             ORDER BY created_at DESC, id DESC
             LIMIT ? OFFSET ?`,
-        ).all(maxDetailsBytes, maxDetailsBytes, batchSize, rowOffset) as Array<
+        ).all(storedDetailsByteLimit, storedDetailsByteLimit, batchSize, rowOffset) as Array<
           EpisodicRow & { details_truncated: 0 | 1 }
         >;
         for (const event of mapRows(rows)) {
@@ -3304,8 +3320,8 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         ORDER BY relevance_score DESC, created_at DESC, id DESC
         LIMIT ? OFFSET ?`,
     ).all(
-      maxDetailsBytes,
-      maxDetailsBytes,
+      storedDetailsByteLimit,
+      storedDetailsByteLimit,
       ...likeParams,
       ...likeParams,
       limit,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -6,6 +6,7 @@ import {
   randomBytes,
   timingSafeEqual,
 } from 'node:crypto';
+import { StringDecoder } from 'node:string_decoder';
 import { resolve as resolvePath } from 'node:path';
 import Database from 'better-sqlite3';
 import type {
@@ -818,6 +819,29 @@ class MemoryCipher {
         decipher.update(Buffer.from(ciphertextB64!, 'base64url')),
         decipher.final(),
       ]).toString('utf8');
+    } catch (error) {
+      throw new MemoryEncryptionWrongKeyError(
+        `Memory encryption key cannot decrypt a persisted payload: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  *decryptBase64UrlChunks(
+    ivB64: string,
+    tagB64: string,
+    chunks: Iterable<string>,
+  ): Generator<Buffer> {
+    try {
+      const decipher = createDecipheriv(
+        MEMORY_ENCRYPTION_ALGORITHM,
+        this.key,
+        Buffer.from(ivB64, 'base64url'),
+      );
+      decipher.setAuthTag(Buffer.from(tagB64, 'base64url'));
+      for (const chunk of chunks) {
+        yield decipher.update(Buffer.from(chunk, 'base64url'));
+      }
+      yield decipher.final();
     } catch (error) {
       throw new MemoryEncryptionWrongKeyError(
         `Memory encryption key cannot decrypt a persisted payload: ${error instanceof Error ? error.message : String(error)}`,
@@ -3185,6 +3209,47 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
    * Read an HTTP-safe page while dropping oversized details in SQLite, before
    * JSON parsing can materialize an unbounded payload in the Node process.
    */
+  private scoreOversizedEncryptedDetails(eventId: number | string, summary: string, keywords: readonly string[]): number {
+    const summaryLower = summary.toLowerCase();
+    const matched = new Set(keywords.filter(keyword => summaryLower.includes(keyword)));
+    if (!this.encryption || matched.size === keywords.length) return matched.size;
+
+    const metadata = this.db.prepare(
+      'SELECT substr(details, 1, 96) AS header, length(details) AS total_length FROM episodic_events WHERE id = ?',
+    ).get(eventId) as { header: string | null; total_length: number } | undefined;
+    const headerMatch = metadata?.header?.match(/^enc:v1:([^:]+):([^:]+):/);
+    if (!headerMatch || !metadata) return matched.size;
+    const headerLength = headerMatch[0].length;
+    const encodedLength = metadata.total_length - headerLength;
+    const chunkSize = 64 * 1024;
+    const chunks = function* (db: Database.Database): Generator<string> {
+      for (let offset = 0; offset < encodedLength; offset += chunkSize) {
+        const row = db.prepare('SELECT substr(details, ?, ?) AS chunk FROM episodic_events WHERE id = ?')
+          .get(headerLength + offset + 1, Math.min(chunkSize, encodedLength - offset), eventId) as { chunk: string };
+        yield row.chunk;
+      }
+    };
+    const decoder = new StringDecoder('utf8');
+    const overlapLength = Math.max(...keywords.map(keyword => keyword.length), 1) - 1;
+    let overlap = '';
+    try {
+      for (const plaintext of this.encryption.decryptBase64UrlChunks(headerMatch[1]!, headerMatch[2]!, chunks(this.db))) {
+        const text = (overlap + decoder.write(plaintext)).toLowerCase();
+        for (const keyword of keywords) {
+          if (text.includes(keyword)) matched.add(keyword);
+        }
+        overlap = text.slice(-overlapLength);
+      }
+      const tail = (overlap + decoder.end()).toLowerCase();
+      for (const keyword of keywords) {
+        if (tail.includes(keyword)) matched.add(keyword);
+      }
+    } catch {
+      // A malformed encrypted details field must not break the bounded route.
+    }
+    return matched.size;
+  }
+
   readBoundedPage(options: {
     limit: number;
     offset: number;
@@ -3295,7 +3360,9 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           const searchableEvent = rowToEvent({ ...row, details: row.search_details }, this.encryption);
           const boundedEvent = rowToEvent(row, this.encryption);
           if (!searchableEvent || !boundedEvent) continue;
-          const score = recallEventScore(searchableEvent, keywords);
+          const score = row.details_truncated === 1 && row.search_details === null
+            ? this.scoreOversizedEncryptedDetails(row.id, row.summary, keywords)
+            : recallEventScore(searchableEvent, keywords);
           if (score > 0) {
             matches.push({
               event: {
@@ -3318,7 +3385,15 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
         .map(({ event }) => event);
     }
 
-    const searchableDetails = `CASE WHEN json_valid(details) THEN details ELSE '' END`;
+    const searchableDetails = `CASE
+      WHEN json_valid(details)
+       AND NOT (
+         json_type(details, '$.quarantine') = 'object'
+         AND json_extract(details, '$.quarantine.field') = 'details'
+         AND json_extract(details, '$.quarantine.eventId') = id
+         AND json_extract(details, '$.quarantine.reason') = 'invalid JSON'
+       )
+      THEN details ELSE '' END`;
     const scoringCases = keywords.map(() =>
       `(CASE WHEN lower(summary) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END
         + CASE WHEN lower(${searchableDetails}) LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END)`,

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3232,18 +3232,20 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     const decoder = new StringDecoder('utf8');
     const overlapLength = Math.max(...keywords.map(keyword => keyword.length), 1) - 1;
     let overlap = '';
+    const authenticatedMatches = new Set<string>();
     try {
       for (const plaintext of this.encryption.decryptBase64UrlChunks(headerMatch[1]!, headerMatch[2]!, chunks(this.db))) {
         const text = (overlap + decoder.write(plaintext)).toLowerCase();
         for (const keyword of keywords) {
-          if (text.includes(keyword)) matched.add(keyword);
+          if (text.includes(keyword)) authenticatedMatches.add(keyword);
         }
         overlap = text.slice(-overlapLength);
       }
       const tail = (overlap + decoder.end()).toLowerCase();
       for (const keyword of keywords) {
-        if (tail.includes(keyword)) matched.add(keyword);
+        if (tail.includes(keyword)) authenticatedMatches.add(keyword);
       }
+      for (const keyword of authenticatedMatches) matched.add(keyword);
     } catch {
       // A malformed encrypted details field must not break the bounded route.
     }
@@ -3361,7 +3363,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           const boundedEvent = rowToEvent(row, this.encryption);
           if (!searchableEvent || !boundedEvent) continue;
           const score = row.details_truncated === 1 && row.search_details === null
-            ? this.scoreOversizedEncryptedDetails(row.id, row.summary, keywords)
+            ? this.scoreOversizedEncryptedDetails(row.id, boundedEvent.summary, keywords)
             : recallEventScore(searchableEvent, keywords);
           if (score > 0) {
             matches.push({
@@ -3388,7 +3390,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     const searchableDetails = `CASE
       WHEN json_valid(details)
        AND NOT (
-         json_type(details, '$.quarantine') = 'object'
+         json_type(details, '$') = 'object'
+         AND (SELECT count(*) FROM json_each(details)) = 1
+         AND json_type(details, '$.quarantine') = 'object'
+         AND (SELECT count(*) FROM json_each(details, '$.quarantine')) = 3
          AND json_extract(details, '$.quarantine.field') = 'details'
          AND json_extract(details, '$.quarantine.eventId') = id
          AND json_extract(details, '$.quarantine.reason') = 'invalid JSON'

--- a/packages/franken-brain/tests/unit/brain-registry.test.ts
+++ b/packages/franken-brain/tests/unit/brain-registry.test.ts
@@ -35,6 +35,7 @@ describe('BrainRegistry', () => {
       expect(second).not.toBe(first);
       expect(registry.forAgentType('coder')).toBe(second);
       expect(registry.forAgentType('coder', join(root, 'first.db'))).toBe(first);
+      expect(registry.forAgentType('coder')).toBe(first);
     } finally {
       registry.close();
       rmSync(root, { recursive: true, force: true });

--- a/packages/franken-brain/tests/unit/brain-registry.test.ts
+++ b/packages/franken-brain/tests/unit/brain-registry.test.ts
@@ -22,6 +22,25 @@ describe('BrainRegistry', () => {
     }
   });
 
+  it('preserves existing handles when an agent type moves to another explicit path', () => {
+    const root = mkdtempSync(join(tmpdir(), 'franken-brain-registry-path-change-'));
+    const registry = new BrainRegistry();
+    try {
+      const first = registry.forAgentType('coder', join(root, 'first.db'));
+      first.working.set('first', true);
+      const second = registry.forAgentType('coder', join(root, 'second.db'));
+      second.working.set('second', true);
+
+      expect(first.working.get('first')).toBe(true);
+      expect(second).not.toBe(first);
+      expect(registry.forAgentType('coder')).toBe(second);
+      expect(registry.forAgentType('coder', join(root, 'first.db'))).toBe(first);
+    } finally {
+      registry.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('rejects identifiers that are ambiguous or unsafe as path components', () => {
     const registry = new BrainRegistry();
 

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -123,6 +123,40 @@ describe('EpisodicMemory.recall()', () => {
     }
   });
 
+  it('bounds encrypted episodic details by decrypted response size', () => {
+    const encryptedBrain = new SqliteBrain(':memory:', undefined, {
+      encryption: { enabled: true, key: 'episodic-bounds-test-key' },
+    });
+    try {
+      encryptedBrain.episodic.record({
+        type: 'observation',
+        summary: 'within plaintext bound',
+        details: { marker: 'searchable-needle', payload: 'x'.repeat(7_000) },
+        createdAt: '2026-03-18T10:30:00Z',
+      });
+      encryptedBrain.episodic.record({
+        type: 'observation',
+        summary: 'outside plaintext bound',
+        details: { payload: 'x'.repeat(9_000) },
+        createdAt: '2026-03-18T10:31:00Z',
+      });
+
+      expect(encryptedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
+        query: 'searchable-needle',
+        maxDetailsBytes: 8_192,
+      })[0]?.details).toMatchObject({ marker: 'searchable-needle' });
+      expect(encryptedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
+        maxDetailsBytes: 8_192,
+      })[0]).toMatchObject({ detailsTruncated: true });
+    } finally {
+      encryptedBrain.close();
+    }
+  });
+
   it.each([
     ['C++', 'C++ compiler selected', 'compiler selected'],
     ['C#', 'C# compiler selected', 'compiler selected'],

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -137,7 +137,7 @@ describe('EpisodicMemory.recall()', () => {
       encryptedBrain.episodic.record({
         type: 'observation',
         summary: 'outside plaintext bound',
-        details: { payload: 'x'.repeat(9_000) },
+        details: { marker: 'oversized-search-needle', payload: 'x'.repeat(9_000) },
         createdAt: '2026-03-18T10:31:00Z',
       });
 
@@ -150,6 +150,12 @@ describe('EpisodicMemory.recall()', () => {
       expect(encryptedBrain.episodic.readBoundedPage({
         limit: 10,
         offset: 0,
+        maxDetailsBytes: 8_192,
+      })[0]).toMatchObject({ detailsTruncated: true });
+      expect(encryptedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
+        query: 'oversized-search-needle',
         maxDetailsBytes: 8_192,
       })[0]).toMatchObject({ detailsTruncated: true });
     } finally {

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -137,7 +137,7 @@ describe('EpisodicMemory.recall()', () => {
       encryptedBrain.episodic.record({
         type: 'observation',
         summary: 'outside plaintext bound',
-        details: { marker: 'oversized-search-needle', payload: 'x'.repeat(9_000) },
+        details: { marker: 'oversized-search-needle', payload: 'x'.repeat(1_100_000) },
         createdAt: '2026-03-18T10:31:00Z',
       });
 

--- a/packages/franken-brain/tests/unit/episodic-recall.test.ts
+++ b/packages/franken-brain/tests/unit/episodic-recall.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
 import { SqliteBrain } from '../../src/sqlite-brain.js';
 
 describe('EpisodicMemory.recall()', () => {
@@ -155,9 +156,67 @@ describe('EpisodicMemory.recall()', () => {
       expect(encryptedBrain.episodic.readBoundedPage({
         limit: 10,
         offset: 0,
+        query: 'outside plaintext bound',
+        maxDetailsBytes: 8_192,
+      })[0]).toMatchObject({ summary: 'outside plaintext bound', detailsTruncated: true });
+      expect(encryptedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
         query: 'oversized-search-needle',
         maxDetailsBytes: 8_192,
       })[0]).toMatchObject({ detailsTruncated: true });
+    } finally {
+      encryptedBrain.close();
+    }
+  });
+
+  it('searches legitimate payloads that merely contain quarantine-shaped metadata', () => {
+    const isolatedBrain = new SqliteBrain();
+    try {
+      isolatedBrain.episodic.record({
+        type: 'observation',
+        summary: 'ordinary event',
+        createdAt: '2026-03-18T10:32:00Z',
+        details: {
+          quarantine: { field: 'details', eventId: 1, reason: 'invalid JSON' },
+          payload: 'legitimate-search-marker',
+        },
+      });
+      expect(isolatedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
+        query: 'legitimate-search-marker',
+        maxDetailsBytes: 8_192,
+      })).toHaveLength(1);
+    } finally {
+      isolatedBrain.close();
+    }
+  });
+
+  it('does not rank unauthenticated plaintext from tampered oversized encrypted details', () => {
+    const encryptedBrain = new SqliteBrain(':memory:', undefined, {
+      encryption: { enabled: true, key: 'episodic-tamper-test-key' },
+    });
+    try {
+      encryptedBrain.episodic.record({
+        type: 'observation',
+        summary: 'ordinary encrypted event',
+        details: { marker: 'tampered-search-needle', payload: 'x'.repeat(1_100_000) },
+        createdAt: '2026-03-18T10:33:00Z',
+      });
+      const db = (encryptedBrain as unknown as { db: Database.Database }).db;
+      const row = db.prepare('SELECT id, details FROM episodic_events LIMIT 1')
+        .get() as { id: number; details: string };
+      const envelope = row.details.split(':');
+      envelope[3] = `${envelope[3]![0] === 'A' ? 'B' : 'A'}${envelope[3]!.slice(1)}`;
+      db.prepare('UPDATE episodic_events SET details = ? WHERE id = ?').run(envelope.join(':'), row.id);
+
+      expect(encryptedBrain.episodic.readBoundedPage({
+        limit: 10,
+        offset: 0,
+        query: 'tampered-search-needle',
+        maxDetailsBytes: 8_192,
+      })).toEqual([]);
     } finally {
       encryptedBrain.close();
     }

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import { BeastEventBus } from './events/beast-event-bus.js';
 import { BeastLogStore } from './events/beast-log-store.js';
 import { SseConnectionTicketStore } from './events/sse-connection-ticket.js';
@@ -24,6 +24,8 @@ import { MaintenanceModeService } from './services/maintenance-mode-service.js';
 import { PrometheusBeastMetrics } from './telemetry/prometheus-beast-metrics.js';
 import { SkillManager } from '../skills/skill-manager.js';
 import { BrainRegistry } from '@franken/brain';
+import type { BrainRouteContext } from '../http/routes/brain-routes.js';
+import type { ModuleConfig } from './types.js';
 
 
 export interface BeastServicePaths {
@@ -36,6 +38,7 @@ export interface BeastServicePaths {
 export interface BeastServiceBundle {
   agents: AgentService;
   brains: BrainRegistry;
+  resolveBrainContext(agentTypeId: string): BrainRouteContext | undefined;
   catalog: BeastCatalogService;
   dispatch: BeastDispatchService;
   runs: BeastRunService;
@@ -52,6 +55,30 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const logStore = new BeastLogStore(paths.beastLogsDir, createBeastLogStoreOptionsFromEnv());
   const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
   const brains = new BrainRegistry(join(projectRoot, '.fbeast', 'brains'));
+  const resolveBrainContext = (agentTypeId: string): BrainRouteContext | undefined => {
+    const run = repository.listRuns().find((candidate) => candidate.definitionId === agentTypeId);
+    const agent = repository.listTrackedAgents().find((candidate) => candidate.definitionId === agentTypeId);
+    if (!run && !agent) return undefined;
+    const runSnapshot = run?.configSnapshot;
+    const agentSnapshot = agent?.initConfig;
+    const configuredDbPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
+      ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath');
+    const dbPath = configuredDbPath === undefined || configuredDbPath === ':memory:' || isAbsolute(configuredDbPath)
+      ? configuredDbPath
+      : resolve(projectRoot, configuredDbPath);
+    const runModules = recordValue(runSnapshot, 'modules') as ModuleConfig | undefined;
+    const agentModules = recordValue(agentSnapshot, 'modules') as ModuleConfig | undefined;
+    const modules = runModules ?? agent?.moduleConfig ?? agentModules;
+    return {
+      ...(dbPath ? { dbPath } : {}),
+      faculties: {
+        planning: moduleEnabled(modules?.planner, 'FRANKENBEAST_MODULE_PLANNER'),
+        reasoning: moduleEnabled(modules?.critique, 'FRANKENBEAST_MODULE_CRITIQUE'),
+        action: moduleEnabled(modules?.governor, 'FRANKENBEAST_MODULE_GOVERNOR'),
+        learning: false,
+      },
+    };
+  };
   const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
   const catalog = new BeastCatalogService();
   const metrics = new PrometheusBeastMetrics();
@@ -118,6 +145,7 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   return {
     agents: new AgentService(repository, undefined, { capacityPolicy, trustedSkillToolManifests }),
     brains,
+    resolveBrainContext,
     catalog,
     dispatch: new BeastDispatchService(repository, catalog, executors, metrics, logStore, {
       eventBus,
@@ -137,6 +165,25 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
       repository.close();
     },
   };
+}
+
+function moduleEnabled(configured: boolean | undefined, environmentVariable: string): boolean {
+  return configured ?? process.env[environmentVariable] !== 'false';
+}
+
+function recordValue(
+  value: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): Readonly<Record<string, unknown>> | undefined {
+  const candidate = value?.[key];
+  return candidate && typeof candidate === 'object' && !Array.isArray(candidate)
+    ? candidate as Readonly<Record<string, unknown>>
+    : undefined;
+}
+
+function stringValue(value: Readonly<Record<string, unknown>> | undefined, key: string): string | undefined {
+  const candidate = value?.[key];
+  return typeof candidate === 'string' && candidate.trim().length > 0 ? candidate : undefined;
 }
 
 function collectTrustedSkillToolManifests(

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -65,16 +65,25 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     if (!run && !agent) return undefined;
     const runSnapshot = run?.configSnapshot;
     const agentSnapshot = agent?.initConfig;
-    const configuredDbPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
+    const configuredBrainPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
       ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath');
-    const dbPath = configuredDbPath === undefined || configuredDbPath === ':memory:' || isAbsolute(configuredDbPath)
-      ? configuredDbPath
-      : resolve(projectRoot, configuredDbPath);
+    const attempt = run?.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
+    const worktreeExecutionCwd = attempt?.executorMetadata?.worktreeExecutionCwd;
+    const configuredProjectRoot = stringValue(runSnapshot, 'projectRoot')
+      ?? stringValue(agentSnapshot, 'projectRoot');
+    const runtimeRoot = typeof worktreeExecutionCwd === 'string'
+      ? worktreeExecutionCwd
+      : configuredProjectRoot ?? projectRoot;
+    const dbPath = configuredBrainPath === undefined
+      ? join(projectRoot, '.fbeast', 'brains', `${agentTypeId}.db`)
+      : configuredBrainPath === ':memory:' || isAbsolute(configuredBrainPath)
+        ? configuredBrainPath
+        : resolve(runtimeRoot, configuredBrainPath);
     const runModules = recordValue(runSnapshot, 'modules') as ModuleConfig | undefined;
     const agentModules = recordValue(agentSnapshot, 'modules') as ModuleConfig | undefined;
     const modules = runModules ?? agent?.moduleConfig ?? agentModules;
     return {
-      ...(dbPath ? { dbPath } : {}),
+      dbPath,
       faculties: {
         planning: moduleEnabled(modules?.planner, 'FRANKENBEAST_MODULE_PLANNER'),
         reasoning: moduleEnabled(modules?.critique, 'FRANKENBEAST_MODULE_CRITIQUE'),

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -33,6 +33,7 @@ export interface BeastServicePaths {
   beastLogsDir: string;
   root?: string | undefined;
   skillsDir?: string | undefined;
+  brainDbPath?: string | undefined;
 }
 
 export interface BeastServiceBundle {
@@ -66,7 +67,8 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
     const runSnapshot = run?.configSnapshot;
     const agentSnapshot = agent?.initConfig;
     const configuredBrainPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
-      ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath');
+      ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath')
+      ?? paths.brainDbPath;
     const attempt = run?.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
     const worktreeExecutionCwd = attempt?.executorMetadata?.worktreeExecutionCwd;
     const configuredProjectRoot = stringValue(runSnapshot, 'projectRoot')

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -56,8 +56,12 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
   const brains = new BrainRegistry(join(projectRoot, '.fbeast', 'brains'));
   const resolveBrainContext = (agentTypeId: string): BrainRouteContext | undefined => {
-    const run = repository.listRuns().find((candidate) => candidate.definitionId === agentTypeId);
-    const agent = repository.listTrackedAgents().find((candidate) => candidate.definitionId === agentTypeId);
+    const run = repository.getLatestRunForDefinition(agentTypeId);
+    const agent = run?.trackedAgentId
+      ? repository.getTrackedAgent(run.trackedAgentId)
+      : run
+        ? undefined
+        : repository.getLatestTrackedAgentForDefinition(agentTypeId);
     if (!run && !agent) return undefined;
     const runSnapshot = run?.configSnapshot;
     const agentSnapshot = agent?.initConfig;

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -57,30 +57,26 @@ export function createBeastServices(paths: BeastServicePaths): BeastServiceBundl
   const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
   const brains = new BrainRegistry(join(projectRoot, '.fbeast', 'brains'));
   const resolveBrainContext = (agentTypeId: string): BrainRouteContext | undefined => {
-    const run = repository.getLatestRunForDefinition(agentTypeId);
+    const run = repository.getLatestEstablishedRunForDefinition(agentTypeId, { recoverCorruptJson: true });
     const agent = run?.trackedAgentId
-      ? repository.getTrackedAgent(run.trackedAgentId)
+      ? repository.getTrackedAgent(run.trackedAgentId, { recoverCorruptJson: true })
       : run
         ? undefined
-        : repository.getLatestTrackedAgentForDefinition(agentTypeId);
+        : repository.getLatestTrackedAgentForDefinition(agentTypeId, { recoverCorruptJson: true });
     if (!run && !agent) return undefined;
     const runSnapshot = run?.configSnapshot;
     const agentSnapshot = agent?.initConfig;
     const configuredBrainPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
       ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath')
       ?? paths.brainDbPath;
-    const attempt = run?.currentAttemptId ? repository.getAttempt(run.currentAttemptId) : undefined;
-    const worktreeExecutionCwd = attempt?.executorMetadata?.worktreeExecutionCwd;
     const configuredProjectRoot = stringValue(runSnapshot, 'projectRoot')
       ?? stringValue(agentSnapshot, 'projectRoot');
-    const runtimeRoot = typeof worktreeExecutionCwd === 'string'
-      ? worktreeExecutionCwd
-      : configuredProjectRoot ?? projectRoot;
+    const stableRoot = configuredProjectRoot ?? projectRoot;
     const dbPath = configuredBrainPath === undefined
       ? join(projectRoot, '.fbeast', 'brains', `${agentTypeId}.db`)
       : configuredBrainPath === ':memory:' || isAbsolute(configuredBrainPath)
         ? configuredBrainPath
-        : resolve(runtimeRoot, configuredBrainPath);
+        : resolve(stableRoot, configuredBrainPath);
     const runModules = recordValue(runSnapshot, 'modules') as ModuleConfig | undefined;
     const agentModules = recordValue(agentSnapshot, 'modules') as ModuleConfig | undefined;
     const modules = runModules ?? agent?.moduleConfig ?? agentModules;

--- a/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
@@ -5,7 +5,7 @@ import type { BeastEventBus } from '../events/beast-event-bus.js';
 import type { SQLiteBeastRepository } from '../repository/sqlite-beast-repository.js';
 import { ProcessBeastExecutor, type ProcessBeastExecutorOptions } from './process-beast-executor.js';
 import { ProcessSupervisor, type ProcessSupervisorLike } from './process-supervisor.js';
-import { toDockerSpec, writableWorkspaceUser } from './docker-container-runtime.js';
+import { remapHostWorkspacePath, toDockerSpec, writableWorkspaceUser } from './docker-container-runtime.js';
 import { DEFAULT_SANDBOX_POLICY, type SandboxPolicy } from './sandbox-policy.js';
 
 export interface ContainerBeastExecutorDeps {
@@ -76,6 +76,19 @@ export class ContainerBeastExecutor implements BeastExecutor {
       options.eventBus = deps.eventBus;
     }
     options.runConfigOwner = () => parseRunConfigOwner(writableWorkspaceUser(policy));
+    options.transformRunConfigSnapshot = (snapshot) => {
+      const brain = snapshot.brain;
+      if (!brain || typeof brain !== 'object' || Array.isArray(brain)) return snapshot;
+      const dbPath = (brain as Record<string, unknown>).dbPath;
+      if (typeof dbPath !== 'string') return snapshot;
+      return {
+        ...snapshot,
+        brain: {
+          ...brain as Record<string, unknown>,
+          dbPath: remapHostWorkspacePath(dbPath, policy),
+        },
+      };
+    };
     const nextAttemptNumber = (run: BeastRun): number => deps.repository.listAttempts(run.id).length + 1;
     options.transformSpec = (run, _originalSpec, mergedSpec) => toDockerSpec(mergedSpec, policy, {
       containerName: containerNameForRunAttempt(run, nextAttemptNumber(run)),

--- a/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/container-beast-executor.ts
@@ -7,6 +7,7 @@ import { ProcessBeastExecutor, type ProcessBeastExecutorOptions } from './proces
 import { ProcessSupervisor, type ProcessSupervisorLike } from './process-supervisor.js';
 import { remapHostWorkspacePath, toDockerSpec, writableWorkspaceUser } from './docker-container-runtime.js';
 import { DEFAULT_SANDBOX_POLICY, type SandboxPolicy } from './sandbox-policy.js';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 export interface ContainerBeastExecutorDeps {
   readonly repository: SQLiteBeastRepository;
@@ -81,6 +82,12 @@ export class ContainerBeastExecutor implements BeastExecutor {
       if (!brain || typeof brain !== 'object' || Array.isArray(brain)) return snapshot;
       const dbPath = (brain as Record<string, unknown>).dbPath;
       if (typeof dbPath !== 'string') return snapshot;
+      if (dbPath !== ':memory:' && isAbsolute(dbPath)) {
+        const relativePath = relative(resolve(policy.workspaceHostPath), resolve(dbPath));
+        if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+          throw new Error(`Container brain.dbPath must be inside the mounted workspace: ${dbPath}`);
+        }
+      }
       return {
         ...snapshot,
         brain: {

--- a/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/docker-container-runtime.ts
@@ -14,7 +14,7 @@ function canonicalExistingPath(path: string): string {
   }
 }
 
-function remapHostWorkspacePath(value: string, policy: SandboxPolicy): string {
+export function remapHostWorkspacePath(value: string, policy: SandboxPolicy): string {
   if (!isAbsolute(value)) {
     return value;
   }

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -331,6 +331,9 @@ export interface ProcessBeastExecutorOptions {
   runConfigDir?: string;
   runConfigRoot?: string;
   runConfigOwner?: RunConfigSnapshotOwner | RunConfigSnapshotOwnerProvider;
+  transformRunConfigSnapshot?: (
+    snapshot: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
   transformSpec?: (
     run: BeastRun,
     originalSpec: BeastProcessSpec,
@@ -804,7 +807,10 @@ export class ProcessBeastExecutor implements BeastExecutor {
       mergedSpec.env,
       spawnedSpec.env,
     );
-    const redactedConfigSnapshot = redactRunConfigSnapshot(isolatedConfigSnapshot, configuredSecrets);
+    const runtimeConfigSnapshot = this.options.transformRunConfigSnapshot
+      ? this.options.transformRunConfigSnapshot(isolatedConfigSnapshot)
+      : isolatedConfigSnapshot;
+    const redactedConfigSnapshot = redactRunConfigSnapshot(runtimeConfigSnapshot, configuredSecrets);
     const serializedRunConfig = JSON.stringify(redactedConfigSnapshot, null, 2);
     const integrityManifest = createRunConfigIntegrityManifest(serializedRunConfig, runConfigIntegritySecret, {
       configPath: this.resolveSpawnedRunConfigPath(spawnedSpec, configFilePath),

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -301,6 +301,23 @@ function remapRuntimeConfigSnapshot(
   return changed ? remapped : configSnapshot;
 }
 
+function canonicalizePersistentBrainPath(
+  configSnapshot: Readonly<Record<string, unknown>>,
+  stableProjectRoot: string | undefined,
+): Readonly<Record<string, unknown>> {
+  const brain = configSnapshot.brain;
+  if (!stableProjectRoot || !brain || typeof brain !== 'object' || Array.isArray(brain)) return configSnapshot;
+  const dbPath = (brain as Record<string, unknown>).dbPath;
+  if (typeof dbPath !== 'string' || dbPath === ':memory:' || isAbsolute(dbPath)) return configSnapshot;
+  return {
+    ...configSnapshot,
+    brain: {
+      ...brain as Record<string, unknown>,
+      dbPath: resolve(stableProjectRoot, dbPath),
+    },
+  };
+}
+
 function remapRuntimePathArgs(
   args: readonly string[],
   sourceRoot: string | undefined,
@@ -775,10 +792,10 @@ export class ProcessBeastExecutor implements BeastExecutor {
     const moduleEnv = moduleConfigToEnv(run.configSnapshot.modules as ModuleConfig | undefined);
     this.supervisor.validateCwd?.(processSpec.cwd);
     const worktree = this.allocateWorktree(run, processSpec);
-    const identifiedConfigSnapshot = {
+    const identifiedConfigSnapshot = canonicalizePersistentBrainPath({
       ...run.configSnapshot,
       definitionId: run.definitionId,
-    };
+    }, this.options.runConfigRoot ?? processSpec.cwd);
     const isolatedConfigSnapshot = worktree
       ? {
           ...remapRuntimeConfigSnapshot(identifiedConfigSnapshot, processSpec.cwd, worktree.executionCwd),

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -394,6 +394,19 @@ export class SQLiteBeastRepository {
     return row ? mapRun(row) : undefined;
   }
 
+  getLatestRunForDefinition(
+    definitionId: string,
+    options: CorruptJsonRecoveryOptions = {},
+  ): BeastRun | undefined {
+    const row = this.db.prepare(
+      `SELECT * FROM beast_runs
+        WHERE definition_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1`,
+    ).get(definitionId) as BeastRunRow | undefined;
+    return row ? mapRowsRecoveringCorruptJson([row], mapRun, options)[0] : undefined;
+  }
+
   listRuns(options: CorruptJsonRecoveryOptions = {}): BeastRun[] {
     const rows = this.db.prepare('SELECT * FROM beast_runs ORDER BY created_at DESC, id DESC').all() as BeastRunRow[];
     return mapRowsRecoveringCorruptJson(rows, mapRun, options);
@@ -732,6 +745,19 @@ export class SQLiteBeastRepository {
 
   getTrackedAgent(agentId: string, options: CorruptJsonRecoveryOptions = {}): TrackedAgent | undefined {
     const row = this.db.prepare('SELECT * FROM tracked_agents WHERE id = ?').get(agentId) as TrackedAgentRow | undefined;
+    return row ? mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0] : undefined;
+  }
+
+  getLatestTrackedAgentForDefinition(
+    definitionId: string,
+    options: CorruptJsonRecoveryOptions = {},
+  ): TrackedAgent | undefined {
+    const row = this.db.prepare(
+      `SELECT * FROM tracked_agents
+        WHERE definition_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1`,
+    ).get(definitionId) as TrackedAgentRow | undefined;
     return row ? mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0] : undefined;
   }
 

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -401,7 +401,7 @@ export class SQLiteBeastRepository {
     const row = this.db.prepare(
       `SELECT * FROM beast_runs
         WHERE definition_id = ?
-        ORDER BY created_at DESC, id DESC
+        ORDER BY created_at DESC, rowid DESC
         LIMIT 1`,
     ).get(definitionId) as BeastRunRow | undefined;
     return row ? mapRowsRecoveringCorruptJson([row], mapRun, options)[0] : undefined;
@@ -755,7 +755,7 @@ export class SQLiteBeastRepository {
     const row = this.db.prepare(
       `SELECT * FROM tracked_agents
         WHERE definition_id = ?
-        ORDER BY created_at DESC, id DESC
+        ORDER BY created_at DESC, rowid DESC
         LIMIT 1`,
     ).get(definitionId) as TrackedAgentRow | undefined;
     return row ? mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0] : undefined;

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-beast-repository.ts
@@ -407,6 +407,29 @@ export class SQLiteBeastRepository {
     return row ? mapRowsRecoveringCorruptJson([row], mapRun, options)[0] : undefined;
   }
 
+  getLatestEstablishedRunForDefinition(
+    definitionId: string,
+    options: CorruptJsonRecoveryOptions = {},
+  ): BeastRun | undefined {
+    let offset = 0;
+    while (true) {
+      const row = this.db.prepare(
+        `SELECT beast_runs.* FROM beast_runs
+          WHERE definition_id = ?
+            AND EXISTS (
+              SELECT 1 FROM beast_run_attempts
+               WHERE beast_run_attempts.run_id = beast_runs.id
+            )
+          ORDER BY created_at DESC, beast_runs.rowid DESC
+          LIMIT 1 OFFSET ?`,
+      ).get(definitionId, offset) as BeastRunRow | undefined;
+      if (!row) return undefined;
+      const mapped = mapRowsRecoveringCorruptJson([row], mapRun, options)[0];
+      if (mapped) return mapped;
+      offset += 1;
+    }
+  }
+
   listRuns(options: CorruptJsonRecoveryOptions = {}): BeastRun[] {
     const rows = this.db.prepare('SELECT * FROM beast_runs ORDER BY created_at DESC, id DESC').all() as BeastRunRow[];
     return mapRowsRecoveringCorruptJson(rows, mapRun, options);
@@ -752,13 +775,29 @@ export class SQLiteBeastRepository {
     definitionId: string,
     options: CorruptJsonRecoveryOptions = {},
   ): TrackedAgent | undefined {
-    const row = this.db.prepare(
-      `SELECT * FROM tracked_agents
-        WHERE definition_id = ?
-        ORDER BY created_at DESC, rowid DESC
-        LIMIT 1`,
-    ).get(definitionId) as TrackedAgentRow | undefined;
-    return row ? mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0] : undefined;
+    if (!options.recoverCorruptJson) {
+      const row = this.db.prepare(
+        `SELECT * FROM tracked_agents
+          WHERE definition_id = ?
+          ORDER BY created_at DESC, rowid DESC
+          LIMIT 1`,
+      ).get(definitionId) as TrackedAgentRow | undefined;
+      return row ? mapTrackedAgent(row) : undefined;
+    }
+
+    let offset = 0;
+    while (true) {
+      const row = this.db.prepare(
+        `SELECT * FROM tracked_agents
+          WHERE definition_id = ?
+          ORDER BY created_at DESC, rowid DESC
+          LIMIT 1 OFFSET ?`,
+      ).get(definitionId, offset) as TrackedAgentRow | undefined;
+      if (!row) return undefined;
+      const mapped = mapRowsRecoveringCorruptJson([row], mapTrackedAgent, options)[0];
+      if (mapped) return mapped;
+      offset += 1;
+    }
   }
 
   requireTrackedAgent(agentId: string): TrackedAgent {

--- a/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
+++ b/packages/franken-orchestrator/src/beasts/repository/sqlite-schema.ts
@@ -22,6 +22,8 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_beast_runs_created_at_id
     ON beast_runs(created_at DESC, id DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_beast_runs_definition_created_at_id
+    ON beast_runs(definition_id, created_at DESC, id DESC)`,
   `CREATE TABLE IF NOT EXISTS beast_run_attempts (
     id TEXT PRIMARY KEY,
     run_id TEXT NOT NULL,
@@ -86,6 +88,8 @@ export const BEAST_SQLITE_SCHEMA_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_tracked_agents_created_at_id
     ON tracked_agents(created_at DESC, id DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_tracked_agents_definition_created_at_id
+    ON tracked_agents(definition_id, created_at DESC, id DESC)`,
   `CREATE INDEX IF NOT EXISTS idx_tracked_agents_status
     ON tracked_agents(status)`,
   `CREATE INDEX IF NOT EXISTS idx_tracked_agent_events_type_agent

--- a/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
+++ b/packages/franken-orchestrator/src/beasts/services/beast-dispatch-service.ts
@@ -9,6 +9,7 @@ import { wallClockNow } from '@franken/types';
 import { SAFE_DISPATCH_FAILURE_MESSAGE } from './dispatch-failure-message.js';
 import { UnknownBeastDefinitionError } from '../errors.js';
 import { GitConfigSchema, LlmConfigSchema, PromptConfigSchema } from '../../cli/run-config-loader.js';
+import { BrainConfigSchema } from '../../config/orchestrator-config.js';
 import {
   CapacityReservationError,
   type CapacityReservationPolicy,
@@ -47,6 +48,7 @@ const SHARED_RUNTIME_CONFIG_KEYS = [
   'category',
   'categories',
   'issue',
+  'brain',
 ] as const;
 
 const TOOL_POLICY_CONFIG_KEYS = [
@@ -134,6 +136,8 @@ function normalizeSharedRuntimeConfigValue(key: string, value: unknown): unknown
       return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : undefined;
     case 'issue':
       return isRecord(value) ? value : undefined;
+    case 'brain':
+      return parseOptionalSharedConfig(BrainConfigSchema, value);
     default:
       return undefined;
   }

--- a/packages/franken-orchestrator/src/cli/dep-bridge.ts
+++ b/packages/franken-orchestrator/src/cli/dep-bridge.ts
@@ -96,6 +96,11 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
   const brainConfigDir = typeof options.runConfig?.brainConfigDir === 'string'
     ? options.runConfig.brainConfigDir
     : resolve(options.paths.root, '.fbeast');
+  const runBrain = options.runConfig?.brain;
+  const runBrainDbPath = runBrain && typeof runBrain === 'object' && !Array.isArray(runBrain)
+    && typeof (runBrain as Record<string, unknown>).dbPath === 'string'
+    ? (runBrain as Record<string, string>).dbPath
+    : undefined;
   const egressPolicy = config?.network?.egressPolicy;
 
   return {
@@ -116,9 +121,9 @@ export function bridgeToBeastConfig(options: CliDepOptions, config?: Orchestrato
       : { profile: securityProfile },
     ...(agentTypeId ? { agentTypeId } : {}),
     ...(agentTypeId ? { brainConfigDir } : {}),
-    brain: agentTypeId && config?.brain?.dbPath === undefined
+    brain: agentTypeId && runBrainDbPath === undefined && config?.brain?.dbPath === undefined
       ? {}
-      : { dbPath: config?.brain?.dbPath ?? dbPath },
+      : { dbPath: runBrainDbPath ?? config?.brain?.dbPath ?? dbPath },
     skillsDir: options.skillsDir ?? resolve(options.paths.root, '.fbeast', 'skills'),
     configDir: resolve(options.paths.root, '.fbeast'),
     reflection: true,

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1421,6 +1421,7 @@ async function runChatCommandIfRequested(
         beastsDb: join(paths.frankenbeastDir, 'beast.db'),
         beastLogsDir: paths.beastLogsDir,
         root,
+        brainDbPath: config.brain?.dbPath,
         skillsDir: typeof skillManager?.getSkillsDir === 'function'
           ? skillManager.getSkillsDir()
           : join(root, 'skills'),

--- a/packages/franken-orchestrator/src/http/beast-daemon-app.ts
+++ b/packages/franken-orchestrator/src/http/beast-daemon-app.ts
@@ -235,6 +235,7 @@ export function createBeastDaemonApp(options: BeastDaemonAppOptions): Hono {
   app.route('/', beastRoutes(routeDeps));
   app.route('/', brainRoutes({
     registry: services.brains,
+    resolveContext: services.resolveBrainContext,
     operatorToken: options.operatorToken,
     security,
     rateLimit,

--- a/packages/franken-orchestrator/src/http/chat-app.ts
+++ b/packages/franken-orchestrator/src/http/chat-app.ts
@@ -13,7 +13,7 @@ import { agentRoutes } from './routes/agent-routes.js';
 import { AgentInitService } from '../beasts/services/agent-init-service.js';
 import { createBeastSseRoutes } from './routes/beast-sse-routes.js';
 import { beastRoutes, type BeastRoutesDeps } from './routes/beast-routes.js';
-import { brainRoutes } from './routes/brain-routes.js';
+import { brainRoutes, type BrainRouteContext } from './routes/brain-routes.js';
 import { chatRoutes } from './routes/chat-routes.js';
 import { networkRoutes } from './routes/network-routes.js';
 import { commsRoutes } from './routes/comms-routes.js';
@@ -67,7 +67,10 @@ export interface ChatAppOptions {
     getConfig(): OrchestratorConfig;
     setConfig(config: OrchestratorConfig): void;
   };
-  beastControl?: BeastRoutesDeps & { brains?: BrainRegistry };
+  beastControl?: BeastRoutesDeps & {
+    brains?: BrainRegistry;
+    resolveBrainContext?: (agentTypeId: string) => BrainRouteContext | undefined;
+  };
   commsConfig?: CommsConfig;
   commsRuntime?: CommsRuntimePort;
   securityConfig?: {
@@ -295,6 +298,7 @@ export function createChatApp(opts: ChatAppOptions): Hono {
     if (opts.beastControl.brains) {
       app.route('/', brainRoutes({
         registry: opts.beastControl.brains,
+        resolveContext: opts.beastControl.resolveBrainContext,
         operatorToken: opts.beastControl.operatorToken,
         security: opts.beastControl.security ?? transportSecurity,
         rateLimit: opts.beastControl.rateLimit,

--- a/packages/franken-orchestrator/src/http/routes/brain-routes.ts
+++ b/packages/franken-orchestrator/src/http/routes/brain-routes.ts
@@ -31,16 +31,28 @@ const EpisodeQuerySchema = z.object({
 
 export interface BrainRoutesDeps {
   registry: BrainRegistry;
+  resolveContext?: ((agentTypeId: string) => BrainRouteContext | undefined) | undefined;
   operatorToken: string;
   security: TransportSecurityService;
   rateLimit?: BeastRateLimitOptions;
 }
 
-function resolveBrain(c: Context, registry: BrainRegistry): { agentTypeId: string; brain: SqliteBrain } {
+export interface BrainRouteContext {
+  dbPath?: string | undefined;
+  faculties?: Partial<Record<'planning' | 'reasoning' | 'action' | 'learning', boolean>> | undefined;
+}
+
+function resolveBrain(c: Context, deps: BrainRoutesDeps): {
+  agentTypeId: string;
+  brain: SqliteBrain;
+  context: BrainRouteContext | undefined;
+} {
   const agentTypeId = c.req.param('agentTypeId') ?? '';
   let brain: SqliteBrain | undefined;
+  let context: BrainRouteContext | undefined;
   try {
-    brain = registry.getAgentType(agentTypeId);
+    context = deps.resolveContext?.(agentTypeId);
+    brain = deps.registry.getAgentType(agentTypeId, context?.dbPath);
   } catch (error) {
     if (error instanceof RangeError) {
       throw new HttpError(400, 'INVALID_AGENT_TYPE_ID', 'agentTypeId is invalid');
@@ -50,7 +62,7 @@ function resolveBrain(c: Context, registry: BrainRegistry): { agentTypeId: strin
   if (!brain) {
     throw new HttpError(404, 'BRAIN_NOT_FOUND', 'No brain exists for the requested agent type');
   }
-  return { agentTypeId, brain };
+  return { agentTypeId, brain, context };
 }
 
 function parseEpisodeQuery(c: Context): z.infer<typeof EpisodeQuerySchema> {
@@ -80,14 +92,15 @@ function truncateUtf8(value: string, maxBytes: number): { value: string; truncat
   return { value: encoded.subarray(0, maxBytes).toString('utf8'), truncated: true };
 }
 
-function boundEpisode(event: EpisodicEvent) {
+function boundEpisode(event: EpisodicEvent & { detailsTruncated?: true }) {
   const step = event.step === undefined
     ? undefined
     : truncateUtf8(event.step, MAX_EPISODE_STEP_BYTES);
   const summary = truncateUtf8(event.summary, MAX_EPISODE_SUMMARY_BYTES);
   const createdAt = truncateUtf8(event.createdAt, MAX_EPISODE_TIMESTAMP_BYTES);
-  const detailsTooLarge = event.details !== undefined
-    && Buffer.byteLength(JSON.stringify(event.details)) > MAX_EPISODE_DETAILS_BYTES;
+  const detailsTooLarge = event.detailsTruncated === true || (event.details !== undefined
+    && Buffer.byteLength(JSON.stringify(event.details)) > MAX_EPISODE_DETAILS_BYTES
+  );
   return {
     ...event,
     ...(step ? { step: step.value } : {}),
@@ -117,10 +130,8 @@ export function brainRoutes(deps: BrainRoutesDeps): Hono {
   }
 
   app.get('/v1/brain/:agentTypeId', (c) => readBrainState(() => {
-    const { agentTypeId, brain } = resolveBrain(c, deps.registry);
-    // Refresh persisted working memory view to avoid stale in-memory cache
-    (brain as any).refreshPreparedStateForFlush?.();
-    const allWorkingKeys = brain.working.keys().sort();
+    const { agentTypeId, brain, context } = resolveBrain(c, deps);
+    const allWorkingKeys = brain.working.persistedKeys();
     const lastCheckpoint = brain.recovery.lastCheckpoint();
 
     return c.json({
@@ -133,12 +144,11 @@ export function brainRoutes(deps: BrainRoutesDeps): Hono {
         },
         episodic: { eventCount: brain.episodic.count() },
         recovery: { lastCheckpointAt: lastCheckpoint?.timestamp ?? null },
-        // Updated to reflect latest runtime faculty configuration
         faculties: {
-          planning: { configured: brain.planning.configured },
-          reasoning: { configured: brain.reasoning.configured },
-          action: { configured: brain.action.configured },
-          learning: { configured: brain.learning.configured },
+          planning: { configured: context?.faculties?.planning ?? brain.planning.configured },
+          reasoning: { configured: context?.faculties?.reasoning ?? brain.reasoning.configured },
+          action: { configured: context?.faculties?.action ?? brain.action.configured },
+          learning: { configured: context?.faculties?.learning ?? brain.learning.configured },
         },
         capabilities: {
           memoryReview: true,
@@ -154,14 +164,16 @@ export function brainRoutes(deps: BrainRoutesDeps): Hono {
   }));
 
   app.get('/v1/brain/:agentTypeId/episodes', (c) => readBrainState(() => {
-    const { brain } = resolveBrain(c, deps.registry);
+    const { brain } = resolveBrain(c, deps);
     const { limit, offset, query } = parseEpisodeQuery(c);
-    const readLimit = offset + limit + 1;
-    const candidates = query === undefined
-      ? brain.episodic.recent(readLimit)
-      : brain.episodic.recall(query, readLimit);
-    const data = candidates.slice(offset, offset + limit).map(boundEpisode);
-    const hasMore = candidates.length > offset + limit;
+    const candidates = brain.episodic.readBoundedPage({
+      limit: limit + 1,
+      offset,
+      ...(query === undefined ? {} : { query }),
+      maxDetailsBytes: MAX_EPISODE_DETAILS_BYTES,
+    });
+    const data = candidates.slice(0, limit).map(boundEpisode);
+    const hasMore = candidates.length > limit;
 
     return c.json({
       data,
@@ -175,12 +187,12 @@ export function brainRoutes(deps: BrainRoutesDeps): Hono {
   }));
 
   app.get('/v1/brain/:agentTypeId/lessons', (c) => readBrainState(() => {
-    const { brain } = resolveBrain(c, deps.registry);
+    const { brain, context } = resolveBrain(c, deps);
     return c.json({
       data: [],
       meta: {
         available: false,
-        facultyConfigured: brain.learning.configured,
+        facultyConfigured: context?.faculties?.learning ?? brain.learning.configured,
         reason: 'Consolidated lessons are not available until the learning faculty is configured',
       },
     });

--- a/packages/franken-orchestrator/tests/integration/beasts/brain-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/brain-routes.test.ts
@@ -1,22 +1,27 @@
 import { Hono } from 'hono';
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { BrainRegistry } from '@franken/brain';
+import { BrainRegistry, SqliteBrain } from '@franken/brain';
+import Database from 'better-sqlite3';
 
 import { errorHandler } from '../../../src/http/middleware.js';
-import { brainRoutes } from '../../../src/http/routes/brain-routes.js';
+import { brainRoutes, type BrainRouteContext } from '../../../src/http/routes/brain-routes.js';
 import { TransportSecurityService } from '../../../src/http/security/transport-security.js';
 import { testCredential } from '../../support/test-credentials.js';
 
 const OPERATOR_TOKEN = testCredential('TEST_BRAIN_ROUTES_OPERATOR_TOKEN');
 
-function createApp(registry: BrainRegistry): Hono {
+function createApp(
+  registry: BrainRegistry,
+  resolveContext?: (agentTypeId: string) => BrainRouteContext | undefined,
+): Hono {
   const app = new Hono();
   app.onError(errorHandler);
   app.route('/', brainRoutes({
     registry,
+    resolveContext,
     operatorToken: OPERATOR_TOKEN,
     security: new TransportSecurityService(),
   }));
@@ -103,6 +108,65 @@ describe('brain routes integration', () => {
     });
   });
 
+  it('resolves a persisted custom brain path and service-side faculty configuration', async () => {
+    const { registry, brainsDir } = createRegistry();
+    mkdirSync(brainsDir, { recursive: true });
+    const customDbPath = join(brainsDir, 'custom-coder.db');
+    const writer = new SqliteBrain(customDbPath);
+    writer.working.set('custom-key', 'custom-value');
+    writer.working.flushToDb();
+    writer.close();
+
+    const response = await createApp(registry, () => ({
+      dbPath: customDbPath,
+      faculties: {
+        planning: true,
+        reasoning: true,
+        action: true,
+        learning: false,
+      },
+    })).request('/v1/brain/coder', { headers: authorizedHeaders() });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        workingMemory: { keys: ['custom-key'], total: 1 },
+        faculties: {
+          planning: { configured: true },
+          reasoning: { configured: true },
+          action: { configured: true },
+          learning: { configured: false },
+        },
+      },
+    });
+    expect(existsSync(join(brainsDir, 'coder.db'))).toBe(false);
+  });
+
+  it('does not fabricate persisted state for a configured in-memory brain', async () => {
+    const { registry } = createRegistry();
+    const response = await createApp(registry, () => ({ dbPath: ':memory:' }))
+      .request('/v1/brain/coder', { headers: authorizedHeaders() });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('reads working-memory keys written after the route brain was hydrated', async () => {
+    const { registry, brainsDir } = createRegistry();
+    registry.forAgentType('coder');
+    const app = createApp(registry);
+    const writer = new SqliteBrain(join(brainsDir, 'coder.db'));
+    writer.working.set('late-key', 'late-value');
+    writer.working.flushToDb();
+    writer.close();
+
+    const response = await app.request('/v1/brain/coder', { headers: authorizedHeaders() });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { workingMemory: { keys: ['late-key'], total: 1 } },
+    });
+  });
+
   it('paginates and filters episodic history within strict query bounds', async () => {
     const { registry } = createRegistry();
     const brain = registry.forAgentType('planner');
@@ -113,6 +177,12 @@ describe('brain routes integration', () => {
         createdAt: `2026-07-24T10:0${index}:00.000Z`,
       });
     }
+    brain.episodic.record({
+      type: 'observation',
+      summary: 'neutral event',
+      details: { topic: 'gamma' },
+      createdAt: '2026-07-24T09:59:00.000Z',
+    });
     const app = createApp(registry);
 
     const first = await app.request('/v1/brain/planner/episodes?limit=2&offset=0', {
@@ -134,21 +204,40 @@ describe('brain routes integration', () => {
     expect((await filtered.json() as { data: Array<{ summary: string }> }).data.map((event) => event.summary))
       .toEqual(['alpha retry', 'alpha plan']);
 
+    const ranked = await app.request('/v1/brain/planner/episodes?query=alpha%20retry&limit=10', {
+      headers: authorizedHeaders(),
+    });
+    expect((await ranked.json() as { data: Array<{ summary: string }> }).data.map((event) => event.summary))
+      .toEqual(['alpha retry', 'alpha plan']);
+
+    const detailsMatch = await app.request('/v1/brain/planner/episodes?query=gamma&limit=10', {
+      headers: authorizedHeaders(),
+    });
+    expect(await detailsMatch.json()).toMatchObject({ data: [{ summary: 'neutral event' }] });
+    expect(brain.accessAudit.list({ operation: 'episodic.readBoundedPage' })[0]).toMatchObject({
+      outcome: 'success',
+      details: { limit: 11, offset: 0, count: 1 },
+    });
+
     const invalid = await app.request('/v1/brain/planner/episodes?limit=101', {
       headers: authorizedHeaders(),
     });
     expect(invalid.status).toBe(422);
   });
 
-  it('bounds each episodic row even when stored details are very large', async () => {
-    const { registry } = createRegistry();
-    registry.forAgentType('coder').episodic.record({
+  it('bounds each episodic row before parsing oversized stored details', async () => {
+    const { registry, brainsDir } = createRegistry();
+    const eventId = registry.forAgentType('coder').episodic.record({
       type: 'observation',
       step: 's'.repeat(1_000_000),
       summary: 'Large diagnostic event',
       details: { raw: 'x'.repeat(1_000_000) },
       createdAt: '2026-07-24T10:00:00.000Z',
     });
+    const db = new Database(join(brainsDir, 'coder.db'));
+    db.prepare('UPDATE episodic_events SET details = ? WHERE id = ?')
+      .run(`{"raw":"${'x'.repeat(1_000_000)}`, eventId);
+    db.close();
 
     const response = await createApp(registry).request('/v1/brain/coder/episodes?limit=1', {
       headers: authorizedHeaders(),

--- a/packages/franken-orchestrator/tests/integration/beasts/brain-routes.test.ts
+++ b/packages/franken-orchestrator/tests/integration/beasts/brain-routes.test.ts
@@ -227,7 +227,7 @@ describe('brain routes integration', () => {
 
   it('bounds each episodic row before parsing oversized stored details', async () => {
     const { registry, brainsDir } = createRegistry();
-    const eventId = registry.forAgentType('coder').episodic.record({
+    registry.forAgentType('coder').episodic.record({
       type: 'observation',
       step: 's'.repeat(1_000_000),
       summary: 'Large diagnostic event',
@@ -235,6 +235,9 @@ describe('brain routes integration', () => {
       createdAt: '2026-07-24T10:00:00.000Z',
     });
     const db = new Database(join(brainsDir, 'coder.db'));
+    const { id: eventId } = db.prepare(
+      'SELECT id FROM episodic_events ORDER BY id DESC LIMIT 1',
+    ).get() as { id: string };
     db.prepare('UPDATE episodic_events SET details = ? WHERE id = ?')
       .run(`{"raw":"${'x'.repeat(1_000_000)}`, eventId);
     db.close();

--- a/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/beast-dispatch-service.test.ts
@@ -353,6 +353,7 @@ describe('BeastDispatchService', () => {
         promptConfig: { text: 'Launch with this context.' },
         gitConfig: { preset: 'feature-branch', baseBranch: 'develop', branchPattern: '', prCreation: true, mergeStrategy: 'squash', commitConvention: 'conventional' },
         llmConfig: { default: { provider: 'openai', model: 'gpt-5.3-codex-spark' } },
+        brain: { dbPath: '.fbeast/brains/custom.db' },
       },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'pfk',
@@ -371,6 +372,7 @@ describe('BeastDispatchService', () => {
       promptConfig: { text: 'Launch with this context.' },
       gitConfig: { preset: 'feature-branch', baseBranch: 'develop', branchPattern: '', prCreation: 'auto', mergeStrategy: 'squash', commitConvention: 'conventional' },
       llmConfig: { default: { provider: 'openai', model: 'gpt-5.3-codex-spark' } },
+      brain: { dbPath: '.fbeast/brains/custom.db' },
       modules: { firewall: true, skills: true, planner: false },
     });
   });

--- a/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/container-beast-executor.test.ts
@@ -8,7 +8,7 @@ import { DEFAULT_SANDBOX_POLICY } from '../../../src/beasts/execution/sandbox-po
 import { BeastEventBus } from '../../../src/beasts/events/beast-event-bus.js';
 import { BeastLogStore } from '../../../src/beasts/events/beast-log-store.js';
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
-import type { BeastDefinition, BeastProcessSpec } from '../../../src/beasts/types.js';
+import type { BeastProcessSpec } from '../../../src/beasts/types.js';
 import type { ProcessCallbacks, ProcessSupervisorLike } from '../../../src/beasts/execution/process-supervisor.js';
 import { RUN_CONFIG_INTEGRITY_ENV, RUN_CONFIG_INTEGRITY_SECRET_ENV } from '../../../src/cli/run-config-integrity.js';
 
@@ -162,12 +162,12 @@ describe('ContainerBeastExecutor', () => {
       dispatchedByUser: 'pfk',
       createdAt: '2026-03-10T00:00:00.000Z',
     });
-    const definition: BeastDefinition = {
+    const definition = {
       id: 'test-beast',
       version: 1,
       label: 'Test Beast',
       description: 'Test beast',
-      executionModeDefault: 'container',
+      executionModeDefault: 'container' as const,
       configSchema: { parse: (value: unknown) => value as Readonly<Record<string, unknown>> },
       interviewPrompts: [],
       telemetryLabels: {},
@@ -183,6 +183,49 @@ describe('ContainerBeastExecutor', () => {
     const configPath = join(workspaceHostPath, '.fbeast', '.build', 'run-configs', `${run.id}.json`);
     expect(statSync(configPath).uid).toBe(expectedUid);
     expect(statSync(configPath).gid).toBe(expectedGid);
+  });
+
+  it('rejects persistent brain paths outside the mounted workspace', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-container-executor-'));
+    const repository = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+    const logStore = new BeastLogStore(join(workDir, 'logs'));
+    const fakeSupervisor: ProcessSupervisorLike = {
+      spawn: vi.fn(async () => ({ pid: 4242 })),
+      stop: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+    };
+    const executor = new ContainerBeastExecutor({
+      repository,
+      logStore,
+      supervisorFactory: () => fakeSupervisor,
+      policy: { ...DEFAULT_SANDBOX_POLICY, workspaceHostPath: workDir },
+    });
+    const outsideDbPath = join(tmpdir(), 'outside-workspace-brain.db');
+    const run = repository.createRun({
+      definitionId: 'test-beast',
+      definitionVersion: 1,
+      executionMode: 'container',
+      configSnapshot: { brain: { dbPath: outsideDbPath } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'pfk',
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+    const definition = {
+      id: 'test-beast',
+      version: 1,
+      label: 'Test Beast',
+      description: 'Test beast',
+      executionModeDefault: 'container' as const,
+      configSchema: { parse: (value: unknown) => value as Readonly<Record<string, unknown>> },
+      interviewPrompts: [],
+      telemetryLabels: {},
+      buildProcessSpec: () => ({ command: 'node', args: ['agent.js'], cwd: workDir, env: {} }),
+    };
+
+    await expect(executor.start(run, definition)).rejects.toThrow(
+      `Container brain.dbPath must be inside the mounted workspace: ${outsideDbPath}`,
+    );
+    expect(fakeSupervisor.spawn).not.toHaveBeenCalled();
   });
 
   it('uses a distinct Docker container name for each retry attempt', async () => {

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -118,6 +118,21 @@ describe('createBeastServices', () => {
       dispatchedByUser: 'operator',
       createdAt: '2026-07-24T10:02:00.000Z',
     });
+    const worktreeRun = repo.createRun({
+      definitionId: 'worktree-path',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { brain: { dbPath: '.fbeast/brains/custom.db' } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:03:00.000Z',
+    });
+    const worktreeExecutionCwd = join(tempDir, '.worktrees', 'agent-1');
+    repo.createAttempt(worktreeRun.id, {
+      status: 'running',
+      startedAt: '2026-07-24T10:03:01.000Z',
+      executorMetadata: { worktreeExecutionCwd },
+    });
     repo.close();
     const rawDb = new Database(beastsDb);
     rawDb.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
@@ -141,12 +156,16 @@ describe('createBeastServices', () => {
         },
       });
       expect(services.resolveBrainContext('default-modules')).toEqual({
+        dbPath: join(tempDir, '.fbeast', 'brains', 'default-modules.db'),
         faculties: {
           planning: true,
           reasoning: true,
           action: true,
           learning: false,
         },
+      });
+      expect(services.resolveBrainContext('worktree-path')).toMatchObject({
+        dbPath: join(worktreeExecutionCwd, '.fbeast', 'brains', 'custom.db'),
       });
       expect(services.resolveBrainContext('unknown')).toBeUndefined();
     } finally {

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -143,6 +143,7 @@ describe('createBeastServices', () => {
       beastsDb,
       beastLogsDir: join(tempDir, 'logs'),
       root: tempDir,
+      brainDbPath: join(tempDir, 'project-brain.db'),
     });
 
     try {
@@ -156,7 +157,7 @@ describe('createBeastServices', () => {
         },
       });
       expect(services.resolveBrainContext('default-modules')).toEqual({
-        dbPath: join(tempDir, '.fbeast', 'brains', 'default-modules.db'),
+        dbPath: join(tempDir, 'project-brain.db'),
         faculties: {
           planning: true,
           reasoning: true,

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -98,7 +98,31 @@ describe('createBeastServices', () => {
       dispatchedByUser: 'operator',
       createdAt: '2026-07-24T10:01:00.000Z',
     });
+    repo.createTrackedAgent({
+      definitionId: 'default-modules',
+      source: 'api',
+      status: 'completed',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'run', config: {} },
+      initConfig: {},
+      moduleConfig: { planner: false, critique: false, governor: false },
+      createdAt: '2026-07-24T09:00:00.000Z',
+      updatedAt: '2026-07-24T09:00:00.000Z',
+    });
+    const corruptUnrelatedRun = repo.createRun({
+      definitionId: 'unrelated',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { unrelated: true },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:02:00.000Z',
+    });
     repo.close();
+    const rawDb = new Database(beastsDb);
+    rawDb.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
+      .run('{"corrupt":', corruptUnrelatedRun.id);
+    rawDb.close();
     const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
     const services = createBeastServices({
       beastsDb,

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -72,6 +72,64 @@ describe('createBeastServices', () => {
     }
   });
 
+  it('resolves persisted brain paths and module faculty flags from the latest run', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
+    const beastsDb = join(tempDir, 'beast.db');
+    const customDbPath = join(tempDir, 'custom-brain.db');
+    const repo = new SQLiteBeastRepository(beastsDb);
+    repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        brain: { dbPath: customDbPath },
+        modules: { planner: true, critique: true, governor: false, memory: true },
+      },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:00:00.000Z',
+    });
+    repo.createRun({
+      definitionId: 'default-modules',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {},
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:01:00.000Z',
+    });
+    repo.close();
+    const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
+    const services = createBeastServices({
+      beastsDb,
+      beastLogsDir: join(tempDir, 'logs'),
+      root: tempDir,
+    });
+
+    try {
+      expect(services.resolveBrainContext('martin-loop')).toEqual({
+        dbPath: customDbPath,
+        faculties: {
+          planning: true,
+          reasoning: true,
+          action: false,
+          learning: false,
+        },
+      });
+      expect(services.resolveBrainContext('default-modules')).toEqual({
+        faculties: {
+          planning: true,
+          reasoning: true,
+          action: true,
+          learning: false,
+        },
+      });
+      expect(services.resolveBrainContext('unknown')).toBeUndefined();
+    } finally {
+      services.dispose();
+    }
+  });
+
   it('persists SSE tickets in the Beast database across service restarts', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'franken-create-beast-services-'));
     const beastsDb = join(tempDir, 'beast.db');

--- a/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/create-beast-services.test.ts
@@ -77,7 +77,7 @@ describe('createBeastServices', () => {
     const beastsDb = join(tempDir, 'beast.db');
     const customDbPath = join(tempDir, 'custom-brain.db');
     const repo = new SQLiteBeastRepository(beastsDb);
-    repo.createRun({
+    const establishedRun = repo.createRun({
       definitionId: 'martin-loop',
       definitionVersion: 1,
       executionMode: 'process',
@@ -88,6 +88,32 @@ describe('createBeastServices', () => {
       dispatchedBy: 'api',
       dispatchedByUser: 'operator',
       createdAt: '2026-07-24T10:00:00.000Z',
+    });
+    repo.createAttempt(establishedRun.id, {
+      status: 'completed',
+      startedAt: '2026-07-24T10:00:01.000Z',
+    });
+    repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { brain: { dbPath: join(tempDir, 'queued-brain.db') } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:00:03.000Z',
+    });
+    const corruptLatestRun = repo.createRun({
+      definitionId: 'martin-loop',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { brain: { dbPath: join(tempDir, 'corrupt-brain.db') } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-24T10:00:04.000Z',
+    });
+    repo.createAttempt(corruptLatestRun.id, {
+      status: 'failed',
+      startedAt: '2026-07-24T10:00:05.000Z',
     });
     repo.createRun({
       definitionId: 'default-modules',
@@ -108,6 +134,16 @@ describe('createBeastServices', () => {
       moduleConfig: { planner: false, critique: false, governor: false },
       createdAt: '2026-07-24T09:00:00.000Z',
       updatedAt: '2026-07-24T09:00:00.000Z',
+    });
+    const corruptLatestAgent = repo.createTrackedAgent({
+      definitionId: 'default-modules',
+      source: 'api',
+      status: 'failed',
+      createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'run', config: {} },
+      initConfig: { brain: { dbPath: join(tempDir, 'corrupt-agent-brain.db') } },
+      createdAt: '2026-07-24T09:30:00.000Z',
+      updatedAt: '2026-07-24T09:30:00.000Z',
     });
     const corruptUnrelatedRun = repo.createRun({
       definitionId: 'unrelated',
@@ -137,6 +173,10 @@ describe('createBeastServices', () => {
     const rawDb = new Database(beastsDb);
     rawDb.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
       .run('{"corrupt":', corruptUnrelatedRun.id);
+    rawDb.prepare('UPDATE beast_runs SET config_snapshot = ? WHERE id = ?')
+      .run('{"corrupt":', corruptLatestRun.id);
+    rawDb.prepare('UPDATE tracked_agents SET init_config = ? WHERE id = ?')
+      .run('{"corrupt":', corruptLatestAgent.id);
     rawDb.close();
     const { createBeastServices } = await import('../../../src/beasts/create-beast-services.js');
     const services = createBeastServices({
@@ -159,14 +199,14 @@ describe('createBeastServices', () => {
       expect(services.resolveBrainContext('default-modules')).toEqual({
         dbPath: join(tempDir, 'project-brain.db'),
         faculties: {
-          planning: true,
-          reasoning: true,
-          action: true,
+          planning: false,
+          reasoning: false,
+          action: false,
           learning: false,
         },
       });
       expect(services.resolveBrainContext('worktree-path')).toMatchObject({
-        dbPath: join(worktreeExecutionCwd, '.fbeast', 'brains', 'custom.db'),
+        dbPath: join(tempDir, '.fbeast', 'brains', 'custom.db'),
       });
       expect(services.resolveBrainContext('unknown')).toBeUndefined();
     } finally {

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -384,7 +384,7 @@ describe('ProcessBeastExecutor', () => {
       definitionId: 'test-beast',
       definitionVersion: 1,
       executionMode: 'process',
-      configSnapshot: {},
+      configSnapshot: { brain: { dbPath: '.fbeast/brains/custom.db' } },
       dispatchedBy: 'dashboard',
       dispatchedByUser: 'pfk',
       createdAt: '2026-03-10T00:00:00.000Z',
@@ -409,6 +409,7 @@ describe('ProcessBeastExecutor', () => {
     });
     const configPath = (spawnedSpec as { env: Record<string, string> }).env.FRANKENBEAST_RUN_CONFIG;
     expect(JSON.parse(readFileSync(configPath, 'utf8'))).toMatchObject({
+      brain: { dbPath: join(workDir, '.fbeast', 'brains', 'custom.db') },
       brainConfigDir: join(workDir, '.fbeast'),
       definitionId: 'test-beast',
     });

--- a/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/sqlite-beast-repository.test.ts
@@ -189,6 +189,38 @@ describe('SQLiteBeastRepository', () => {
     }
   });
 
+  it('uses insertion order to break latest-context timestamp ties', async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
+    const dbPath = join(workDir, 'beasts.db');
+    const repo = new SQLiteBeastRepository(dbPath);
+    const createdAt = '2026-03-10T00:00:00.000Z';
+    const oldRun = repo.createRun({
+      definitionId: 'martin-loop', definitionVersion: 1, executionMode: 'process',
+      configSnapshot: { generation: 'old' }, dispatchedBy: 'api', dispatchedByUser: 'operator', createdAt,
+    });
+    const newRun = repo.createRun({
+      definitionId: 'martin-loop', definitionVersion: 1, executionMode: 'process',
+      configSnapshot: { generation: 'new' }, dispatchedBy: 'api', dispatchedByUser: 'operator', createdAt,
+    });
+    const createAgent = (name: string) => repo.createTrackedAgent({
+      definitionId: 'martin-loop', source: 'api', status: 'completed', createdByUser: 'operator',
+      initAction: { kind: 'martin-loop', command: 'martin-loop', config: {} },
+      initConfig: { name }, createdAt, updatedAt: createdAt,
+    });
+    const oldAgent = createAgent('old');
+    const newAgent = createAgent('new');
+    const database = new Database(dbPath);
+    database.prepare('UPDATE beast_runs SET id = ? WHERE id = ?').run('run_z_old', oldRun.id);
+    database.prepare('UPDATE beast_runs SET id = ? WHERE id = ?').run('run_a_new', newRun.id);
+    database.prepare('UPDATE tracked_agents SET id = ? WHERE id = ?').run('agent_z_old', oldAgent.id);
+    database.prepare('UPDATE tracked_agents SET id = ? WHERE id = ?').run('agent_a_new', newAgent.id);
+    database.close();
+
+    expect(repo.getLatestRunForDefinition('martin-loop')?.id).toBe('run_a_new');
+    expect(repo.getLatestTrackedAgentForDefinition('martin-loop')?.id).toBe('agent_a_new');
+    repo.close();
+  });
+
   it('creates, loads, and lists durable beast runs', async () => {
     workDir = await mkdtemp(join(tmpdir(), 'franken-beasts-repo-'));
     const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-bridge.test.ts
@@ -349,6 +349,14 @@ describe('bridgeToBeastConfig()', () => {
       expect(config.brain?.dbPath).toBe('/custom/brain.db');
     });
 
+    it('prefers a persisted per-run brain override over project configuration', () => {
+      const orchestratorConfig = { brain: { dbPath: '/project/brain.db' } } as any;
+      const config = bridgeToBeastConfig(makeOptions({
+        runConfig: { definitionId: 'martin-loop', brain: { dbPath: '/run/brain.db' } },
+      }), orchestratorConfig);
+      expect(config.brain?.dbPath).toBe('/run/brain.db');
+    });
+
     it('passes network egress policy into runtime config', () => {
       const egressPolicy = { enabled: true, lanes: { triage: { allowedDomains: ['api.github.com'] } } };
       const orchestratorConfig = { network: { egressPolicy } } as any;


### PR DESCRIPTION
## Summary
- resolve read-only brain routes against persisted custom database paths without fabricating in-memory state
- read working-memory keys from durable SQLite state and derive faculty flags from effective runtime module configuration
- bound episodic details in SQLite before JSON parsing while preserving recall ranking, pagination, encryption handling, and memory-access auditing
- remove unresolved ADR-041 merge markers while preserving both related issues from the competing metadata lines

## Verification
- `npm run typecheck` and 304 targeted brain tests
- orchestrator typecheck, ESLint, and 19 targeted route/service tests
- independent review findings addressed (module defaults, recall semantics, in-memory lookup, audit coverage)
- all Codex threads on merged PR #3757 and duplicate PR #3761 answered and resolved

Follow-up to #3704 and merged PR #3757.