### PR TITLE
feat(web): add Hive Brain dashboard panel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ Unless a section explicitly says otherwise, diagrams should use current package 
 | `@franken/types` | Shared type definitions and runtime Zod schemas. |
 | `@franken/orchestrator` | Beast Loop, CLI, issue runner, provider registry, middleware, chat/network/comms/security/skills/dashboard/analytics HTTP routes. |
 | `@franken/mcp-suite` | `fbeast` CLI, MCP servers, hooks, proxy server, shared `.fbeast/beast.db`, Beast-mode activation shim. |
-| `@franken/web` | React dashboard for chat, tracked Beast agents, network controls, analytics/cost/safety views. |
+| `@franken/web` | React dashboard for chat, tracked Beast agents, read-only per-agent-type Brain faculty/lesson inspection, network controls, analytics/cost/safety views. |
 | `@franken/live-bench` | Live CLI benchmark tooling. |
 
 Earlier standalone package surfaces from the pre-consolidation architecture have been absorbed mostly into `@franken/orchestrator` or `@franken/mcp-suite`. The ten-package table above is the authoritative current workspace inventory.
@@ -1023,7 +1023,7 @@ the stable `BRAIN_READ_FAILED` response.
 |-------|--------------------|
 | `GET /v1/brain/:agentTypeId` | Summary with at most 100 working-memory keys, episodic count, latest checkpoint time, faculty configuration, and capability availability |
 | `GET /v1/brain/:agentTypeId/episodes?limit=&offset=&query=` | Episodic history or recall search; `limit` defaults to 25 and is capped at 100, `offset` at 1,000, and `query` at 256 characters. Oversized stored step, summary, timestamp, and details fields are truncated or omitted with explicit `*Truncated` markers |
-| `GET /v1/brain/:agentTypeId/lessons` | Incremental lesson capability response; returns `available: false` with an empty collection until consolidated lesson reads are implemented |
+| `GET /v1/brain/:agentTypeId/lessons?query=&limit=` | Lesson availability plus bounded relevance search. Without `query` the route returns no rows rather than presenting an unfiltered collection as a recent feed; `limit` defaults to 10 and is capped at 100 |
 
 See [ADR-041](adr/041-hive-brain-command-center.md) for the command-center and
 registry ownership decision.
@@ -1078,7 +1078,7 @@ flowchart TD
 
 ## Web Dashboard (franken-web)
 
-React-based development tool for chat, tracked-agent launch/detail flows, configuration, and metrics visualization. Lives in `packages/franken-web/`, connects to `frankenbeast chat-server` via WebSocket, and uses authenticated Beast control HTTP routes for operator actions. Not published to npm; private monorepo package for local development.
+React-based development tool for chat, tracked-agent launch/detail flows, configuration, and metrics visualization. The overview includes a read-only Brain panel that accepts an explicit agent-type id, reads the bounded `/v1/brain/:agentTypeId` summary, shows memory plus planning/reasoning/action/learning configuration, and searches persisted lessons by topic through the bounded lesson route. It does not invent an agent-type list or claim an unfiltered recent lesson feed that the API does not provide. Lives in `packages/franken-web/`, connects to `frankenbeast chat-server` via WebSocket, and uses authenticated Beast control HTTP routes through the same-origin server/BFF boundary. Not published to npm; private monorepo package for local development.
 
 ## Secret Store
 

--- a/docs/adr/041-hive-brain-command-center.md
+++ b/docs/adr/041-hive-brain-command-center.md
@@ -4,7 +4,7 @@
 - **Status:** Accepted
 - **Deciders:** Frankenbeast maintainers
 - **Supersedes:** none
-- **Related:** ADR-014, issues #3685, #3690, #3695, #3696, #3700, #3701, #3702, #3703, and #3704
+- **Related:** ADR-014, issues #3685, #3690, #3695, #3696, #3700, #3701, #3702, #3703, #3704, and #3705
 
 ## Context
 
@@ -145,14 +145,21 @@ The initial additive contract is:
   capability/lesson availability;
 - `GET /v1/brain/:agentTypeId/episodes` for bounded episodic paging and optional
   recall query; and
-- `GET /v1/brain/:agentTypeId/lessons` for explicit incremental lesson support.
-  Until consolidated lesson reads exist, this returns an empty collection with
-  `available: false` rather than inventing lesson storage or returning 404.
+- `GET /v1/brain/:agentTypeId/lessons` for explicit lesson availability and
+  bounded relevance search. A non-empty `query` retrieves consolidated lessons;
+  an omitted query returns an empty collection rather than misrepresenting an
+  unfiltered result as a recent feed.
 
 All three routes require Beast operator authentication. Collection responses
 have fixed maximum limits, invalid identifiers and queries receive typed client
 errors, and storage failures map to a stable error without exposing internal
 database paths or exception text.
+
+The `franken-web` overview now exposes these reads through a read-only Brain
+panel. The operator selects an explicit agent-type id, sees memory and faculty
+configuration from the summary, and can search lessons by topic. The browser
+does not receive the operator token, fabricate unavailable state, or add a
+parallel command-center chat transport.
 
 ### 4. Migrate without breaking `franken-web`
 

--- a/docs/onboarding/RAMP_UP.md
+++ b/docs/onboarding/RAMP_UP.md
@@ -42,7 +42,7 @@ npm run check:package-manager
 | `packages/franken-observer/` | Traces, cost tracking, circuit breakers, evals, OTEL/Prometheus/Langfuse adapters |
 | `packages/franken-critique/` | Self-critique pipeline, evaluators, lesson recording |
 | `packages/franken-governor/` | HITL approval gates, triggers (budget/skill/confidence/ambiguity), CLI/Slack channels |
