### PR TITLE
feat(brain): consult lessons from faculties

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Unless a section explicitly says otherwise, diagrams should use current package 
 
 | Package | Role |
 |---------|------|
-|| `@franken/brain` | SQLite-backed memory plus a process-local `BrainRegistry` whose safe agent-type IDs default to durable `.fbeast/brains/<agentTypeId>.db` files, and planning/reasoning/action/learning faculty surfaces. The local Beast CLI attaches the existing planner, critique chain, and governor; the built-in learning faculty clusters similar failure episodes into review-gated lesson candidates and exposes occurrence-aware retrieval without consumer wiring. |
+|| `@franken/brain` | SQLite-backed memory plus a process-local `BrainRegistry` whose safe agent-type IDs default to durable `.fbeast/brains/<agentTypeId>.db` files, and planning/reasoning/action/learning faculty surfaces. The local Beast CLI attaches the existing planner, critique chain, and governor; planning/reasoning consult bounded relevant lessons, while negative reasoning/action outcomes trigger bounded review-gated consolidation. |
 | `@franken/planner` | DAG planning primitives, planning strategies, HITL plan export, recovery task insertion. |
 | `@franken/observer` | Tracing, spans, token/cost tracking, loop detection, circuit breakers, export adapters. |
 | `@franken/critique` | Critique pipeline and correction-request loop. The caller applies regenerated input; MOD-06 does not call the actor itself. |
@@ -478,6 +478,30 @@ their existing TTL/write-path semantics. Candidate ordering uses retention-class
 priority and then oldest-first age; v1 does not recognize rare-but-important
 patterns semantically, so callers must classify durable/audit memories correctly.
 Lessons-aware pruning is intentionally outside this path.
+
+### Faculty lesson consultation and consolidation trigger
+
+`createBeastDeps()` wires the planning and reasoning adapters to the same
+agent-scoped `SqliteBrain.learning` port. Before delegating, each adapter calls
+`relevantLessons()` with a deterministic query (the planning goal or joined plan
+objectives) and a hard limit of five. It records an advisory
+`<faculty>:lesson-consultation` observation containing the redacted,
+512-byte-bounded query, match count, and stable lesson keys. This makes
+consultation observable without changing the planner/critique result or
+injecting lesson text into an LLM prompt.
+
+Consolidation is event-triggered rather than timer- or run-boundary-based. After
+a successfully recorded negative reasoning verdict or rejected/aborted governor
+decision, the adapter asynchronously schedules the existing
+`learning.consolidate()` core with a threshold of three, a 100-event lookback,
+and similarity threshold `0.5`. Bursts coalesce into one pending pass so review
+queue work does not block faculty results.
+`SqliteBrain` includes those explicitly marked negative faculty decisions beside
+ordinary failure events, while retaining the existing exclusions for planning
+lifecycle and skill-evolution rows. Each trigger is deterministic, scans bounded
+episodic windows, remains best-effort relative to the authoritative faculty
+result, and continues to propose lessons through operator review rather than
+approving them.
 
 ### Hive Brain central-command chat (accepted design)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -483,22 +483,27 @@ Lessons-aware pruning is intentionally outside this path.
 
 `createBeastDeps()` wires the planning and reasoning adapters to the same
 agent-scoped `SqliteBrain.learning` port. Before delegating, each adapter calls
-`relevantLessons()` with a deterministic query (the planning goal or joined plan
-objectives) and a hard limit of five. It records an advisory
+`relevantLessons()` with a deterministic query (the planning goal or bounded plan
+objectives) and a hard limit of five. Query assembly inspects at most 100
+objectives and 2,048 characters, removes truncated PEM spans before general
+redaction, and records an advisory
 `<faculty>:lesson-consultation` observation containing the redacted,
 512-byte-bounded query, match count, and stable lesson keys. This makes
 consultation observable without changing the planner/critique result or
 injecting lesson text into an LLM prompt.
 
 Consolidation is event-triggered rather than timer- or run-boundary-based. After
-a successfully recorded negative reasoning verdict or rejected/aborted governor
+a successfully recorded non-halted negative reasoning verdict or rejected/aborted governor
 decision, the adapter asynchronously schedules the existing
 `learning.consolidate()` core with a threshold of three, a 100-event lookback,
 and similarity threshold `0.5`. Bursts coalesce into one pending pass so review
-queue work does not block faculty results.
+queue work does not block faculty results; CLI shutdown drains that pass before
+closing SQLite.
 `SqliteBrain` includes those explicitly marked negative faculty decisions beside
 ordinary failure events, while retaining the existing exclusions for planning
-lifecycle and skill-evolution rows. Each trigger is deterministic, scans bounded
+lifecycle and skill-evolution rows. Faculty outcomes cluster on their bounded
+objective/request context rather than lifecycle boilerplate, and equal timestamps
+use descending event IDs. Each trigger is deterministic, scans bounded
 episodic windows, remains best-effort relative to the authoritative faculty
 result, and continues to propose lessons through operator review rather than
 approving them.

--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -279,8 +279,13 @@ deterministic normalized-token connected-component heuristic, proposes
 consolidated patterns through the existing memory-review queue, refreshes pending
 candidates as evidence grows, and exposes occurrence/confidence-aware retrieval.
 Confidence is evidence-count based and capped rather than presented as model
