### PR TITLE
feat(brain): add CLI inspection commands

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Unless a section explicitly says otherwise, diagrams should use current package 
 | `@franken/critique` | Critique pipeline and correction-request loop. The caller applies regenerated input; MOD-06 does not call the actor itself. |
 | `@franken/governor` | HITL trigger evaluation, approval gateway/channels, audit recording, HMAC/session-token helpers. |
 | `@franken/types` | Shared type definitions and runtime Zod schemas. |
-| `@franken/orchestrator` | Beast Loop, CLI, issue runner, provider registry, middleware, chat/network/comms/security/skills/dashboard/analytics HTTP routes. |
+| `@franken/orchestrator` | Beast Loop, CLI, issue runner, provider registry, middleware, chat/network/comms/security/skills/dashboard/analytics HTTP routes. Its read-only `brain show` and `brain lessons` CLI commands inspect existing local agent-type databases with bounded human or JSON output; unknown or unsafe identifiers never create brain state. |
 | `@franken/mcp-suite` | `fbeast` CLI, MCP servers, hooks, proxy server, shared `.fbeast/beast.db`, Beast-mode activation shim. |
 | `@franken/web` | React dashboard for chat, tracked Beast agents, read-only per-agent-type Brain faculty/lesson inspection, network controls, analytics/cost/safety views. |
 | `@franken/live-bench` | Live CLI benchmark tooling. |

--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -161,6 +161,16 @@ configuration from the summary, and can search lessons by topic. The browser
 does not receive the operator token, fabricate unavailable state, or add a
 parallel command-center chat transport.
 
+The local `frankenbeast brain show <agentTypeId>` and `frankenbeast brain
+lessons <agentTypeId>` commands provide the corresponding bounded operator
+inspection surface for persisted default agent-type databases. They follow the
+existing direct-local CLI pattern rather than bypassing HTTP authentication:
+local filesystem access is the authority, while remote `/v1/brain/*` requests
+still require the Beast operator token. The CLI validates the same portable
+agent-type identifiers, never creates an unknown brain during inspection,
+reports unavailable lesson faculties explicitly, and caps human/JSON output at
+100 working-memory keys and 10 lesson candidates.
+
 ### 4. Migrate without breaking `franken-web`
 
 Existing `ChatSession` JSON records remain valid lower-level sessions. Migration

--- a/docs/onboarding/RAMP_UP.md
+++ b/docs/onboarding/RAMP_UP.md
@@ -124,6 +124,7 @@ packages/franken-orchestrator/src/
   - `sanitizeChatOutput()` strips raw web search JSON and REMINDER instruction blocks from Claude CLI output
   - `chat-runtime-factory.ts` wires the engine, runtime, and turn runner from config
 - `frankenbeast beasts-daemon` — standalone Beast control plane (default port `4050`) that owns `/v1/beasts/*`, `/v1/beasts/agents/*`, SSE tickets/events, run persistence/logs, PID-file stale detection, and graceful child-run shutdown. PID file: `.frankenbeast/beasts-daemon.pid`.
+- `frankenbeast brain show <agentTypeId>` and `frankenbeast brain lessons <agentTypeId>` — bounded, read-only inspection of an existing local `.fbeast/brains/<agentTypeId>.db`; add `--json` for the machine-readable form. These local commands follow the existing direct CLI pattern and therefore do not use daemon bearer auth; remote HTTP reads still require the Beast operator token. Unsafe or unknown identifiers fail without creating a database.
 - `frankenbeast chat-server` — HTTP + WebSocket server for franken-web dashboard:
   - `startChatServer()` binds TCP, wires auth (session tokens), session persistence, and WebSocket attachment
   - In managed/default dashboard flows it is a chat/control gateway client of `beasts-daemon`; it proxies `/v1/beasts/*` only after operator auth.

--- a/packages/franken-orchestrator/README.md
+++ b/packages/franken-orchestrator/README.md
@@ -46,7 +46,18 @@ frankenbeast dr dead-letter-list .fbeast/dead-letter-actions.json
 frankenbeast dr dead-letter-replay-dry-run .fbeast/dead-letter-actions.json <entry-id>
 frankenbeast chat-server
 frankenbeast beasts-daemon