-| `packages/franken-web/` | React web dashboard — chat UI, beast catalog/dispatch controls, network config, metrics |
+| `packages/franken-web/` | React web dashboard — chat UI, beast catalog/dispatch controls, read-only per-agent-type Brain faculty/lesson inspection, network config, metrics |
 | `packages/franken-orchestrator/` | Beast Loop, CLI, chat server, comms gateway (Slack/Discord/Telegram/WhatsApp), beast control APIs, phases, circuit breakers, skill execution, crash recovery |
 | `packages/franken-mcp-suite/` | MCP suite (`@franken/mcp-suite`) for tool registry/server/proxy integrations |
 | `packages/live-bench/` | Live benchmark harness (`@franken/live-bench`) and fixture workspace tooling |
@@ -143,6 +143,11 @@ packages/franken-orchestrator/src/
   transcript/routing/approval state bound to the planned `BrainRegistry`, and
   requires every Beast launch to reuse the existing governed dispatch path.
   Do not add a second socket protocol or dispatch directly from a brain/faculty.
+- **Brain dashboard inspection is implemented and remains read-only.** The
+  overview panel reads one explicit existing agent-type id through bounded
+  `/v1/brain/*` routes, displays memory and faculty configuration, and searches
+  consolidated lessons by topic. It does not enumerate/create brains, expose
+  browser credentials, or claim an unfiltered recent lesson feed.
 - Beast control catalog currently exposes three operator flows: `design-interview`, `chunk-plan` (labeled `Design Doc -> Chunk Creation` and using a `file` prompt for `designDocPath`), and `martin-loop` (now requiring `chunkDirectory` with a `directory` prompt)
 - Tracked-agent domain types, HTTP routes, and dashboard wiring now sit below the beast control layer so init lifecycle state can exist before a Beast run is dispatched
 - **Beast daemon execution pipeline**: `ProcessBeastExecutor` manages spawned agent processes with config file passthrough (`FRANKENBEAST_RUN_CONFIG` env var), `ProcessSupervisor` three-way exit gate, early stdout/stderr buffering, and stop/kill escalation (SIGTERM → timeout → SIGKILL). `BeastEventBus` publishes real-time `run.status`, `run.log`, and `agent.status` events to SSE subscribers. `SseConnectionTicketStore` authenticates EventSource connections via single-use tickets (ADR-030). Config files are written to `.fbeast/.build/run-configs/` and cleaned up on terminal state.

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -63,6 +63,15 @@ connect to `/v1/chat/ws` with `franken.chat.v1`, and reconcile from
 `session.ready`/the session GET route. Hive/faculty selection will be additive;
 no second brain-chat socket or browser-side Beast dispatch path is permitted.
 
+The overview dashboard includes a separate read-only Brain inspection panel.
+Enter an existing agent-type id to read its bounded memory/faculty summary from
+`/v1/brain/:agentTypeId`; when the learning faculty is available, search
+persisted consolidated lessons by topic through `/v1/brain/:agentTypeId/lessons`.
+The route intentionally returns no lesson rows without a query, so the UI states
+that no unfiltered recent feed exists instead of fabricating one. These requests
+stay behind the same-origin `/v1` proxy and never attach a browser-readable
+operator credential.
+
 If you use a non-default backend port in local development, keep `VITE_API_URL` unset and set `VITE_API_PROXY_TARGET` so the Vite `/v1/chat` proxy keeps chat auth server-side. Beast routes (`/v1/beasts/*`) reuse that same target by default. Set `VITE_BEAST_API_PROXY_TARGET` only when Beast controls run on a different backend, for example a separate local orchestrator or daemon port:
 
 | Local workflow | Backend topology | Vite env vars to set |

--- a/packages/franken-web/docs/RAMP_UP.md
+++ b/packages/franken-web/docs/RAMP_UP.md
@@ -8,7 +8,7 @@ A React-based single-page application (SPA) that provides a browser control plan
 
 ## Current Functionality
 
-- **Overview Dashboard**: Skills, security profile, and provider controls sourced from the dashboard API.
+- **Overview Dashboard**: Skills, security profile, provider controls, and read-only per-agent-type Brain faculty/lesson inspection sourced from the dashboard and `/v1/brain/*` APIs.
 - **Live Chat**: Real-time interaction via the orchestrator chat server and chat WebSocket/session APIs.
 - **Tracked Beast Agents**: Launch, inspect, edit, and control long-running tracked-agent workflows and their linked Beast runs.
 - **Network Controls**: Service status, logs, and editable network configuration.
@@ -29,7 +29,7 @@ Start with these files when changing the dashboard:
 - `app.tsx`: Creates `ChatShell` with the resolved same-origin base URL, project id, and package version.
 - `components/chat-shell.tsx`: Main dashboard shell, route/tab definitions, shared client construction, chat transcript/composer wiring, and page routing.
 - `hooks/use-chat-session.ts`: Chat WebSocket and session state management for the live operator console.
-- `pages/dashboard-page.tsx`: Overview route for skills, security, and providers via `components/skills/*`, `components/security/*`, and `components/providers/*`.
+- `pages/dashboard-page.tsx`: Overview route for skills, security, providers, and the read-only Brain panel via `components/skills/*`, `components/security/*`, `components/providers/*`, and `components/brain/*`.
 - `pages/beasts-page.tsx`: Tracked Beast agent list/detail/launch surface; related wizard, panels, logs, and agent controls live under `components/beasts/*`.
 - `pages/network-page.tsx`: Network status, service actions, logs, and network config editor wiring via the network components.
 - `pages/analytics-page.tsx`: Analytics route for observer/governor/security/cost telemetry.
@@ -37,7 +37,7 @@ Start with these files when changing the dashboard:
 - `lib/beast-api.ts`: Typed client and types for `/v1/beasts/*` tracked-agent and Beast run routes.
 - `lib/network-api.ts`: Typed client and types for `/v1/network/*` service and config routes.
 - `lib/analytics-api.ts`: Typed client and types for analytics/telemetry routes.
-- `lib/dashboard-api.ts`: Typed client and types for overview dashboard snapshots and mutations.
+- `lib/dashboard-api.ts`: Typed client and types for overview dashboard snapshots/mutations plus bounded read-only `/v1/brain/*` summary and lesson-query calls.
 - `lib/resolve-base-url.ts`: Runtime base URL resolver; current browser code should prefer same-origin paths over browser-readable backend URLs.
 
 ## Local Development Workflow