-certainty. It does not inject lessons into planning or reasoning (#3699), share
-them across brains (#3689), or change the dispatch boundaries above.
+certainty. Agent-scoped planning and reasoning now consult at most five relevant
+lesson keys before delegation and record that consultation as an episodic
+observation with a redacted, 512-byte-bounded query. Negative reasoning/action
+decisions asynchronously schedule the same consolidation core with the fixed
+input policy (threshold 3, lookback 100, similarity 0.5); bursts coalesce into one
+pending pass. This does not inject lesson text into prompts, share lessons across
+brains (#3689), or change the dispatch boundaries above.
 
 ## Consequences
 

--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -284,7 +284,9 @@ lesson keys before delegation and record that consultation as an episodic
 observation with a redacted, 512-byte-bounded query. Negative reasoning/action
 decisions asynchronously schedule the same consolidation core with the fixed
 input policy (threshold 3, lookback 100, similarity 0.5); bursts coalesce into one
-pending pass. This does not inject lesson text into prompts, share lessons across
+pending pass and CLI shutdown drains it. Halted critiques are excluded, query
+assembly is capped before redaction, and clustering uses objective/request context
+rather than lifecycle boilerplate. This does not inject lesson text into prompts, share lessons across
 brains (#3689), or change the dispatch boundaries above.
 
 ## Consequences

--- a/docs/onboarding/RAMP_UP.md
+++ b/docs/onboarding/RAMP_UP.md
@@ -63,9 +63,9 @@ User Input → [Ingestion] → [Planning] → [Execution] → [Closure] → Beas
 ## Key API Patterns
 
 - Brain `ILlmClient`: `complete(prompt: string): Promise<string>`
-- `ReasoningFacultyAdapter`: preserves the enabled `ICritiqueModule` result and records its verdict as a queryable episodic decision when memory is enabled; disabled critique remains an inert faculty and health probes do not create episodes
+- `ReasoningFacultyAdapter`: consults up to five relevant lesson keys before critique, preserves the enabled `ICritiqueModule` result, and records its verdict as a queryable episodic decision when memory is enabled; disabled critique remains an inert faculty and health probes do not create episodes
 - `ActionFacultyAdapter`: preserves governor approval outcomes and records real gating decisions as queryable episodic context without approval tokens; synthetic health probes do not create episodes
-- Learning faculty: `consolidate()` runs a bounded normalized-token clustering pass over recent failures and proposes patterns through `memoryReview`; `relevantLessons()` returns pending/approved matches with occurrence counts and confidence. No planning/reasoning consumer is wired until #3699.
+- Learning faculty: `consolidate()` clusters bounded episodic inputs and proposes patterns through `memoryReview`; `relevantLessons()` returns pending/approved matches with occurrence counts and confidence. Planning and reasoning record observable consultations with redacted 512-byte queries. Negative reasoning/action outcomes asynchronously schedule the existing consolidation core with threshold 3, lookback 100, and similarity 0.5, coalescing bursts into one pending pass; this remains review-gated and does not inject lesson text into prompts.
 - `GovernorCritiqueAdapter`: passes rationale as `unknown` to evaluators
 - `BudgetTrigger()`, `SkillTrigger()`: parameterless constructors
 - `TriggerRegistry.evaluateAll()` (not `.evaluate()`)

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -155,10 +155,12 @@ for (const lesson of relevantLessons) {
 // In the orchestrator wiring, planning and reasoning consult at most five
 // relevant lessons before delegating and record the consulted lesson keys plus a
 // redacted, 512-byte-bounded query as an episodic observation. A recorded negative
-// reasoning verdict or rejected/aborted action asynchronously schedules this same
+// non-halted reasoning verdict or rejected/aborted action asynchronously schedules this same
 // consolidate() implementation with threshold 3, lookback 100, and similarity
-// 0.5. Bursts coalesce into one pending pass, episodic inputs stay bounded, and
-// review remains mandatory; lesson text is not injected into provider prompts.
+// 0.5. Bursts coalesce into one pending pass that CLI shutdown drains. Objective
+// scans, episodic inputs, and persisted query bytes stay bounded, and faculty
+// outcomes cluster on objective/request context rather than lifecycle boilerplate.
+// Review remains mandatory; lesson text is not injected into provider prompts.
 
 // Candidate durable memories stay user-visible until reviewed. They are not
 // written to working memory until approval, and approvals retain provenance.

--- a/packages/franken-brain/README.md
+++ b/packages/franken-brain/README.md
@@ -152,6 +152,13 @@ for (const lesson of relevantLessons) {
 // suppressed, approved lessons are returned only while live provenance matches
 // their durable value. Skill-evolution and planning-lifecycle duplicates stay in
 // their dedicated gates rather than inflating generic lesson occurrence counts.
+// In the orchestrator wiring, planning and reasoning consult at most five
+// relevant lessons before delegating and record the consulted lesson keys plus a
+// redacted, 512-byte-bounded query as an episodic observation. A recorded negative
+// reasoning verdict or rejected/aborted action asynchronously schedules this same
+// consolidate() implementation with threshold 3, lookback 100, and similarity
+// 0.5. Bursts coalesce into one pending pass, episodic inputs stay bounded, and
+// review remains mandatory; lesson text is not injected into provider prompts.
 
 // Candidate durable memories stay user-visible until reviewed. They are not
 // written to working memory until approval, and approvals retain provenance.

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3276,7 +3276,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     try {
       const quarantinedEventIds = new Set<number>();
       const stmt = this.db.prepare(
-        `SELECT * FROM episodic_events ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+        `SELECT * FROM episodic_events ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`,
       );
       const result = collectRowsToEvents(
         (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
@@ -6128,6 +6128,12 @@ function normalizeSemanticMemoryToken(token: string): string {
 }
 
 function lessonEventText(event: EpisodicEvent): string {
+  if (isConsolidatableFacultyNegativeOutcome(event)) {
+    const lessonContext = event.details?.lessonContext;
+    if (typeof lessonContext === 'string' && lessonContext.trim().length > 0) {
+      return lessonContext;
+    }
+  }
   return event.summary;
 }
 

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -6131,6 +6131,13 @@ function lessonEventText(event: EpisodicEvent): string {
   return event.summary;
 }
 
+function isConsolidatableFacultyNegativeOutcome(event: EpisodicEvent): boolean {
+  return event.type === 'decision'
+    && event.details?.outcome === 'negative'
+    && (event.details?.category === 'reasoning-lifecycle'
+      || event.details?.category === 'action-lifecycle');
+}
+
 function clusterSimilarFailureEvents(
   events: readonly EpisodicEvent[],
   similarityThreshold: number,
@@ -6656,8 +6663,15 @@ export class SqliteBrain implements IBrain {
     }
 
     const consolidate = this.db.transaction(() => {
-    const events = this.episodic
-      .recentFailures(lookback, false, ['skill-evolution', 'planning-lifecycle'], lookback)
+    const failures = this.episodic
+      .recentFailures(lookback, false, ['skill-evolution', 'planning-lifecycle'], lookback);
+    const facultyNegativeOutcomes = this.episodic
+      .recent(lookback)
+      .filter(isConsolidatableFacultyNegativeOutcome);
+    const events = [...new Map(
+      [...failures, ...facultyNegativeOutcomes]
+        .map((event) => [event.id ?? `${event.createdAt}:${event.summary}`, event]),
+    ).values()]
       .sort((left, right) =>
         left.createdAt.localeCompare(right.createdAt) || Number(left.id ?? 0) - Number(right.id ?? 0),
       );

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3269,6 +3269,34 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
   }
 
+  recentFacultyNegativeOutcomes(n = 10): EpisodicEvent[] {
+    const quarantinedEventIds = new Set<number>();
+    const stmt = this.db.prepare(
+      `SELECT * FROM episodic_events WHERE type = 'decision'
+       ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`,
+    );
+    const result = collectRowsToEvents(
+      (limit, offset) => stmt.all(limit, offset) as EpisodicRow[],
+      n,
+      this.encryption,
+      (eventId) => quarantinedEventIds.add(eventId),
+      isConsolidatableFacultyNegativeOutcome,
+    );
+    this.audit?.({
+      operation: 'episodic.recent',
+      store: 'episodic',
+      outcome: 'success',
+      details: {
+        limit: n,
+        count: result.length,
+        ...(quarantinedEventIds.size > 0
+          ? { quarantinedEventIds: [...quarantinedEventIds] }
+          : {}),
+      },
+    });
+    return result;
+  }
+
   recent(
     n = 10,
     reportCorruptDetails?: CorruptEpisodicDetailsReporter,
@@ -6179,8 +6207,8 @@ function consolidatedLesson(cluster: readonly EpisodicEvent[]): ConsolidatedLess
   const ordered = [...cluster].sort((left, right) =>
     left.createdAt.localeCompare(right.createdAt) || Number(left.id ?? 0) - Number(right.id ?? 0),
   );
-  const summaries = ordered.map((event) => event.summary);
-  const pattern = [...summaries].sort((left, right) =>
+  const lessonTexts = ordered.map(lessonEventText);
+  const pattern = [...lessonTexts].sort((left, right) =>
     left.length - right.length || left.localeCompare(right),
   )[0]!;
   const tokenSets = ordered.map((event) => semanticMemoryTokens(lessonEventText(event)));
@@ -6672,8 +6700,7 @@ export class SqliteBrain implements IBrain {
     const failures = this.episodic
       .recentFailures(lookback, false, ['skill-evolution', 'planning-lifecycle'], lookback);
     const facultyNegativeOutcomes = this.episodic
-      .recent(lookback)
-      .filter(isConsolidatableFacultyNegativeOutcome);
+      .recentFacultyNegativeOutcomes(lookback);
     const events = [...new Map(
       [...failures, ...facultyNegativeOutcomes]
         .map((event) => [event.id ?? `${event.createdAt}:${event.summary}`, event]),

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1732,6 +1732,44 @@ describe('SqliteBrain', () => {
       expect(candidate?.value.evidenceEventIds).toEqual([2, 3]);
     });
 
+    it('uses event id as the stable faculty-outcome lookback tie-breaker', () => {
+      for (const index of [1, 2, 3]) {
+        brain.episodic.record({
+          type: 'decision',
+          step: 'reasoning:critique',
+          summary: `Reasoning verdict: fail — workspace failure ${index}`,
+          details: {
+            category: 'reasoning-lifecycle',
+            outcome: 'negative',
+            lessonContext: 'workspace declaration failure',
+          },
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+      }
+
+      const [candidate] = brain.learning.consolidate({ threshold: 2, lookback: 2 });
+
+      expect(candidate?.value.evidenceEventIds).toEqual([2, 3]);
+    });
+
+    it('clusters faculty outcomes by their context rather than lifecycle boilerplate', () => {
+      for (const context of ['frontend', 'backend', 'storage']) {
+        brain.episodic.record({
+          type: 'decision',
+          step: 'reasoning:critique',
+          summary: `Reasoning verdict: fail — ${context}`,
+          details: {
+            category: 'reasoning-lifecycle',
+            outcome: 'negative',
+            lessonContext: context,
+          },
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+      }
+
+      expect(brain.learning.consolidate({ threshold: 3, lookback: 10 })).toEqual([]);
+    });
+
     it('does not cluster skill-evolution review signals as generic lessons', () => {
       brain.episodic.recordSkillFailure({
         skillName: 'resolve-issues',

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -2151,7 +2151,7 @@ describe('SqliteBrain', () => {
       ]);
       expect(brain.learning.relevantLessons('NeedleMarker', { limit: 1 })[0]?.pattern)
         .toBe('NeedleMarker exact lesson');
-    });
+    }, 20_000);
 
     it('stops paging each lesson status after satisfying the requested limit', () => {
       const base = brain.memoryReview.propose({

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1770,6 +1770,54 @@ describe('SqliteBrain', () => {
       expect(brain.learning.consolidate({ threshold: 3, lookback: 10 })).toEqual([]);
     });
 
+    it('persists the sanitized faculty lesson context instead of the raw action summary', () => {
+      for (const secret of ['raw-token-first', 'raw-token-second']) {
+        brain.episodic.record({
+          type: 'decision',
+          step: 'action:request',
+          summary: `Action rejected for leaked credential ${secret}`,
+          details: {
+            category: 'action-lifecycle',
+            outcome: 'negative',
+            lessonContext: 'Action request rejected for a redacted credential',
+          },
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+      }
+
+      const [candidate] = brain.learning.consolidate({ threshold: 2, lookback: 2 });
+
+      expect(candidate?.value.pattern).toBe('Action request rejected for a redacted credential');
+      expect(JSON.stringify(candidate?.value)).not.toContain('raw-token-');
+    });
+
+    it('applies the faculty-outcome lookback after filtering unrelated episodes', () => {
+      for (const index of [1, 2, 3]) {
+        brain.episodic.record({
+          type: 'decision',
+          step: 'reasoning:critique',
+          summary: `Reasoning verdict: fail — bounded failure ${index}`,
+          details: {
+            category: 'reasoning-lifecycle',
+            outcome: 'negative',
+            lessonContext: 'bounded faculty failure',
+          },
+          createdAt: `2026-07-24T10:0${index}:00.000Z`,
+        });
+      }
+      for (const index of [4, 5, 6]) {
+        brain.episodic.record({
+          type: 'observation',
+          summary: `Unrelated consultation ${index}`,
+          createdAt: `2026-07-24T10:0${index}:00.000Z`,
+        });
+      }
+
+      const [candidate] = brain.learning.consolidate({ threshold: 2, lookback: 2 });
+
+      expect(candidate?.value.evidenceEventIds).toEqual([2, 3]);
+    });
+
     it('does not cluster skill-evolution review signals as generic lessons', () => {
       brain.episodic.recordSkillFailure({
         skillName: 'resolve-issues',

--- a/packages/franken-orchestrator/src/adapters/action-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/action-faculty-adapter.ts
@@ -1,5 +1,6 @@
-import type { IEpisodicMemory, IActionFaculty } from '@franken/types';
+import type { IEpisodicMemory, IActionFaculty, ILearningFaculty } from '@franken/types';
 import type { ApprovalOutcome, ApprovalPayload, IGovernorModule } from '../deps.js';
+import { consolidateFacultyNegativeOutcome } from './faculty-learning.js';
 
 /**
  * Makes governor decisions available through the brain action faculty while
@@ -15,6 +16,7 @@ export class ActionFacultyAdapter implements IActionFaculty, IGovernorModule {
     private readonly clock: () => Date = () => new Date(),
     private readonly onRecordError: (error: unknown) => void = () => undefined,
     private readonly recordEpisodes = true,
+    private readonly learning?: ILearningFaculty,
   ) {}
 
   async requestApproval(request: ApprovalPayload): Promise<ApprovalOutcome> {
@@ -28,6 +30,8 @@ export class ActionFacultyAdapter implements IActionFaculty, IGovernorModule {
         step: 'action:governor',
         summary: `Action decision (${outcome.decision}): ${request.summary}`,
         details: {
+          category: 'action-lifecycle',
+          outcome: outcome.decision === 'approved' ? 'positive' : 'negative',
           taskId: request.taskId,
           ...(request.skillId === undefined ? {} : { skillId: request.skillId }),
           requiresHitl: request.requiresHitl,
@@ -36,6 +40,9 @@ export class ActionFacultyAdapter implements IActionFaculty, IGovernorModule {
         },
         createdAt: this.clock().toISOString(),
       });
+      if (outcome.decision !== 'approved') {
+        consolidateFacultyNegativeOutcome(this.learning);
+      }
     } catch (error) {
       // Observability must never replace or bypass the governor's decision.
       try {

--- a/packages/franken-orchestrator/src/adapters/action-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/action-faculty-adapter.ts
@@ -1,6 +1,9 @@
 import type { IEpisodicMemory, IActionFaculty, ILearningFaculty } from '@franken/types';
 import type { ApprovalOutcome, ApprovalPayload, IGovernorModule } from '../deps.js';
-import { consolidateFacultyNegativeOutcome } from './faculty-learning.js';
+import {
+  consolidateFacultyNegativeOutcome,
+  prepareFacultyLessonQuery,
+} from './faculty-learning.js';
 
 /**
  * Makes governor decisions available through the brain action faculty while
@@ -32,6 +35,9 @@ export class ActionFacultyAdapter implements IActionFaculty, IGovernorModule {
         details: {
           category: 'action-lifecycle',
           outcome: outcome.decision === 'approved' ? 'positive' : 'negative',
+          ...(outcome.decision === 'approved'
+            ? {}
+            : { lessonContext: prepareFacultyLessonQuery(request.summary) }),
           taskId: request.taskId,
           ...(request.skillId === undefined ? {} : { skillId: request.skillId }),
           requiresHitl: request.requiresHitl,

--- a/packages/franken-orchestrator/src/adapters/faculty-learning.ts
+++ b/packages/franken-orchestrator/src/adapters/faculty-learning.ts
@@ -1,0 +1,88 @@
+import type { IEpisodicMemory, ILearningFaculty, RelevantLesson } from '@franken/types';
+import { redactSensitiveText } from '../logging/redaction.js';
+
+const MAX_LESSON_QUERY_INPUT_CHARS = 2_048;
+const MAX_LESSON_QUERY_BYTES = 512;
+const scheduledConsolidations = new WeakSet<ILearningFaculty>();
+
+export const FACULTY_LESSON_POLICY = Object.freeze({
+  consultationLimit: 5,
+  consolidation: Object.freeze({
+    threshold: 3,
+    lookback: 100,
+    similarityThreshold: 0.5,
+  }),
+});
+
+export type LessonConsultingFaculty = 'planning' | 'reasoning';
+
+export function consultFacultyLessons(
+  faculty: LessonConsultingFaculty,
+  query: string,
+  episodic: IEpisodicMemory,
+  learning: ILearningFaculty | undefined,
+  createdAt: string,
+): RelevantLesson[] {
+  if (!learning) return [];
+  try {
+    const boundedQuery = prepareFacultyLessonQuery(query);
+    const lessons = learning.relevantLessons(boundedQuery, {
+      limit: FACULTY_LESSON_POLICY.consultationLimit,
+    });
+    episodic.record({
+      type: 'observation',
+      step: `${faculty}:lesson-consultation`,
+      summary: `${capitalize(faculty)} consulted relevant lessons: ${lessons.length}`,
+      details: {
+        category: 'lesson-consultation',
+        faculty,
+        query: boundedQuery,
+        lessonCount: lessons.length,
+        lessonKeys: lessons.map((lesson) => lesson.key),
+      },
+      createdAt,
+    });
+    return lessons;
+  } catch {
+    // Lesson consultation is advisory and must not replace planner/critique behavior.
+    return [];
+  }
+}
+
+export function consolidateFacultyNegativeOutcome(
+  learning: ILearningFaculty | undefined,
+): void {
+  if (!learning || scheduledConsolidations.has(learning)) return;
+  scheduledConsolidations.add(learning);
+  setTimeout(() => {
+    scheduledConsolidations.delete(learning);
+    try {
+      learning.consolidate(FACULTY_LESSON_POLICY.consolidation);
+    } catch {
+      // Consolidation is review/telemetry work and must not replace a faculty result.
+    }
+  }, 0);
+}
+
+export function prepareFacultyLessonQuery(query: string): string {
+  const redacted = redactSensitiveText(query.slice(0, MAX_LESSON_QUERY_INPUT_CHARS))
+    .replace(/\s+/gu, ' ')
+    .trim();
+  return truncateUtf8(redacted, MAX_LESSON_QUERY_BYTES);
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  let bytes = 0;
+  let bounded = '';
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (bytes + characterBytes > maxBytes) break;
+    bounded += character;
+    bytes += characterBytes;
+  }
+  return bounded;
+}

--- a/packages/franken-orchestrator/src/adapters/faculty-learning.ts
+++ b/packages/franken-orchestrator/src/adapters/faculty-learning.ts
@@ -1,7 +1,7 @@
 import type { IEpisodicMemory, ILearningFaculty, RelevantLesson } from '@franken/types';
 import { redactSensitiveText } from '../logging/redaction.js';
 
-const MAX_LESSON_QUERY_INPUT_CHARS = 2_048;
+export const MAX_LESSON_QUERY_INPUT_CHARS = 2_048;
 const MAX_LESSON_QUERY_BYTES = 512;
 const scheduledConsolidations = new WeakSet<ILearningFaculty>();
 

--- a/packages/franken-orchestrator/src/adapters/faculty-learning.ts
+++ b/packages/franken-orchestrator/src/adapters/faculty-learning.ts
@@ -3,10 +3,11 @@ import { redactSensitiveText } from '../logging/redaction.js';
 
 export const MAX_LESSON_QUERY_INPUT_CHARS = 2_048;
 const MAX_LESSON_QUERY_BYTES = 512;
-const scheduledConsolidations = new WeakSet<ILearningFaculty>();
+const scheduledConsolidations = new WeakMap<ILearningFaculty, ReturnType<typeof setTimeout>>();
 
 export const FACULTY_LESSON_POLICY = Object.freeze({
   consultationLimit: 5,
+  objectiveLimit: 100,
   consolidation: Object.freeze({
     threshold: 3,
     lookback: 100,
@@ -53,22 +54,37 @@ export function consolidateFacultyNegativeOutcome(
   learning: ILearningFaculty | undefined,
 ): void {
   if (!learning || scheduledConsolidations.has(learning)) return;
-  scheduledConsolidations.add(learning);
-  setTimeout(() => {
-    scheduledConsolidations.delete(learning);
-    try {
-      learning.consolidate(FACULTY_LESSON_POLICY.consolidation);
-    } catch {
-      // Consolidation is review/telemetry work and must not replace a faculty result.
-    }
-  }, 0);
+  const timer = setTimeout(() => runFacultyConsolidation(learning), 0);
+  scheduledConsolidations.set(learning, timer);
+}
+
+export function drainFacultyConsolidation(learning: ILearningFaculty | undefined): void {
+  if (!learning) return;
+  const timer = scheduledConsolidations.get(learning);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  runFacultyConsolidation(learning);
 }
 
 export function prepareFacultyLessonQuery(query: string): string {
-  const redacted = redactSensitiveText(query.slice(0, MAX_LESSON_QUERY_INPUT_CHARS))
+  const boundedInput = redactTruncatedPem(query.slice(0, MAX_LESSON_QUERY_INPUT_CHARS));
+  const redacted = redactSensitiveText(boundedInput)
     .replace(/\s+/gu, ' ')
     .trim();
   return truncateUtf8(redacted, MAX_LESSON_QUERY_BYTES);
+}
+
+function redactTruncatedPem(value: string): string {
+  return value.replace(/-----BEGIN [^-\r\n]+-----[\s\S]*$/giu, '<redacted>');
+}
+
+function runFacultyConsolidation(learning: ILearningFaculty): void {
+  scheduledConsolidations.delete(learning);
+  try {
+    learning.consolidate(FACULTY_LESSON_POLICY.consolidation);
+  } catch {
+    // Consolidation is review/telemetry work and must not replace a faculty result.
+  }
 }
 
 function capitalize(value: string): string {

--- a/packages/franken-orchestrator/src/adapters/planning-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/planning-faculty-adapter.ts
@@ -1,9 +1,16 @@
-import type { EpisodicEvent, IEpisodicMemory, IPlanningFaculty } from '@franken/types';
+import type {
+  EpisodicEvent,
+  IEpisodicMemory,
+  ILearningFaculty,
+  IPlanningFaculty,
+} from '@franken/types';
 import { isoNow } from '@franken/types';
 import type { IPlannerModule, PlanGraph, PlanIntent, PlanTask } from '../deps.js';
+import { consultFacultyLessons } from './faculty-learning.js';
 
 export interface PlanningFacultyAdapterOptions {
   recordEpisodes?: boolean;
+  learning?: ILearningFaculty;
 }
 
 /**
@@ -21,6 +28,15 @@ export class PlanningFacultyAdapter implements IPlannerModule, IPlanningFaculty 
   ) {}
 
   async createPlan(intent: PlanIntent): Promise<PlanGraph> {
+    if (this.options.recordEpisodes !== false) {
+      consultFacultyLessons(
+        'planning',
+        intent.goal,
+        this.episodic,
+        this.options.learning,
+        isoNow(),
+      );
+    }
     const plan = await this.delegate.createPlan(intent);
     this.recordPlanCreated(intent, plan);
     return plan;

--- a/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
@@ -3,6 +3,7 @@ import type { CritiqueResult, ICritiqueModule, PlanGraph } from '../deps.js';
 import {
   consolidateFacultyNegativeOutcome,
   consultFacultyLessons,
+  MAX_LESSON_QUERY_INPUT_CHARS,
   prepareFacultyLessonQuery,
 } from './faculty-learning.js';
 
@@ -26,14 +27,13 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
   ) {}
 
   async reviewPlan(plan: PlanGraph, context?: unknown): Promise<CritiqueResult> {
-    const query = prepareFacultyLessonQuery(
-      plan.tasks.map((task) => task.objective).join(' ').trim() || 'reasoning plan review',
-    );
-    if (this.options.recordEpisodes !== false) {
+    const recordEpisodes = this.options.recordEpisodes !== false;
+    const query = recordEpisodes ? reasoningLessonQuery(plan) : '';
+    if (recordEpisodes) {
       consultFacultyLessons('reasoning', query, this.brain.episodic, this.brain.learning, this.clock().toISOString());
     }
     const result = await this.critique.reviewPlan(plan, context);
-    if (this.options.recordEpisodes === false) return result;
+    if (!recordEpisodes) return result;
 
     this.brain.episodic.record({
       type: 'decision',
@@ -64,4 +64,15 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
     }
     await this.critique.reviewPlan({ tasks: [] });
   }
+}
+
+function reasoningLessonQuery(plan: PlanGraph): string {
+  let query = '';
+  for (const task of plan.tasks) {
+    const separator = query.length === 0 ? '' : ' ';
+    const remaining = MAX_LESSON_QUERY_INPUT_CHARS - query.length - separator.length;
+    if (remaining <= 0) break;
+    query += `${separator}${task.objective.slice(0, remaining)}`;
+  }
+  return prepareFacultyLessonQuery(query.trim() || 'reasoning plan review');
 }

--- a/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
@@ -1,5 +1,10 @@
 import type { IBrain, IReasoningFaculty } from '@franken/types';
 import type { CritiqueResult, ICritiqueModule, PlanGraph } from '../deps.js';
+import {
+  consolidateFacultyNegativeOutcome,
+  consultFacultyLessons,
+  prepareFacultyLessonQuery,
+} from './faculty-learning.js';
 
 export interface ReasoningFacultyAdapterOptions {
   readonly recordEpisodes?: boolean;
@@ -15,20 +20,28 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
 
   constructor(
     private readonly critique: ICritiqueModule,
-    private readonly brain: Pick<IBrain, 'episodic'>,
+    private readonly brain: Pick<IBrain, 'episodic' | 'learning'>,
     private readonly clock: () => Date,
     private readonly options: ReasoningFacultyAdapterOptions = {},
   ) {}
 
   async reviewPlan(plan: PlanGraph, context?: unknown): Promise<CritiqueResult> {
+    const query = prepareFacultyLessonQuery(
+      plan.tasks.map((task) => task.objective).join(' ').trim() || 'reasoning plan review',
+    );
+    if (this.options.recordEpisodes !== false) {
+      consultFacultyLessons('reasoning', query, this.brain.episodic, this.brain.learning, this.clock().toISOString());
+    }
     const result = await this.critique.reviewPlan(plan, context);
     if (this.options.recordEpisodes === false) return result;
 
     this.brain.episodic.record({
       type: 'decision',
       step: 'reasoning:critique',
-      summary: `Reasoning verdict: ${result.verdict}`,
+      summary: `Reasoning verdict: ${result.verdict}${result.verdict === 'fail' ? ` — ${query}` : ''}`,
       details: {
+        category: 'reasoning-lifecycle',
+        outcome: result.verdict === 'fail' ? 'negative' : 'positive',
         verdict: result.verdict,
         score: result.score,
         findingCount: result.findings.length,
@@ -38,6 +51,9 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
       },
       createdAt: this.clock().toISOString(),
     });
+    if (result.verdict === 'fail') {
+      consolidateFacultyNegativeOutcome(this.brain.learning);
+    }
     return result;
   }
 

--- a/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/reasoning-faculty-adapter.ts
@@ -3,6 +3,7 @@ import type { CritiqueResult, ICritiqueModule, PlanGraph } from '../deps.js';
 import {
   consolidateFacultyNegativeOutcome,
   consultFacultyLessons,
+  FACULTY_LESSON_POLICY,
   MAX_LESSON_QUERY_INPUT_CHARS,
   prepareFacultyLessonQuery,
 } from './faculty-learning.js';
@@ -41,7 +42,10 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
       summary: `Reasoning verdict: ${result.verdict}${result.verdict === 'fail' ? ` — ${query}` : ''}`,
       details: {
         category: 'reasoning-lifecycle',
-        outcome: result.verdict === 'fail' ? 'negative' : 'positive',
+        outcome: result.halted === true
+          ? 'halted'
+          : result.verdict === 'fail' ? 'negative' : 'positive',
+        lessonContext: query,
         verdict: result.verdict,
         score: result.score,
         findingCount: result.findings.length,
@@ -51,7 +55,7 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
       },
       createdAt: this.clock().toISOString(),
     });
-    if (result.verdict === 'fail') {
+    if (result.verdict === 'fail' && result.halted !== true) {
       consolidateFacultyNegativeOutcome(this.brain.learning);
     }
     return result;
@@ -68,7 +72,7 @@ export class ReasoningFacultyAdapter implements ICritiqueModule, IReasoningFacul
 
 function reasoningLessonQuery(plan: PlanGraph): string {
   let query = '';
-  for (const task of plan.tasks) {
+  for (const task of plan.tasks.slice(0, FACULTY_LESSON_POLICY.objectiveLimit)) {
     const separator = query.length === 0 ? '' : ' ';
     const remaining = MAX_LESSON_QUERY_INPUT_CHARS - query.length - separator.length;
     if (remaining <= 0) break;

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -187,6 +187,7 @@ export function createBeastDeps(
   // 6. Adapters
   const firewall = new MiddlewareChainFirewallAdapter(middlewareChain);
   const planning = new PlanningFacultyAdapter(existingDeps.planner, brain.episodic, {
+    learning: brain.learning,
     ...(config.planning?.recordEpisodes !== undefined
       ? { recordEpisodes: config.planning.recordEpisodes }
       : {}),
@@ -215,6 +216,7 @@ export function createBeastDeps(
           'brain.action',
         ),
         config.action?.recordEpisodes !== false,
+        brain.learning,
       )
     : undefined;
   if (actionFaculty) brain.attachActionFaculty(actionFaculty);

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -16,6 +16,7 @@ import { ChunkSessionCompactor } from '../session/chunk-session-compactor.js';
 import { ChunkSessionGc } from '../session/chunk-session-gc.js';
 import { PrCreator } from '../closure/pr-creator.js';
 import { AdapterLlmClient } from '../adapters/adapter-llm-client.js';
+import { drainFacultyConsolidation } from '../adapters/faculty-learning.js';
 import { CachedCliLlmClient, type LlmCacheHint } from '../cache/cached-cli-llm-client.js';
 import { CritiquePortAdapter } from '../adapters/critique-adapter.js';
 import { bridgeToBeastConfig, bridgeToExistingDeps } from './dep-bridge.js';
@@ -1116,6 +1117,7 @@ function appendAuditFinalize(
 ): () => Promise<void> {
   return async () => {
     const runId = observer.runSessionId;
+    drainFacultyConsolidation(consolidated.sqliteBrain?.learning);
     try {
       consolidated.persistAuditTrail?.(runId);
       const bridgeManifest = observer.observerBridge.getReplayManifest();

--- a/packages/franken-orchestrator/tests/unit/adapters/action-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/action-faculty-adapter.test.ts
@@ -57,13 +57,13 @@ describe('ActionFacultyAdapter', () => {
         step: 'action:governor',
         summary: `Action decision (${outcome.decision}): Deploy production release`,
         createdAt: '2026-07-24T15:00:00.000Z',
-        details: {
+        details: expect.objectContaining({
           taskId: 'task-3696',
           skillId: 'deploy-prod',
           requiresHitl: true,
           decision: outcome.decision,
           reason: expectedReason,
-        },
+        }),
       }),
     ]);
   });
@@ -106,6 +106,9 @@ describe('ActionFacultyAdapter', () => {
         decision: 'rejected',
         reason: 'Policy requires a safer action',
       });
+      await deps.sqliteBrain?.action.requestApproval(request);
+      await deps.sqliteBrain?.action.requestApproval(request);
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(governor.requestApproval).toHaveBeenCalledWith(request);
       expect(deps.sqliteBrain?.episodic.recall('wired-task', 1)).toEqual([
@@ -116,6 +119,9 @@ describe('ActionFacultyAdapter', () => {
             reason: 'Policy requires a safer action',
           }),
         }),
+      ]);
+      expect(deps.sqliteBrain?.learning.relevantLessons('action decision rejected governed action')).toEqual([
+        expect.objectContaining({ occurrenceCount: 3 }),
       ]);
     } finally {
       deps.sqliteBrain?.close();

--- a/packages/franken-orchestrator/tests/unit/adapters/planning-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/planning-faculty-adapter.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SqliteBrain } from '@franken/brain';
 import type { IPlannerModule, PlanGraph, PlanIntent, PlanTask } from '../../../src/deps.js';
-import { PlanningFacultyAdapter } from '../../../src/adapters/planning-faculty-adapter.js';
+import {
+  PlanningFacultyAdapter,
+  type PlanningFacultyAdapterOptions,
+} from '../../../src/adapters/planning-faculty-adapter.js';
 
 function planTask(id: string, objective: string): PlanTask {
   return { id, objective, requiredSkills: [], dependsOn: [] };
@@ -55,6 +58,83 @@ describe('PlanningFacultyAdapter', () => {
       step: 'planning',
       details: { taskCount: 1, taskIds: ['implement'] },
     });
+  });
+
+  it('consults bounded relevant lessons before planning and records the consulted keys', async () => {
+    const intent: PlanIntent = { goal: 'Repair the workspace TypeScript build' };
+    const delegate: IPlannerModule = { createPlan: vi.fn().mockResolvedValue({ tasks: [] }) };
+    const brain = makeBrain();
+    const relevantLessons = vi.fn().mockReturnValue([
+      {
+        kind: 'consolidated-lesson',
+        key: 'lesson.review.stale-declarations',
+        status: 'approved',
+        pattern: 'Build workspace declarations before package typecheck',
+        keywords: ['build', 'workspace'],
+        occurrenceCount: 3,
+        confidence: 0.65,
+        evidenceEventIds: [1, 2, 3],
+        firstSeenAt: '2026-07-24T10:00:00.000Z',
+        lastSeenAt: '2026-07-24T10:02:00.000Z',
+        relevance: 0.75,
+      },
+    ]);
+    const faculty = new PlanningFacultyAdapter(delegate, brain.episodic, {
+      learning: {
+        kind: 'learning',
+        configured: true,
+        consolidate: brain.learning.consolidate,
+        relevantLessons,
+      },
+    } as PlanningFacultyAdapterOptions);
+
+    await faculty.createPlan(intent);
+
+    expect(relevantLessons).toHaveBeenCalledWith(intent.goal, { limit: 5 });
+    expect(relevantLessons.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(delegate.createPlan).mock.invocationCallOrder[0]!,
+    );
+    expect(brain.episodic.recall('planning consulted relevant lessons').find(
+      (episode) => episode.step === 'planning:lesson-consultation',
+    )).toMatchObject({
+      type: 'observation',
+      details: {
+        category: 'lesson-consultation',
+        faculty: 'planning',
+        query: intent.goal,
+        lessonCount: 1,
+        lessonKeys: ['lesson.review.stale-declarations'],
+      },
+    });
+  });
+
+  it('redacts and byte-bounds lesson queries without changing the delegated intent', async () => {
+    const brain = makeBrain();
+    const relevantLessons = vi.fn((_query: string) => []);
+    const delegate: IPlannerModule = { createPlan: vi.fn().mockResolvedValue({ tasks: [] }) };
+    const faculty = new PlanningFacultyAdapter(delegate, brain.episodic, {
+      learning: {
+        kind: 'learning',
+        configured: true,
+        consolidate: vi.fn(() => []),
+        relevantLessons,
+      },
+    });
+    const intent: PlanIntent = {
+      goal: `Repair API_TOKEN=super-secret ${'workspace '.repeat(200)}`,
+    };
+
+    await faculty.createPlan(intent);
+
+    expect(delegate.createPlan).toHaveBeenCalledWith(intent);
+    const query = relevantLessons.mock.calls[0]![0];
+    expect(query).not.toContain('super-secret');
+    expect(query).toContain('API_TOKEN=<redacted>');
+    expect(Buffer.byteLength(query, 'utf8')).toBeLessThanOrEqual(512);
+    const consultation = brain.episodic.recent().find(
+      (episode) => episode.step === 'planning:lesson-consultation',
+    );
+    expect(consultation?.details?.query).toBe(query);
   });
 
   it('does not record a created episode when the delegated planner rejects', async () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/planning-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/planning-faculty-adapter.test.ts
@@ -137,6 +137,28 @@ describe('PlanningFacultyAdapter', () => {
     expect(consultation?.details?.query).toBe(query);
   });
 
+  it('redacts a private key whose closing delimiter is beyond the input cap', async () => {
+    const brain = makeBrain();
+    const relevantLessons = vi.fn((_query: string) => []);
+    const delegate: IPlannerModule = { createPlan: vi.fn().mockResolvedValue({ tasks: [] }) };
+    const faculty = new PlanningFacultyAdapter(delegate, brain.episodic, {
+      learning: {
+        kind: 'learning',
+        configured: true,
+        consolidate: vi.fn(() => []),
+        relevantLessons,
+      },
+    });
+
+    await faculty.createPlan({
+      goal: `-----BEGIN PRIVATE KEY-----\n${'A'.repeat(3_000)}\n-----END PRIVATE KEY-----`,
+    });
+
+    const query = relevantLessons.mock.calls[0]?.[0] ?? '';
+    expect(query).toContain('<redacted>');
+    expect(query).not.toContain('AAAA');
+  });
+
   it('does not record a created episode when the delegated planner rejects', async () => {
     const delegate: IPlannerModule = {
       createPlan: vi.fn().mockRejectedValue(new Error('planner unavailable')),

--- a/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SqliteBrain } from '@franken/brain';
 import { ReasoningFacultyAdapter } from '../../../src/adapters/reasoning-faculty-adapter.js';
-import type { ICritiqueModule, PlanGraph } from '../../../src/deps.js';
+import type { CritiqueResult, ICritiqueModule, PlanGraph } from '../../../src/deps.js';
 
 describe('ReasoningFacultyAdapter', () => {
   const brains: SqliteBrain[] = [];
@@ -37,21 +37,36 @@ describe('ReasoningFacultyAdapter', () => {
     await expect(faculty.reviewPlan(plan, context)).resolves.toBe(result);
     expect(critique.reviewPlan).toHaveBeenCalledWith(plan, context);
     expect(faculty).toMatchObject({ kind: 'reasoning', configured: true });
-    expect(brain.episodic.recall('reasoning verdict warn')).toEqual([
-      expect.objectContaining({
-        type: 'decision',
-        step: 'reasoning:critique',
-        summary: 'Reasoning verdict: warn',
-        createdAt: '2026-07-24T12:00:00.000Z',
-        details: {
+    const verdictEpisode = brain.episodic.recall('reasoning verdict warn').find(
+      (episode) => episode.step === 'reasoning:critique',
+    );
+    expect(verdictEpisode).toEqual(expect.objectContaining({
+      type: 'decision',
+      step: 'reasoning:critique',
+      summary: 'Reasoning verdict: warn',
+      createdAt: '2026-07-24T12:00:00.000Z',
+      details: expect.objectContaining({
           verdict: 'warn',
           score: 0.75,
           findingCount: 1,
           severities: ['medium'],
           taskCount: 1,
-        },
       }),
-    ]);
+    }));
+    const consultationEpisode = brain.episodic.recent().find(
+      (episode) => episode.step === 'reasoning:lesson-consultation',
+    );
+    expect(consultationEpisode).toMatchObject({
+      type: 'observation',
+      details: {
+        category: 'lesson-consultation',
+        faculty: 'reasoning',
+        query: 'Check the claim',
+        lessonCount: 0,
+        lessonKeys: [],
+      },
+    });
+    expect(consultationEpisode!.id).toBeLessThan(verdictEpisode!.id!);
   });
 
   it('records a failed verdict as a decision rather than an execution failure', async () => {
@@ -66,8 +81,85 @@ describe('ReasoningFacultyAdapter', () => {
     await faculty.reviewPlan({ tasks: [] });
 
     expect(brain.episodic.recentFailures()).toEqual([]);
-    expect(brain.episodic.recall('reasoning verdict fail')).toEqual([
-      expect.objectContaining({ type: 'decision', summary: 'Reasoning verdict: fail' }),
+    expect(brain.episodic.recall('reasoning verdict fail').find(
+      (episode) => episode.step === 'reasoning:critique',
+    )).toEqual(expect.objectContaining({
+      type: 'decision',
+      summary: expect.stringContaining('Reasoning verdict: fail'),
+    }));
+  });
+
+  it('coalesces automatic bounded consolidation after negative verdicts', async () => {
+    const brain = new SqliteBrain();
+    brains.push(brain);
+    const consolidate = vi.fn((options) => brain.learning.consolidate(options));
+    const faculty = new ReasoningFacultyAdapter(
+      { reviewPlan: async () => ({
+        verdict: 'fail',
+        findings: [{ evaluator: 'verification', severity: 'high', message: 'Build failed' }],
+        score: 0,
+      }) },
+      {
+        episodic: brain.episodic,
+        learning: {
+          kind: 'learning',
+          configured: true,
+          consolidate,
+          relevantLessons: brain.learning.relevantLessons,
+        },
+      },
+      () => new Date('2026-07-24T12:00:00.000Z'),
+    );
+
+    await faculty.reviewPlan({ tasks: [] });
+    await faculty.reviewPlan({ tasks: [] });
+    await faculty.reviewPlan({ tasks: [] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consolidate).toHaveBeenCalledTimes(1);
+    expect(consolidate).toHaveBeenLastCalledWith({
+      threshold: 3,
+      lookback: 100,
+      similarityThreshold: 0.5,
+    });
+    expect(brain.learning.relevantLessons('reasoning verdict fail')).toEqual([
+      expect.objectContaining({
+        occurrenceCount: 3,
+        evidenceEventIds: [2, 4, 6],
+      }),
+    ]);
+  });
+
+  it('keeps failed reasoning lesson patterns relevant to later objective consultations', async () => {
+    const brain = new SqliteBrain();
+    brains.push(brain);
+    const result: CritiqueResult = {
+      verdict: 'fail',
+      findings: [],
+      score: 0.2,
+    };
+    const critique: ICritiqueModule = { reviewPlan: vi.fn().mockResolvedValue(result) };
+    const faculty = new ReasoningFacultyAdapter(
+      critique,
+      brain,
+      () => new Date('2025-01-01T00:00:00.000Z'),
+    );
+    const plan = {
+      tasks: [{
+        id: 'task-1',
+        objective: 'Verify workspace declaration output',
+        requiredSkills: [],
+        dependsOn: [],
+      }],
+    };
+
+    await faculty.reviewPlan(plan);
+    await faculty.reviewPlan(plan);
+    await faculty.reviewPlan(plan);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(brain.learning.relevantLessons('workspace declaration output')).toEqual([
+      expect.objectContaining({ occurrenceCount: 3 }),
     ]);
   });
 

--- a/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
@@ -163,6 +163,36 @@ describe('ReasoningFacultyAdapter', () => {
     ]);
   });
 
+  it('stops reading objectives once the bounded consultation prefix is full', async () => {
+    const brain = new SqliteBrain();
+    brains.push(brain);
+    const critique: ICritiqueModule = {
+      reviewPlan: vi.fn(async () => ({ verdict: 'pass' as const, findings: [], score: 1 })),
+    };
+    const faculty = new ReasoningFacultyAdapter(
+      critique,
+      brain,
+      () => new Date('2025-01-01T00:00:00.000Z'),
+    );
+    const unreadTask = {
+      id: 'unread',
+      get objective(): string {
+        throw new Error('objective beyond bounded prefix was read');
+      },
+      requiredSkills: [],
+      dependsOn: [],
+    };
+
+    await expect(faculty.reviewPlan({
+      tasks: [{
+        id: 'prefix',
+        objective: 'x'.repeat(3_000),
+        requiredSkills: [],
+        dependsOn: [],
+      }, unreadTask],
+    })).resolves.toEqual({ verdict: 'pass', findings: [], score: 1 });
+  });
+
   it('can delegate without recording when memory is disabled', async () => {
     const brain = new SqliteBrain();
     brains.push(brain);
@@ -175,8 +205,18 @@ describe('ReasoningFacultyAdapter', () => {
       () => new Date('2026-07-24T12:00:00.000Z'),
       { recordEpisodes: false },
     );
+    const planWithUnreadObjective = {
+      tasks: [{
+        id: 'disabled',
+        get objective(): string {
+          throw new Error('disabled memory must not inspect objectives');
+        },
+        requiredSkills: [],
+        dependsOn: [],
+      }],
+    };
 
-    await expect(faculty.reviewPlan({ tasks: [] })).resolves.toMatchObject({ verdict: 'pass' });
+    await expect(faculty.reviewPlan(planWithUnreadObjective)).resolves.toMatchObject({ verdict: 'pass' });
     expect(critique.reviewPlan).toHaveBeenCalledOnce();
     expect(brain.episodic.count()).toBe(0);
   });

--- a/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/reasoning-faculty-adapter.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SqliteBrain } from '@franken/brain';
+import type { LessonConsolidationOptions } from '@franken/types';
 import { ReasoningFacultyAdapter } from '../../../src/adapters/reasoning-faculty-adapter.js';
+import {
+  consolidateFacultyNegativeOutcome,
+  drainFacultyConsolidation,
+} from '../../../src/adapters/faculty-learning.js';
 import type { CritiqueResult, ICritiqueModule, PlanGraph } from '../../../src/deps.js';
 
 describe('ReasoningFacultyAdapter', () => {
@@ -191,6 +196,77 @@ describe('ReasoningFacultyAdapter', () => {
         dependsOn: [],
       }, unreadTask],
     })).resolves.toEqual({ verdict: 'pass', findings: [], score: 1 });
+  });
+
+  it('caps objective inspection when empty objectives do not consume characters', async () => {
+    const brain = new SqliteBrain();
+    brains.push(brain);
+    const critique: ICritiqueModule = {
+      reviewPlan: vi.fn(async () => ({ verdict: 'pass' as const, findings: [], score: 1 })),
+    };
+    const faculty = new ReasoningFacultyAdapter(critique, brain, () => new Date());
+    const tasks = Array.from({ length: 100 }, (_, index) => ({
+      id: `empty-${index}`,
+      objective: '',
+      requiredSkills: [],
+      dependsOn: [],
+    }));
+    tasks.push({
+      id: 'unread',
+      get objective(): string {
+        throw new Error('task beyond inspection cap was read');
+      },
+      requiredSkills: [],
+      dependsOn: [],
+    });
+
+    await expect(faculty.reviewPlan({ tasks })).resolves.toMatchObject({ verdict: 'pass' });
+  });
+
+  it('does not consolidate halted critique failures as plan lessons', async () => {
+    const brain = new SqliteBrain();
+    brains.push(brain);
+    const consolidate = vi.fn((options?: LessonConsolidationOptions) => brain.learning.consolidate(options));
+    const critique: ICritiqueModule = {
+      reviewPlan: vi.fn(async () => ({
+        verdict: 'fail' as const,
+        findings: [],
+        score: 0,
+        halted: true,
+        haltReason: 'budget',
+      })),
+    };
+    const faculty = new ReasoningFacultyAdapter(critique, {
+      episodic: brain.episodic,
+      learning: {
+        kind: 'learning',
+        configured: true,
+        consolidate,
+        relevantLessons: (query, options) => brain.learning.relevantLessons(query, options),
+      },
+    }, () => new Date());
+
+    await faculty.reviewPlan({ tasks: [] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consolidate).not.toHaveBeenCalled();
+    expect(brain.episodic.recent(1)[0]?.details).toEqual(expect.objectContaining({ outcome: 'halted' }));
+  });
+
+  it('drains one pending coalesced consolidation before shutdown', async () => {
+    const consolidate = vi.fn(() => []);
+    const learning = {
+      kind: 'learning' as const,
+      configured: true,
+      consolidate,
+      relevantLessons: vi.fn(() => []),
+    };
+
+    consolidateFacultyNegativeOutcome(learning);
+    drainFacultyConsolidation(learning);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consolidate).toHaveBeenCalledOnce();
   });
 
   it('can delegate without recording when memory is disabled', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/create-beast-deps.test.ts
@@ -169,15 +169,15 @@ describe('createBeastDeps', () => {
     expect(result).toBe(verdict);
     expect(critique.reviewPlan).toHaveBeenCalledWith(plan, { source: 'test' });
     expect(deps.sqliteBrain!.reasoning.configured).toBe(true);
-    expect(deps.sqliteBrain!.episodic.recall('reasoning verdict warn')).toEqual([
-      expect.objectContaining({
-        type: 'decision',
-        step: 'reasoning:critique',
-        summary: 'Reasoning verdict: warn',
-        details: expect.objectContaining({ verdict: 'warn', score: 0.75, findingCount: 1 }),
-        createdAt: '2026-01-01T00:00:00.000Z',
-      }),
-    ]);
+    expect(deps.sqliteBrain!.episodic.recall('reasoning verdict warn').find(
+      (episode) => episode.step === 'reasoning:critique',
+    )).toEqual(expect.objectContaining({
+      type: 'decision',
+      step: 'reasoning:critique',
+      summary: 'Reasoning verdict: warn',
+      details: expect.objectContaining({ verdict: 'warn', score: 0.75, findingCount: 1 }),
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
   });
 
   it('leaves the reasoning faculty inert when critique is disabled', async () => {

--- a/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
+++ b/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
@@ -9,6 +9,7 @@
 - [x] Update architecture, onboarding, package README, and ADR-041 where relevant.
 - [x] Run focused tests and package/root quality gates.
 - [x] Address independent-review findings: asynchronous coalescing, objective-relevant reasoning patterns, and redacted byte-bounded queries.
+- [x] Address follow-up review finding by bounding objective iteration before concatenation and skipping query reads when memory is disabled.
 - [ ] Commit as David Mendez, push one branch, and open one PR with `Closes #3699`.
 - [ ] Reach current-head Codex clean with zero unresolved threads and green CI.
 - [ ] Merge, post root evidence, append reusable shared lessons, and close the Kanban task.

--- a/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
+++ b/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
@@ -1,0 +1,14 @@
+# Issue #3699 — Hive Brain lesson consultation progress
+
+- [x] Verify issue #3699 is open, unassigned, and dependencies #3695/#3697/#3698 are merged.
+- [x] Fast-forward the isolated issue branch to current `origin/main`.
+- [x] Trace the learning query/consolidation surface, faculty adapters, construction wiring, trigger conventions, tests, and docs.
+- [x] Add a focused failing test proving planning/reasoning consultation is observable.
+- [x] Add a focused failing test proving a negative outcome is automatically included by the next bounded consolidation trigger.
+- [x] Implement the minimal deterministic bounded policy by reusing `brain.learning`.
+- [x] Update architecture, onboarding, package README, and ADR-041 where relevant.
+- [x] Run focused tests and package/root quality gates.
+- [x] Address independent-review findings: asynchronous coalescing, objective-relevant reasoning patterns, and redacted byte-bounded queries.
+- [ ] Commit as David Mendez, push one branch, and open one PR with `Closes #3699`.
+- [ ] Reach current-head Codex clean with zero unresolved threads and green CI.
+- [ ] Merge, post root evidence, append reusable shared lessons, and close the Kanban task.

--- a/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
+++ b/tasks/issue-3699-hive-brain-lesson-consultation-progress.md
@@ -10,6 +10,7 @@
 - [x] Run focused tests and package/root quality gates.
 - [x] Address independent-review findings: asynchronous coalescing, objective-relevant reasoning patterns, and redacted byte-bounded queries.
 - [x] Address follow-up review finding by bounding objective iteration before concatenation and skipping query reads when memory is disabled.
-- [ ] Commit as David Mendez, push one branch, and open one PR with `Closes #3699`.
+- [x] Commit as David Mendez, push one branch, and open one PR with `Closes #3699`.
+- [x] Batch the six second-round Codex findings with focused regressions and package quality gates.
 - [ ] Reach current-head Codex clean with zero unresolved threads and green CI.
 - [ ] Merge, post root evidence, append reusable shared lessons, and close the Kanban task.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-25 — Faculty lesson consultation must stay bounded before lookup
+- Apply input caps while iterating plan objectives, before `map()`/`join()` or redaction; truncating only after concatenation still allows adversarial plans to cause unbounded synchronous work. Skip query construction entirely when episode recording and lesson consultation are disabled.
+- Keep automatic consolidation off the planning/reasoning/action return path and coalesce pending triggers per learning port. Persist stable lesson keys—not full lesson text—in consultation telemetry so the consulted set stays observable without duplicating reviewed memory content.
+
 ## 2026-07-25 — Retention enforcement must preserve upstream invariants
 - Retention deletion must honor producer-side lifecycle windows such as learning cooldowns, not only the generic memory-class TTL. Validate persisted cooldown metadata before classifying an expired learning row as a compaction candidate.
 - Cached rollback floors are references to mutable rows: validate the referenced checkpoint inside the enforcement transaction before excluding older checkpoints. When a shared delete budget leaves scanned checkpoint candidates pending, rewind the checkpoint cursor as well as the episodic cursor; otherwise continuous inserts can starve old checkpoints indefinitely.


### PR DESCRIPTION
## Summary
- consult up to five relevant consolidated lessons before planning and reasoning delegation
- record redacted, 512-byte-bounded consultation metadata without injecting prompts
- asynchronously coalesce consolidation after negative reasoning and action outcomes
- bound objective scanning before concatenation and skip it entirely when memory is disabled
- document the deterministic threshold/lookback/similarity policy

## Verification
- 30 focused orchestrator adapter/wiring tests passed
- 454 `@franken/brain` tests passed in the isolated package run
- root typecheck, lint, and build passed
- root parallel test run has one unrelated 5-second timeout in the existing “older relevant lesson beyond the first bounded review page” test; the exact test passes in 1.6 seconds when run directly
- `git diff --check` passed

Closes #3699