### PR TITLE
fix(brain): harden lesson consolidation follow-up

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -31,6 +31,7 @@ import type {
   LessonConsolidationOptions,
   RelevantLessonsOptions,
   ConsolidatedLesson,
+  LessonReplacement,
   LessonConsolidationItem,
   RelevantLesson,
 } from '@franken/types';
@@ -234,6 +235,8 @@ export interface MemoryCandidate extends MemoryCandidateProposal {
   status: MemoryCandidateStatus;
   suppressionReason?: MemorySuppressionReason;
   mergeSuggestions?: MemoryMergeSuggestion[];
+  /** Approved lessons that approval of this candidate will retire. */
+  replaces?: readonly LessonReplacement[];
   createdAt: string;
   updatedAt: string;
   decidedAt?: string;
@@ -868,6 +871,14 @@ class MemoryCipher {
 
   verifier(): string {
     return this.encrypt(MEMORY_ENCRYPTION_VERIFIER);
+  }
+
+  fingerprint(namespace: string, value: string): string {
+    return createHmac('sha256', this.key)
+      .update(namespace, 'utf8')
+      .update('\0', 'utf8')
+      .update(value, 'utf8')
+      .digest('hex');
   }
 }
 
@@ -3124,6 +3135,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     n = 10,
     includeQuarantined = true,
     excludeCategory?: string | readonly string[],
+    rawScanLimit?: number,
   ): EpisodicEvent[] {
     try {
       const excludedCategories = typeof excludeCategory === 'string'
@@ -3143,6 +3155,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
           (includeQuarantined || !isQuarantinedEpisodicDetails(event))
           && !excludedCategories.includes(String(event.details?.category ?? ''))
         ),
+        rawScanLimit,
       );
       this.audit?.({
         operation: 'episodic.recentFailures',
@@ -3791,6 +3804,7 @@ export class SqliteMemoryReviewQueue {
     private dbPath: string,
     private encryption?: MemoryCipher,
     private audit?: MemoryAccessAuditRecorder,
+    private expireWorkingKeys?: (keys: readonly string[]) => void,
   ) {
     this.backfillCandidateKinds();
   }
@@ -3844,7 +3858,7 @@ export class SqliteMemoryReviewQueue {
             ? JSON.stringify(candidate.value.evidenceEventIds)
             : null,
           isConsolidatedLesson(candidate.value)
-            ? JSON.stringify(lessonSuppressionTokens(candidate.value))
+            ? JSON.stringify(lessonSuppressionTokens(candidate.value, this.encryption))
             : null,
           normalizeMemorySourceType(candidate.sourceType, candidate.source),
           this.encodeSourceId(candidate.sourceId, candidate.source),
@@ -3919,12 +3933,12 @@ export class SqliteMemoryReviewQueue {
   listByKind(
     status: MemoryCandidateStatus,
     kind: string,
-    options: { limit?: number } = {},
+    options: { limit?: number; offset?: number } = {},
   ): MemoryCandidate[] {
-    const limitClause = options.limit === undefined ? '' : ' LIMIT ?';
+    const limitClause = options.limit === undefined ? '' : ' LIMIT ? OFFSET ?';
     const params = options.limit === undefined
       ? [status, kind]
-      : [status, kind, options.limit];
+      : [status, kind, options.limit, options.offset ?? 0];
     const rows = this.db
       .prepare(
         `SELECT * FROM memory_review_candidates
@@ -4012,7 +4026,7 @@ export class SqliteMemoryReviewQueue {
               ? JSON.stringify(updated.value.evidenceEventIds)
               : null,
             isConsolidatedLesson(updated.value)
-              ? JSON.stringify(lessonSuppressionTokens(updated.value))
+              ? JSON.stringify(lessonSuppressionTokens(updated.value, this.encryption))
               : null,
             normalizeMemorySourceType(updated.sourceType, updated.source),
             this.encodeSourceId(updated.sourceId, updated.source),
@@ -4214,6 +4228,7 @@ export class SqliteMemoryReviewQueue {
     if (retiredLessonKeys.length > 0) {
       for (const key of retiredLessonKeys) this.working.delete(key);
       this.working.flushToDb();
+      this.expireWorkingKeys?.(retiredLessonKeys);
     }
     const result = approvedCandidate ?? this.requireCandidate(id);
     return result;
@@ -5721,6 +5736,9 @@ export class SqliteMemoryReviewQueue {
       ...(row.decided_at ? { decidedAt: row.decided_at } : {}),
       ...(row.reviewer ? { reviewer: this.decodeText(row.reviewer) } : {}),
       ...(row.note ? { note: this.decodeText(row.note) } : {}),
+      ...(parseLessonReplacementKeys(row.lesson_replaces_keys).length > 0
+        ? { replaces: parseLessonReplacementKeys(row.lesson_replaces_keys) }
+        : {}),
     };
   }
 
@@ -5767,11 +5785,20 @@ export class SqliteMemoryReviewQueue {
 
   private backfillCandidateKinds(): void {
     const rows = this.db.prepare(
-      `SELECT id, value FROM memory_review_candidates
+      `SELECT id, value, candidate_kind, lesson_evidence_ids, lesson_suppression_tokens
+         FROM memory_review_candidates
        WHERE candidate_kind IS NULL
           OR (candidate_kind = 'consolidated-lesson'
-              AND (lesson_evidence_ids IS NULL OR lesson_suppression_tokens IS NULL))`,
-    ).all() as Array<{ id: string; value: string }>;
+              AND (${this.encryption
+                ? '1 = 1'
+                : 'lesson_evidence_ids IS NULL OR lesson_suppression_tokens IS NULL'}))`,
+    ).all() as Array<{
+      id: string;
+      value: string;
+      candidate_kind: string | null;
+      lesson_evidence_ids: string | null;
+      lesson_suppression_tokens: string | null;
+    }>;
     if (rows.length === 0) return;
     const update = this.db.prepare(
       `UPDATE memory_review_candidates
@@ -5779,18 +5806,30 @@ export class SqliteMemoryReviewQueue {
     );
     const backfill = this.db.transaction(() => {
       for (const row of rows) {
-        let kind = 'other';
-        let evidenceIds: string | null = null;
-        let suppressionTokens: string | null = null;
+        let kind = row.candidate_kind ?? 'other';
+        let evidenceIds = row.lesson_evidence_ids;
+        let suppressionTokens = row.lesson_suppression_tokens;
+        let decodedLesson = false;
         try {
           const value = this.decodeValue(row.value);
           if (isConsolidatedLesson(value)) {
+            decodedLesson = true;
             kind = 'consolidated-lesson';
             evidenceIds = JSON.stringify(value.evidenceEventIds);
-            suppressionTokens = JSON.stringify(lessonSuppressionTokens(value));
+            suppressionTokens = JSON.stringify(lessonSuppressionTokens(value, this.encryption));
+          } else if (row.candidate_kind === null) {
+            kind = 'other';
+            evidenceIds = null;
+            suppressionTokens = null;
           }
         } catch {
           // Leave malformed legacy payload handling to the normal review read path.
+        }
+        if (!decodedLesson && kind === 'consolidated-lesson' && this.encryption) {
+          suppressionTokens = JSON.stringify(migrateEncryptedLessonSuppressionTokens(
+            suppressionTokens,
+            this.encryption,
+          ));
         }
         update.run(kind, evidenceIds, suppressionTokens, row.id);
       }
@@ -5908,6 +5947,9 @@ const SEMANTIC_MEMORY_SYNONYMS = new Map([
 ]);
 
 function semanticMemorySimilarity(left: unknown, right: unknown): number {
+  const leftText = normalizedSemanticMemoryText(left);
+  const rightText = normalizedSemanticMemoryText(right);
+  if (leftText.length > 0 && leftText === rightText) return 1;
   const leftTokens = semanticMemoryTokens(left);
   const rightTokens = semanticMemoryTokens(right);
   if (leftTokens.size < 3 || rightTokens.size < 3) return 0;
@@ -5949,13 +5991,21 @@ function decodeAgentWorkingKeyScope(key: string): string | undefined {
 }
 
 function semanticMemoryTokens(value: unknown): Set<string> {
-  const text = semanticMemoryText(canonicalMemoryValue(value)).toLowerCase();
-  const tokens = text.match(/[a-z0-9]+/g) ?? [];
+  const text = normalizedSemanticMemoryText(value);
+  const tokens = text.match(/[\p{L}\p{N}]+/gu) ?? [];
   return new Set(
     tokens
       .map(normalizeSemanticMemoryToken)
       .filter((token) => token.length >= 3 && !SEMANTIC_MEMORY_STOP_WORDS.has(token)),
   );
+}
+
+function normalizedSemanticMemoryText(value: unknown): string {
+  return semanticMemoryText(canonicalMemoryValue(value))
+    .normalize('NFKC')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
 }
 
 function semanticMemoryText(value: unknown): string {
@@ -6053,6 +6103,7 @@ function lessonReviewKey(lesson: ConsolidatedLesson): string {
   const signature = createHash('sha256')
     .update(JSON.stringify({
       tokens: identityTokens,
+      context: [...(lesson.searchTerms ?? semanticMemoryTokens(lesson.pattern))].sort(),
     }))
     .digest('hex');
   return `lesson.review.${signature.slice(0, 16)}`;
@@ -6131,20 +6182,41 @@ function parseLessonSuppressionTokens(value: string | null | undefined): string[
   try {
     const parsed = JSON.parse(value) as unknown;
     return Array.isArray(parsed)
-      ? parsed.filter((token): token is string => /^[a-f0-9]{64}$/.test(token))
+      ? parsed.filter((token): token is string => /^(?:h[01]:)?[a-f0-9]{64}$/.test(token))
       : [];
   } catch {
     return [];
   }
 }
 
-function lessonSuppressionTokens(lesson: ConsolidatedLesson): string[] {
+function lessonSuppressionTokens(
+  lesson: ConsolidatedLesson,
+  encryption?: MemoryCipher,
+): string[] {
   return [...semanticMemoryTokens([
     lesson.pattern,
     ...lesson.keywords,
     ...(lesson.searchTerms ?? []),
   ])]
-    .map((token) => createHash('sha256').update(token).digest('hex'))
+    .flatMap((token) => {
+      const dictionaryHash = createHash('sha256').update(token).digest('hex');
+      if (!encryption) return [dictionaryHash];
+      return [
+        `h1:${encryption.fingerprint('lesson-suppression-token:v1', token)}`,
+        `h0:${encryption.fingerprint('lesson-suppression-token-sha256:v1', dictionaryHash)}`,
+      ];
+    })
+    .sort();
+}
+
+function migrateEncryptedLessonSuppressionTokens(
+  storedTokens: string | null,
+  encryption: MemoryCipher,
+): string[] {
+  return parseLessonSuppressionTokens(storedTokens)
+    .map((token) => token.startsWith('h0:') || token.startsWith('h1:')
+      ? token
+      : `h0:${encryption.fingerprint('lesson-suppression-token-sha256:v1', token)}`)
     .sort();
 }
 
@@ -6345,6 +6417,7 @@ export class SqliteBrain implements IBrain {
       this.dbPath,
       encryption,
       (event) => this.auditRecorder(event),
+      (keys) => SqliteBrain.expireLivePrunedWorkingKeys(this.dbPath, keys),
     );
     SqliteBrain.registerLiveBrain(this.dbPath, this);
   }
@@ -6463,7 +6536,7 @@ export class SqliteBrain implements IBrain {
 
     const consolidate = this.db.transaction(() => {
     const events = this.episodic
-      .recentFailures(lookback, false, ['skill-evolution', 'planning-lifecycle'])
+      .recentFailures(lookback, false, ['skill-evolution', 'planning-lifecycle'], lookback)
       .sort((left, right) =>
         left.createdAt.localeCompare(right.createdAt) || Number(left.id ?? 0) - Number(right.id ?? 0),
       );
@@ -6479,6 +6552,10 @@ export class SqliteBrain implements IBrain {
     const suppressedLessons = (['rejected', 'suppressed'] as const)
       .flatMap((status) => this.memoryReview.listByKind(status, 'consolidated-lesson'))
       .filter((candidate) => isConsolidatedLesson(candidate.value));
+    const suppressedLessonLineage = suppressedLessons.map((candidate) => ({
+      candidate,
+      tokens: new Set(this.memoryReview.lessonSuppressionTokens(candidate.id)),
+    }));
     const neverStoredLessonEvidence = this.memoryReview
       .listByKind('never_store', 'consolidated-lesson')
       .map((candidate) => ({
@@ -6490,7 +6567,7 @@ export class SqliteBrain implements IBrain {
       if (cluster.length < threshold) continue;
       const value = consolidatedLesson(cluster);
       const evidenceIds = new Set(value.evidenceEventIds);
-      const suppressionTokens = new Set(lessonSuppressionTokens(value));
+      const suppressionTokens = new Set(lessonSuppressionTokens(value, this.encryption));
       if (neverStoredLessonEvidence.some((lineage) => (
         [...evidenceIds].some((id) => lineage.evidence.has(id))
         || lessonSuppressionSimilarity(lineage.tokens, suppressionTokens) >= similarityThreshold
@@ -6509,8 +6586,8 @@ export class SqliteBrain implements IBrain {
             value.pattern,
           ),
         }))
-        .filter(({ exactKey, sharesEvidence, similarity }) =>
-          exactKey || sharesEvidence || similarity >= similarityThreshold)
+        .filter(({ sharesEvidence, similarity }) =>
+          sharesEvidence || similarity >= similarityThreshold)
         .sort((left, right) => Number(right.exactKey) - Number(left.exactKey)
           || Number(right.sharesEvidence) - Number(left.sharesEvidence)
           || right.similarity - left.similarity
@@ -6581,13 +6658,14 @@ export class SqliteBrain implements IBrain {
         }
         continue;
       }
-      const matchingSuppressed = suppressedLessons.some((candidate) => (
+      const matchingSuppressed = suppressedLessonLineage.some(({ candidate, tokens }) => (
         candidate.key === key
         || (candidate.value as ConsolidatedLesson).evidenceEventIds.some((id) => evidenceIds.has(id))
         || semanticMemorySimilarity(
           (candidate.value as ConsolidatedLesson).pattern,
           value.pattern,
         ) >= similarityThreshold
+        || lessonSuppressionSimilarity(tokens, suppressionTokens) >= similarityThreshold
       ));
       if (matchingSuppressed) continue;
       const matchingApproved = approvedLessons
@@ -6601,8 +6679,8 @@ export class SqliteBrain implements IBrain {
             value.pattern,
           ),
         }))
-        .filter(({ exactKey, sharesEvidence, similarity }) =>
-          exactKey || sharesEvidence || similarity >= similarityThreshold)
+        .filter(({ sharesEvidence, similarity }) =>
+          sharesEvidence || similarity >= similarityThreshold)
         .sort((left, right) => Number(right.exactKey) - Number(left.exactKey)
           || Number(right.sharesEvidence) - Number(left.sharesEvidence)
           || right.similarity - left.similarity
@@ -6636,7 +6714,7 @@ export class SqliteBrain implements IBrain {
           lastSeenAt: [...mergedApprovedLessons.map((lesson) => lesson.lastSeenAt), value.lastSeenAt]
             .sort().at(-1)!,
         };
-        const candidate = this.memoryReview.propose({
+        let candidate = this.memoryReview.propose({
           targetStore: 'working',
           key: approved.key,
           value: revisedValue,
@@ -6648,18 +6726,26 @@ export class SqliteBrain implements IBrain {
           reason: `${mergedOccurrenceCount} similar failure episodes formed an expanded lesson revision for review.`,
         });
         if (candidate.status === 'pending') {
+          const replacements = matchingApproved.slice(1).map(({ candidate: matched }) => ({
+            key: matched.key,
+            candidateId: matched.id,
+          }));
           this.memoryReview.setLessonReplacementKeys(
             candidate.id,
-            matchingApproved.slice(1).map(({ candidate: matched }) => ({
-              key: matched.key,
-              candidateId: matched.id,
-            })),
+            replacements,
             LESSON_LINEAGE_EDIT_TOKEN,
           );
+          if (replacements.length > 0) candidate = { ...candidate, replaces: replacements };
         }
         if (candidate.status === 'pending' && isConsolidatedLesson(candidate.value)) {
           pendingLessons.push(candidate);
-          created.push({ id: candidate.id, key: candidate.key, status: 'pending', value: candidate.value });
+          created.push({
+            id: candidate.id,
+            key: candidate.key,
+            status: 'pending',
+            value: candidate.value,
+            ...(candidate.replaces ? { replaces: candidate.replaces } : {}),
+          });
         }
         continue;
       }
@@ -6712,26 +6798,43 @@ export class SqliteBrain implements IBrain {
       throw new RangeError('Relevant lesson minConfidence must be between 0 and 1');
     }
 
-    const scanLimit = Math.min(1_000, Math.max(100, limit * 20));
-    const lessons = (['pending', 'approved'] as const)
-      .flatMap((status) => this.memoryReview
-        .listByKind(status, 'consolidated-lesson', { limit: scanLimit })
-        .filter((candidate) => (
-          status === 'pending'
-          || this.memoryReview.provenanceFor('working', candidate.key)?.candidateId === candidate.id
-        ))
-        .map((candidate) => ({ status, candidate })))
-      .filter(({ candidate }) => isConsolidatedLesson(candidate.value))
-      .map(({ status, candidate }) => {
-        const value = candidate.value as ConsolidatedLesson;
-        return {
-          ...value,
-          key: candidate.key,
+    const pageSize = Math.max(100, limit * 20);
+    const relevantLessonsForStatus = (status: 'pending' | 'approved'): RelevantLesson[] => {
+      const lessons: RelevantLesson[] = [];
+      const matchedKeys = new Set<string>();
+      for (let offset = 0; ; offset += pageSize) {
+        const page = this.memoryReview.listByKind(
           status,
-          relevance: lessonRelevance(normalizedQuery, value),
-        } satisfies RelevantLesson;
-      })
-      .filter((lesson) => lesson.relevance > 0 && lesson.confidence >= minConfidence)
+          'consolidated-lesson',
+          { limit: pageSize, offset },
+        );
+        for (const candidate of page) {
+          if (
+            status === 'approved'
+            && this.memoryReview.provenanceFor('working', candidate.key)?.candidateId !== candidate.id
+          ) {
+            continue;
+          }
+          if (!isConsolidatedLesson(candidate.value) || matchedKeys.has(candidate.key)) continue;
+          const value = candidate.value;
+          const lesson = {
+            ...value,
+            confidence: candidate.confidence,
+            key: candidate.key,
+            status,
+            relevance: lessonRelevance(normalizedQuery, value),
+          } satisfies RelevantLesson;
+          if (lesson.relevance <= 0 || lesson.confidence < minConfidence) continue;
+          lessons.push(lesson);
+          matchedKeys.add(candidate.key);
+          if (lessons.length >= limit) return lessons;
+        }
+        if (page.length < pageSize) break;
+      }
+      return lessons;
+    };
+    const lessons = (['pending', 'approved'] as const)
+      .flatMap((status) => relevantLessonsForStatus(status))
       .sort((left, right) =>
         right.relevance - left.relevance
         || right.confidence - left.confidence
@@ -9601,6 +9704,7 @@ function collectRowsToEvents(
   encryption?: MemoryCipher,
   reportCorruptDetails?: CorruptEpisodicDetailsReporter,
   includeEvent?: (event: EpisodicEvent) => boolean,
+  rawScanLimit = Number.POSITIVE_INFINITY,
 ): EpisodicEvent[] {
   if (limit === 0) {
     return [];
@@ -9613,8 +9717,10 @@ function collectRowsToEvents(
       ? CORRUPT_JSON_SCAN_BATCH_SIZE
       : Math.max(CORRUPT_JSON_SCAN_BATCH_SIZE, limit * 2);
 
-  for (let offset = 0; events.length < target; offset += batchSize) {
-    const rows = fetchRows(batchSize, offset);
+  let offset = 0;
+  while (events.length < target && offset < rawScanLimit) {
+    const fetchLimit = Math.min(batchSize, rawScanLimit - offset);
+    const rows = fetchRows(fetchLimit, offset);
     for (const row of rows) {
       const event = rowToEvent(row, encryption, reportCorruptDetails);
       if (includeEvent?.(event) ?? true) {
@@ -9624,7 +9730,8 @@ function collectRowsToEvents(
         }
       }
     }
-    if (rows.length < batchSize) {
+    offset += rows.length;
+    if (rows.length < fetchLimit) {
       break;
     }
   }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -5790,7 +5790,18 @@ export class SqliteMemoryReviewQueue {
        WHERE candidate_kind IS NULL
           OR (candidate_kind = 'consolidated-lesson'
               AND (${this.encryption
-                ? '1 = 1'
+                ? `lesson_evidence_ids IS NULL
+                   OR lesson_suppression_tokens IS NULL
+                   OR json_valid(lesson_suppression_tokens) = 0
+                   OR EXISTS (
+                     SELECT 1
+                       FROM json_each(CASE
+                         WHEN json_valid(lesson_suppression_tokens)
+                         THEN lesson_suppression_tokens
+                         ELSE '[]'
+                       END)
+                      WHERE value NOT GLOB 'h0:*' AND value NOT GLOB 'h1:*'
+                   )`
                 : 'lesson_evidence_ids IS NULL OR lesson_suppression_tokens IS NULL'}))`,
     ).all() as Array<{
       id: string;
@@ -6221,14 +6232,35 @@ function migrateEncryptedLessonSuppressionTokens(
 }
 
 function lessonSuppressionSimilarity(left: ReadonlySet<string>, right: ReadonlySet<string>): number {
-  if (left.size < 3 || right.size < 3) return 0;
-  const intersection = [...left].filter((token) => right.has(token)).length;
+  const namespace = leftHasPrefix(left, 'h1:') && leftHasPrefix(right, 'h1:')
+    ? 'h1:'
+    : leftHasPrefix(left, 'h0:') && leftHasPrefix(right, 'h0:')
+      ? 'h0:'
+      : '';
+  const comparableLeft = lessonTokensInNamespace(left, namespace);
+  const comparableRight = lessonTokensInNamespace(right, namespace);
+  if (comparableLeft.size < 3 || comparableRight.size < 3) return 0;
+  const intersection = [...comparableLeft]
+    .filter((token) => comparableRight.has(token)).length;
   if (intersection < 3) return 0;
-  const unionSize = new Set([...left, ...right]).size;
+  const unionSize = new Set([...comparableLeft, ...comparableRight]).size;
   return Math.max(
     intersection / unionSize,
-    (intersection / Math.min(left.size, right.size)) * 0.72,
+    (intersection / Math.min(comparableLeft.size, comparableRight.size)) * 0.72,
   );
+}
+
+function leftHasPrefix(tokens: ReadonlySet<string>, prefix: 'h0:' | 'h1:'): boolean {
+  return [...tokens].some((token) => token.startsWith(prefix));
+}
+
+function lessonTokensInNamespace(
+  tokens: ReadonlySet<string>,
+  namespace: '' | 'h0:' | 'h1:',
+): Set<string> {
+  return new Set([...tokens].filter((token) => namespace
+    ? token.startsWith(namespace)
+    : !token.startsWith('h0:') && !token.startsWith('h1:')));
 }
 
 function stableStringify(value: unknown): string {
@@ -6654,7 +6686,13 @@ export class SqliteBrain implements IBrain {
         pendingLessons = pendingLessons.filter((candidate) => !matchedIds.has(candidate.id));
         pendingLessons.push(updated);
         if ((lessonChanged || duplicateIds.size > 0) && isConsolidatedLesson(updated.value)) {
-          created.push({ id: updated.id, key: updated.key, status: 'pending', value: updated.value });
+          created.push({
+            id: updated.id,
+            key: updated.key,
+            status: 'pending',
+            value: updated.value,
+            ...(updated.replaces ? { replaces: updated.replaces } : {}),
+          });
         }
         continue;
       }
@@ -6802,7 +6840,8 @@ export class SqliteBrain implements IBrain {
     const relevantLessonsForStatus = (status: 'pending' | 'approved'): RelevantLesson[] => {
       const lessons: RelevantLesson[] = [];
       const matchedKeys = new Set<string>();
-      for (let offset = 0; ; offset += pageSize) {
+      const scanLimit = pageSize * 10;
+      for (let offset = 0; offset < scanLimit; offset += pageSize) {
         const page = this.memoryReview.listByKind(
           status,
           'consolidated-lesson',

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1037,6 +1037,54 @@ describe('SqliteBrain', () => {
       expect(brain.learning.consolidate({ threshold: 2, lookback: 10 })).toEqual([]);
     });
 
+    it('bounds lesson consolidation by raw failure rows before category filtering', () => {
+      recordStaleDeclarationFailure(
+        'TypeScript workspace build failed with stale declarations',
+        '2026-07-24T10:00:00.000Z',
+      );
+      for (const [index, category] of ['skill-evolution', 'planning-lifecycle'].entries()) {
+        brain.episodic.record({
+          type: 'failure',
+          step: 'excluded-signal',
+          summary: `Excluded failure ${index}`,
+          details: { category },
+          createdAt: `2026-07-24T10:0${index + 1}:00.000Z`,
+        });
+      }
+
+      expect(brain.learning.consolidate({ threshold: 1, lookback: 2 })).toEqual([]);
+    });
+
+    it('keeps disconnected same-key lesson clusters separate without semantic evidence', () => {
+      for (const [index, summary] of [
+        'common shared anchor alpha pairone',
+        'common shared anchor alpha bridge',
+        'common shared anchor bridge tail',
+        'common shared anchor beta pairtwo',
+        'common shared anchor beta relay',
+        'common shared anchor relay finish',
+      ].entries()) {
+        recordStaleDeclarationFailure(summary, `2026-07-24T10:0${index}:00.000Z`);
+      }
+
+      const lessons = brain.learning.consolidate({
+        threshold: 3,
+        lookback: 10,
+        similarityThreshold: 0.5,
+      });
+
+      expect(lessons).toHaveLength(2);
+      expect(lessons.map((lesson) => lesson.value.occurrenceCount)).toEqual([3, 3]);
+    });
+
+    it('consolidates and retrieves identical non-ASCII failure text', () => {
+      recordStaleDeclarationFailure('型宣言の読み込みに失敗しました', '2026-07-24T10:00:00.000Z');
+      recordStaleDeclarationFailure('型宣言の読み込みに失敗しました', '2026-07-24T10:01:00.000Z');
+
+      expect(brain.learning.consolidate({ threshold: 2, lookback: 2 })).toHaveLength(1);
+      expect(brain.learning.relevantLessons('型宣言の読み込みに失敗しました')).toHaveLength(1);
+    });
+
     it('preserves reviewer-authored pattern fields when refreshing evidence', () => {
       recordStaleDeclarationFailure('TypeScript workspace build failed with stale declarations', '2026-07-24T10:00:00.000Z');
       recordStaleDeclarationFailure('Stale declarations broke the TypeScript workspace build', '2026-07-24T10:01:00.000Z');
@@ -1146,6 +1194,15 @@ describe('SqliteBrain', () => {
         similarityThreshold: 0.5,
       });
       expect(revision).toBeDefined();
+      expect(revision).toMatchObject({
+        replaces: [expect.objectContaining({
+          key: expect.stringMatching(/^lesson\.review\./),
+          candidateId: expect.stringMatching(/^memcand_/),
+        })],
+      });
+      expect(brain.memoryReview.list('pending')[0]).toMatchObject({
+        replaces: revision!.replaces,
+      });
       brain.memoryReview.resolveConflict(revision!.id, {
         resolution: 'replace_existing',
         reviewer: 'operator',
@@ -1218,6 +1275,231 @@ describe('SqliteBrain', () => {
 
       expect(brain.learning.consolidate({ threshold: 2, lookback: 10, similarityThreshold: 0.25 })).toEqual([]);
       expect(brain.memoryReview.list('pending')).toEqual([]);
+    });
+
+    it('uses rejected lesson token lineage after the representative and key evolve', () => {
+      for (const [index, summary] of [
+        'common shared anchor alpha pairone',
+        'common shared anchor alpha bridge',
+        'common shared anchor bridge tail',
+      ].entries()) {
+        recordStaleDeclarationFailure(summary, `2026-07-24T10:0${index}:00.000Z`);
+      }
+      const [rejected] = brain.learning.consolidate({
+        threshold: 3,
+        lookback: 3,
+        similarityThreshold: 0.5,
+      });
+      brain.memoryReview.reject(rejected!.id, { reviewer: 'operator' });
+
+      for (const [index, summary] of [
+        'bridge tail pairone common xmarker',
+        'bridge tail pairone common shared',
+        'bridge tail pairone shared anchor',
+      ].entries()) {
+        recordStaleDeclarationFailure(summary, `2026-07-24T10:0${index + 3}:00.000Z`);
+      }
+
+      expect(brain.learning.consolidate({
+        threshold: 3,
+        lookback: 3,
+        similarityThreshold: 0.5,
+      })).toEqual([]);
+      expect(brain.memoryReview.list('pending')).toEqual([]);
+    });
+
+    it('preserves encrypted never-store lesson lineage across restart', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-encrypted-never-store-lesson-'));
+      const dbPath = join(dir, 'brain.db');
+      const options = {
+        encryption: { enabled: true, key: 'encrypted-never-store-lesson-key' },
+      } as const;
+      let encrypted: SqliteBrain | undefined;
+      try {
+        encrypted = new SqliteBrain(dbPath, undefined, options);
+        for (const [index, summary] of [
+          'common shared anchor alpha pairone',
+          'common shared anchor alpha bridge',
+          'common shared anchor bridge tail',
+        ].entries()) {
+          encrypted.episodic.record({
+            type: 'failure',
+            step: 'build',
+            summary,
+            createdAt: `2026-07-24T10:0${index}:00.000Z`,
+          });
+        }
+        const [candidate] = encrypted.learning.consolidate({
+          threshold: 3,
+          lookback: 3,
+          similarityThreshold: 0.5,
+        });
+        encrypted.memoryReview.neverStore(candidate!.id);
+        const lineageBeforeRestart = encrypted.memoryReview.lessonSuppressionTokens(candidate!.id);
+        expect(lineageBeforeRestart.length).toBeGreaterThan(0);
+        encrypted.close();
+
+        encrypted = new SqliteBrain(dbPath, undefined, options);
+        expect(encrypted.memoryReview.lessonSuppressionTokens(candidate!.id)).toEqual(lineageBeforeRestart);
+        for (const [index, summary] of [
+          'bridge tail pairone common xmarker',
+          'bridge tail pairone common shared',
+          'bridge tail pairone shared anchor',
+        ].entries()) {
+          encrypted.episodic.record({
+            type: 'failure',
+            step: 'build',
+            summary,
+            createdAt: `2026-07-24T10:0${index + 3}:00.000Z`,
+          });
+        }
+
+        expect(encrypted.learning.consolidate({
+          threshold: 3,
+          lookback: 3,
+          similarityThreshold: 0.5,
+        })).toEqual([]);
+      } finally {
+        encrypted?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('finds an older relevant lesson beyond the first bounded review page', () => {
+      const lesson = (pattern: string, evidenceEventId: number) => ({
+        kind: 'consolidated-lesson' as const,
+        pattern,
+        keywords: pattern.toLowerCase().split(' '),
+        searchTerms: pattern.toLowerCase().split(' '),
+        occurrenceCount: 1,
+        confidence: 0.35,
+        evidenceEventIds: [evidenceEventId],
+        firstSeenAt: '2026-07-24T10:00:00.000Z',
+        lastSeenAt: '2026-07-24T10:00:00.000Z',
+      });
+      brain.memoryReview.propose({
+        targetStore: 'working',
+        key: 'lesson.review.older-needle',
+        value: lesson('NeedleMarker exact lesson', 1),
+        source: 'test',
+        confidence: 0.35,
+        reason: 'Older exact lesson',
+      });
+      for (let index = 0; index < 200; index += 1) {
+        brain.memoryReview.propose({
+          targetStore: 'working',
+          key: `lesson.review.unrelated-${index}`,
+          value: lesson(`UnrelatedMarker${index} filler lesson`, index + 2),
+          source: 'test',
+          confidence: 0.35,
+          reason: 'Newer unrelated lesson',
+        });
+      }
+
+      expect(brain.learning.relevantLessons('NeedleMarker exact')).toEqual([
+        expect.objectContaining({ key: 'lesson.review.older-needle' }),
+      ]);
+      expect(brain.learning.relevantLessons('NeedleMarker', { limit: 1 })[0]?.pattern)
+        .toBe('NeedleMarker exact lesson');
+    });
+
+    it('stops paging each lesson status after satisfying the requested limit', () => {
+      const base = brain.memoryReview.propose({
+          targetStore: 'working',
+          key: 'lesson.review.page-base',
+          value: {
+            kind: 'consolidated-lesson',
+            pattern: 'shared matching lesson',
+            keywords: ['shared', 'matching', 'lesson'],
+            searchTerms: ['shared', 'matching', 'lesson'],
+            occurrenceCount: 1,
+            evidenceEventIds: [1],
+            firstSeenAt: '2026-07-24T10:00:00.000Z',
+            lastSeenAt: '2026-07-24T10:00:00.000Z',
+            confidence: 0.35,
+          },
+          source: 'learning:failure-consolidation',
+          sourceType: 'inferred',
+          confidence: 0.35,
+          reason: 'page-bound fixture',
+        });
+        const candidates = Array.from({ length: 150 }, (_, index) => ({
+          ...base,
+          id: `${base.id}-${index}`,
+          key: `${base.key}-${index}`,
+        }));
+        const listByKind = vi.spyOn(brain.memoryReview, 'listByKind').mockImplementation(
+          (status, _kind, options = {}) => status === 'pending'
+            ? candidates.slice(options.offset ?? 0, (options.offset ?? 0) + (options.limit ?? candidates.length))
+            : [],
+        );
+
+        expect(brain.learning.relevantLessons('shared', { limit: 1 })).toHaveLength(1);
+        expect(listByKind).toHaveBeenCalledTimes(2);
+        expect(listByKind).not.toHaveBeenCalledWith(
+          'pending',
+          'consolidated-lesson',
+          expect.objectContaining({ offset: 100 }),
+        );
+      });
+
+    it('uses reviewer-edited candidate confidence for lesson retrieval', () => {
+      for (let index = 0; index < 3; index += 1) {
+        recordStaleDeclarationFailure(
+          'TypeScript workspace build failed with stale declarations',
+          `2026-07-24T10:0${index}:00.000Z`,
+        );
+      }
+      const [candidate] = brain.learning.consolidate({ threshold: 3, lookback: 3 });
+      brain.memoryReview.edit(candidate!.id, { confidence: 0.2 });
+
+      expect(brain.learning.relevantLessons(
+        'TypeScript workspace build',
+        { minConfidence: 0.5 },
+      )).toEqual([]);
+      expect(brain.learning.relevantLessons('TypeScript workspace build')[0]?.confidence).toBe(0.2);
+    });
+
+    it('invalidates absorbed lesson keys in every live brain instance', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-live-lesson-retirement-'));
+      const dbPath = join(dir, 'brain.db');
+      let writer: SqliteBrain | undefined;
+      let stale: SqliteBrain | undefined;
+      try {
+        writer = new SqliteBrain(dbPath);
+        for (const [summary, createdAt] of [
+          ['AlphaOnlyMarker parser timeout crash', '2026-07-24T10:00:00.000Z'],
+          ['AlphaOnlyMarker parser timeout crash', '2026-07-24T10:01:00.000Z'],
+          ['OmegaOnlyMarker cache mismatch overflow', '2026-07-24T10:02:00.000Z'],
+          ['OmegaOnlyMarker cache mismatch overflow', '2026-07-24T10:03:00.000Z'],
+        ] as const) {
+          writer.episodic.record({ type: 'failure', step: 'build', summary, createdAt });
+        }
+        const initial = writer.learning.consolidate({ threshold: 2, lookback: 10 });
+        for (const candidate of initial) writer.memoryReview.approve(candidate.id);
+        stale = new SqliteBrain(dbPath);
+        expect(initial.every((candidate) => stale!.working.has(candidate.key))).toBe(true);
+
+        writer.episodic.record({
+          type: 'failure',
+          step: 'build',
+          summary: 'AlphaOnlyMarker parser timeout crash OmegaOnlyMarker cache mismatch overflow',
+          createdAt: '2026-07-24T10:04:00.000Z',
+        });
+        const [revision] = writer.learning.consolidate({
+          threshold: 2,
+          lookback: 10,
+          similarityThreshold: 0.5,
+        });
+        writer.memoryReview.resolveConflict(revision!.id, { resolution: 'replace_existing' });
+        const retired = initial.find((candidate) => candidate.key !== revision!.key)!;
+
+        expect(stale.working.get(retired.key)).toBeUndefined();
+      } finally {
+        stale?.close();
+        writer?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('does not return an approved lesson after its durable working value is removed', () => {
@@ -6035,6 +6317,36 @@ describe('SqliteBrain', () => {
       enabled: true,
       key: 'correct horse battery staple',
     } as const;
+
+    it('keys encrypted lesson token fingerprints instead of storing dictionary hashes', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-encrypted-lesson-tokens-'));
+      const dbPath = join(dir, 'brain.db');
+      try {
+        const encrypted = new SqliteBrain(dbPath, undefined, { encryption });
+        encrypted.episodic.record({
+          type: 'failure',
+          step: 'build',
+          summary: 'SecretProjectMarker build failed repeatedly',
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+        encrypted.learning.consolidate({ threshold: 1, lookback: 1 });
+        encrypted.close();
+
+        const raw = new Database(dbPath, { readonly: true });
+        const row = raw.prepare(
+          `SELECT lesson_suppression_tokens AS tokens
+             FROM memory_review_candidates
+            WHERE candidate_kind = 'consolidated-lesson'`,
+        ).get() as { tokens: string };
+        raw.close();
+        const tokens = JSON.parse(row.tokens) as string[];
+        const dictionaryHash = createHash('sha256').update('secretprojectmarker').digest('hex');
+
+        expect(tokens).not.toContain(dictionaryHash);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
 
     it('encrypts persisted working, episodic, and checkpoint payloads while preserving runtime roundtrip', () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-encrypted-'));

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1443,6 +1443,150 @@ describe('SqliteBrain', () => {
         );
       });
 
+    it('caps lesson relevance scans when no rows match', () => {
+      const base = brain.memoryReview.propose({
+        targetStore: 'working',
+        key: 'lesson.review.scan-budget',
+        value: {
+          kind: 'consolidated-lesson',
+          pattern: 'unrelated filler lesson',
+          keywords: ['unrelated', 'filler', 'lesson'],
+          occurrenceCount: 1,
+          confidence: 0.35,
+          evidenceEventIds: [1],
+          firstSeenAt: '2026-07-24T10:00:00.000Z',
+          lastSeenAt: '2026-07-24T10:00:00.000Z',
+        },
+        source: 'test',
+        confidence: 0.35,
+        reason: 'scan budget fixture',
+      });
+      const page = Array.from({ length: 100 }, (_, index) => ({
+        ...base,
+        id: `${base.id}-${index}`,
+        key: `${base.key}-${index}`,
+      }));
+      const listByKind = vi.spyOn(brain.memoryReview, 'listByKind').mockImplementation(
+        (status) => status === 'pending' ? page : [],
+      );
+
+      expect(brain.learning.relevantLessons('needle', { limit: 1 })).toEqual([]);
+      const pendingOffsets = listByKind.mock.calls
+        .filter(([status]) => status === 'pending')
+        .map(([, , options]) => options?.offset ?? 0);
+      expect(pendingOffsets).toEqual(Array.from({ length: 10 }, (_, index) => index * 100));
+    });
+
+    it('does not count h0 and h1 forms as separate suppression tokens', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-encrypted-token-count-'));
+      const encrypted = new SqliteBrain(join(dir, 'brain.db'), undefined, {
+        encryption: { enabled: true, key: 'encrypted-token-count-key' },
+      });
+      try {
+        encrypted.episodic.record({
+          type: 'failure',
+          step: 'build',
+          summary: 'alpha beta',
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+        const [rejected] = encrypted.learning.consolidate({ threshold: 1, lookback: 1 });
+        encrypted.memoryReview.reject(rejected!.id, { reviewer: 'operator' });
+        encrypted.episodic.record({
+          type: 'failure',
+          step: 'build',
+          summary: 'alpha beta gamma',
+          createdAt: '2026-07-24T10:01:00.000Z',
+        });
+
+        expect(encrypted.learning.consolidate({
+          threshold: 1,
+          lookback: 1,
+          similarityThreshold: 0.7,
+        })).toHaveLength(1);
+      } finally {
+        encrypted.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not rewrite modern encrypted lesson tokens on restart', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-encrypted-token-migration-'));
+      const dbPath = join(dir, 'brain.db');
+      const options = {
+        encryption: { enabled: true, key: 'encrypted-token-migration-key' },
+      } as const;
+      let encrypted: SqliteBrain | undefined;
+      try {
+        encrypted = new SqliteBrain(dbPath, undefined, options);
+        encrypted.episodic.record({
+          type: 'failure',
+          step: 'build',
+          summary: 'modern encrypted token lesson',
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+        encrypted.learning.consolidate({ threshold: 1, lookback: 1 });
+        encrypted.close();
+        encrypted = undefined;
+        const raw = new Database(dbPath);
+        raw.exec(`
+          CREATE TRIGGER reject_redundant_lesson_token_rewrite
+          BEFORE UPDATE ON memory_review_candidates
+          WHEN OLD.candidate_kind = 'consolidated-lesson'
+          BEGIN
+            SELECT RAISE(ABORT, 'modern lesson tokens must not be rewritten');
+          END;
+        `);
+        raw.close();
+
+        expect(() => {
+          encrypted = new SqliteBrain(dbPath, undefined, options);
+        }).not.toThrow();
+      } finally {
+        encrypted?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves replacement metadata when a bridging revision is refreshed', () => {
+      for (const [summary, createdAt] of [
+        ['AlphaRefresh parser timeout crash', '2026-07-24T10:00:00.000Z'],
+        ['AlphaRefresh parser timeout crash', '2026-07-24T10:01:00.000Z'],
+        ['OmegaRefresh cache mismatch overflow', '2026-07-24T10:02:00.000Z'],
+        ['OmegaRefresh cache mismatch overflow', '2026-07-24T10:03:00.000Z'],
+      ] as const) {
+        recordStaleDeclarationFailure(summary, createdAt);
+      }
+      const initial = brain.learning.consolidate({
+        threshold: 2,
+        lookback: 10,
+        similarityThreshold: 0.5,
+      });
+      for (const candidate of initial) brain.memoryReview.approve(candidate.id);
+      recordStaleDeclarationFailure(
+        'AlphaRefresh parser timeout crash OmegaRefresh cache mismatch overflow',
+        '2026-07-24T10:04:00.000Z',
+      );
+      const [revision] = brain.learning.consolidate({
+        threshold: 2,
+        lookback: 10,
+        similarityThreshold: 0.5,
+      });
+      expect(revision?.replaces).toHaveLength(1);
+      recordStaleDeclarationFailure(
+        'AlphaRefresh parser timeout crash OmegaRefresh cache mismatch overflow again',
+        '2026-07-24T10:05:00.000Z',
+      );
+
+      const [refreshed] = brain.learning.consolidate({
+        threshold: 2,
+        lookback: 10,
+        similarityThreshold: 0.5,
+      });
+
+      expect(refreshed?.id).toBe(revision?.id);
+      expect(refreshed?.replaces).toEqual(revision?.replaces);
+    });
+
     it('uses reviewer-edited candidate confidence for lesson retrieval', () => {
       for (let index = 0; index < 3; index += 1) {
         recordStaleDeclarationFailure(

--- a/packages/franken-types/src/brain.ts
+++ b/packages/franken-types/src/brain.ts
@@ -148,11 +148,18 @@ export interface ConsolidatedLesson {
   readonly lastSeenAt: string;
 }
 
+export interface LessonReplacement {
+  readonly key: string;
+  readonly candidateId: string;
+}
+
 export interface LessonConsolidationItem {
   readonly id: string;
   readonly key: string;
   readonly status: 'pending';
   readonly value: ConsolidatedLesson;
+  /** Approved lessons that this candidate will retire when approved. */
+  readonly replaces?: readonly LessonReplacement[];
 }
 
 export interface RelevantLesson extends ConsolidatedLesson {

--- a/packages/franken-types/src/index.ts
+++ b/packages/franken-types/src/index.ts
@@ -74,6 +74,7 @@ export type {
   LessonConsolidationOptions,
   RelevantLessonsOptions,
   ConsolidatedLesson,
+  LessonReplacement,
   LessonConsolidationItem,
   RelevantLesson,
   IPlanningFaculty,

--- a/tasks/pr3760-post-merge-codex-progress.md
+++ b/tasks/pr3760-post-merge-codex-progress.md
@@ -1,0 +1,15 @@
+# PR #3760 post-merge Codex follow-up
+
+- [x] Fetch the nine specified Codex comments from live GitHub and map each to code/tests.
+- [x] Validate each finding against the clean `origin/main` base; all nine are real.
+- [x] Add focused regression tests first and observe expected failures.
+- [x] Implement only the real fixes and make focused tests pass (9/9 focused tests).
+- [x] Address independent-review follow-ups for encrypted never-store restarts and bounded relevance paging.
+- [x] Run focused test suites plus `@franken/brain` and `@franken/types` test, lint, typecheck, and build gates.
+- [ ] Commit with the required David Mendez identity.
+- [ ] Route exact push and PR-creation commands through the dedicated Approval Cop ledger.
+- [ ] Trigger and complete the current-head GitHub Codex review loop through approved commands.
+- [ ] Reply to and resolve all nine original PR #3760 threads with follow-up evidence.
+- [ ] Verify green CI and zero fully paginated unresolved Codex threads.
+- [ ] Route merge through Approval Cop and verify the follow-up merged.
+- [ ] Record structured Kanban evidence and finish the task.


### PR DESCRIPTION
## Summary
- harden repeated-failure lesson consolidation identified by post-merge Codex review on #3760
- preserve restart-safe lineage and never-store behavior across encrypted/plaintext brains
- bound relevance pagination and validate consolidation/storage edge cases

## Verification
- `npm test --workspace @franken/brain` (425 tests passed)
- `npm run lint --workspace @franken/brain`
- `npm run typecheck --workspace @franken/brain`
- `npm run build --workspace @franken/brain`
- `npm test --workspace @franken/types`
- `npm run lint --workspace @franken/types`
- `npm run typecheck --workspace @franken/types`
- `npm run build --workspace @franken/types`
- `git diff --check`

Follow-up to #3760.