@@ -71,6 +71,12 @@ FRANKENBEAST_BEAST_OPERATOR_TOKEN=<token-from-frankenbeast-init>
 ```
 
 The Vite server reads that value only for same-origin proxy requests. Browser clients should continue calling same-origin `/api/*` and `/v1/*` paths without receiving a long-lived bearer token.
+
+For Brain-panel verification, use an agent-type id whose durable database already
+exists under the backend project root. The panel does not enumerate or create
+brains: unknown ids display the backend `BRAIN_NOT_FOUND` error. Lesson reads are
+topic searches; the current API deliberately does not expose an unfiltered
+recent lesson feed.
 
 ## Build & Test
 

--- a/packages/franken-web/src/components/brain/brain-panel.test.tsx
+++ b/packages/franken-web/src/components/brain/brain-panel.test.tsx
@@ -1,0 +1,253 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BrainPanel } from './brain-panel';
+import type {
+  DashboardApiClient,
+  DashboardBrainLessons,
+  DashboardBrainState,
+} from '../../lib/dashboard-api';
+
+const brainState: DashboardBrainState = {
+  agentTypeId: 'reviewer',
+  workingMemory: { keys: ['goal'], total: 1, truncated: false },
+  episodic: { eventCount: 3 },
+  recovery: { lastCheckpointAt: '2026-07-25T01:02:03.000Z' },
+  faculties: {
+    planning: { configured: true },
+    reasoning: { configured: false },
+    action: { configured: true },
+    learning: { configured: true },
+  },
+  capabilities: { memoryReview: true, retentionReporting: true, recordLearning: true },
+  lessons: { available: true, count: null },
+};
+
+const emptyLessons: DashboardBrainLessons = {
+  data: [],
+  meta: { available: true, facultyConfigured: true },
+};
+
+function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiClient {
+  return {
+    fetchBrainState: vi.fn().mockResolvedValue(brainState),
+    fetchBrainLessons: vi.fn().mockResolvedValue(emptyLessons),
+    ...overrides,
+  } as unknown as DashboardApiClient;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(cleanup);
+
+describe('BrainPanel', () => {
+  it('starts with an accessible empty state and does not invent an agent type', () => {
+    const client = mockClient();
+
+    render(<BrainPanel client={client} />);
+
+    expect(screen.getByRole('region', { name: 'Brain faculties' })).toBeTruthy();
+    expect(screen.getByLabelText('Agent type')).toBeTruthy();
+    expect(screen.getByText('Enter an agent type to inspect its persisted Brain state.')).toBeTruthy();
+    expect(client.fetchBrainState).not.toHaveBeenCalled();
+  });
+
+  it('renders loading and truthful memory, faculty, recovery, and lesson availability state', async () => {
+    const stateRequest = deferred<DashboardBrainState>();
+    const lessonsRequest = deferred<DashboardBrainLessons>();
+    const client = mockClient({
+      fetchBrainState: vi.fn().mockReturnValue(stateRequest.promise),
+      fetchBrainLessons: vi.fn().mockReturnValue(lessonsRequest.promise),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: ' reviewer ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+
+    expect(screen.getByRole('status').textContent).toContain('Loading Brain state for reviewer');
+    stateRequest.resolve(brainState);
+
+    const region = await screen.findByRole('region', { name: 'Brain faculties for reviewer' });
+    expect(screen.getByRole('status').textContent).toContain('Loading lesson availability');
+    lessonsRequest.resolve(emptyLessons);
+    await waitFor(() => expect(region.textContent).toContain('The Brain API does not expose an unfiltered recent lesson feed.'));
+    expect(region.textContent).toContain('Memory');
+    expect(region.textContent).toContain('1 persisted key');
+    expect(region.textContent).toContain('3 episodic events');
+    expect(region.textContent).toContain('Planning');
+    expect(region.textContent).toContain('Reasoning');
+    expect(region.textContent).toContain('[not configured]');
+    expect(region.textContent).toContain('2026-07-25T01:02:03.000Z');
+
+    expect(client.fetchBrainState).toHaveBeenCalledWith('reviewer');
+    expect(client.fetchBrainLessons).toHaveBeenCalledWith('reviewer', undefined, 5);
+  });
+
+  it('surfaces a read error and retries the selected agent type', async () => {
+    const client = mockClient({
+      fetchBrainState: vi.fn()
+        .mockRejectedValueOnce(new Error('No brain exists for the requested agent type'))
+        .mockResolvedValueOnce(brainState),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.submit(screen.getByRole('form', { name: 'Select Brain agent type' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Unable to load Brain state for reviewer. No brain exists for the requested agent type',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry reviewer' }));
+
+    expect(await screen.findByRole('region', { name: 'Brain faculties for reviewer' })).toBeTruthy();
+    expect(client.fetchBrainState).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a successful faculty summary visible when the lesson read fails', async () => {
+    const client = mockClient({
+      fetchBrainLessons: vi.fn().mockRejectedValue(new Error('HTTP 503')),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+
+    const region = await screen.findByRole('region', { name: 'Brain faculties for reviewer' });
+    expect(region.textContent).toContain('Memory');
+    expect(region.textContent).toContain('Planning');
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Unable to load lessons for reviewer. HTTP 503',
+    );
+    expect(region.textContent).not.toContain('[unavailable]');
+  });
+
+  it('allows selecting another Brain while the previous lesson availability read is pending', async () => {
+    const firstLessonsRequest = deferred<DashboardBrainLessons>();
+    const client = mockClient({
+      fetchBrainState: vi.fn()
+        .mockResolvedValueOnce(brainState)
+        .mockResolvedValueOnce({ ...brainState, agentTypeId: 'planner' }),
+      fetchBrainLessons: vi.fn()
+        .mockReturnValueOnce(firstLessonsRequest.promise)
+        .mockResolvedValueOnce(emptyLessons),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+    await screen.findByRole('region', { name: 'Brain faculties for reviewer' });
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'planner' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+
+    expect(await screen.findByRole('region', { name: 'Brain faculties for planner' })).toBeTruthy();
+    expect(client.fetchBrainState).toHaveBeenLastCalledWith('planner');
+  });
+
+  it('shows the backend lesson-unavailable reason instead of an empty lesson claim', async () => {
+    const client = mockClient({
+      fetchBrainState: vi.fn().mockResolvedValue({
+        ...brainState,
+        faculties: { ...brainState.faculties, learning: { configured: false } },
+        lessons: { available: false, count: null },
+      }),
+      fetchBrainLessons: vi.fn().mockResolvedValue({
+        data: [],
+        meta: {
+          available: false,
+          facultyConfigured: false,
+          reason: 'Consolidated lessons are not available until the learning faculty is configured',
+        },
+      }),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+
+    expect(await screen.findByText(
+      'Consolidated lessons are not available until the learning faculty is configured',
+    )).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Search lessons' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('searches real lessons by topic and renders bounded lesson evidence as text', async () => {
+    const lesson: DashboardBrainLessons['data'][number] = {
+      kind: 'consolidated-lesson',
+      key: 'lesson-1',
+      status: 'approved',
+      pattern: 'Run <script>alert(1)</script> focused tests before the workspace build',
+      keywords: ['tests', 'build'],
+      occurrenceCount: 4,
+      confidence: 0.4,
+      evidenceEventIds: [1, 2, 3, 4],
+      firstSeenAt: '2026-07-24T01:00:00.000Z',
+      lastSeenAt: '2026-07-25T01:00:00.000Z',
+      relevance: 0.9,
+    };
+    const client = mockClient({
+      fetchBrainLessons: vi.fn()
+        .mockResolvedValueOnce(emptyLessons)
+        .mockResolvedValueOnce({ data: [lesson], meta: emptyLessons.meta }),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+    await screen.findByRole('region', { name: 'Brain faculties for reviewer' });
+    fireEvent.change(screen.getByLabelText('Lesson topic'), { target: { value: ' workspace build ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search lessons' }));
+
+    await waitFor(() => expect(client.fetchBrainLessons).toHaveBeenLastCalledWith('reviewer', 'workspace build', 5));
+    expect(await screen.findByText(/Run <script>alert\(1\)<\/script> focused tests/)).toBeTruthy();
+    expect(document.querySelector('script')).toBeNull();
+    expect(screen.getByText(/approved · 4 occurrences · 40% confidence/)).toBeTruthy();
+  });
+
+  it('does not relabel stale lesson results as matches while a new search is pending or failed', async () => {
+    const oldLesson: DashboardBrainLessons['data'][number] = {
+      kind: 'consolidated-lesson',
+      key: 'old-lesson',
+      status: 'approved',
+      pattern: 'Old workspace lesson',
+      keywords: ['workspace'],
+      occurrenceCount: 2,
+      confidence: 0.5,
+      evidenceEventIds: [1, 2],
+      firstSeenAt: '2026-07-24T01:00:00.000Z',
+      lastSeenAt: '2026-07-25T01:00:00.000Z',
+      relevance: 1,
+    };
+    const nextSearch = deferred<DashboardBrainLessons>();
+    const client = mockClient({
+      fetchBrainLessons: vi.fn()
+        .mockResolvedValueOnce(emptyLessons)
+        .mockResolvedValueOnce({ data: [oldLesson], meta: emptyLessons.meta })
+        .mockReturnValueOnce(nextSearch.promise),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+    await screen.findByRole('region', { name: 'Brain faculties for reviewer' });
+    fireEvent.change(screen.getByLabelText('Lesson topic'), { target: { value: 'workspace' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search lessons' }));
+    expect(await screen.findByText('Old workspace lesson')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Lesson topic'), { target: { value: 'security' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search lessons' }));
+
+    expect(screen.queryByText('Old workspace lesson')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('Searching lessons');
+    nextSearch.reject(new Error('HTTP 503'));
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to search lessons for reviewer. HTTP 503');
+    expect(screen.queryByText('Old workspace lesson')).toBeNull();
+  });
+});

--- a/packages/franken-web/src/components/brain/brain-panel.test.tsx
+++ b/packages/franken-web/src/components/brain/brain-panel.test.tsx
@@ -151,6 +151,44 @@ describe('BrainPanel', () => {
     expect(client.fetchBrainState).toHaveBeenLastCalledWith('planner');
   });
 
+  it('allows selecting another Brain while the previous summary read is pending', async () => {
+    const firstStateRequest = deferred<DashboardBrainState>();
+    const client = mockClient({
+      fetchBrainState: vi.fn()
+        .mockReturnValueOnce(firstStateRequest.promise)
+        .mockResolvedValueOnce({ ...brainState, agentTypeId: 'planner' }),
+    });
+    render(<BrainPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+    expect(screen.getByRole('status').textContent).toContain('Loading Brain state for reviewer');
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'planner' } });
+    expect(screen.getByRole('button', { name: 'Inspect Brain' }).hasAttribute('disabled')).toBe(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+
+    expect(await screen.findByRole('region', { name: 'Brain faculties for planner' })).toBeTruthy();
+    expect(client.fetchBrainState).toHaveBeenLastCalledWith('planner');
+  });
+
+  it('invalidates and clears Brain data when the API client changes', async () => {
+    const staleStateRequest = deferred<DashboardBrainState>();
+    const firstClient = mockClient({ fetchBrainState: vi.fn().mockReturnValue(staleStateRequest.promise) });
+    const nextClient = mockClient();
+    const { rerender } = render(<BrainPanel client={firstClient} />);
+
+    fireEvent.change(screen.getByLabelText('Agent type'), { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Brain' }));
+    rerender(<BrainPanel client={nextClient} />);
+    staleStateRequest.resolve(brainState);
+
+    expect(await screen.findByRole('region', { name: 'Brain faculties' })).toBeTruthy();
+    expect(screen.getByText('Enter an agent type to inspect its persisted Brain state.')).toBeTruthy();
+    expect(screen.queryByText('1 persisted key')).toBeNull();
+    expect(nextClient.fetchBrainState).not.toHaveBeenCalled();
+  });
+
   it('shows the backend lesson-unavailable reason instead of an empty lesson claim', async () => {
     const client = mockClient({
       fetchBrainState: vi.fn().mockResolvedValue({

--- a/packages/franken-web/src/components/brain/brain-panel.tsx
+++ b/packages/franken-web/src/components/brain/brain-panel.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import type {
+  DashboardApiClient,
+  DashboardBrainFacultyName,
+  DashboardBrainLessons,
+  DashboardBrainState,
+} from '../../lib/dashboard-api';
+
+interface BrainPanelProps {
+  client: DashboardApiClient;
+}
+
+const FACULTY_LABELS: Record<DashboardBrainFacultyName, string> = {
+  planning: 'Planning',
+  reasoning: 'Reasoning',
+  action: 'Action',
+  learning: 'Learning',
+};
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function facultyStatus(configured: boolean): string {
+  return configured ? '[configured]' : '[not configured]';
+}
+
+export function BrainPanel({ client }: BrainPanelProps) {
+  const requestSequenceRef = useRef(0);
+  const lessonRequestSequenceRef = useRef(0);
+  const [agentTypeInput, setAgentTypeInput] = useState('');
+  const [selectedAgentType, setSelectedAgentType] = useState<string | null>(null);
+  const [brain, setBrain] = useState<DashboardBrainState | null>(null);
+  const [lessons, setLessons] = useState<DashboardBrainLessons | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lessonQuery, setLessonQuery] = useState('');
+  const [searchedLessonQuery, setSearchedLessonQuery] = useState<string | null>(null);
+  const [lessonLoading, setLessonLoading] = useState(false);
+  const [lessonError, setLessonError] = useState<string | null>(null);
+
+  useEffect(() => () => {
+    requestSequenceRef.current += 1;
+    lessonRequestSequenceRef.current += 1;
+  }, []);
+
+  async function loadBrain(agentType: string): Promise<void> {
+    const sequence = requestSequenceRef.current + 1;
+    requestSequenceRef.current = sequence;
+    const lessonSequence = lessonRequestSequenceRef.current + 1;
+    lessonRequestSequenceRef.current = lessonSequence;
+    setSelectedAgentType(agentType);
+    setBrain(null);
+    setLessons(null);
+    setLessonQuery('');
+    setSearchedLessonQuery(null);
+    setLessonError(null);
+    setLessonLoading(false);
+    setError(null);
+    setLoading(true);
+
+    try {
+      const nextBrain = await client.fetchBrainState(agentType);
+      if (requestSequenceRef.current !== sequence) return;
+      setBrain(nextBrain);
+      setLoading(false);
+      setLessonLoading(true);
+      try {
+        const nextLessons = await client.fetchBrainLessons(agentType, undefined, 5);
+        if (requestSequenceRef.current !== sequence || lessonRequestSequenceRef.current !== lessonSequence) return;
+        setLessons(nextLessons);
+      } catch (loadError) {
+        if (requestSequenceRef.current !== sequence || lessonRequestSequenceRef.current !== lessonSequence) return;
+        setLessonError(`Unable to load lessons for ${agentType}. ${describeError(loadError)}`);
+      } finally {
+        if (requestSequenceRef.current === sequence && lessonRequestSequenceRef.current === lessonSequence) {
+          setLessonLoading(false);
+        }
+      }
+    } catch (loadError) {
+      if (requestSequenceRef.current !== sequence) return;
+      setError(`Unable to load Brain state for ${agentType}. ${describeError(loadError)}`);
+    } finally {
+      if (requestSequenceRef.current === sequence) setLoading(false);
+    }
+  }
+
+  function handleAgentTypeSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const agentType = agentTypeInput.trim();
+    if (!agentType) return;
+    void loadBrain(agentType);
+  }
+
+  async function searchLessons(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (!selectedAgentType || !lessons?.meta.available) return;
+    const query = lessonQuery.trim();
+    if (!query) return;
+    const sequence = lessonRequestSequenceRef.current + 1;
+    lessonRequestSequenceRef.current = sequence;
+    setLessonLoading(true);
+    setLessonError(null);
+    setSearchedLessonQuery(query);
+    setLessons((current) => current ? { ...current, data: [] } : current);
+
+    try {
+      const nextLessons = await client.fetchBrainLessons(selectedAgentType, query, 5);
+      if (lessonRequestSequenceRef.current !== sequence) return;
+      setLessons(nextLessons);
+    } catch (searchError) {
+      if (lessonRequestSequenceRef.current !== sequence) return;
+      setLessonError(`Unable to search lessons for ${selectedAgentType}. ${describeError(searchError)}`);
+    } finally {
+      if (lessonRequestSequenceRef.current === sequence) setLessonLoading(false);
+    }
+  }
+
+  const regionLabel = brain
+    ? `Brain faculties for ${brain.agentTypeId}`
+    : 'Brain faculties';
+  const lessonAvailable = lessons?.meta.available === true;
+
+  return (
+    <section className="brain-panel rail-card" role="region" aria-label={regionLabel}>
+      <h3>Brain</h3>
+      <form
+        className="brain-panel__selector"
+        aria-label="Select Brain agent type"
+        onSubmit={handleAgentTypeSubmit}
+      >
+        <label htmlFor="brain-agent-type">Agent type</label>
+        <div className="brain-panel__form-row">
+          <input
+            id="brain-agent-type"
+            className="field-control"
+            value={agentTypeInput}
+            onChange={(event) => setAgentTypeInput(event.target.value)}
+            placeholder="for example, reviewer"
+            autoComplete="off"
+          />
+          <button
+            className="button button--primary button--compact"
+            type="submit"
+            disabled={!agentTypeInput.trim() || loading}
+          >
+            Inspect Brain
+          </button>
+        </div>
+      </form>
+
+      {!selectedAgentType && (
+        <p className="rail-card__empty">Enter an agent type to inspect its persisted Brain state.</p>
+      )}
+
+      {loading && selectedAgentType && (
+        <p className="brain-panel__status" role="status" aria-live="polite">
+          Loading Brain state for {selectedAgentType}...
+        </p>
+      )}
+
+      {error && selectedAgentType && (
+        <div className="brain-panel__alert" role="alert">
+          <span>{error}</span>
+          <button
+            className="button button--secondary button--small"
+            type="button"
+            onClick={() => void loadBrain(selectedAgentType)}
+          >
+            Retry {selectedAgentType}
+          </button>
+        </div>
+      )}
+
+      {brain && (
+        <div className="brain-panel__content">
+          <div className="brain-panel__faculties" aria-label="Faculty state">
+            <article className="brain-panel__faculty">
+              <h4>Memory</h4>
+              <strong>[available]</strong>
+              <ul>
+                <li>{brain.workingMemory.total} persisted {brain.workingMemory.total === 1 ? 'key' : 'keys'}{brain.workingMemory.truncated ? ' (list truncated)' : ''}</li>
+                <li>{brain.episodic.eventCount} episodic {brain.episodic.eventCount === 1 ? 'event' : 'events'}</li>
+                <li>Checkpoint: {brain.recovery.lastCheckpointAt ?? 'none'}</li>
+              </ul>
+            </article>
+            {(Object.keys(FACULTY_LABELS) as DashboardBrainFacultyName[]).map((faculty) => (
+              <article className="brain-panel__faculty" key={faculty}>
+                <h4>{FACULTY_LABELS[faculty]}</h4>
+                <strong>{facultyStatus(brain.faculties[faculty].configured)}</strong>
+              </article>
+            ))}
+          </div>
+
+          <section className="brain-panel__lessons" aria-labelledby="brain-lessons-heading">
+            <div className="brain-panel__lessons-heading">
+              <h4 id="brain-lessons-heading">Lessons</h4>
+              <span>{lessons ? (lessonAvailable ? '[available]' : '[unavailable]') : '[unknown]'}</span>
+            </div>
+            {lessonLoading && !lessons && (
+              <p role="status" aria-live="polite">Loading lesson availability...</p>
+            )}
+            {lessons && (
+              <form className="brain-panel__lesson-search" aria-label="Search Brain lessons" onSubmit={(event) => void searchLessons(event)}>
+                <label htmlFor="brain-lesson-topic">Lesson topic</label>
+                <div className="brain-panel__form-row">
+                  <input
+                    id="brain-lesson-topic"
+                    className="field-control"
+                    value={lessonQuery}
+                    onChange={(event) => setLessonQuery(event.target.value)}
+                    placeholder="for example, workspace build"
+                    maxLength={256}
+                    disabled={!lessonAvailable}
+                  />
+                  <button
+                    className="button button--secondary button--compact"
+                    type="submit"
+                    disabled={!lessonAvailable || !lessonQuery.trim() || lessonLoading}
+                  >
+                    Search lessons
+                  </button>
+                </div>
+              </form>
+            )}
+            {lessonError && !lessons && <p className="brain-panel__alert" role="alert">{lessonError}</p>}
+            {lessons && !lessonAvailable && (
+              <p className="rail-card__empty">
+                {lessons.meta.reason ?? 'Consolidated lessons are not available for this agent type.'}
+              </p>
+            )}
+            {lessons && lessonAvailable && (
+              <>
+                {lessonLoading && (
+                  <p role="status" aria-live="polite">
+                    {searchedLessonQuery ? 'Searching lessons...' : 'Loading lesson availability...'}
+                  </p>
+                )}
+                {lessonError && <p className="brain-panel__alert" role="alert">{lessonError}</p>}
+                {!searchedLessonQuery && lessons.data.length === 0 && (
+                  <p className="rail-card__empty">
+                    The Brain API does not expose an unfiltered recent lesson feed. Search by topic to retrieve relevant persisted lessons.
+                  </p>
+                )}
+                {searchedLessonQuery && !lessonLoading && !lessonError && lessons.data.length === 0 && (
+                  <p className="rail-card__empty">No lessons matched “{searchedLessonQuery}”.</p>
+                )}
+                {lessons.data.length > 0 && (
+                  <ol className="brain-panel__lesson-list" aria-label={`Lessons matching ${searchedLessonQuery ?? 'the selected topic'}`}>
+                    {lessons.data.map((lesson) => (
+                      <li key={lesson.key}>
+                        <p>{lesson.pattern}</p>
+                        <small>
+                          {lesson.status} · {lesson.occurrenceCount} occurrences · {Math.round(lesson.confidence * 100)}% confidence · last seen {lesson.lastSeenAt}
+                        </small>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/franken-web/src/components/brain/brain-panel.tsx
+++ b/packages/franken-web/src/components/brain/brain-panel.tsx
@@ -39,10 +39,25 @@ export function BrainPanel({ client }: BrainPanelProps) {
   const [lessonLoading, setLessonLoading] = useState(false);
   const [lessonError, setLessonError] = useState<string | null>(null);
 
-  useEffect(() => () => {
+  useEffect(() => {
     requestSequenceRef.current += 1;
     lessonRequestSequenceRef.current += 1;
-  }, []);
+    setAgentTypeInput('');
+    setSelectedAgentType(null);
+    setBrain(null);
+    setLessons(null);
+    setLoading(false);
+    setLessonLoading(false);
+    setError(null);
+    setLessonError(null);
+    setLessonQuery('');
+    setSearchedLessonQuery(null);
+
+    return () => {
+      requestSequenceRef.current += 1;
+      lessonRequestSequenceRef.current += 1;
+    };
+  }, [client]);
 
   async function loadBrain(agentType: string): Promise<void> {
     const sequence = requestSequenceRef.current + 1;
@@ -142,7 +157,7 @@ export function BrainPanel({ client }: BrainPanelProps) {
           <button
             className="button button--primary button--compact"
             type="submit"
-            disabled={!agentTypeInput.trim() || loading}
+            disabled={!agentTypeInput.trim() || (loading && agentTypeInput.trim() === selectedAgentType)}
           >
             Inspect Brain
           </button>

--- a/packages/franken-web/src/lib/dashboard-api.test.ts
+++ b/packages/franken-web/src/lib/dashboard-api.test.ts
@@ -197,6 +197,75 @@ describe('DashboardApiClient', () => {
     });
   });
 
+  describe('brain reads', () => {
+    it('reads one encoded agent-type brain summary from the real v1 route shape', async () => {
+      const summary = {
+        agentTypeId: 'code/reviewer',
+        workingMemory: { keys: ['goal'], total: 1, truncated: false },
+        episodic: { eventCount: 3 },
+        recovery: { lastCheckpointAt: '2026-07-25T01:02:03.000Z' },
+        faculties: {
+          planning: { configured: true },
+          reasoning: { configured: false },
+          action: { configured: true },
+          learning: { configured: true },
+        },
+        capabilities: { memoryReview: true, retentionReporting: true, recordLearning: true },
+        lessons: { available: true, count: null },
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: summary }),
+      });
+
+      const client = new DashboardApiClient(BASE_URL);
+
+      await expect(client.fetchBrainState('code/reviewer')).resolves.toEqual(summary);
+      expect(globalThis.fetch).toHaveBeenCalledWith(`${BASE_URL}/v1/brain/code%2Freviewer`);
+    });
+
+    it('queries bounded lessons and preserves route availability metadata', async () => {
+      const response = {
+        data: [{
+          kind: 'consolidated-lesson' as const,
+          key: 'lesson-1',
+          status: 'approved' as const,
+          pattern: 'Run focused tests before the workspace build',
+          keywords: ['tests', 'build'],
+          occurrenceCount: 4,
+          confidence: 0.4,
+          evidenceEventIds: [1, 2, 3, 4],
+          firstSeenAt: '2026-07-24T01:00:00.000Z',
+          lastSeenAt: '2026-07-25T01:00:00.000Z',
+          relevance: 0.9,
+        }],
+        meta: { available: true, facultyConfigured: true },
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => response });
+
+      const client = new DashboardApiClient(BASE_URL);
+
+      await expect(client.fetchBrainLessons('reviewer', 'workspace build', 5)).resolves.toEqual(response);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/v1/brain/reviewer/lessons?query=workspace+build&limit=5`,
+      );
+    });
+
+    it('surfaces typed brain route error messages without adding browser credentials', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { code: 'BRAIN_NOT_FOUND', message: 'No brain exists for the requested agent type' } }),
+      });
+
+      const client = new DashboardApiClient(BASE_URL);
+
+      await expect(client.fetchBrainState('missing')).rejects.toThrow('No brain exists for the requested agent type');
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1] as RequestInit | undefined;
+      expect(init).toBeUndefined();
+    });
+  });
+
   describe('subscribeToDashboard', () => {
     it('mints a short-lived ticket before opening EventSource', async () => {
       const closeFn = vi.fn();

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -90,6 +90,53 @@ export interface DashboardSnapshot {
   slo?: DashboardSlo | undefined;
 }
 
+export type DashboardBrainFacultyName = 'planning' | 'reasoning' | 'action' | 'learning';
+
+export interface DashboardBrainState {
+  agentTypeId: string;
+  workingMemory: {
+    keys: string[];
+    total: number;
+    truncated: boolean;
+  };
+  episodic: { eventCount: number };
+  recovery: { lastCheckpointAt: string | null };
+  faculties: Record<DashboardBrainFacultyName, { configured: boolean }>;
+  capabilities: {
+    memoryReview: boolean;
+    retentionReporting: boolean;
+    recordLearning: boolean;
+  };
+  lessons: {
+    available: boolean;
+    count: number | null;
+  };
+}
+
+export interface DashboardBrainLessons {
+  data: DashboardBrainLesson[];
+  meta: {
+    available: boolean;
+    facultyConfigured: boolean;
+    reason?: string;
+  };
+}
+
+export interface DashboardBrainLesson {
+  kind: 'consolidated-lesson';
+  key: string;
+  status: 'pending' | 'approved';
+  pattern: string;
+  keywords: readonly string[];
+  searchTerms?: readonly string[];
+  occurrenceCount: number;
+  confidence: number;
+  evidenceEventIds: readonly number[];
+  firstSeenAt: string;
+  lastSeenAt: string;
+  relevance: number;
+}
+
 export class DashboardApiClient {
   constructor(private readonly baseUrl: string) {}
 
@@ -97,6 +144,27 @@ export class DashboardApiClient {
     const res = await fetch(`${this.baseUrl}/api/dashboard`);
     if (!res.ok) throw await createResponseError(res);
     return (await res.json()) as DashboardSnapshot;
+  }
+
+  async fetchBrainState(agentTypeId: string): Promise<DashboardBrainState> {
+    const res = await fetch(`${this.baseUrl}/v1/brain/${encodeURIComponent(agentTypeId)}`);
+    if (!res.ok) throw await createResponseError(res);
+    const body = await res.json() as { data: DashboardBrainState };
+    return body.data;
+  }
+
+  async fetchBrainLessons(
+    agentTypeId: string,
+    query?: string,
+    limit?: number,
+  ): Promise<DashboardBrainLessons> {
+    const search = new URLSearchParams();
+    if (query?.trim()) search.set('query', query.trim());
+    if (limit !== undefined) search.set('limit', String(limit));
+    const suffix = search.size > 0 ? `?${search.toString()}` : '';
+    const res = await fetch(`${this.baseUrl}/v1/brain/${encodeURIComponent(agentTypeId)}/lessons${suffix}`);
+    if (!res.ok) throw await createResponseError(res);
+    return res.json() as Promise<DashboardBrainLessons>;
   }
 
   async toggleSkill(name: string, enabled: boolean): Promise<void> {

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -85,6 +85,8 @@ const snapshot: DashboardSnapshot = {
 function mockClient(overrides: Partial<DashboardApiClient> = {}): DashboardApiClient {
   return {
     fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    fetchBrainState: vi.fn(),
+    fetchBrainLessons: vi.fn(),
     toggleSkill: vi.fn().mockResolvedValue(undefined),
     updateSecurityProfile: vi.fn().mockResolvedValue(undefined),
     subscribeToDashboard: vi.fn().mockResolvedValue(() => undefined),
@@ -107,6 +109,16 @@ describe('DashboardPage', () => {
   afterEach(() => {
     cleanup();
     useDashboardStore.getState().reset();
+  });
+
+  it('mounts the read-only Brain panel without selecting or fabricating an agent type', async () => {
+    const client = mockClient();
+
+    render(<DashboardPage client={client} />);
+
+    expect(await screen.findByRole('region', { name: 'Brain faculties' })).toBeTruthy();
+    expect(screen.getByText('Enter an agent type to inspect its persisted Brain state.')).toBeTruthy();
+    expect(client.fetchBrainState).not.toHaveBeenCalled();
   });
 
   it('renders partial dependency outages with remediation and safe work guidance', async () => {

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -5,6 +5,7 @@ import { SecurityPanel } from '../components/security/security-panel';
 import { ProviderPanel } from '../components/providers/provider-panel';
 import { AvailabilityPanel } from '../components/availability/availability-panel';
 import { SloPanel } from '../components/availability/slo-panel';
+import { BrainPanel } from '../components/brain/brain-panel';
 import type { DashboardApiClient, DashboardSecurity, DashboardSnapshot } from '../lib/dashboard-api';
 
 interface DashboardPageProps {
@@ -388,6 +389,7 @@ export function DashboardPage({ client }: DashboardPageProps) {
           />
         )}
         <ProviderPanel providers={providers} />
+        <BrainPanel client={client} />
         <AvailabilityPanel availability={availability ?? undefined} />
         <SloPanel slo={slo} />
       </div>

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -784,6 +784,127 @@ button {
   padding: 1rem;
 }
 
+.brain-panel {
+  display: grid;
+  gap: 1rem;
+  grid-column: 1 / -1;
+}
+
+.brain-panel__selector,
+.brain-panel__lesson-search {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.brain-panel__form-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.brain-panel__status {
+  color: var(--text-muted);
+}
+
+.brain-panel__alert {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(255, 126, 126, 0.32);
+  border-radius: 0.9rem;
+  background: rgba(255, 126, 126, 0.1);
+  color: var(--danger);
+}
+
+.brain-panel__content,
+.brain-panel__lessons {
+  display: grid;
+  gap: 1rem;
+}
+
+.brain-panel__faculties {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem;
+}
+
+.brain-panel__faculty {
+  display: grid;
+  align-content: start;
+  gap: 0.45rem;
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.brain-panel__faculty strong,
+.brain-panel__lessons-heading span {
+  color: var(--accent-strong);
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.brain-panel__faculty ul {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.brain-panel__lessons {
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.brain-panel__lessons-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.brain-panel__lesson-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.brain-panel__lesson-list li {
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.brain-panel__lesson-list p {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.brain-panel__lesson-list small {
+  display: block;
+  margin-top: 0.45rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 42rem) {
+  .brain-panel__form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .provider-panel__incident-banner {
   margin: 0.75rem 0 1rem;
   padding: 0.85rem 0.95rem;

--- a/tasks/issue-3705-hive-brain-dashboard-progress.md
+++ b/tasks/issue-3705-hive-brain-dashboard-progress.md
@@ -1,0 +1,13 @@
+# Issue #3705 Hive Brain dashboard progress
+
+- [x] Verify the live issue is open and unassigned, and reset the isolated worktree to current `origin/main`.
+- [x] Read merged #3704 route contract, ADR-041, shared lessons, dashboard/API/panel conventions, docs, and focused tests.
+- [x] Add focused failing API-client and Brain-panel tests for real route wiring, faculty/lesson rendering, loading, error, empty, retry, and accessibility states.
+- [x] Implement the typed read-only Brain API client and dashboard panel without browser-side credentials or fabricated data.
+- [x] Mount and style the panel using existing dashboard conventions.
+- [x] Update architecture, web README/ramp-up, and ADR documentation to reflect the implemented read-only panel and current lesson-query contract.
+- [x] Run focused web tests, package lint/typecheck/build, and relevant root verification.
+- [x] Start the real backend and Vite proxy, then manually exercise the browser golden path against persisted agent-type Brain data.
+- [ ] Inspect the final diff, commit as David Mendez <me@davidmendez.dev>, push one PR with `Closes #3705`, and verify CI.
+- [ ] Run the current-head GitHub Codex review loop to clean with zero unresolved Codex threads, then merge.
+- [ ] Post root evidence, append compact reusable lessons, and complete the Kanban handoff.


### PR DESCRIPTION
## Summary
- add a typed, read-only Brain dashboard panel for an explicit agent type
- show truthful memory and faculty configuration plus bounded lesson-topic search
- cover loading, error, empty, retry, stale-response, accessibility, and no-browser-credential behavior
- update architecture, ADR, onboarding, and franken-web documentation

## Verification
- `npm --workspace @franken/web test` (739 passed)
- `npm --workspace @franken/web run lint` (0 errors; 17 pre-existing warnings)
- `npm --workspace @franken/web run typecheck`
- `npm --workspace @franken/web run build`
- Playwright golden path against the real beasts-daemon and a persisted SQLite `reviewer` Brain: rendered 1 working key, 2 episodes, all five faculty states, and the searched consolidated lesson with no browser errors

Closes #3705