+frankenbeast brain show <agent-type-id>
+frankenbeast brain lessons <agent-type-id> --json
 ```
+
+Brain inspection is local and read-only. `brain show` reports at most 100
+working-memory keys plus aggregate episodic, recovery, faculty, capability, and
+lesson-availability state. `brain lessons` reports at most 10 real pending or
+approved consolidated lesson candidates. Both commands open only an existing
+`.fbeast/brains/<agentTypeId>.db`; invalid or unknown identifiers fail instead
+of creating state. Because this follows the CLI's direct-local inspection
+pattern, no daemon token is required; the equivalent `/v1/brain/*` HTTP routes
+remain operator-token authenticated.
 
 For local development from the monorepo, build and link the CLI from the root:
 

--- a/packages/franken-orchestrator/src/beasts/create-beast-services.ts
+++ b/packages/franken-orchestrator/src/beasts/create-beast-services.ts
@@ -51,45 +51,69 @@ export interface BeastServiceBundle {
   dispose(): void;
 }
 
+type BrainContextRepository = Pick<
+  SQLiteBeastRepository,
+  | 'getLatestEstablishedRunForDefinition'
+  | 'getTrackedAgent'
+  | 'getLatestTrackedAgentForDefinition'
+>;
+
+export interface PersistedBrainContextOptions {
+  projectRoot: string;
+  brainDbPath?: string | undefined;
+}
+
+/** Resolve persisted brain path and process-local faculty flags without starting Beast services. */
+export function resolvePersistedBrainContext(
+  repository: BrainContextRepository,
+  agentTypeId: string,
+  options: PersistedBrainContextOptions,
+): BrainRouteContext | undefined {
+  const projectRoot = resolve(options.projectRoot);
+  const run = repository.getLatestEstablishedRunForDefinition(agentTypeId, { recoverCorruptJson: true });
+  const agent = run?.trackedAgentId
+    ? repository.getTrackedAgent(run.trackedAgentId, { recoverCorruptJson: true })
+    : run
+      ? undefined
+      : repository.getLatestTrackedAgentForDefinition(agentTypeId, { recoverCorruptJson: true });
+  if (!run && !agent) return undefined;
+  const runSnapshot = run?.configSnapshot;
+  const agentSnapshot = agent?.initConfig;
+  const configuredBrainPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
+    ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath')
+    ?? options.brainDbPath;
+  const configuredProjectRoot = stringValue(runSnapshot, 'projectRoot')
+    ?? stringValue(agentSnapshot, 'projectRoot');
+  const stableRoot = configuredProjectRoot ?? projectRoot;
+  const dbPath = configuredBrainPath === undefined
+    ? join(projectRoot, '.fbeast', 'brains', `${agentTypeId}.db`)
+    : configuredBrainPath === ':memory:' || isAbsolute(configuredBrainPath)
+      ? configuredBrainPath
+      : resolve(stableRoot, configuredBrainPath);
+  const runModules = recordValue(runSnapshot, 'modules') as ModuleConfig | undefined;
+  const agentModules = recordValue(agentSnapshot, 'modules') as ModuleConfig | undefined;
+  const modules = runModules ?? agent?.moduleConfig ?? agentModules;
+  return {
+    dbPath,
+    faculties: {
+      planning: moduleEnabled(modules?.planner, 'FRANKENBEAST_MODULE_PLANNER'),
+      reasoning: moduleEnabled(modules?.critique, 'FRANKENBEAST_MODULE_CRITIQUE'),
+      action: moduleEnabled(modules?.governor, 'FRANKENBEAST_MODULE_GOVERNOR'),
+      learning: true,
+    },
+  };
+}
+
 export function createBeastServices(paths: BeastServicePaths): BeastServiceBundle {
   const repository = new SQLiteBeastRepository(paths.beastsDb);
   const logStore = new BeastLogStore(paths.beastLogsDir, createBeastLogStoreOptionsFromEnv());
   const projectRoot = resolve(paths.root ?? process.env.FBEAST_ROOT ?? process.cwd());
   const brains = new BrainRegistry(join(projectRoot, '.fbeast', 'brains'));
-  const resolveBrainContext = (agentTypeId: string): BrainRouteContext | undefined => {
-    const run = repository.getLatestEstablishedRunForDefinition(agentTypeId, { recoverCorruptJson: true });
-    const agent = run?.trackedAgentId
-      ? repository.getTrackedAgent(run.trackedAgentId, { recoverCorruptJson: true })
-      : run
-        ? undefined
-        : repository.getLatestTrackedAgentForDefinition(agentTypeId, { recoverCorruptJson: true });
-    if (!run && !agent) return undefined;
-    const runSnapshot = run?.configSnapshot;
-    const agentSnapshot = agent?.initConfig;
-    const configuredBrainPath = stringValue(recordValue(runSnapshot, 'brain'), 'dbPath')
-      ?? stringValue(recordValue(agentSnapshot, 'brain'), 'dbPath')
-      ?? paths.brainDbPath;
-    const configuredProjectRoot = stringValue(runSnapshot, 'projectRoot')
-      ?? stringValue(agentSnapshot, 'projectRoot');
-    const stableRoot = configuredProjectRoot ?? projectRoot;
-    const dbPath = configuredBrainPath === undefined
-      ? join(projectRoot, '.fbeast', 'brains', `${agentTypeId}.db`)
-      : configuredBrainPath === ':memory:' || isAbsolute(configuredBrainPath)
-        ? configuredBrainPath
-        : resolve(stableRoot, configuredBrainPath);
-    const runModules = recordValue(runSnapshot, 'modules') as ModuleConfig | undefined;
-    const agentModules = recordValue(agentSnapshot, 'modules') as ModuleConfig | undefined;
-    const modules = runModules ?? agent?.moduleConfig ?? agentModules;
-    return {
-      dbPath,
-      faculties: {
-        planning: moduleEnabled(modules?.planner, 'FRANKENBEAST_MODULE_PLANNER'),
-        reasoning: moduleEnabled(modules?.critique, 'FRANKENBEAST_MODULE_CRITIQUE'),
-        action: moduleEnabled(modules?.governor, 'FRANKENBEAST_MODULE_GOVERNOR'),
-        learning: true,
-      },
-    };
-  };
+  const resolveBrainContext = (agentTypeId: string): BrainRouteContext | undefined =>
+    resolvePersistedBrainContext(repository, agentTypeId, {
+      projectRoot,
+      ...(paths.brainDbPath === undefined ? {} : { brainDbPath: paths.brainDbPath }),
+    });
   const runConfigDir = join(projectRoot, '.fbeast', '.build', 'run-configs');
   const catalog = new BeastCatalogService();
   const metrics = new PrometheusBeastMetrics();

--- a/packages/franken-orchestrator/src/cli/args.ts
+++ b/packages/franken-orchestrator/src/cli/args.ts
@@ -14,6 +14,7 @@ export type Subcommand =
   | 'chat'
   | 'chat-server'
   | 'beasts-daemon'
+  | 'brain'
   | 'network'
   | 'memory'
   | 'dr'
@@ -52,6 +53,7 @@ export type BeastAction =
 
 export type SkillAction = 'list' | 'add' | 'scaffold' | 'remove' | 'enable' | 'disable' | 'info' | undefined;
 export type SecurityAction = 'status' | 'set' | undefined;
+export type BrainAction = 'show' | 'lessons' | undefined;
 export type MemoryAction = 'snapshot-diff' | 'verify-backup' | 'duplicate-report' | undefined;
 export type DrAction =
   | 'backup'
@@ -71,6 +73,8 @@ export interface CliArgs {
   subcommand: Subcommand;
   beastAction?: BeastAction;
   beastTarget?: string | undefined;
+  brainAction?: BrainAction;
+  brainTarget?: string | undefined;
   networkAction?: NetworkAction;
   networkTarget?: string | undefined;
   memoryAction?: MemoryAction;
@@ -131,7 +135,7 @@ export interface CliArgs {
   moduleConfig?: import('../beasts/types.js').ModuleConfig | undefined;
 }
 
-const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'issues', 'chat', 'chat-server', 'beasts-daemon', 'network', 'memory', 'dr', 'skill', 'security']);
+const VALID_SUBCOMMANDS = new Set(['init', 'interview', 'plan', 'run', 'beasts', 'beasts-daemon', 'brain', 'issues', 'chat', 'chat-server', 'network', 'memory', 'dr', 'skill', 'security']);
 const VALID_NETWORK_ACTIONS = new Set(['up', 'down', 'status', 'health', 'start', 'stop', 'restart', 'logs', 'config', 'credentials', 'help']);
 const VALID_MEMORY_ACTIONS = new Set(['snapshot-diff', 'verify-backup', 'duplicate-report']);
 const VALID_DR_ACTIONS = new Set([
@@ -150,6 +154,7 @@ const VALID_DR_ACTIONS = new Set([
 const VALID_BEAST_ACTIONS = new Set(['catalog', 'create', 'spawn', 'list', 'status', 'logs', 'stop', 'kill', 'restart', 'resume', 'delete', 'maintenance']);
 const VALID_SKILL_ACTIONS = new Set(['list', 'add', 'scaffold', 'remove', 'enable', 'disable', 'info']);
 const VALID_SECURITY_ACTIONS = new Set(['status', 'set']);
+const VALID_BRAIN_ACTIONS = new Set(['show', 'lessons']);
 const STRING_OPTIONS = new Set([
   'base-dir', 'base-branch', 'budget', 'provider', 'providers', 'design-doc', 'plan-dir', 'plan-name', 'output-dir',
   'goal', 'output', 'config', 'host', 'port', 'allow-origin', 'label', 'milestone', 'search', 'assignee', 'limit',
@@ -209,6 +214,7 @@ Subcommands:
   chat                    Interactive chat REPL with ConversationEngine
   chat-server             Run the local HTTP+WebSocket chat server for franken-web
   beasts-daemon           Run the standalone Beast control-plane daemon
+  brain                   Inspect persisted agent-type brain and lesson state
   network                 Manage Frankenbeast request-serving services
   memory                  Inspect persisted BrainSnapshot JSON artifacts and SQLite backups
   dr                      Disaster-recovery encrypted backup and restore utilities
@@ -316,6 +322,10 @@ Beast Commands:
   beasts delete <agent-id>            Soft-delete a tracked agent
   beasts maintenance [status|on|off]  Show, activate, or deactivate dispatch maintenance mode
 
+Brain Commands:
+  brain show <agent-type-id> [--json]     Show a bounded persisted brain summary
+  brain lessons <agent-type-id> [--json] Show up to 10 consolidated lesson candidates
+
 Skill Commands:
   skill list                          List installed skills
   skill add <name> <command> [args]   Install a custom skill with runnable MCP command
@@ -351,6 +361,8 @@ Examples:
   frankenbeast init                         # guided init wizard
   frankenbeast init --verify                # verify init readiness
   frankenbeast beasts spawn martin-loop     # spawn a martin-loop beast
+  frankenbeast brain show martin-loop       # inspect persisted brain state
+  frankenbeast brain lessons martin-loop --json
   frankenbeast chat-server                  # local chat server
   frankenbeast chat-server --port 4242      # local chat server on custom port
   frankenbeast beasts-daemon                # standalone Beast API on port 4050
@@ -498,6 +510,11 @@ function maxBeastPositionals(action: BeastAction): number {
   return 1;
 }
 
+function maxBrainPositionals(action: BrainAction): number {
+  if (action === 'show' || action === 'lessons') return 2;
+  return 0;
+}
+
 function maxSkillPositionals(action: SkillAction): number {
   if (action === 'add') return 3;
   if (action === 'scaffold' || action === 'remove' || action === 'enable' || action === 'disable' || action === 'info') return 2;
@@ -582,6 +599,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let networkTarget: string | undefined;
   let beastAction: BeastAction;
   let beastTarget: string | undefined;
+  let brainAction: BrainAction;
+  let brainTarget: string | undefined;
   let memoryAction: MemoryAction;
   let memorySnapshotBefore: string | undefined;
   let memorySnapshotAfter: string | undefined;
@@ -618,6 +637,16 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     }
     assertNoExtraPositionals('beasts', positionals, maxBeastPositionals(beastAction));
     beastTarget = positionals[1];
+  } else if (subcommand === 'brain') {
+    const actionCandidate = positionals[0];
+    if (actionCandidate !== undefined) {
+      if (!VALID_BRAIN_ACTIONS.has(actionCandidate)) {
+        throw new TypeError(`Unknown brain action: ${actionCandidate}`);
+      }
+      brainAction = actionCandidate as BrainAction;
+    }
+    assertNoExtraPositionals('brain', positionals, maxBrainPositionals(brainAction));
+    brainTarget = positionals[1];
   } else if (subcommand === 'memory') {
     const actionCandidate = positionals[0];
     if (actionCandidate !== undefined) {
@@ -800,6 +829,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     subcommand,
     beastAction,
     beastTarget,
+    brainAction,
+    brainTarget,
     networkAction,
     networkTarget,
     memoryAction,

--- a/packages/franken-orchestrator/src/cli/brain-cli.ts
+++ b/packages/franken-orchestrator/src/cli/brain-cli.ts
@@ -1,0 +1,252 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { BrainRegistry } from '@franken/brain';
+import type { MemoryCandidate, SqliteBrain } from '@franken/brain';
+import Database from 'better-sqlite3';
+
+import type { BrainAction } from './args.js';
+import type { BrainRouteContext } from '../http/routes/brain-routes.js';
+
+const MAX_WORKING_MEMORY_KEYS = 100;
+const MAX_LESSONS = 10;
+const MAX_LESSON_PATTERN_BYTES = 2 * 1024;
+const MAX_LESSON_KEY_BYTES = 512;
+const LESSON_UNAVAILABLE_REASON = 'Consolidated lessons are not available until the learning faculty is configured';
+
+type BrainRegistryReader = Pick<BrainRegistry, 'getAgentType'>;
+
+export interface BrainInspectionHandle {
+  registry: BrainRegistry;
+  dispose(): Promise<void>;
+}
+
+/** Open a consistent disposable copy so inspection never writes to the source brain. */
+export async function createBrainInspectionHandle(
+  brainsDir: string,
+  agentTypeId: string,
+): Promise<BrainInspectionHandle> {
+  const snapshotDir = await mkdtemp(join(tmpdir(), 'franken-brain-inspect-'));
+  const registry = new BrainRegistry(snapshotDir);
+  try {
+    // Validate with BrainRegistry's canonical portable-id rules before deriving a path.
+    registry.getAgentType(agentTypeId);
+    const sourcePath = join(brainsDir, `${agentTypeId}.db`);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`No persisted brain exists for agent type '${agentTypeId}'`);
+    }
+
+    const source = new Database(sourcePath, { readonly: true, fileMustExist: true });
+    try {
+      await source.backup(join(snapshotDir, `${agentTypeId}.db`));
+    } finally {
+      source.close();
+    }
+  } catch (error) {
+    registry.close();
+    await rm(snapshotDir, { recursive: true, force: true });
+    if (error instanceof RangeError) {
+      throw new Error('Invalid agent type id: use a non-empty portable path-component identifier');
+    }
+    throw error;
+  }
+
+  return {
+    registry,
+    dispose: async () => {
+      registry.close();
+      await rm(snapshotDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export interface BrainCommandDeps {
+  action: BrainAction;
+  target?: string | undefined;
+  json?: boolean | undefined;
+  registry: BrainRegistryReader;
+  resolveContext?: ((agentTypeId: string) => BrainRouteContext | undefined) | undefined;
+  print(message: string): void;
+}
+
+function truncateUtf8(value: string, maxBytes: number): { value: string; truncated: boolean } {
+  const encoded = Buffer.from(value);
+  if (encoded.byteLength <= maxBytes) return { value, truncated: false };
+  return { value: encoded.subarray(0, maxBytes).toString('utf8'), truncated: true };
+}
+
+function resolveBrain(deps: BrainCommandDeps): {
+  agentTypeId: string;
+  brain: SqliteBrain;
+  context: BrainRouteContext | undefined;
+} {
+  if (!deps.action || !deps.target) {
+    throw new Error('Usage: frankenbeast brain <show|lessons> <agentTypeId> [--json]');
+  }
+
+  const agentTypeId = deps.target;
+  try {
+    const context = deps.resolveContext?.(agentTypeId);
+    const brain = deps.registry.getAgentType(agentTypeId, context?.dbPath);
+    if (!brain) {
+      throw new Error(`No persisted brain exists for agent type '${agentTypeId}'`);
+    }
+    return { agentTypeId, brain, context };
+  } catch (error) {
+    if (error instanceof RangeError) {
+      throw new Error('Invalid agent type id: use a non-empty portable path-component identifier');
+    }
+    throw error;
+  }
+}
+
+function brainSummary(agentTypeId: string, brain: SqliteBrain, context: BrainRouteContext | undefined) {
+  const allWorkingKeys = brain.working.persistedKeys();
+  const lastCheckpoint = brain.recovery.lastCheckpoint();
+  const learningConfigured = context?.faculties?.learning ?? brain.learning.configured;
+  return {
+    agentTypeId,
+    workingMemory: {
+      keys: allWorkingKeys.slice(0, MAX_WORKING_MEMORY_KEYS),
+      total: allWorkingKeys.length,
+      truncated: allWorkingKeys.length > MAX_WORKING_MEMORY_KEYS,
+    },
+    episodic: { eventCount: brain.episodic.count() },
+    recovery: { lastCheckpointAt: lastCheckpoint?.timestamp ?? null },
+    faculties: {
+      planning: { configured: context?.faculties?.planning ?? brain.planning.configured },
+      reasoning: { configured: context?.faculties?.reasoning ?? brain.reasoning.configured },
+      action: { configured: context?.faculties?.action ?? brain.action.configured },
+      learning: { configured: learningConfigured },
+    },
+    capabilities: {
+      memoryReview: true,
+      retentionReporting: true,
+      recordLearning: true,
+    },
+    lessons: { available: learningConfigured, count: null },
+  };
+}
+
+function plural(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
+function renderSummary(summary: ReturnType<typeof brainSummary>): string {
+  const configuredFaculties = Object.entries(summary.faculties)
+    .filter(([, state]) => state.configured)
+    .map(([name]) => name);
+  const keys = summary.workingMemory.keys.length === 0
+    ? 'none'
+    : summary.workingMemory.keys.join(', ') + (summary.workingMemory.truncated ? ', …' : '');
+  return [
+    `Brain: ${summary.agentTypeId}`,
+    `Working memory: ${plural(summary.workingMemory.total, 'key')} (${keys})`,
+    `Episodic memory: ${plural(summary.episodic.eventCount, 'event')}`,
+    `Last checkpoint: ${summary.recovery.lastCheckpointAt ?? 'none'}`,
+    `Faculties configured: ${configuredFaculties.join(', ') || 'none'}`,
+    `Lessons available: ${summary.lessons.available ? 'yes' : 'no'}`,
+  ].join('\n');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function lessonProjection(candidate: MemoryCandidate) {
+  if (!isRecord(candidate.value) || candidate.value.kind !== 'consolidated-lesson') return undefined;
+  const pattern = typeof candidate.value.pattern === 'string'
+    ? truncateUtf8(candidate.value.pattern, MAX_LESSON_PATTERN_BYTES)
+    : undefined;
+  const key = truncateUtf8(candidate.key, MAX_LESSON_KEY_BYTES);
+  return {
+    key: key.value,
+    ...(key.truncated ? { keyTruncated: true as const } : {}),
+    status: candidate.status,
+    kind: 'consolidated-lesson' as const,
+    ...(pattern ? { pattern: pattern.value } : {}),
+    ...(pattern?.truncated ? { patternTruncated: true as const } : {}),
+    ...(typeof candidate.value.occurrenceCount === 'number'
+      ? { occurrenceCount: candidate.value.occurrenceCount }
+      : {}),
+    ...(typeof candidate.confidence === 'number' ? { confidence: candidate.confidence } : {}),
+    ...(typeof candidate.value.firstSeenAt === 'string' ? { firstSeenAt: candidate.value.firstSeenAt } : {}),
+    ...(typeof candidate.value.lastSeenAt === 'string' ? { lastSeenAt: candidate.value.lastSeenAt } : {}),
+  };
+}
+
+function lessonsView(brain: SqliteBrain, context: BrainRouteContext | undefined) {
+  const facultyConfigured = context?.faculties?.learning ?? brain.learning.configured;
+  if (!facultyConfigured) {
+    return {
+      data: [],
+      meta: {
+        available: false,
+        facultyConfigured: false,
+        limit: MAX_LESSONS,
+        truncated: false,
+        reason: LESSON_UNAVAILABLE_REASON,
+      },
+    };
+  }
+
+  const candidates = (['pending', 'approved'] as const)
+    .flatMap((status) => brain.memoryReview.listByKind(status, 'consolidated-lesson', { limit: MAX_LESSONS + 1 }))
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  const projected = candidates
+    .map(lessonProjection)
+    .filter((lesson): lesson is NonNullable<ReturnType<typeof lessonProjection>> => lesson !== undefined);
+  return {
+    data: projected.slice(0, MAX_LESSONS),
+    meta: {
+      available: true,
+      facultyConfigured: true,
+      limit: MAX_LESSONS,
+      truncated: projected.length > MAX_LESSONS,
+    },
+  };
+}
+
+function renderLessons(agentTypeId: string, view: ReturnType<typeof lessonsView>): string {
+  if (!view.meta.available) {
+    return `Lessons for ${agentTypeId}: not available\n${view.meta.reason}`;
+  }
+  if (view.data.length === 0) {
+    return `Lessons for ${agentTypeId}: no consolidated lesson candidates found`;
+  }
+  return [
+    `Lessons for ${agentTypeId} (${view.data.length}${view.meta.truncated ? '+' : ''} shown):`,
+    ...view.data.map((lesson) => (
+      `- [${lesson.status}] ${lesson.pattern ?? lesson.key}`
+      + (lesson.occurrenceCount === undefined ? '' : ` (${plural(lesson.occurrenceCount, 'occurrence')})`)
+    )),
+  ].join('\n');
+}
+
+export async function handleBrainCommand(deps: BrainCommandDeps): Promise<void> {
+  const { agentTypeId, brain, context } = resolveBrain(deps);
+  try {
+    if (deps.action === 'show') {
+      const summary = brainSummary(agentTypeId, brain, context);
+      deps.print(deps.json ? JSON.stringify({ data: summary }, null, 2) : renderSummary(summary));
+      return;
+    }
+    if (deps.action === 'lessons') {
+      const view = lessonsView(brain, context);
+      deps.print(deps.json ? JSON.stringify(view, null, 2) : renderLessons(agentTypeId, view));
+      return;
+    }
+    throw new Error('Usage: frankenbeast brain <show|lessons> <agentTypeId> [--json]');
+  } catch (error) {
+    if (error instanceof Error && (
+      error.message.startsWith('Usage:')
+      || error.message.startsWith('No persisted brain')
+      || error.message.startsWith('Invalid agent type id')
+    )) {
+      throw error;
+    }
+    throw new Error('Brain state could not be read');
+  }
+}

--- a/packages/franken-orchestrator/src/cli/brain-cli.ts
+++ b/packages/franken-orchestrator/src/cli/brain-cli.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import { BrainRegistry } from '@franken/brain';
 import type { MemoryCandidate, SqliteBrain } from '@franken/brain';
@@ -16,6 +16,7 @@ const MAX_WORKING_MEMORY_KEYS = 100;
 const MAX_LESSONS = 10;
 const MAX_LESSON_PATTERN_BYTES = 2 * 1024;
 const MAX_LESSON_KEY_BYTES = 512;
+const MAX_LESSON_TIMESTAMP_BYTES = 128;
 const LESSON_UNAVAILABLE_REASON = 'Consolidated lessons are not available until the learning faculty is configured';
 
 type BrainRegistryReader = Pick<BrainRegistry, 'getAgentType'>;
@@ -43,13 +44,15 @@ export async function createBrainInspectionHandle(
   const snapshotDir = await mkdtemp(join(tmpdir(), 'franken-brain-inspect-'));
   const registry = new BrainRegistry(snapshotDir);
   try {
-    // Validate with BrainRegistry's canonical portable-id rules before deriving a path.
-    registry.getAgentType(agentTypeId);
+    const snapshotBrainDb = join(snapshotDir, 'brain.db');
+    // An explicit path applies the 255-byte portable-id rule without deriving a filename.
+    registry.getAgentType(agentTypeId, snapshotBrainDb);
     const projectRoot = dirname(dirname(brainsDir));
     const sourceBeastsDb = join(dirname(brainsDir), 'beast.db');
     let persistedContext: BrainRouteContext | undefined;
+    let snapshotBeastsDb: string | undefined;
     if (existsSync(sourceBeastsDb)) {
-      const snapshotBeastsDb = join(snapshotDir, 'beast.db');
+      snapshotBeastsDb = join(snapshotDir, 'beast.db');
       await backupDatabase(sourceBeastsDb, snapshotBeastsDb);
       const repository = new SQLiteBeastRepository(snapshotBeastsDb);
       try {
@@ -62,11 +65,18 @@ export async function createBrainInspectionHandle(
     if (!existsSync(sourcePath)) {
       throw new Error(`No persisted brain exists for agent type '${agentTypeId}'`);
     }
-    await backupDatabase(sourcePath, join(snapshotDir, `${agentTypeId}.db`));
+    const inspectionDbPath = snapshotBeastsDb !== undefined
+      && resolve(sourcePath) === resolve(sourceBeastsDb)
+      ? snapshotBeastsDb
+      : snapshotBrainDb;
+    if (inspectionDbPath !== snapshotBeastsDb) {
+      await backupDatabase(sourcePath, inspectionDbPath);
+    }
 
-    const inspectionContext = persistedContext?.faculties
-      ? { faculties: persistedContext.faculties }
-      : undefined;
+    const inspectionContext: BrainRouteContext = {
+      dbPath: inspectionDbPath,
+      ...(persistedContext?.faculties ? { faculties: persistedContext.faculties } : {}),
+    };
     return {
       registry,
       resolveContext: (candidateAgentTypeId: string) => (
@@ -98,9 +108,16 @@ export interface BrainCommandDeps {
 }
 
 function truncateUtf8(value: string, maxBytes: number): { value: string; truncated: boolean } {
-  const encoded = Buffer.from(value);
-  if (encoded.byteLength <= maxBytes) return { value, truncated: false };
-  return { value: encoded.subarray(0, maxBytes).toString('utf8'), truncated: true };
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return { value, truncated: false };
+  let bytes = 0;
+  let bounded = '';
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
+    if (bytes + codePointBytes > maxBytes) break;
+    bounded += codePoint;
+    bytes += codePointBytes;
+  }
+  return { value: bounded, truncated: true };
 }
 
 function resolveBrain(deps: BrainCommandDeps): {
@@ -160,6 +177,12 @@ function plural(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? '' : 's'}`;
 }
 
+function escapeTerminalControls(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, (character) => (
+    `\\u${character.codePointAt(0)!.toString(16).padStart(4, '0')}`
+  ));
+}
+
 function renderSummary(summary: ReturnType<typeof brainSummary>): string {
   const configuredFaculties = Object.entries(summary.faculties)
     .filter(([, state]) => state.configured)
@@ -187,6 +210,12 @@ function lessonProjection(candidate: MemoryCandidate) {
     ? truncateUtf8(candidate.value.pattern, MAX_LESSON_PATTERN_BYTES)
     : undefined;
   const key = truncateUtf8(candidate.key, MAX_LESSON_KEY_BYTES);
+  const firstSeenAt = typeof candidate.value.firstSeenAt === 'string'
+    ? truncateUtf8(candidate.value.firstSeenAt, MAX_LESSON_TIMESTAMP_BYTES)
+    : undefined;
+  const lastSeenAt = typeof candidate.value.lastSeenAt === 'string'
+    ? truncateUtf8(candidate.value.lastSeenAt, MAX_LESSON_TIMESTAMP_BYTES)
+    : undefined;
   return {
     key: key.value,
     ...(key.truncated ? { keyTruncated: true as const } : {}),
@@ -198,8 +227,10 @@ function lessonProjection(candidate: MemoryCandidate) {
       ? { occurrenceCount: candidate.value.occurrenceCount }
       : {}),
     ...(typeof candidate.confidence === 'number' ? { confidence: candidate.confidence } : {}),
-    ...(typeof candidate.value.firstSeenAt === 'string' ? { firstSeenAt: candidate.value.firstSeenAt } : {}),
-    ...(typeof candidate.value.lastSeenAt === 'string' ? { lastSeenAt: candidate.value.lastSeenAt } : {}),
+    ...(firstSeenAt ? { firstSeenAt: firstSeenAt.value } : {}),
+    ...(firstSeenAt?.truncated ? { firstSeenAtTruncated: true as const } : {}),
+    ...(lastSeenAt ? { lastSeenAt: lastSeenAt.value } : {}),
+    ...(lastSeenAt?.truncated ? { lastSeenAtTruncated: true as const } : {}),
   };
 }
 
@@ -245,15 +276,15 @@ function renderLessons(agentTypeId: string, view: ReturnType<typeof lessonsView>
   return [
     `Lessons for ${agentTypeId} (${view.data.length}${view.meta.truncated ? '+' : ''} shown):`,
     ...view.data.map((lesson) => (
-      `- [${lesson.status}] ${lesson.pattern ?? lesson.key}`
+      `- [${lesson.status}] ${escapeTerminalControls(lesson.pattern ?? lesson.key)}`
       + (lesson.occurrenceCount === undefined ? '' : ` (${plural(lesson.occurrenceCount, 'occurrence')})`)
     )),
   ].join('\n');
 }
 
 export async function handleBrainCommand(deps: BrainCommandDeps): Promise<void> {
-  const { agentTypeId, brain, context } = resolveBrain(deps);
   try {
+    const { agentTypeId, brain, context } = resolveBrain(deps);
     if (deps.action === 'show') {
       const summary = brainSummary(agentTypeId, brain, context);
       deps.print(deps.json ? JSON.stringify({ data: summary }, null, 2) : renderSummary(summary));

--- a/packages/franken-orchestrator/src/cli/brain-cli.ts
+++ b/packages/franken-orchestrator/src/cli/brain-cli.ts
@@ -17,6 +17,7 @@ const MAX_LESSONS = 10;
 const MAX_LESSON_PATTERN_BYTES = 2 * 1024;
 const MAX_LESSON_KEY_BYTES = 512;
 const MAX_LESSON_TIMESTAMP_BYTES = 128;
+const MAX_CHECKPOINT_TIMESTAMP_BYTES = 128;
 const LESSON_UNAVAILABLE_REASON = 'Consolidated lessons are not available until the learning faculty is configured';
 
 type BrainRegistryReader = Pick<BrainRegistry, 'getAgentType'>;
@@ -93,7 +94,10 @@ export async function createBrainInspectionHandle(
     if (error instanceof RangeError) {
       throw new Error('Invalid agent type id: use a non-empty portable path-component identifier');
     }
-    throw error;
+    if (error instanceof Error && error.message.startsWith('No persisted brain')) {
+      throw error;
+    }
+    throw new Error('Brain state could not be read');
   }
 
 }
@@ -148,6 +152,9 @@ function resolveBrain(deps: BrainCommandDeps): {
 function brainSummary(agentTypeId: string, brain: SqliteBrain, context: BrainRouteContext | undefined) {
   const allWorkingKeys = brain.working.persistedKeys();
   const lastCheckpoint = brain.recovery.lastCheckpoint();
+  const lastCheckpointAt = typeof lastCheckpoint?.timestamp === 'string'
+    ? truncateUtf8(lastCheckpoint.timestamp, MAX_CHECKPOINT_TIMESTAMP_BYTES)
+    : undefined;
   const learningConfigured = context?.faculties?.learning ?? brain.learning.configured;
   return {
     agentTypeId,
@@ -157,7 +164,10 @@ function brainSummary(agentTypeId: string, brain: SqliteBrain, context: BrainRou
       truncated: allWorkingKeys.length > MAX_WORKING_MEMORY_KEYS,
     },
     episodic: { eventCount: brain.episodic.count() },
-    recovery: { lastCheckpointAt: lastCheckpoint?.timestamp ?? null },
+    recovery: {
+      lastCheckpointAt: lastCheckpointAt?.value ?? null,
+      ...(lastCheckpointAt?.truncated ? { lastCheckpointAtTruncated: true as const } : {}),
+    },
     faculties: {
       planning: { configured: context?.faculties?.planning ?? brain.planning.configured },
       reasoning: { configured: context?.faculties?.reasoning ?? brain.reasoning.configured },
@@ -178,9 +188,12 @@ function plural(count: number, singular: string): string {
 }
 
 function escapeTerminalControls(value: string): string {
-  return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, (character) => (
-    `\\u${character.codePointAt(0)!.toString(16).padStart(4, '0')}`
-  ));
+  return value.replace(/[\u0000-\u001f\u007f-\u009f\p{Cf}]/gu, (character) => {
+    const codePoint = character.codePointAt(0)!;
+    return codePoint <= 0xffff
+      ? `\\u${codePoint.toString(16).padStart(4, '0')}`
+      : `\\u{${codePoint.toString(16)}}`;
+  });
 }
 
 function renderSummary(summary: ReturnType<typeof brainSummary>): string {
@@ -194,7 +207,9 @@ function renderSummary(summary: ReturnType<typeof brainSummary>): string {
     `Brain: ${summary.agentTypeId}`,
     `Working memory: ${plural(summary.workingMemory.total, 'key')} (${keys})`,
     `Episodic memory: ${plural(summary.episodic.eventCount, 'event')}`,
-    `Last checkpoint: ${summary.recovery.lastCheckpointAt ?? 'none'}`,
+    `Last checkpoint: ${summary.recovery.lastCheckpointAt === null
+      ? 'none'
+      : escapeTerminalControls(summary.recovery.lastCheckpointAt)}`,
     `Faculties configured: ${configuredFaculties.join(', ') || 'none'}`,
     `Lessons available: ${summary.lessons.available ? 'yes' : 'no'}`,
   ].join('\n');

--- a/packages/franken-orchestrator/src/cli/brain-cli.ts
+++ b/packages/franken-orchestrator/src/cli/brain-cli.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { BrainRegistry } from '@franken/brain';
 import type { MemoryCandidate, SqliteBrain } from '@franken/brain';
@@ -9,6 +9,8 @@ import Database from 'better-sqlite3';
 
 import type { BrainAction } from './args.js';
 import type { BrainRouteContext } from '../http/routes/brain-routes.js';
+import { SQLiteBeastRepository } from '../beasts/repository/sqlite-beast-repository.js';
+import { resolvePersistedBrainContext } from '../beasts/create-beast-services.js';
 
 const MAX_WORKING_MEMORY_KEYS = 100;
 const MAX_LESSONS = 10;
@@ -20,7 +22,17 @@ type BrainRegistryReader = Pick<BrainRegistry, 'getAgentType'>;
 
 export interface BrainInspectionHandle {
   registry: BrainRegistry;
+  resolveContext(agentTypeId: string): BrainRouteContext | undefined;
   dispose(): Promise<void>;
+}
+
+async function backupDatabase(sourcePath: string, destinationPath: string): Promise<void> {
+  const source = new Database(sourcePath, { readonly: true, fileMustExist: true });
+  try {
+    await source.backup(destinationPath);
+  } finally {
+    source.close();
+  }
 }
 
 /** Open a consistent disposable copy so inspection never writes to the source brain. */
@@ -33,17 +45,38 @@ export async function createBrainInspectionHandle(
   try {
     // Validate with BrainRegistry's canonical portable-id rules before deriving a path.
     registry.getAgentType(agentTypeId);
-    const sourcePath = join(brainsDir, `${agentTypeId}.db`);
+    const projectRoot = dirname(dirname(brainsDir));
+    const sourceBeastsDb = join(dirname(brainsDir), 'beast.db');
+    let persistedContext: BrainRouteContext | undefined;
+    if (existsSync(sourceBeastsDb)) {
+      const snapshotBeastsDb = join(snapshotDir, 'beast.db');
+      await backupDatabase(sourceBeastsDb, snapshotBeastsDb);
+      const repository = new SQLiteBeastRepository(snapshotBeastsDb);
+      try {
+        persistedContext = resolvePersistedBrainContext(repository, agentTypeId, { projectRoot });
+      } finally {
+        repository.close();
+      }
+    }
+    const sourcePath = persistedContext?.dbPath ?? join(brainsDir, `${agentTypeId}.db`);
     if (!existsSync(sourcePath)) {
       throw new Error(`No persisted brain exists for agent type '${agentTypeId}'`);
     }
+    await backupDatabase(sourcePath, join(snapshotDir, `${agentTypeId}.db`));
 
-    const source = new Database(sourcePath, { readonly: true, fileMustExist: true });
-    try {
-      await source.backup(join(snapshotDir, `${agentTypeId}.db`));
-    } finally {
-      source.close();
-    }
+    const inspectionContext = persistedContext?.faculties
+      ? { faculties: persistedContext.faculties }
+      : undefined;
+    return {
+      registry,
+      resolveContext: (candidateAgentTypeId: string) => (
+        candidateAgentTypeId === agentTypeId ? inspectionContext : undefined
+      ),
+      dispose: async () => {
+        registry.close();
+        await rm(snapshotDir, { recursive: true, force: true });
+      },
+    };
   } catch (error) {
     registry.close();
     await rm(snapshotDir, { recursive: true, force: true });
@@ -53,13 +86,6 @@ export async function createBrainInspectionHandle(
     throw error;
   }
 
-  return {
-    registry,
-    dispose: async () => {
-      registry.close();
-      await rm(snapshotDir, { recursive: true, force: true });
-    },
-  };
 }
 
 export interface BrainCommandDeps {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -13,6 +13,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
 import { handleBeastCommand } from './beast-cli.js';
+import { createBrainInspectionHandle, handleBrainCommand } from './brain-cli.js';
 import { handleInitCommand } from './init-command.js';
 import { handleSkillCommand } from './skill-cli.js';
 import { handleSecurityCommand } from './security-cli.js';
@@ -1587,8 +1588,10 @@ export async function main(): Promise<void> {
     return;
   }
 
-  const suppressBanner = args.subcommand === 'network'
-    && (args.networkAction === 'credentials' || (args.networkAction === 'health' && args.json));
+  const suppressBanner = (
+    args.subcommand === 'network'
+    && (args.networkAction === 'credentials' || (args.networkAction === 'health' && args.json))
+  ) || (args.subcommand === 'brain' && args.json);
   if (!suppressBanner && process.env.FRANKENBEAST_NETWORK_MANAGED !== '1') {
     printLine(await renderBanner(root));
   }
@@ -1610,6 +1613,27 @@ export async function main(): Promise<void> {
       ? undefined
       : (resumeTarget?.planName ?? implicitPlanName)));
   const paths = getProjectPaths(root, planName);
+  if (args.subcommand === 'brain') {
+    if (!args.brainAction || !args.brainTarget) {
+      throw new Error('Usage: frankenbeast brain <show|lessons> <agentTypeId> [--json]');
+    }
+    const inspection = await createBrainInspectionHandle(
+      join(paths.frankenbeastDir, 'brains'),
+      args.brainTarget,
+    );
+    try {
+      await handleBrainCommand({
+        action: args.brainAction,
+        target: args.brainTarget,
+        json: args.json,
+        registry: inspection.registry,
+        print: printLine,
+      });
+    } finally {
+      await inspection.dispose();
+    }
+    return;
+  }
   let config: OrchestratorConfig;
   let configLoadFallback = false;
   try {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1627,6 +1627,7 @@ export async function main(): Promise<void> {
         target: args.brainTarget,
         json: args.json,
         registry: inspection.registry,
+        resolveContext: inspection.resolveContext,
         print: printLine,
       });
     } finally {

--- a/packages/franken-orchestrator/tests/unit/cli/args.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/args.test.ts
@@ -121,6 +121,26 @@ describe('parseArgs', () => {
     expect(args.beastAction).toBe('catalog');
   });
 
+  it('parses bounded brain inspection commands and JSON output', () => {
+    const show = parseArgs(['brain', 'show', 'coder']);
+    expect(show.subcommand).toBe('brain');
+    expect(show.brainAction).toBe('show');
+    expect(show.brainTarget).toBe('coder');
+
+    const lessons = parseArgs(['brain', 'lessons', 'reviewer', '--json']);
+    expect(lessons.subcommand).toBe('brain');
+    expect(lessons.brainAction).toBe('lessons');
+    expect(lessons.brainTarget).toBe('reviewer');
+    expect(lessons.json).toBe(true);
+  });
+
+  it('rejects unknown brain actions and extra targets', () => {
+    expect(() => parseArgs(['brain', 'mutate', 'coder'])).toThrow('Unknown brain action: mutate');
+    expect(() => parseArgs(['brain', 'show', 'coder', 'extra'])).toThrow(
+      "Unexpected argument 'extra' for brain command",
+    );
+  });
+
   it('parses beasts spawn target', () => {
     const args = parseArgs(['beasts', 'spawn', 'martin-loop']);
     expect(args.subcommand).toBe('beasts');

--- a/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BrainRegistry } from '@franken/brain';
+
+import {
+  createBrainInspectionHandle,
+  handleBrainCommand,
+} from '../../../src/cli/brain-cli.js';
+
+const roots: string[] = [];
+const registries: BrainRegistry[] = [];
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'franken-brain-cli-'));
+  const brainsDir = join(root, '.fbeast', 'brains');
+  const registry = new BrainRegistry(brainsDir);
+  roots.push(root);
+  registries.push(registry);
+  return { root, brainsDir, registry };
+}
+
+afterEach(async () => {
+  for (const registry of registries.splice(0)) registry.close();
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe('handleBrainCommand()', () => {
+  it('inspects a consistent snapshot without mutating the source brain database', async () => {
+    const { brainsDir, registry } = await fixture();
+    const brain = registry.forAgentType('readonly');
+    brain.working.set('goal', 'inspect without writes');
+    brain.flush();
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+    const sourcePath = join(brainsDir, 'readonly.db');
+    const before = await readFile(sourcePath);
+
+    const inspection = await createBrainInspectionHandle(brainsDir, 'readonly');
+    try {
+      const print = vi.fn();
+      await handleBrainCommand({
+        action: 'show',
+        target: 'readonly',
+        registry: inspection.registry,
+        print,
+      });
+      expect(vi.mocked(print).mock.calls[0]?.[0]).toContain('goal');
+    } finally {
+      await inspection.dispose();
+    }
+
+    expect(await readFile(sourcePath)).toEqual(before);
+  });
+
+  it('prints the bounded HTTP-compatible brain summary as JSON', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('coder');
+    for (let index = 0; index < 105; index += 1) brain.working.set(`key-${String(index).padStart(3, '0')}`, index);
+    brain.flush();
+    brain.episodic.record({
+      type: 'decision',
+      summary: 'Used the verified build path',
+      createdAt: '2026-07-24T10:00:00.000Z',
+    });
+    const print = vi.fn();
+
+    await handleBrainCommand({
+      action: 'show',
+      target: 'coder',
+      json: true,
+      registry,
+      resolveContext: () => ({ faculties: { planning: true, reasoning: false, action: true, learning: true } }),
+      print,
+    });
+
+    const output = JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string);
+    expect(output.data).toMatchObject({
+      agentTypeId: 'coder',
+      workingMemory: { total: 105, truncated: true },
+      episodic: { eventCount: 1 },
+      faculties: {
+        planning: { configured: true },
+        reasoning: { configured: false },
+        action: { configured: true },
+        learning: { configured: true },
+      },
+      lessons: { available: true, count: null },
+    });
+    expect(output.data.workingMemory.keys).toHaveLength(100);
+  });
+
+  it('prints a concise human brain summary by default', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('reviewer');
+    brain.working.set('current-goal', 'review safely');
+    brain.flush();
+    const print = vi.fn();
+
+    await handleBrainCommand({ action: 'show', target: 'reviewer', registry, print });
+
+    const output = vi.mocked(print).mock.calls[0]?.[0] as string;
+    expect(output).toContain('Brain: reviewer');
+    expect(output).toContain('Working memory: 1 key');
+    expect(output).toContain('current-goal');
+  });
+
+  it('lists a bounded set of real consolidated lesson candidates', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('builder');
+    brain.episodic.record({
+      type: 'failure',
+      step: 'typecheck',
+      summary: 'TypeScript workspace build failed because declarations were stale',
+      createdAt: '2026-07-24T10:00:00.000Z',
+    });
+    brain.learning.consolidate({ threshold: 1, lookback: 10 });
+    const print = vi.fn();
+
+    await handleBrainCommand({ action: 'lessons', target: 'builder', json: true, registry, print });
+
+    const output = JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string);
+    expect(output.meta).toMatchObject({ available: true, facultyConfigured: true, limit: 10, truncated: false });
+    expect(output.data).toHaveLength(1);
+    expect(output.data[0]).toMatchObject({
+      status: 'pending',
+      kind: 'consolidated-lesson',
+      occurrenceCount: 1,
+    });
+    expect(output.data[0].pattern).toContain('TypeScript workspace build failed');
+  });
+
+  it('reports unavailable lessons without inventing records', async () => {
+    const { registry } = await fixture();
+    registry.forAgentType('planner');
+    const print = vi.fn();
+
+    await handleBrainCommand({
+      action: 'lessons',
+      target: 'planner',
+      json: true,
+      registry,
+      resolveContext: () => ({ faculties: { learning: false } }),
+      print,
+    });
+
+    const output = JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string);
+    expect(output.data).toEqual([]);
+    expect(output.meta).toMatchObject({
+      available: false,
+      facultyConfigured: false,
+      reason: 'Consolidated lessons are not available until the learning faculty is configured',
+    });
+  });
+
+  it('rejects unsafe identifiers and does not create a brain database', async () => {
+    const { brainsDir, registry } = await fixture();
+
+    await expect(handleBrainCommand({ action: 'show', target: '../escape', registry, print: vi.fn() }))
+      .rejects.toThrow('Invalid agent type id');
+    expect(existsSync(join(brainsDir, 'escape.db'))).toBe(false);
+  });
+
+  it('fails clearly when no persisted brain exists and does not create one', async () => {
+    const { brainsDir, registry } = await fixture();
+
+    await expect(handleBrainCommand({ action: 'show', target: 'missing', registry, print: vi.fn() }))
+      .rejects.toThrow("No persisted brain exists for agent type 'missing'");
+    expect(existsSync(join(brainsDir, 'missing.db'))).toBe(false);
+  });
+
+  it('requires an action and agent type id', async () => {
+    const { registry } = await fixture();
+    await expect(handleBrainCommand({ action: undefined, target: undefined, registry, print: vi.fn() }))
+      .rejects.toThrow('Usage: frankenbeast brain <show|lessons> <agentTypeId> [--json]');
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BrainRegistry } from '@franken/brain';
 
+import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import {
   createBrainInspectionHandle,
   handleBrainCommand,
@@ -53,6 +54,61 @@ describe('handleBrainCommand()', () => {
     }
 
     expect(await readFile(sourcePath)).toEqual(before);
+  });
+
+  it('reports persisted faculty configuration from the latest established Beast run', async () => {
+    const { root, brainsDir, registry } = await fixture();
+    registry.forAgentType('faculty-state');
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+
+    const beastsDb = join(root, '.fbeast', 'beast.db');
+    const brainDb = join(brainsDir, 'faculty-state.db');
+    const repository = new SQLiteBeastRepository(beastsDb);
+    const run = repository.createRun({
+      definitionId: 'faculty-state',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: {
+        modules: { planner: true, critique: true, governor: false, memory: true },
+      },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-25T10:00:00.000Z',
+    });
+    repository.createAttempt(run.id, {
+      status: 'completed',
+      startedAt: '2026-07-25T10:00:01.000Z',
+    });
+    repository.close();
+    const beforeBrain = await readFile(brainDb);
+    const beforeBeasts = await readFile(beastsDb);
+
+    const inspection = await createBrainInspectionHandle(brainsDir, 'faculty-state');
+    try {
+      expect(inspection.resolveContext('faculty-state')).toMatchObject({
+        faculties: { planning: true, reasoning: true, action: false, learning: true },
+      });
+      const print = vi.fn();
+      await handleBrainCommand({
+        action: 'show',
+        target: 'faculty-state',
+        json: true,
+        registry: inspection.registry,
+        resolveContext: inspection.resolveContext,
+        print,
+      });
+      expect(JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string).data.faculties).toEqual({
+        planning: { configured: true },
+        reasoning: { configured: true },
+        action: { configured: false },
+        learning: { configured: true },
+      });
+    } finally {
+      await inspection.dispose();
+    }
+    expect(await readFile(brainDb)).toEqual(beforeBrain);
+    expect(await readFile(beastsDb)).toEqual(beforeBeasts);
   });
 
   it('prints the bounded HTTP-compatible brain summary as JSON', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -232,6 +232,31 @@ describe('handleBrainCommand()', () => {
     expect(output).toContain('current-goal');
   });
 
+  it('bounds checkpoint timestamps and escapes display controls in human output', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('checkpoint-output');
+    brain.recovery.checkpoint({
+      runId: 'run-checkpoint-output',
+      phase: 'execution',
+      step: 1,
+      context: {},
+      timestamp: `trusted\n\u001bspoofed-${'t'.repeat(200)}💥`,
+    });
+    const jsonPrint = vi.fn();
+    const humanPrint = vi.fn();
+
+    await handleBrainCommand({ action: 'show', target: 'checkpoint-output', json: true, registry, print: jsonPrint });
+    await handleBrainCommand({ action: 'show', target: 'checkpoint-output', registry, print: humanPrint });
+
+    const timestamp = JSON.parse(vi.mocked(jsonPrint).mock.calls[0]?.[0] as string).data.recovery.lastCheckpointAt;
+    expect(Buffer.byteLength(timestamp, 'utf8')).toBeLessThanOrEqual(128);
+    expect(timestamp).not.toContain('�');
+    const human = vi.mocked(humanPrint).mock.calls[0]?.[0] as string;
+    expect(human).not.toContain('\u001b');
+    expect(human.split('\n')).toHaveLength(6);
+    expect(human).toContain('trusted\\u000a\\u001bspoofed');
+  });
+
   it('lists a bounded set of real consolidated lesson candidates', async () => {
     const { registry } = await fixture();
     const brain = registry.forAgentType('builder');
@@ -297,7 +322,7 @@ describe('handleBrainCommand()', () => {
       key: 'terminal-control',
       value: {
         kind: 'consolidated-lesson',
-        pattern: 'trusted line\n\u001b]8;;https://attacker.invalid\u0007spoofed',
+        pattern: 'trusted line\n\u001b]8;;https://attacker.invalid\u0007spoofed\u202ereordered\u2066isolated',
         keywords: [],
         searchTerms: [],
         occurrenceCount: 1,
@@ -316,8 +341,12 @@ describe('handleBrainCommand()', () => {
 
     const output = vi.mocked(print).mock.calls[0]?.[0] as string;
     expect(output).not.toContain('\u001b');
+    expect(output).not.toContain('\u202e');
+    expect(output).not.toContain('\u2066');
     expect(output.split('\n')).toHaveLength(2);
-    expect(output).toContain('trusted line\\u000a\\u001b]8;;https://attacker.invalid\\u0007spoofed');
+    expect(output).toContain(
+      'trusted line\\u000a\\u001b]8;;https://attacker.invalid\\u0007spoofed\\u202ereordered\\u2066isolated',
+    );
   });
 
   it('bounds agent-produced lesson timestamps in JSON output', async () => {
@@ -412,6 +441,17 @@ describe('handleBrainCommand()', () => {
     } finally {
       await inspection.dispose();
     }
+  });
+
+  it('sanitizes failures raised while creating the Beast context snapshot', async () => {
+    const { root, brainsDir, registry } = await fixture();
+    registry.forAgentType('corrupt-beast-snapshot');
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+    await writeFile(join(root, '.fbeast', 'beast.db'), 'not a sqlite database');
+
+    await expect(createBrainInspectionHandle(brainsDir, 'corrupt-beast-snapshot'))
+      .rejects.toThrow('Brain state could not be read');
   });
 
   it('requires an action and agent type id', async () => {

--- a/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/brain-cli.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BrainRegistry } from '@franken/brain';
+import Database from 'better-sqlite3';
 
 import { SQLiteBeastRepository } from '../../../src/beasts/repository/sqlite-beast-repository.js';
 import {
@@ -46,6 +47,7 @@ describe('handleBrainCommand()', () => {
         action: 'show',
         target: 'readonly',
         registry: inspection.registry,
+        resolveContext: inspection.resolveContext,
         print,
       });
       expect(vi.mocked(print).mock.calls[0]?.[0]).toContain('goal');
@@ -109,6 +111,73 @@ describe('handleBrainCommand()', () => {
     }
     expect(await readFile(brainDb)).toEqual(beforeBrain);
     expect(await readFile(beastsDb)).toEqual(beforeBeasts);
+  });
+
+  it('inspects a portable 255-byte agent id when persisted context provides an explicit brain path', async () => {
+    const { root, brainsDir, registry } = await fixture();
+    const agentTypeId = 'a'.repeat(255);
+    const customBrainDb = join(root, 'custom-brain.db');
+    registry.forAgentType(agentTypeId, customBrainDb);
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+
+    const repository = new SQLiteBeastRepository(join(root, '.fbeast', 'beast.db'));
+    const run = repository.createRun({
+      definitionId: agentTypeId,
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { brain: { dbPath: customBrainDb } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-25T10:00:00.000Z',
+    });
+    repository.createAttempt(run.id, { status: 'completed', startedAt: '2026-07-25T10:00:01.000Z' });
+    repository.close();
+
+    const inspection = await createBrainInspectionHandle(brainsDir, agentTypeId);
+    try {
+      expect(inspection.resolveContext(agentTypeId)?.dbPath).toBeDefined();
+      await expect(handleBrainCommand({
+        action: 'show',
+        target: agentTypeId,
+        registry: inspection.registry,
+        resolveContext: inspection.resolveContext,
+        print: vi.fn(),
+      })).resolves.toBeUndefined();
+    } finally {
+      await inspection.dispose();
+    }
+  });
+
+  it('reuses one snapshot when the Beast repository is also the configured brain database', async () => {
+    const { root, brainsDir, registry } = await fixture();
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+    const sharedDb = join(root, '.fbeast', 'beast.db');
+    await mkdir(join(root, '.fbeast'), { recursive: true });
+    const sharedBrainRegistry = new BrainRegistry(brainsDir);
+    sharedBrainRegistry.forAgentType('shared-database', sharedDb);
+    sharedBrainRegistry.close();
+
+    const repository = new SQLiteBeastRepository(sharedDb);
+    const run = repository.createRun({
+      definitionId: 'shared-database',
+      definitionVersion: 1,
+      executionMode: 'process',
+      configSnapshot: { brain: { dbPath: sharedDb } },
+      dispatchedBy: 'api',
+      dispatchedByUser: 'operator',
+      createdAt: '2026-07-25T10:00:00.000Z',
+    });
+    repository.createAttempt(run.id, { status: 'completed', startedAt: '2026-07-25T10:00:01.000Z' });
+    repository.close();
+
+    const inspection = await createBrainInspectionHandle(brainsDir, 'shared-database');
+    try {
+      expect(inspection.resolveContext('shared-database')?.dbPath).toMatch(/\/beast\.db$/u);
+    } finally {
+      await inspection.dispose();
+    }
   });
 
   it('prints the bounded HTTP-compatible brain summary as JSON', async () => {
@@ -188,6 +257,101 @@ describe('handleBrainCommand()', () => {
     expect(output.data[0].pattern).toContain('TypeScript workspace build failed');
   });
 
+  it('truncates lesson strings only at complete UTF-8 code point boundaries', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('unicode-lessons');
+    brain.memoryReview.propose({
+      targetStore: 'working',
+      key: `${'k'.repeat(511)}💥tail`,
+      value: {
+        kind: 'consolidated-lesson',
+        pattern: `${'p'.repeat(2047)}💥tail`,
+        keywords: [],
+        searchTerms: [],
+        occurrenceCount: 1,
+        confidence: 0.9,
+        evidenceEventIds: [],
+        firstSeenAt: '2026-07-25T10:00:00.000Z',
+        lastSeenAt: '2026-07-25T10:00:00.000Z',
+      },
+      source: 'operator',
+      confidence: 0.9,
+      reason: 'Exercise bounded UTF-8 lesson projection.',
+    });
+    const print = vi.fn();
+
+    await handleBrainCommand({ action: 'lessons', target: 'unicode-lessons', json: true, registry, print });
+
+    const lesson = JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string).data[0];
+    expect(Buffer.byteLength(lesson.key, 'utf8')).toBeLessThanOrEqual(512);
+    expect(Buffer.byteLength(lesson.pattern, 'utf8')).toBeLessThanOrEqual(2 * 1024);
+    expect(lesson.key).not.toContain('�');
+    expect(lesson.pattern).not.toContain('�');
+  });
+
+  it('escapes terminal control characters in human lesson output', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('terminal-lessons');
+    brain.memoryReview.propose({
+      targetStore: 'working',
+      key: 'terminal-control',
+      value: {
+        kind: 'consolidated-lesson',
+        pattern: 'trusted line\n\u001b]8;;https://attacker.invalid\u0007spoofed',
+        keywords: [],
+        searchTerms: [],
+        occurrenceCount: 1,
+        confidence: 0.9,
+        evidenceEventIds: [],
+        firstSeenAt: '2026-07-25T10:00:00.000Z',
+        lastSeenAt: '2026-07-25T10:00:00.000Z',
+      },
+      source: 'operator',
+      confidence: 0.9,
+      reason: 'Exercise safe terminal rendering.',
+    });
+    const print = vi.fn();
+
+    await handleBrainCommand({ action: 'lessons', target: 'terminal-lessons', registry, print });
+
+    const output = vi.mocked(print).mock.calls[0]?.[0] as string;
+    expect(output).not.toContain('\u001b');
+    expect(output.split('\n')).toHaveLength(2);
+    expect(output).toContain('trusted line\\u000a\\u001b]8;;https://attacker.invalid\\u0007spoofed');
+  });
+
+  it('bounds agent-produced lesson timestamps in JSON output', async () => {
+    const { registry } = await fixture();
+    const brain = registry.forAgentType('timestamp-lessons');
+    brain.memoryReview.propose({
+      targetStore: 'working',
+      key: 'timestamp-bound',
+      value: {
+        kind: 'consolidated-lesson',
+        pattern: 'Bound every projected string.',
+        keywords: [],
+        searchTerms: [],
+        occurrenceCount: 1,
+        confidence: 0.9,
+        evidenceEventIds: [],
+        firstSeenAt: `${'f'.repeat(127)}💥tail`,
+        lastSeenAt: 'l'.repeat(1024),
+      },
+      source: 'operator',
+      confidence: 0.9,
+      reason: 'Exercise bounded timestamp projection.',
+    });
+    const print = vi.fn();
+
+    await handleBrainCommand({ action: 'lessons', target: 'timestamp-lessons', json: true, registry, print });
+
+    const lesson = JSON.parse(vi.mocked(print).mock.calls[0]?.[0] as string).data[0];
+    expect(Buffer.byteLength(lesson.firstSeenAt, 'utf8')).toBeLessThanOrEqual(128);
+    expect(Buffer.byteLength(lesson.lastSeenAt, 'utf8')).toBeLessThanOrEqual(128);
+    expect(lesson.firstSeenAt).not.toContain('�');
+    expect(lesson).toMatchObject({ firstSeenAtTruncated: true, lastSeenAtTruncated: true });
+  });
+
   it('reports unavailable lessons without inventing records', async () => {
     const { registry } = await fixture();
     registry.forAgentType('planner');
@@ -225,6 +389,29 @@ describe('handleBrainCommand()', () => {
     await expect(handleBrainCommand({ action: 'show', target: 'missing', registry, print: vi.fn() }))
       .rejects.toThrow("No persisted brain exists for agent type 'missing'");
     expect(existsSync(join(brainsDir, 'missing.db'))).toBe(false);
+  });
+
+  it('sanitizes storage failures raised while opening an incompatible brain snapshot', async () => {
+    const { brainsDir, registry } = await fixture();
+    registry.close();
+    registries.splice(registries.indexOf(registry), 1);
+    await mkdir(brainsDir, { recursive: true });
+    const damaged = new Database(join(brainsDir, 'damaged.db'));
+    damaged.exec('CREATE TABLE working_memory (not_a_key TEXT)');
+    damaged.close();
+
+    const inspection = await createBrainInspectionHandle(brainsDir, 'damaged');
+    try {
+      await expect(handleBrainCommand({
+        action: 'show',
+        target: 'damaged',
+        registry: inspection.registry,
+        resolveContext: inspection.resolveContext,
+        print: vi.fn(),
+      })).rejects.toThrow('Brain state could not be read');
+    } finally {
+      await inspection.dispose();
+    }
   });
 
   it('requires an action and agent type id', async () => {

--- a/tasks/issue-3706-hive-brain-cli-progress.md
+++ b/tasks/issue-3706-hive-brain-cli-progress.md
@@ -1,0 +1,13 @@
+# Issue 3706 Hive Brain CLI progress
+
+- [x] Verify issue #3706 is open, unassigned, and scoped to read-only CLI inspection.
+- [x] Branch from current `origin/main` after merged brain HTTP/faculty work.
+- [x] Read two existing CLI command handlers, parser/registration flow, BrainRegistry safety rules, HTTP contract, ADR-041, docs, and shared lessons.
+- [x] Add parser tests for `brain show|lessons <agentTypeId>` and `--json`.
+- [x] Add failing command tests for bounded human/JSON summaries, safe identifiers, missing brains, and lesson availability.
+- [x] Implement direct local read-only BrainRegistry inspection without creating unknown state.
+- [x] Update CLI help, architecture/ramp-up/package documentation, and ADR-041.
+- [x] Run focused CLI tests, orchestrator tests/gates, compiled CLI smoke checks, root typecheck, and root build.
+- [ ] Inspect staged diff, commit as David Mendez, push, and open one PR closing #3706.
+- [ ] Drive CI and current-head GitHub Codex review to clean with zero unresolved threads.
+- [ ] Merge, post root evidence, append reusable lessons, and finish the Kanban handoff.

--- a/tasks/issue-3706-hive-brain-cli-progress.md
+++ b/tasks/issue-3706-hive-brain-cli-progress.md
@@ -8,6 +8,6 @@
 - [x] Implement direct local read-only BrainRegistry inspection without creating unknown state.
 - [x] Update CLI help, architecture/ramp-up/package documentation, and ADR-041.
 - [x] Run focused CLI tests, orchestrator tests/gates, compiled CLI smoke checks, root typecheck, and root build.
-- [ ] Inspect staged diff, commit as David Mendez, push, and open one PR closing #3706.
+- [x] Inspect staged diff, commit as David Mendez, push, and open one PR closing #3706.
 - [ ] Drive CI and current-head GitHub Codex review to clean with zero unresolved threads.
 - [ ] Merge, post root evidence, append reusable lessons, and finish the Kanban handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-25 — Read-only brain inspection must snapshot context and sanitize persisted output
+- Resolve persisted brain paths and faculty flags from a snapshot of the Beast repository before opening the brain snapshot. If both contexts share one SQLite file, reuse the same backup so inspection cannot combine different live moments; always use an explicit fixed snapshot filename so a valid 255-byte agent id never becomes an invalid derived filename.
+- Treat every persisted string as untrusted output: truncate on complete UTF-8 code-point boundaries, bound timestamps and lesson fields independently, escape C0/C1 plus Unicode format/display controls in human output, and map storage/snapshot failures to stable operator errors without leaking paths or SQLite internals.
+
 ## 2026-07-25 — Faculty lesson consultation must stay bounded before lookup
 - Apply input caps while iterating plan objectives, before `map()`/`join()` or redaction; truncating only after concatenation still allows adversarial plans to cause unbounded synchronous work. Skip query construction entirely when episode recording and lesson consultation are disabled.
 - Keep automatic consolidation off the planning/reasoning/action return path and coalesce pending triggers per learning port. Persist stable lesson keys—not full lesson text—in consultation telemetry so the consulted set stays observable without duplicating reviewed memory content.


### PR DESCRIPTION
## Summary
- add `frankenbeast brain show <agentTypeId>` and `brain lessons <agentTypeId>`
- inspect a consistent disposable SQLite snapshot without creating or mutating persisted brain state
- provide bounded human/JSON output, portable identifier validation, clear local-auth semantics, and updated operator docs

## Verification
- `npm run test --workspace @franken/orchestrator -- tests/unit/cli/args.test.ts tests/unit/cli/brain-cli.test.ts` (116 passed)
- `npm run test --workspace @franken/orchestrator` (4,475 passed)
- `npm run lint` (pass; pre-existing warnings only)
- `npm run typecheck`
- `npm run build`
- compiled CLI smoke: show/lessons JSON parsed, source DB hash unchanged, missing/unsafe IDs failed without creating state

Closes #3706