### PR TITLE
feat(observer): export session compaction metrics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -174,7 +174,7 @@ flowchart TD
     COB -.->|"budget enforcement"| CSE
 ```
 
-**Observer integration:** Each iteration records spans via `TraceContext.startSpan()`, token usage via `SpanLifecycle.recordTokenUsage()`, and cost via `CostCalculator`. The `CircuitBreaker` checks budget before each CLI spawn. `LoopDetector` detects repeated failures. `CliObserverBridge` also estimates rendered context-window usage so chunk execution can snapshot and compact before exceeding the provider budget. Completed threshold or manual compactions are written to the observer SQLite database with the chunk-session id, Beast run id, generation, trigger reason, before/after token estimates, and timestamp. `CompactionMetrics` provides bounded event queries and a windowed `compactionRate()` aggregation for later Brain Vitals consumers.
+**Observer integration:** Each iteration records spans via `TraceContext.startSpan()`, token usage via `SpanLifecycle.recordTokenUsage()`, and cost via `CostCalculator`. The `CircuitBreaker` checks budget before each CLI spawn. `LoopDetector` detects repeated failures. `CliObserverBridge` also estimates rendered context-window usage so chunk execution can snapshot and compact before exceeding the provider budget. Completed threshold compactions, plus manual compactions committed through `ChunkSessionCompactor.compactAndRecord()`, are written to the observer SQLite database with the chunk-session id, Beast run id, generation, trigger reason, before/after token estimates, and a wall-clock timestamp. `CompactionMetrics` provides bounded event queries and a windowed `compactionRate()` aggregation for later Brain Vitals consumers.
 
 #### Canonical Chunk Sessions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,7 @@ Provider-native session continuation is now an optimization only:
 - if the provider changes or its native state is lost, the next provider replays from the canonical chunk session
 - before compaction, MartinLoop writes a snapshot to `.fbeast/.build/chunk-session-snapshots/`
 - at `>= 85%` rendered context usage, the loop compacts transcript history into a `compaction_summary` and resumes from that compacted state
-- after a successful compaction, `ChunkSessionCompactor` emits the operational record through `CliObserverBridge`; the in-memory session counter remains the CLI display source while SQLite provides the queryable export path
+- after a successful compaction is persisted, `MartinLoop` asks `ChunkSessionCompactor` to emit the operational record through `CliObserverBridge`; telemetry is best-effort so observer storage failures cannot roll back the canonical session, while the in-memory session counter remains the CLI display source and SQLite provides the queryable export path
 
 **Design reference:** See `docs/plans/2026-03-05-beast-runner-design.md` and [ADR-007](adr/007-cli-skill-execution-type.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,7 +76,7 @@ The orchestrator supports `executionType: 'cli'` skills that spawn external CLI 
 | `GeminiProvider` | `packages/franken-orchestrator/src/skills/providers/gemini-provider.ts` | Gemini CLI provider. `gemini -p --yolo` with stream-json, strips `GEMINI*`/`GOOGLE*` env vars. |
 | `AiderProvider` | `packages/franken-orchestrator/src/skills/providers/aider-provider.ts` | Aider CLI provider. `aider --message --yes-always`. LiteLLM handles retries internally. |
 | `CliLlmAdapter` | `packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts` | Implements `IAdapter` by wrapping an `ICliProvider` for single-shot LLM completions. Used by plan/interview phases. Delegates env filtering and output normalization to the provider. |
-| `CliObserverBridge` | `packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts` | Bridges `IObserverModule` ↔ `ObserverDeps`. Wires real `TokenCounter`, `CostCalculator`, `CircuitBreaker`, `LoopDetector` from franken-observer into the CLI pipeline and estimates context-window usage for compaction. |
+| `CliObserverBridge` | `packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts` | Bridges `IObserverModule` ↔ `ObserverDeps`. Wires real `TokenCounter`, `CostCalculator`, `CircuitBreaker`, `LoopDetector` from franken-observer into the CLI pipeline, estimates context-window usage for compaction, and persists completed compaction telemetry to the canonical traces database. |
 | `CliSkillExecutor` | `packages/franken-orchestrator/src/skills/cli-skill-executor.ts` | Implements skill execution for `executionType: 'cli'`. Spawns CLI tools, runs MartinLoop, manages recovery commits, and passes chunk-session services into the loop. |
 | `MartinLoop` | `packages/franken-orchestrator/src/skills/martin-loop.ts` | Core loop: load or create canonical `ChunkSession`, render the provider request, capture output, snapshot before compaction, compact at `>= 85%` usage, and continue until `<promise>TAG</promise>` or max iterations. Rate-limit cascade still rotates through fallback providers. |
 | `FileChunkSessionStore` | `packages/franken-orchestrator/src/session/chunk-session-store.ts` | Persists canonical chunk execution state under `.fbeast/.build/chunk-sessions/<plan>/<chunk>.json`. |
@@ -174,7 +174,7 @@ flowchart TD
     COB -.->|"budget enforcement"| CSE
 ```
 
-**Observer integration:** Each iteration records spans via `TraceContext.startSpan()`, token usage via `SpanLifecycle.recordTokenUsage()`, and cost via `CostCalculator`. The `CircuitBreaker` checks budget before each CLI spawn. `LoopDetector` detects repeated failures. `CliObserverBridge` also estimates rendered context-window usage so chunk execution can snapshot and compact before exceeding the provider budget.
+**Observer integration:** Each iteration records spans via `TraceContext.startSpan()`, token usage via `SpanLifecycle.recordTokenUsage()`, and cost via `CostCalculator`. The `CircuitBreaker` checks budget before each CLI spawn. `LoopDetector` detects repeated failures. `CliObserverBridge` also estimates rendered context-window usage so chunk execution can snapshot and compact before exceeding the provider budget. Completed threshold or manual compactions are written to the observer SQLite database with the chunk-session id, Beast run id, generation, trigger reason, before/after token estimates, and timestamp. `CompactionMetrics` provides bounded event queries and a windowed `compactionRate()` aggregation for later Brain Vitals consumers.
 
 #### Canonical Chunk Sessions
 
@@ -186,6 +186,7 @@ Provider-native session continuation is now an optimization only:
 - if the provider changes or its native state is lost, the next provider replays from the canonical chunk session
 - before compaction, MartinLoop writes a snapshot to `.fbeast/.build/chunk-session-snapshots/`
 - at `>= 85%` rendered context usage, the loop compacts transcript history into a `compaction_summary` and resumes from that compacted state
+- after a successful compaction, `ChunkSessionCompactor` emits the operational record through `CliObserverBridge`; the in-memory session counter remains the CLI display source while SQLite provides the queryable export path
 
 **Design reference:** See `docs/plans/2026-03-05-beast-runner-design.md` and [ADR-007](adr/007-cli-skill-execution-type.md).
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -49,7 +49,7 @@ describe('SQLiteAdapter', () => {
       'busy_timeout = 5000',
       'journal_mode = WAL',
       'foreign_keys = ON',
-      "index_list('traces')",
+      "index_list('compaction_events')",
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
@@ -58,8 +58,10 @@ describe('SQLiteAdapter', () => {
 
   it('executes schema DDL only once when multiple adapters open the same initialized database', () => {
     pragmaMock.mockImplementation((statement: string) => {
-      if (statement === "index_list('traces')") {
-        return execMock.mock.calls.length === 0 ? [] : [{ name: 'idx_traces_startedAt' }]
+      if (statement === "index_list('compaction_events')") {
+        return execMock.mock.calls.length === 0
+          ? []
+          : [{ name: 'idx_compaction_events_session_timestamp' }]
       }
       return undefined
     })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -75,6 +75,29 @@ describe('SQLiteAdapter', () => {
     second.close()
   })
 
+  it('migrates the legacy compaction identity to include runId', () => {
+    pragmaMock.mockImplementation((statement: string) => {
+      if (statement === "index_list('compaction_events')") {
+        return [{ name: 'idx_compaction_events_session_timestamp' }]
+      }
+      if (statement === "table_info('compaction_events')") {
+        return [
+          { name: 'sessionId', pk: 1 },
+          { name: 'generation', pk: 2 },
+          { name: 'runId', pk: 0 },
+        ]
+      }
+      return undefined
+    })
+
+    const adapter = createSQLiteAdapter('/tmp/legacy-compactions.db')
+
+    expect(execMock).toHaveBeenCalledWith(expect.stringContaining(
+      'PRIMARY KEY (runId, sessionId, generation)',
+    ))
+    adapter.close()
+  })
+
   it('validates retry options before opening a database handle', () => {
     expect(() => createSQLiteAdapter('/tmp/traces.db', { maxLockRetries: -1 })).toThrow(
       'maxLockRetries must be an integer between 0 and 10',

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -17,6 +17,7 @@ import {
   SELECT_ALL_TRACE_IDS,
   SELECT_TRACE_SUMMARIES,
   DELETE_SPANS_BY_TRACE,
+  DELETE_COMPACTIONS_BY_RUN,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
   SELECT_COMPACTION_EVENTS,
@@ -197,9 +198,11 @@ function execute(operation, payload) {
       return db.prepare(sql.selectTraceSummaries).all()
     case 'deleteTrace': {
       const deleteSpans = db.prepare(sql.deleteSpansByTrace)
+      const deleteCompactions = db.prepare(sql.deleteCompactionsByRun)
       const deleteTrace = db.prepare(sql.deleteTrace)
       db.transaction((traceId) => {
         deleteSpans.run(traceId)
+        deleteCompactions.run(traceId)
         deleteTrace.run(traceId)
       })(payload.traceId)
       return undefined
@@ -282,6 +285,7 @@ class SQLiteWorkerClient {
             selectAllTraceIds: SELECT_ALL_TRACE_IDS,
             selectTraceSummaries: SELECT_TRACE_SUMMARIES,
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
+            deleteCompactionsByRun: DELETE_COMPACTIONS_BY_RUN,
             deleteTrace: DELETE_TRACE,
             upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
             selectCompactionEvents: SELECT_COMPACTION_EVENTS,
@@ -892,9 +896,11 @@ export class SQLiteAdapter implements ExportAdapter {
     } else {
       await this.withSqliteLockRetry('delete trace transaction', () => {
         const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
+        const deleteCompactions = this.db.prepare(DELETE_COMPACTIONS_BY_RUN)
         const deleteTrace = this.db.prepare(DELETE_TRACE)
         const transaction = this.db.transaction((id: string) => {
           deleteSpans.run(id)
+          deleteCompactions.run(id)
           deleteTrace.run(id)
         })
 
@@ -940,7 +946,7 @@ export class SQLiteAdapter implements ExportAdapter {
     })
   }
 
-  async aggregateCompactions(query: { sessionId: string; since: number }): Promise<{
+  async aggregateCompactions(query: { sessionId: string; since: number; before: number }): Promise<{
     count: number
     latestAt: number | null
   }> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -10,6 +10,7 @@ import type { CompactionEvent, CompactionEventQuery } from '../../compaction-met
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import {
   CREATE_TABLES,
+  MIGRATE_COMPACTION_EVENT_IDENTITY,
   UPSERT_TRACE,
   UPSERT_SPAN,
   SELECT_TRACE,
@@ -18,6 +19,7 @@ import {
   SELECT_TRACE_SUMMARIES,
   DELETE_SPANS_BY_TRACE,
   DELETE_COMPACTIONS_BY_RUN,
+  DELETE_COMPACTIONS_BEFORE,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
   SELECT_COMPACTION_EVENTS,
@@ -68,6 +70,8 @@ interface FlushedSpanState {
 }
 
 const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_compaction_events_session_timestamp'
+const COMPACTION_RETENTION_MS = 24 * 60 * 60 * 1000
+const COMPACTION_PRIMARY_KEY = ['runId', 'sessionId', 'generation']
 
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
@@ -208,7 +212,10 @@ function execute(operation, payload) {
       return undefined
     }
     case 'recordCompaction':
-      db.prepare(sql.upsertCompactionEvent).run(payload.event)
+      db.transaction((event, retentionMs) => {
+        db.prepare(sql.upsertCompactionEvent).run(event)
+        db.prepare(sql.deleteCompactionsBefore).run(event.timestamp - retentionMs)
+      })(payload.event, payload.retentionMs)
       return undefined
     case 'queryCompactions':
       return db.prepare(sql.selectCompactionEvents).all(payload.query)
@@ -286,6 +293,7 @@ class SQLiteWorkerClient {
             selectTraceSummaries: SELECT_TRACE_SUMMARIES,
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
             deleteCompactionsByRun: DELETE_COMPACTIONS_BY_RUN,
+            deleteCompactionsBefore: DELETE_COMPACTIONS_BEFORE,
             deleteTrace: DELETE_TRACE,
             upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
             selectCompactionEvents: SELECT_COMPACTION_EVENTS,
@@ -622,6 +630,22 @@ export class SQLiteAdapter implements ExportAdapter {
           && compactionIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
         if (!schemaInitialized) {
           this.db.exec(CREATE_TABLES)
+        } else {
+          const rawTableInfo = this.db.pragma("table_info('compaction_events')") as unknown
+          const tableInfo = (Array.isArray(rawTableInfo) ? rawTableInfo : []) as Array<{
+            name?: unknown
+            pk?: unknown
+          }>
+          const primaryKey = tableInfo
+            .filter(column => typeof column.pk === 'number' && column.pk > 0)
+            .sort((left, right) => (left.pk as number) - (right.pk as number))
+            .map(column => column.name)
+          if (primaryKey.length > 0 && (
+            primaryKey.length !== COMPACTION_PRIMARY_KEY.length
+            || !COMPACTION_PRIMARY_KEY.every((name, index) => primaryKey[index] === name)
+          )) {
+            this.db.exec(MIGRATE_COMPACTION_EVENT_IDENTITY)
+          }
         }
       })
       const isTransientDatabase = databasePath === ':memory:' || databasePath === ''
@@ -918,12 +942,19 @@ export class SQLiteAdapter implements ExportAdapter {
     return this.enqueueSqliteOperation(async () => {
       if (this.workerClient !== undefined) {
         await this.withSqliteLockRetry('record compaction event', () => (
-          this.workerClient!.request<void>('recordCompaction', { event })
+          this.workerClient!.request<void>('recordCompaction', {
+            event,
+            retentionMs: COMPACTION_RETENTION_MS,
+          })
         ))
         return
       }
       await this.withSqliteLockRetry('record compaction event', () => {
-        this.db.prepare(UPSERT_COMPACTION_EVENT).run(event)
+        const transaction = this.db.transaction((record: CompactionEvent) => {
+          this.db.prepare(UPSERT_COMPACTION_EVENT).run(record)
+          this.db.prepare(DELETE_COMPACTIONS_BEFORE).run(record.timestamp - COMPACTION_RETENTION_MS)
+        })
+        transaction(event)
       })
     })
   }

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
+import type { CompactionEvent, CompactionEventQuery } from '../../compaction-metrics.js'
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import {
   CREATE_TABLES,
@@ -17,6 +18,9 @@ import {
   SELECT_TRACE_SUMMARIES,
   DELETE_SPANS_BY_TRACE,
   DELETE_TRACE,
+  UPSERT_COMPACTION_EVENT,
+  SELECT_COMPACTION_EVENTS,
+  SELECT_COMPACTION_AGGREGATE,
 } from './schema.js'
 
 interface TraceRow {
@@ -62,7 +66,7 @@ interface FlushedSpanState {
   thoughtBlocksJson: string
 }
 
-const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_traces_startedAt'
+const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_compaction_events_session_timestamp'
 
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
@@ -117,7 +121,15 @@ interface NormalizedLockRetryOptions {
   onDiagnostic?: (diagnostic: SQLiteLockRetryDiagnostic) => void
 }
 
-type SQLiteWorkerOperation = 'flush' | 'queryByTraceId' | 'listTraceIds' | 'listTraceSummaries' | 'deleteTrace'
+type SQLiteWorkerOperation =
+  | 'flush'
+  | 'queryByTraceId'
+  | 'listTraceIds'
+  | 'listTraceSummaries'
+  | 'deleteTrace'
+  | 'recordCompaction'
+  | 'queryCompactions'
+  | 'aggregateCompactions'
 
 interface SQLiteWorkerResponse {
   id: number
@@ -192,6 +204,13 @@ function execute(operation, payload) {
       })(payload.traceId)
       return undefined
     }
+    case 'recordCompaction':
+      db.prepare(sql.upsertCompactionEvent).run(payload.event)
+      return undefined
+    case 'queryCompactions':
+      return db.prepare(sql.selectCompactionEvents).all(payload.query)
+    case 'aggregateCompactions':
+      return db.prepare(sql.selectCompactionAggregate).get(payload.query)
     default:
       throw new Error('Unknown SQLite worker operation: ' + operation)
   }
@@ -264,6 +283,9 @@ class SQLiteWorkerClient {
             selectTraceSummaries: SELECT_TRACE_SUMMARIES,
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
             deleteTrace: DELETE_TRACE,
+            upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
+            selectCompactionEvents: SELECT_COMPACTION_EVENTS,
+            selectCompactionAggregate: SELECT_COMPACTION_AGGREGATE,
           },
         },
       },
@@ -591,9 +613,9 @@ export class SQLiteAdapter implements ExportAdapter {
       this.withSqliteLockRetrySync('initialize SQLite adapter', () => {
         this.db.pragma('journal_mode = WAL')
         this.db.pragma('foreign_keys = ON')
-        const traceIndexes = this.db.pragma("index_list('traces')") as Array<{ name?: unknown }>
-        const schemaInitialized = Array.isArray(traceIndexes)
-          && traceIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
+        const compactionIndexes = this.db.pragma("index_list('compaction_events')") as Array<{ name?: unknown }>
+        const schemaInitialized = Array.isArray(compactionIndexes)
+          && compactionIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
         if (!schemaInitialized) {
           this.db.exec(CREATE_TABLES)
         }
@@ -884,6 +906,60 @@ export class SQLiteAdapter implements ExportAdapter {
       this.flushedSpanSnapshotCount -= flushed.size
       this.flushedSpans.delete(traceId)
     }
+  }
+
+  async recordCompaction(event: CompactionEvent): Promise<void> {
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        await this.withSqliteLockRetry('record compaction event', () => (
+          this.workerClient!.request<void>('recordCompaction', { event })
+        ))
+        return
+      }
+      await this.withSqliteLockRetry('record compaction event', () => {
+        this.db.prepare(UPSERT_COMPACTION_EVENT).run(event)
+      })
+    })
+  }
+
+  async queryCompactions(query: CompactionEventQuery): Promise<CompactionEvent[]> {
+    return this.enqueueSqliteOperation(async () => {
+      const params = {
+        sessionId: query.sessionId,
+        since: query.since ?? 0,
+        limit: query.limit,
+      }
+      if (this.workerClient !== undefined) {
+        return this.withSqliteLockRetry('query compaction events', () => (
+          this.workerClient!.request<CompactionEvent[]>('queryCompactions', { query: params })
+        ))
+      }
+      return this.withSqliteLockRetry('query compaction events', () => (
+        this.db.prepare(SELECT_COMPACTION_EVENTS).all(params) as CompactionEvent[]
+      ))
+    })
+  }
+
+  async aggregateCompactions(query: { sessionId: string; since: number }): Promise<{
+    count: number
+    latestAt: number | null
+  }> {
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        return this.withSqliteLockRetry('aggregate compaction events', () => (
+          this.workerClient!.request<{ count: number; latestAt: number | null }>(
+            'aggregateCompactions',
+            { query },
+          )
+        ))
+      }
+      return this.withSqliteLockRetry('aggregate compaction events', () => (
+        this.db.prepare(SELECT_COMPACTION_AGGREGATE).get(query) as {
+          count: number
+          latestAt: number | null
+        }
+      ))
+    })
   }
 
   private enqueueSqliteOperation<T>(action: () => Promise<T>): Promise<T> {

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -4,9 +4,14 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { Worker } from 'node:worker_threads'
+import { wallClockNow } from '@franken/types'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
-import type { CompactionEvent, CompactionEventQuery } from '../../compaction-metrics.js'
+import {
+  COMPACTION_RETENTION_MS,
+  type CompactionEvent,
+  type CompactionEventQuery,
+} from '../../compaction-metrics.js'
 import { warnIfTraceHasActiveSpans } from '../../export/ExportAdapter.js'
 import {
   CREATE_TABLES,
@@ -70,7 +75,6 @@ interface FlushedSpanState {
 }
 
 const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_compaction_events_session_timestamp'
-const COMPACTION_RETENTION_MS = 24 * 60 * 60 * 1000
 const COMPACTION_PRIMARY_KEY = ['runId', 'sessionId', 'generation']
 
 export interface SQLiteAdapterOptions {
@@ -212,15 +216,21 @@ function execute(operation, payload) {
       return undefined
     }
     case 'recordCompaction':
-      db.transaction((event, retentionMs) => {
+      db.transaction((event, retentionCutoff) => {
         db.prepare(sql.upsertCompactionEvent).run(event)
-        db.prepare(sql.deleteCompactionsBefore).run(event.timestamp - retentionMs)
-      })(payload.event, payload.retentionMs)
+        db.prepare(sql.deleteCompactionsBefore).run(retentionCutoff)
+      })(payload.event, payload.retentionCutoff)
       return undefined
     case 'queryCompactions':
-      return db.prepare(sql.selectCompactionEvents).all(payload.query)
+      return db.transaction((query, retentionCutoff) => {
+        db.prepare(sql.deleteCompactionsBefore).run(retentionCutoff)
+        return db.prepare(sql.selectCompactionEvents).all(query)
+      })(payload.query, payload.retentionCutoff)
     case 'aggregateCompactions':
-      return db.prepare(sql.selectCompactionAggregate).get(payload.query)
+      return db.transaction((query, retentionCutoff) => {
+        db.prepare(sql.deleteCompactionsBefore).run(retentionCutoff)
+        return db.prepare(sql.selectCompactionAggregate).get(query)
+      })(payload.query, payload.retentionCutoff)
     default:
       throw new Error('Unknown SQLite worker operation: ' + operation)
   }
@@ -944,7 +954,7 @@ export class SQLiteAdapter implements ExportAdapter {
         await this.withSqliteLockRetry('record compaction event', () => (
           this.workerClient!.request<void>('recordCompaction', {
             event,
-            retentionMs: COMPACTION_RETENTION_MS,
+            retentionCutoff: wallClockNow() - COMPACTION_RETENTION_MS,
           })
         ))
         return
@@ -952,7 +962,7 @@ export class SQLiteAdapter implements ExportAdapter {
       await this.withSqliteLockRetry('record compaction event', () => {
         const transaction = this.db.transaction((record: CompactionEvent) => {
           this.db.prepare(UPSERT_COMPACTION_EVENT).run(record)
-          this.db.prepare(DELETE_COMPACTIONS_BEFORE).run(record.timestamp - COMPACTION_RETENTION_MS)
+          this.db.prepare(DELETE_COMPACTIONS_BEFORE).run(wallClockNow() - COMPACTION_RETENTION_MS)
         })
         transaction(event)
       })
@@ -968,12 +978,16 @@ export class SQLiteAdapter implements ExportAdapter {
       }
       if (this.workerClient !== undefined) {
         return this.withSqliteLockRetry('query compaction events', () => (
-          this.workerClient!.request<CompactionEvent[]>('queryCompactions', { query: params })
+          this.workerClient!.request<CompactionEvent[]>('queryCompactions', {
+            query: params,
+            retentionCutoff: wallClockNow() - COMPACTION_RETENTION_MS,
+          })
         ))
       }
-      return this.withSqliteLockRetry('query compaction events', () => (
-        this.db.prepare(SELECT_COMPACTION_EVENTS).all(params) as CompactionEvent[]
-      ))
+      return this.withSqliteLockRetry('query compaction events', () => this.db.transaction(() => {
+        this.db.prepare(DELETE_COMPACTIONS_BEFORE).run(wallClockNow() - COMPACTION_RETENTION_MS)
+        return this.db.prepare(SELECT_COMPACTION_EVENTS).all(params) as CompactionEvent[]
+      })())
     })
   }
 
@@ -986,16 +1000,20 @@ export class SQLiteAdapter implements ExportAdapter {
         return this.withSqliteLockRetry('aggregate compaction events', () => (
           this.workerClient!.request<{ count: number; latestAt: number | null }>(
             'aggregateCompactions',
-            { query },
+            {
+              query,
+              retentionCutoff: wallClockNow() - COMPACTION_RETENTION_MS,
+            },
           )
         ))
       }
-      return this.withSqliteLockRetry('aggregate compaction events', () => (
-        this.db.prepare(SELECT_COMPACTION_AGGREGATE).get(query) as {
+      return this.withSqliteLockRetry('aggregate compaction events', () => this.db.transaction(() => {
+        this.db.prepare(DELETE_COMPACTIONS_BEFORE).run(wallClockNow() - COMPACTION_RETENTION_MS)
+        return this.db.prepare(SELECT_COMPACTION_AGGREGATE).get(query) as {
           count: number
           latestAt: number | null
         }
-      ))
+      })())
     })
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -25,6 +25,20 @@ export const CREATE_TABLES = `
   CREATE INDEX IF NOT EXISTS idx_spans_traceId ON spans(traceId);
   CREATE INDEX IF NOT EXISTS idx_spans_traceId_startedAt ON spans(traceId, startedAt);
   CREATE INDEX IF NOT EXISTS idx_traces_startedAt ON traces(startedAt);
+
+  CREATE TABLE IF NOT EXISTS compaction_events (
+    sessionId      TEXT    NOT NULL,
+    runId          TEXT    NOT NULL,
+    generation     INTEGER NOT NULL,
+    triggerReason  TEXT    NOT NULL CHECK (triggerReason IN ('threshold', 'manual')),
+    tokensBefore   INTEGER NOT NULL CHECK (tokensBefore >= 0),
+    tokensAfter    INTEGER NOT NULL CHECK (tokensAfter >= 0),
+    timestamp      INTEGER NOT NULL,
+    PRIMARY KEY (sessionId, generation)
+  ) STRICT;
+
+  CREATE INDEX IF NOT EXISTS idx_compaction_events_session_timestamp
+    ON compaction_events(sessionId, timestamp);
 `
 
 export const UPSERT_TRACE = `
@@ -69,3 +83,30 @@ export const SELECT_TRACE_SUMMARIES = `
 
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
+
+export const UPSERT_COMPACTION_EVENT = `
+  INSERT INTO compaction_events
+    (sessionId, runId, generation, triggerReason, tokensBefore, tokensAfter, timestamp)
+  VALUES
+    (@sessionId, @runId, @generation, @triggerReason, @tokensBefore, @tokensAfter, @timestamp)
+  ON CONFLICT(sessionId, generation) DO UPDATE SET
+    runId         = excluded.runId,
+    triggerReason = excluded.triggerReason,
+    tokensBefore  = excluded.tokensBefore,
+    tokensAfter   = excluded.tokensAfter,
+    timestamp     = excluded.timestamp
+`
+
+export const SELECT_COMPACTION_EVENTS = `
+  SELECT sessionId, runId, generation, triggerReason, tokensBefore, tokensAfter, timestamp
+  FROM compaction_events
+  WHERE sessionId = @sessionId AND timestamp >= @since
+  ORDER BY timestamp DESC, generation DESC
+  LIMIT @limit
+`
+
+export const SELECT_COMPACTION_AGGREGATE = `
+  SELECT COUNT(*) AS count, MAX(timestamp) AS latestAt
+  FROM compaction_events
+  WHERE sessionId = @sessionId AND timestamp >= @since
+`

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -34,11 +34,41 @@ export const CREATE_TABLES = `
     tokensBefore   INTEGER NOT NULL CHECK (tokensBefore >= 0),
     tokensAfter    INTEGER NOT NULL CHECK (tokensAfter >= 0),
     timestamp      INTEGER NOT NULL,
-    PRIMARY KEY (sessionId, generation)
+    PRIMARY KEY (runId, sessionId, generation)
   ) STRICT;
 
   CREATE INDEX IF NOT EXISTS idx_compaction_events_session_timestamp
     ON compaction_events(sessionId, timestamp);
+  CREATE INDEX IF NOT EXISTS idx_compaction_events_timestamp
+    ON compaction_events(timestamp);
+`
+
+export const MIGRATE_COMPACTION_EVENT_IDENTITY = `
+  BEGIN IMMEDIATE;
+  ALTER TABLE compaction_events RENAME TO compaction_events_legacy;
+
+  CREATE TABLE compaction_events (
+    sessionId      TEXT    NOT NULL,
+    runId          TEXT    NOT NULL,
+    generation     INTEGER NOT NULL,
+    triggerReason  TEXT    NOT NULL CHECK (triggerReason IN ('threshold', 'manual')),
+    tokensBefore   INTEGER NOT NULL CHECK (tokensBefore >= 0),
+    tokensAfter    INTEGER NOT NULL CHECK (tokensAfter >= 0),
+    timestamp      INTEGER NOT NULL,
+    PRIMARY KEY (runId, sessionId, generation)
+  ) STRICT;
+
+  INSERT INTO compaction_events
+    (sessionId, runId, generation, triggerReason, tokensBefore, tokensAfter, timestamp)
+  SELECT sessionId, runId, generation, triggerReason, tokensBefore, tokensAfter, timestamp
+  FROM compaction_events_legacy;
+
+  DROP TABLE compaction_events_legacy;
+  CREATE INDEX idx_compaction_events_session_timestamp
+    ON compaction_events(sessionId, timestamp);
+  CREATE INDEX idx_compaction_events_timestamp
+    ON compaction_events(timestamp);
+  COMMIT;
 `
 
 export const UPSERT_TRACE = `
@@ -83,6 +113,7 @@ export const SELECT_TRACE_SUMMARIES = `
 
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
+export const DELETE_COMPACTIONS_BEFORE = `DELETE FROM compaction_events WHERE timestamp < ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 
 export const UPSERT_COMPACTION_EVENT = `
@@ -90,8 +121,7 @@ export const UPSERT_COMPACTION_EVENT = `
     (sessionId, runId, generation, triggerReason, tokensBefore, tokensAfter, timestamp)
   VALUES
     (@sessionId, @runId, @generation, @triggerReason, @tokensBefore, @tokensAfter, @timestamp)
-  ON CONFLICT(sessionId, generation) DO UPDATE SET
-    runId         = excluded.runId,
+  ON CONFLICT(runId, sessionId, generation) DO UPDATE SET
     triggerReason = excluded.triggerReason,
     tokensBefore  = excluded.tokensBefore,
     tokensAfter   = excluded.tokensAfter,

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -82,6 +82,7 @@ export const SELECT_TRACE_SUMMARIES = `
 `
 
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
+export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 
 export const UPSERT_COMPACTION_EVENT = `
@@ -108,5 +109,5 @@ export const SELECT_COMPACTION_EVENTS = `
 export const SELECT_COMPACTION_AGGREGATE = `
   SELECT COUNT(*) AS count, MAX(timestamp) AS latestAt
   FROM compaction_events
-  WHERE sessionId = @sessionId AND timestamp >= @since
+  WHERE sessionId = @sessionId AND timestamp >= @since AND timestamp <= @before
 `

--- a/packages/franken-observer/src/compaction-metrics.test.ts
+++ b/packages/franken-observer/src/compaction-metrics.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js';
+import { CompactionMetrics } from './compaction-metrics.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('CompactionMetrics', () => {
+  it('persists and queries a session compaction record through SQLite', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-metrics-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+
+    await metrics.record({
+      sessionId: 'chunk-session-1',
+      runId: 'run-1',
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: 1_750_000_000_000,
+    });
+
+    await expect(metrics.query('chunk-session-1')).resolves.toEqual([
+      {
+        sessionId: 'chunk-session-1',
+        runId: 'run-1',
+        generation: 1,
+        triggerReason: 'threshold',
+        tokensBefore: 900,
+        tokensAfter: 120,
+        timestamp: 1_750_000_000_000,
+      },
+    ]);
+
+    await adapter.close();
+  });
+
+  it('calculates a windowed compaction rate without hydrating event payloads', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-rate-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+    const now = 1_750_000_000_000;
+
+    for (const [generation, timestamp] of [[1, now - 3_600_001], [2, now - 1_000], [3, now]] as const) {
+      await metrics.record({
+        sessionId: 'chunk-session-rate',
+        runId: 'run-rate',
+        generation,
+        triggerReason: 'threshold',
+        tokensBefore: 900,
+        tokensAfter: 120,
+        timestamp,
+      });
+    }
+
+    await expect(metrics.compactionRate('chunk-session-rate', 3_600_000, now)).resolves.toEqual({
+      count: 2,
+      windowMs: 3_600_000,
+      perHour: 2,
+      latestAt: now,
+    });
+
+    await adapter.close();
+  });
+});

--- a/packages/franken-observer/src/compaction-metrics.test.ts
+++ b/packages/franken-observer/src/compaction-metrics.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js';
 import { CompactionMetrics } from './compaction-metrics.js';
+import { TraceContext } from './core/TraceContext.js';
 
 const tempDirs: string[] = [];
 
@@ -52,7 +53,7 @@ describe('CompactionMetrics', () => {
     const metrics = new CompactionMetrics(adapter);
     const now = 1_750_000_000_000;
 
-    for (const [generation, timestamp] of [[1, now - 3_600_001], [2, now - 1_000], [3, now]] as const) {
+    for (const [generation, timestamp] of [[1, now - 3_600_001], [2, now - 1_000], [3, now], [4, now + 1]] as const) {
       await metrics.record({
         sessionId: 'chunk-session-rate',
         runId: 'run-rate',
@@ -71,6 +72,29 @@ describe('CompactionMetrics', () => {
       latestAt: now,
     });
 
+    await adapter.close();
+  });
+
+  it('removes compaction telemetry when its retained trace run is deleted', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-retention-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+    const trace = TraceContext.createTrace('retained run');
+    await adapter.flush(trace);
+    await metrics.record({
+      sessionId: 'chunk-session-retention',
+      runId: trace.id,
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: 1_750_000_000_000,
+    });
+
+    await adapter.deleteTrace(trace.id);
+
+    await expect(metrics.query('chunk-session-retention')).resolves.toEqual([]);
     await adapter.close();
   });
 });

--- a/packages/franken-observer/src/compaction-metrics.test.ts
+++ b/packages/franken-observer/src/compaction-metrics.test.ts
@@ -1,14 +1,16 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js';
 import { CompactionMetrics } from './compaction-metrics.js';
 import { TraceContext } from './core/TraceContext.js';
+import { wallClockNow } from '@franken/types';
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -20,6 +22,7 @@ describe('CompactionMetrics', () => {
     tempDirs.push(dir);
     const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
     const metrics = new CompactionMetrics(adapter);
+    const now = wallClockNow();
 
     await metrics.record({
       sessionId: 'chunk-session-1',
@@ -28,7 +31,7 @@ describe('CompactionMetrics', () => {
       triggerReason: 'threshold',
       tokensBefore: 900,
       tokensAfter: 120,
-      timestamp: 1_750_000_000_000,
+      timestamp: now,
     });
 
     await expect(metrics.query('chunk-session-1')).resolves.toEqual([
@@ -39,7 +42,7 @@ describe('CompactionMetrics', () => {
         triggerReason: 'threshold',
         tokensBefore: 900,
         tokensAfter: 120,
-        timestamp: 1_750_000_000_000,
+        timestamp: now,
       },
     ]);
 
@@ -51,8 +54,9 @@ describe('CompactionMetrics', () => {
     tempDirs.push(dir);
     const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
     const metrics = new CompactionMetrics(adapter);
+    const now = wallClockNow();
 
-    for (const [runId, timestamp] of [['run-1', 100], ['run-2', 200]] as const) {
+    for (const [runId, timestamp] of [['run-1', now - 1], ['run-2', now]] as const) {
       await metrics.record({
         sessionId: 'seeded-session',
         runId,
@@ -76,7 +80,7 @@ describe('CompactionMetrics', () => {
     tempDirs.push(dir);
     const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
     const metrics = new CompactionMetrics(adapter);
-    const now = 1_750_000_000_000;
+    const now = wallClockNow();
     const retentionMs = 24 * 60 * 60 * 1_000;
 
     await metrics.record({
@@ -102,12 +106,36 @@ describe('CompactionMetrics', () => {
     await adapter.close();
   });
 
+  it('prunes expired orphaned compactions when telemetry is only read', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-07-25T12:00:00.000Z');
+    vi.setSystemTime(now);
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-idle-retention-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+
+    await metrics.record({
+      sessionId: 'idle-session',
+      runId: 'orphaned-idle-run',
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: now.getTime(),
+    });
+    vi.setSystemTime(now.getTime() + (24 * 60 * 60 * 1_000) + 1);
+
+    await expect(metrics.query('idle-session')).resolves.toEqual([]);
+    await adapter.close();
+  });
+
   it('calculates a windowed compaction rate without hydrating event payloads', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compaction-rate-'));
     tempDirs.push(dir);
     const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
     const metrics = new CompactionMetrics(adapter);
-    const now = 1_750_000_000_000;
+    const now = wallClockNow();
 
     for (const [generation, timestamp] of [[1, now - 3_600_001], [2, now - 1_000], [3, now], [4, now + 1]] as const) {
       await metrics.record({
@@ -131,6 +159,17 @@ describe('CompactionMetrics', () => {
     await adapter.close();
   });
 
+  it('rejects rate windows longer than retained compaction history', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-rate-retention-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+
+    await expect(metrics.compactionRate('chunk-session-rate', (24 * 60 * 60 * 1_000) + 1))
+      .rejects.toThrow(/no greater than 86400000/);
+    await adapter.close();
+  });
+
   it('removes compaction telemetry when its retained trace run is deleted', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compaction-retention-'));
     tempDirs.push(dir);
@@ -145,7 +184,7 @@ describe('CompactionMetrics', () => {
       triggerReason: 'threshold',
       tokensBefore: 900,
       tokensAfter: 120,
-      timestamp: 1_750_000_000_000,
+      timestamp: wallClockNow(),
     });
 
     await adapter.deleteTrace(trace.id);

--- a/packages/franken-observer/src/compaction-metrics.test.ts
+++ b/packages/franken-observer/src/compaction-metrics.test.ts
@@ -46,6 +46,62 @@ describe('CompactionMetrics', () => {
     await adapter.close();
   });
 
+  it('keeps identically numbered generations from separate runs', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-run-identity-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+
+    for (const [runId, timestamp] of [['run-1', 100], ['run-2', 200]] as const) {
+      await metrics.record({
+        sessionId: 'seeded-session',
+        runId,
+        generation: 1,
+        triggerReason: 'threshold',
+        tokensBefore: 900,
+        tokensAfter: 120,
+        timestamp,
+      });
+    }
+
+    await expect(metrics.query('seeded-session')).resolves.toEqual([
+      expect.objectContaining({ runId: 'run-2', generation: 1 }),
+      expect.objectContaining({ runId: 'run-1', generation: 1 }),
+    ]);
+    await adapter.close();
+  });
+
+  it('prunes expired compaction events even when they have no retained trace row', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compaction-orphan-retention-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+    const now = 1_750_000_000_000;
+    const retentionMs = 24 * 60 * 60 * 1_000;
+
+    await metrics.record({
+      sessionId: 'orphaned-session',
+      runId: 'orphaned-run',
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: now - retentionMs - 1,
+    });
+    await metrics.record({
+      sessionId: 'active-session',
+      runId: 'active-run',
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: now,
+    });
+
+    await expect(metrics.query('orphaned-session')).resolves.toEqual([]);
+    await adapter.close();
+  });
+
   it('calculates a windowed compaction rate without hydrating event payloads', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compaction-rate-'));
     tempDirs.push(dir);

--- a/packages/franken-observer/src/compaction-metrics.ts
+++ b/packages/franken-observer/src/compaction-metrics.ts
@@ -21,7 +21,7 @@ export interface CompactionEventQuery {
 export interface CompactionEventAdapter {
   recordCompaction(event: CompactionEvent): Promise<void>
   queryCompactions(query: CompactionEventQuery): Promise<CompactionEvent[]>
-  aggregateCompactions(query: { sessionId: string; since: number }): Promise<{
+  aggregateCompactions(query: { sessionId: string; since: number; before: number }): Promise<{
     count: number
     latestAt: number | null
   }>
@@ -61,6 +61,7 @@ export class CompactionMetrics {
     const aggregate = await this.adapter.aggregateCompactions({
       sessionId,
       since: now - windowMs,
+      before: now,
     })
     return {
       count: aggregate.count,

--- a/packages/franken-observer/src/compaction-metrics.ts
+++ b/packages/franken-observer/src/compaction-metrics.ts
@@ -36,6 +36,7 @@ export interface CompactionRate {
 
 const DEFAULT_QUERY_LIMIT = 100
 const MAX_QUERY_LIMIT = 1_000
+export const COMPACTION_RETENTION_MS = 24 * 60 * 60 * 1_000
 
 export class CompactionMetrics {
   constructor(private readonly adapter: CompactionEventAdapter) {}
@@ -55,8 +56,8 @@ export class CompactionMetrics {
   }
 
   async compactionRate(sessionId: string, windowMs: number, now = wallClockNow()): Promise<CompactionRate> {
-    if (!Number.isSafeInteger(windowMs) || windowMs <= 0) {
-      throw new RangeError('windowMs must be a positive safe integer')
+    if (!Number.isSafeInteger(windowMs) || windowMs <= 0 || windowMs > COMPACTION_RETENTION_MS) {
+      throw new RangeError(`windowMs must be a positive safe integer no greater than ${COMPACTION_RETENTION_MS}`)
     }
     const aggregate = await this.adapter.aggregateCompactions({
       sessionId,

--- a/packages/franken-observer/src/compaction-metrics.ts
+++ b/packages/franken-observer/src/compaction-metrics.ts
@@ -1,0 +1,72 @@
+import { wallClockNow } from '@franken/types'
+
+export type CompactionTriggerReason = 'threshold' | 'manual'
+
+export interface CompactionEvent {
+  readonly sessionId: string
+  readonly runId: string
+  readonly generation: number
+  readonly triggerReason: CompactionTriggerReason
+  readonly tokensBefore: number
+  readonly tokensAfter: number
+  readonly timestamp: number
+}
+
+export interface CompactionEventQuery {
+  readonly sessionId: string
+  readonly since?: number
+  readonly limit: number
+}
+
+export interface CompactionEventAdapter {
+  recordCompaction(event: CompactionEvent): Promise<void>
+  queryCompactions(query: CompactionEventQuery): Promise<CompactionEvent[]>
+  aggregateCompactions(query: { sessionId: string; since: number }): Promise<{
+    count: number
+    latestAt: number | null
+  }>
+}
+
+export interface CompactionRate {
+  readonly count: number
+  readonly windowMs: number
+  readonly perHour: number
+  readonly latestAt: number | null
+}
+
+const DEFAULT_QUERY_LIMIT = 100
+const MAX_QUERY_LIMIT = 1_000
+
+export class CompactionMetrics {
+  constructor(private readonly adapter: CompactionEventAdapter) {}
+
+  record(event: CompactionEvent): Promise<void> {
+    return this.adapter.recordCompaction(event)
+  }
+
+  query(sessionId: string, options: { since?: number; limit?: number } = {}): Promise<CompactionEvent[]> {
+    const requestedLimit = options.limit ?? DEFAULT_QUERY_LIMIT
+    const limit = Math.min(MAX_QUERY_LIMIT, Math.max(1, Math.floor(requestedLimit)))
+    return this.adapter.queryCompactions({
+      sessionId,
+      limit,
+      ...(options.since === undefined ? {} : { since: options.since }),
+    })
+  }
+
+  async compactionRate(sessionId: string, windowMs: number, now = wallClockNow()): Promise<CompactionRate> {
+    if (!Number.isSafeInteger(windowMs) || windowMs <= 0) {
+      throw new RangeError('windowMs must be a positive safe integer')
+    }
+    const aggregate = await this.adapter.aggregateCompactions({
+      sessionId,
+      since: now - windowMs,
+    })
+    return {
+      count: aggregate.count,
+      windowMs,
+      perHour: aggregate.count * (3_600_000 / windowMs),
+      latestAt: aggregate.latestAt,
+    }
+  }
+}

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -52,6 +52,7 @@ export {
 } from './security/transcript-retention.js'
 export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
+export { CompactionMetrics } from './compaction-metrics.js'
 
 export type { ExportAdapter, TraceSummary } from './export/ExportAdapter.js'
 export type { MultiAdapterOptions } from './adapters/multi/MultiAdapter.js'
@@ -64,6 +65,13 @@ export type { InterruptSignal } from './incident/InterruptEmitter.js'
 export type { PostMortemOptions } from './incident/PostMortemGenerator.js'
 export type { LangfuseAdapterOptions, FetchFn } from './adapters/langfuse/LangfuseAdapter.js'
 export type { SQLiteAdapterOptions, SQLiteLockRetryDiagnostic } from './adapters/sqlite/SQLiteAdapter.js'
+export type {
+  CompactionEvent,
+  CompactionEventAdapter,
+  CompactionEventQuery,
+  CompactionRate,
+  CompactionTriggerReason,
+} from './compaction-metrics.js'
 export type { PrometheusAdapterOptions } from './adapters/prometheus/PrometheusAdapter.js'
 export type { TempoAdapterOptions, TempoBasicAuth } from './adapters/tempo/TempoAdapter.js'
 export type {

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -6,8 +6,9 @@ import {
   DEFAULT_PRICING,
   TraceContext,
   SpanLifecycle,
+  CompactionMetrics,
 } from '@franken/observer';
-import type { Trace, Span } from '@franken/observer';
+import type { CompactionEventAdapter, Trace, Span } from '@franken/observer';
 import { makeTokenSpend, isoNow } from '@franken/types';
 import type { IObserverModule, SpanHandle, TokenSpendData } from '../deps.js';
 import type { ContextWindowUsage, ObserverDeps } from '../skills/cli-skill-executor.js';
@@ -15,7 +16,11 @@ import type { ReplayContentStoreLike, ReplayRecord, ReplayRecordKind } from '../
 
 export interface CliObserverBridgeConfig {
   budgetLimitUsd: number;
+  sessionId?: string | undefined;
   replayStore?: ReplayContentStoreLike | undefined;
+  compactionAdapter?: (CompactionEventAdapter & {
+    close?: (() => void | Promise<void>) | undefined;
+  }) | undefined;
 }
 
 interface ReplayCaptureRecord {
@@ -56,6 +61,8 @@ export class CliObserverBridge implements IObserverModule {
   private readonly breaker: CircuitBreaker;
   private readonly loopDet: LoopDetector;
   private readonly replayStore?: ReplayContentStoreLike | undefined;
+  private readonly compactionMetrics?: CompactionMetrics | undefined;
+  private readonly compactionAdapter?: CliObserverBridgeConfig['compactionAdapter'];
   private readonly replayManifest: ReplayRecord[] = [];
   private trace: Trace | undefined;
   private activeSessionId: string | undefined;
@@ -66,6 +73,11 @@ export class CliObserverBridge implements IObserverModule {
     this.breaker = new CircuitBreaker({ limitUsd: config.budgetLimitUsd });
     this.loopDet = new LoopDetector();
     this.replayStore = config.replayStore;
+    this.activeSessionId = config.sessionId;
+    this.compactionAdapter = config.compactionAdapter;
+    this.compactionMetrics = config.compactionAdapter
+      ? new CompactionMetrics(config.compactionAdapter)
+      : undefined;
   }
 
   startTrace(sessionId: string): void {
@@ -188,6 +200,21 @@ export class CliObserverBridge implements IObserverModule {
 
   getReplayManifest(): readonly ReplayRecord[] {
     return [...this.replayManifest];
+  }
+
+  async recordCompaction(event: Omit<import('@franken/observer').CompactionEvent, 'runId'>): Promise<void> {
+    if (!this.compactionMetrics) return;
+    if (!this.activeSessionId) {
+      throw new Error('No active observer session for compaction telemetry. Call startTrace() first.');
+    }
+    await this.compactionMetrics.record({
+      ...event,
+      runId: this.activeSessionId,
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.compactionAdapter?.close?.();
   }
 
   private requireTrace(): Trace {

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -214,7 +214,11 @@ export class CliObserverBridge implements IObserverModule {
   }
 
   async close(): Promise<void> {
-    await this.compactionAdapter?.close?.();
+    try {
+      await this.compactionAdapter?.close?.();
+    } catch {
+      // Observer shutdown is best-effort and must not fail a completed run.
+    }
   }
 
   private requireTrace(): Trace {

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -209,7 +209,7 @@ export class CliObserverBridge implements IObserverModule {
     }
     await this.compactionMetrics.record({
       ...event,
-      runId: this.activeSessionId,
+      runId: this.trace?.id ?? this.activeSessionId,
     });
   }
 

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -1178,10 +1178,13 @@ function appendAuditFinalize(
 
 function createObserverFinalize(observer: ObserverDepsBundle): () => Promise<void> {
   return async () => {
-    if (observer.traceViewerHandle) {
-      await observer.traceViewerHandle.stop();
+    try {
+      if (observer.traceViewerHandle) {
+        await observer.traceViewerHandle.stop();
+      }
+    } finally {
+      await observer.observerBridge.close();
     }
-    await observer.observerBridge.close();
   };
 }
 

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -1194,6 +1194,10 @@ export async function createCliDeps(options: CliDepOptions): Promise<CliDeps> {
     allowTrustedCommandOverrides: options.trustProviderCommandOverrides,
   };
   assertTrustedProviderCommandOverrides(options.providersConfig, commandOverridePolicy);
+  assertTrustedProviderCommandOverrideEntries(
+    consolidatedProviderCommandOverrides(options.orchestratorConfig?.consolidatedProviders),
+    commandOverridePolicy,
+  );
   const artifacts = createSessionArtifacts(options);
   clearSessionArtifacts(options, artifacts);
 

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -460,6 +460,24 @@ type CleanupWarningLogger = Pick<BeastLogger, 'warn'> | ((message: string, scope
 
 type SessionArtifactRemover = (targetPath: string) => void;
 
+export function createBestEffortCompactionAdapter(
+  databasePath: string,
+  warn: CleanupWarningLogger,
+  createAdapter: (path: string) => SQLiteAdapter = path => new SQLiteAdapter(path),
+): SQLiteAdapter | undefined {
+  try {
+    return createAdapter(databasePath);
+  } catch (error) {
+    const message = `Compaction telemetry disabled: ${errorMessage(error)}`;
+    if (typeof warn === 'function') {
+      warn(message, 'dep-factory');
+    } else {
+      warn.warn(message, 'dep-factory');
+    }
+    return undefined;
+  }
+}
+
 function warnSessionArtifactCleanupFailure(
   artifactPath: string,
   error: unknown,
@@ -530,7 +548,7 @@ async function createObserverDeps(
     budgetLimitUsd: config.budget,
     sessionId: runSessionId,
     replayStore,
-    compactionAdapter: new SQLiteAdapter(options.paths.tracesDb),
+    compactionAdapter: createBestEffortCompactionAdapter(options.paths.tracesDb, logger),
   });
   if (config.enableTracing) {
     observerBridge.startTrace(runSessionId);

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync, readdirSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
 import { basename, resolve, join } from 'node:path';
-import { AuditTrailStore, type ReplayRecord } from '@franken/observer';
+import { AuditTrailStore, SQLiteAdapter, type ReplayRecord } from '@franken/observer';
 import { BeastLogger, setPlainOutput } from '../logging/beast-logger.js';
 import { MartinLoop } from '../skills/martin-loop.js';
 import { GitBranchIsolator } from '../skills/git-branch-isolator.js';
@@ -525,8 +525,13 @@ async function createObserverDeps(
   });
   const replayAuditRoot = resolve(options.paths.root, '.fbeast', 'audit');
   const replayStore = new ReplayContentStore(replayAuditRoot);
-  const observerBridge = new CliObserverBridge({ budgetLimitUsd: config.budget, replayStore });
   const runSessionId = options.runSessionId ?? `cli-session-${process.pid}-${deterministicUuid('packages/franken-orchestrator/src/cli/dep-factory.ts')}`;
+  const observerBridge = new CliObserverBridge({
+    budgetLimitUsd: config.budget,
+    sessionId: runSessionId,
+    replayStore,
+    compactionAdapter: new SQLiteAdapter(options.paths.tracesDb),
+  });
   if (config.enableTracing) {
     observerBridge.startTrace(runSessionId);
   }
@@ -973,6 +978,16 @@ function createCliExecutorDeps(
           });
           return response.trim();
         },
+        measureCompactedTokens: (session) => {
+          const providerName = session.activeProvider ?? session.contextWindow.provider;
+          const rendered = stack.chunkSessionRenderer.render(session, stack.registry.get(providerName));
+          return observer.observerBridge.estimateContextWindow({
+            renderedPrompt: rendered.prompt,
+            provider: providerName,
+            maxTokens: session.contextWindow.maxTokens,
+          }).usedTokens;
+        },
+        onCompaction: event => observer.observerBridge.recordCompaction(event),
       }),
       contextUsage: (prompt: string, provider: string, maxTokens: number) =>
         observer.observerBridge.estimateContextWindow({
@@ -1148,6 +1163,7 @@ function createObserverFinalize(observer: ObserverDepsBundle): () => Promise<voi
     if (observer.traceViewerHandle) {
       await observer.traceViewerHandle.stop();
     }
+    await observer.observerBridge.close();
   };
 }
 

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -978,7 +978,7 @@ function createCliExecutorDeps(
           });
           return response.trim();
         },
-        measureCompactedTokens: (session) => {
+        measureSessionTokens: (session) => {
           const providerName = session.activeProvider ?? session.contextWindow.provider;
           const rendered = stack.chunkSessionRenderer.render(session, stack.registry.get(providerName));
           return observer.observerBridge.estimateContextWindow({

--- a/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
+++ b/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
@@ -19,7 +19,11 @@ export interface ChunkSessionCompactorDeps {
 }
 
 export class ChunkSessionCompactor {
-  constructor(private readonly deps: ChunkSessionCompactorDeps) {}
+  constructor(private readonly deps: ChunkSessionCompactorDeps) {
+    if (deps.onCompaction !== undefined && deps.measureSessionTokens === undefined) {
+      throw new Error('measureSessionTokens is required when onCompaction is configured');
+    }
+  }
 
   buildCompactionPrompt(session: ChunkSession): string {
     const transcript = session.transcript
@@ -72,8 +76,8 @@ export class ChunkSessionCompactor {
       sessionId: compacted.sessionId,
       generation: compacted.compactionGeneration,
       triggerReason,
-      tokensBefore: this.deps.measureSessionTokens?.(previous) ?? previous.contextWindow.usedTokens,
-      tokensAfter: this.deps.measureSessionTokens?.(compacted) ?? compacted.contextWindow.usedTokens,
+      tokensBefore: this.deps.measureSessionTokens!(previous),
+      tokensAfter: this.deps.measureSessionTokens!(compacted),
       timestamp: wallClockNow(),
     });
   }

--- a/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
+++ b/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
@@ -1,5 +1,5 @@
 import { createChunkTranscriptEntry, type ChunkSession, type ChunkTranscriptEntry } from './chunk-session.js';
-import { isoNow } from '@franken/types';
+import { isoNow, wallClockNow } from '@franken/types';
 
 export type ChunkCompactionTriggerReason = 'threshold' | 'manual';
 
@@ -74,8 +74,23 @@ export class ChunkSessionCompactor {
       triggerReason,
       tokensBefore: this.deps.measureSessionTokens?.(previous) ?? previous.contextWindow.usedTokens,
       tokensAfter: this.deps.measureSessionTokens?.(compacted) ?? compacted.contextWindow.usedTokens,
-      timestamp: Date.parse(compacted.updatedAt),
+      timestamp: wallClockNow(),
     });
+  }
+
+  async compactAndRecord(
+    session: ChunkSession,
+    persist: (compacted: ChunkSession) => void | Promise<void>,
+    triggerReason: ChunkCompactionTriggerReason = 'manual',
+  ): Promise<ChunkSession> {
+    const compacted = await this.compact(session);
+    await persist(compacted);
+    try {
+      await this.recordCompaction(session, compacted, triggerReason);
+    } catch {
+      // Operational telemetry must not abort a successfully committed compaction.
+    }
+    return compacted;
   }
 
   private retainCriticalTranscript(entries: readonly ChunkTranscriptEntry[]): ChunkTranscriptEntry[] {

--- a/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
+++ b/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
@@ -1,8 +1,21 @@
 import { createChunkTranscriptEntry, type ChunkSession, type ChunkTranscriptEntry } from './chunk-session.js';
 import { isoNow } from '@franken/types';
 
+export type ChunkCompactionTriggerReason = 'threshold' | 'manual';
+
+export interface ChunkCompactionObservation {
+  readonly sessionId: string;
+  readonly generation: number;
+  readonly triggerReason: ChunkCompactionTriggerReason;
+  readonly tokensBefore: number;
+  readonly tokensAfter: number;
+  readonly timestamp: number;
+}
+
 export interface ChunkSessionCompactorDeps {
   summarize(prompt: string): Promise<string>;
+  measureCompactedTokens?: ((session: ChunkSession) => number) | undefined;
+  onCompaction?: ((event: ChunkCompactionObservation) => Promise<void>) | undefined;
 }
 
 export class ChunkSessionCompactor {
@@ -21,13 +34,16 @@ export class ChunkSessionCompactor {
     ].join('\n\n');
   }
 
-  async compact(session: ChunkSession): Promise<ChunkSession> {
+  async compact(
+    session: ChunkSession,
+    triggerReason: ChunkCompactionTriggerReason = 'manual',
+  ): Promise<ChunkSession> {
     const summary = await this.deps.summarize(this.buildCompactionPrompt(session));
     const now = isoNow();
     const retained = this.retainCriticalTranscript(session.transcript);
     const compactionEntry = createChunkTranscriptEntry('compaction_summary', summary);
 
-    return {
+    const compacted: ChunkSession = {
       ...session,
       compactionGeneration: session.compactionGeneration + 1,
       transcript: [...retained, compactionEntry],
@@ -45,6 +61,19 @@ export class ChunkSessionCompactor {
       },
       updatedAt: now,
     };
+
+    if (this.deps.onCompaction) {
+      await this.deps.onCompaction({
+        sessionId: compacted.sessionId,
+        generation: compacted.compactionGeneration,
+        triggerReason,
+        tokensBefore: session.contextWindow.usedTokens,
+        tokensAfter: this.deps.measureCompactedTokens?.(compacted) ?? compacted.contextWindow.usedTokens,
+        timestamp: Date.parse(now),
+      });
+    }
+
+    return compacted;
   }
 
   private retainCriticalTranscript(entries: readonly ChunkTranscriptEntry[]): ChunkTranscriptEntry[] {

--- a/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
+++ b/packages/franken-orchestrator/src/session/chunk-session-compactor.ts
@@ -14,7 +14,7 @@ export interface ChunkCompactionObservation {
 
 export interface ChunkSessionCompactorDeps {
   summarize(prompt: string): Promise<string>;
-  measureCompactedTokens?: ((session: ChunkSession) => number) | undefined;
+  measureSessionTokens?: ((session: ChunkSession) => number) | undefined;
   onCompaction?: ((event: ChunkCompactionObservation) => Promise<void>) | undefined;
 }
 
@@ -34,10 +34,7 @@ export class ChunkSessionCompactor {
     ].join('\n\n');
   }
 
-  async compact(
-    session: ChunkSession,
-    triggerReason: ChunkCompactionTriggerReason = 'manual',
-  ): Promise<ChunkSession> {
+  async compact(session: ChunkSession): Promise<ChunkSession> {
     const summary = await this.deps.summarize(this.buildCompactionPrompt(session));
     const now = isoNow();
     const retained = this.retainCriticalTranscript(session.transcript);
@@ -62,18 +59,23 @@ export class ChunkSessionCompactor {
       updatedAt: now,
     };
 
-    if (this.deps.onCompaction) {
-      await this.deps.onCompaction({
-        sessionId: compacted.sessionId,
-        generation: compacted.compactionGeneration,
-        triggerReason,
-        tokensBefore: session.contextWindow.usedTokens,
-        tokensAfter: this.deps.measureCompactedTokens?.(compacted) ?? compacted.contextWindow.usedTokens,
-        timestamp: Date.parse(now),
-      });
-    }
-
     return compacted;
+  }
+
+  async recordCompaction(
+    previous: ChunkSession,
+    compacted: ChunkSession,
+    triggerReason: ChunkCompactionTriggerReason = 'manual',
+  ): Promise<void> {
+    if (!this.deps.onCompaction) return;
+    await this.deps.onCompaction({
+      sessionId: compacted.sessionId,
+      generation: compacted.compactionGeneration,
+      triggerReason,
+      tokensBefore: this.deps.measureSessionTokens?.(previous) ?? previous.contextWindow.usedTokens,
+      tokensAfter: this.deps.measureSessionTokens?.(compacted) ?? compacted.contextWindow.usedTokens,
+      timestamp: Date.parse(compacted.updatedAt),
+    });
   }
 
   private retainCriticalTranscript(entries: readonly ChunkTranscriptEntry[]): ChunkTranscriptEntry[] {

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -811,7 +811,7 @@ export class MartinLoop {
       config.snapshotStore.writeSnapshot(nextSession, 'pre-compaction');
       config.sessionStore?.save(nextSession);
       try {
-        nextSession = await config.compactor.compact(nextSession);
+        nextSession = await config.compactor.compact(nextSession, 'threshold');
       } catch (error) {
         if (config.abortSignal?.aborted || isAbortError(error)) {
           restorePreviousSession();

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -769,6 +769,7 @@ export class MartinLoop {
     if (!chunkSession) return undefined;
 
     let nextSession = this.appendIterationOutput(chunkSession, activeProvider, normalizedStdout, iteration);
+    let compactionSourceSession: ChunkSession | undefined;
 
     if (config.contextUsage) {
       const usage = config.contextUsage(renderedPrompt, activeProvider, resolved.defaultContextWindowTokens());
@@ -811,7 +812,8 @@ export class MartinLoop {
       config.snapshotStore.writeSnapshot(nextSession, 'pre-compaction');
       config.sessionStore?.save(nextSession);
       try {
-        nextSession = await config.compactor.compact(nextSession, 'threshold');
+        compactionSourceSession = nextSession;
+        nextSession = await config.compactor.compact(nextSession);
       } catch (error) {
         if (config.abortSignal?.aborted || isAbortError(error)) {
           restorePreviousSession();
@@ -830,6 +832,14 @@ export class MartinLoop {
     }
 
     config.sessionStore?.save(nextSession);
+
+    if (compactionSourceSession && config.compactor) {
+      try {
+        await config.compactor.recordCompaction(compactionSourceSession, nextSession, 'threshold');
+      } catch {
+        // Operational telemetry must not abort a successfully committed compaction.
+      }
+    }
 
     return nextSession;
   }

--- a/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
@@ -17,6 +17,7 @@ import { SqliteBrain } from '@franken/brain';
 import type { ProjectPaths } from '../../../src/cli/project-root.js';
 import type { RunConfig } from '../../../src/cli/run-config-loader.js';
 import { isPlainOutput, setPlainOutput } from '../../../src/logging/beast-logger.js';
+import { CompactionMetrics, SQLiteAdapter } from '@franken/observer';
 
 function createTempPaths(): ProjectPaths {
   const root = join(tmpdir(), `dep-factory-wiring-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -91,6 +92,39 @@ describe('dep-factory wiring integration', () => {
     });
 
     expect(isPlainOutput()).toBe(true);
+    await finalize();
+  });
+
+  it('wires compaction telemetry to the canonical traces database', async () => {
+    const paths = createTempPaths();
+    cleanups.push(paths.root);
+
+    const { observerBridge, finalize } = await createCliDeps({
+      paths,
+      baseBranch: 'main',
+      budget: 1.0,
+      provider: 'claude',
+      noPr: true,
+      verbose: false,
+      reset: false,
+      runSessionId: 'run-wiring',
+    });
+
+    await observerBridge.recordCompaction({
+      sessionId: 'chunk-wiring',
+      generation: 1,
+      triggerReason: 'threshold',
+      tokensBefore: 900,
+      tokensAfter: 120,
+      timestamp: 1_750_000_000_000,
+    });
+
+    const reader = new SQLiteAdapter(paths.tracesDb, { useWorkerThread: false });
+    const metrics = new CompactionMetrics(reader);
+    await expect(metrics.query('chunk-wiring')).resolves.toEqual([
+      expect.objectContaining({ runId: 'run-wiring' }),
+    ]);
+    await reader.close();
     await finalize();
   });
 

--- a/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
+++ b/packages/franken-orchestrator/tests/integration/cli/dep-factory-wiring.test.ts
@@ -18,6 +18,7 @@ import type { ProjectPaths } from '../../../src/cli/project-root.js';
 import type { RunConfig } from '../../../src/cli/run-config-loader.js';
 import { isPlainOutput, setPlainOutput } from '../../../src/logging/beast-logger.js';
 import { CompactionMetrics, SQLiteAdapter } from '@franken/observer';
+import { wallClockNow } from '@franken/types';
 
 function createTempPaths(): ProjectPaths {
   const root = join(tmpdir(), `dep-factory-wiring-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -116,7 +117,7 @@ describe('dep-factory wiring integration', () => {
       triggerReason: 'threshold',
       tokensBefore: 900,
       tokensAfter: 120,
-      timestamp: 1_750_000_000_000,
+      timestamp: wallClockNow(),
     });
 
     const reader = new SQLiteAdapter(paths.tracesDb, { useWorkerThread: false });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
@@ -1,10 +1,11 @@
 import { readFile } from 'node:fs/promises';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   TokenCounter,
   CostCalculator,
   CircuitBreaker,
   LoopDetector,
+  type CompactionEventAdapter,
 } from '@franken/observer';
 import { CliObserverBridge } from '../../../src/adapters/cli-observer-bridge.js';
 import type { IObserverModule } from '../../../src/deps.js';
@@ -278,6 +279,25 @@ describe('CliObserverBridge', () => {
       const source = await readFile(new URL('../../../src/adapters/cli-observer-bridge.ts', import.meta.url), 'utf-8');
       expect(source).not.toContain('as unknown as Trace');
       expect(source).not.toContain('as unknown as Span');
+    });
+  });
+
+  describe('close()', () => {
+    it('keeps observer adapter shutdown failures best-effort', async () => {
+      const close = vi.fn(async () => { throw new Error('SQLite worker close timed out'); });
+      const compactionAdapter: CompactionEventAdapter & { close(): Promise<void> } = {
+        recordCompaction: vi.fn(async () => undefined),
+        queryCompactions: vi.fn(async () => []),
+        aggregateCompactions: vi.fn(async () => ({ count: 0, latestAt: null })),
+        close,
+      };
+      const bridge = new CliObserverBridge({
+        ...defaultConfig,
+        compactionAdapter,
+      });
+
+      await expect(bridge.close()).resolves.toBeUndefined();
+      expect(close).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
@@ -301,6 +301,34 @@ describe('CliObserverBridge', () => {
     });
   });
 
+  describe('recordCompaction()', () => {
+    it('correlates compaction telemetry with the persisted trace id', async () => {
+      const recordCompaction = vi.fn(async () => undefined);
+      const compactionAdapter: CompactionEventAdapter = {
+        recordCompaction,
+        queryCompactions: vi.fn(async () => []),
+        aggregateCompactions: vi.fn(async () => ({ count: 0, latestAt: null })),
+      };
+      const bridge = new CliObserverBridge({ ...defaultConfig, compactionAdapter });
+      bridge.startTrace('chunk-session-1');
+      const traceId = bridge.observerDeps.trace.id;
+
+      await bridge.recordCompaction({
+        sessionId: 'chunk-session-1',
+        generation: 1,
+        triggerReason: 'threshold',
+        tokensBefore: 900,
+        tokensAfter: 120,
+        timestamp: 1_750_000_000_000,
+      });
+
+      expect(recordCompaction).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'chunk-session-1',
+        runId: traceId,
+      }));
+    });
+  });
+
   // ── Integration (chunk 05) ──
 
   describe('integration', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -291,6 +291,23 @@ describe('dep-factory provider wiring', () => {
     }
   });
 
+  it('keeps compaction telemetry initialization failures best-effort', async () => {
+    const { createBestEffortCompactionAdapter } = await import('../../../src/cli/dep-factory.js');
+    const warn = vi.fn();
+
+    const adapter = createBestEffortCompactionAdapter(
+      '/readonly/traces.db',
+      warn,
+      () => { throw new Error('database is locked'); },
+    );
+
+    expect(adapter).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Compaction telemetry disabled: database is locked'),
+      'dep-factory',
+    );
+  });
+
   it('throws descriptive error for unknown provider name', async () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({ provider: 'unknown-provider' });

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -68,6 +68,7 @@ vi.mock('../../../src/adapters/cli-observer-bridge.js', () => ({
     this.getActiveSessionId = vi.fn(() => undefined);
     this.recordReplay = vi.fn();
     this.getReplayManifest = vi.fn(() => [...mockBridgeReplayManifest]);
+    this.close = vi.fn(async () => {});
     this.observerDeps = observerDepsMocks.enabled;
     this.disabledObserverDeps = observerDepsMocks.disabled;
   }),

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -754,6 +754,21 @@ describe('dep-factory provider wiring', () => {
     await expect(createCliDeps(opts)).rejects.toThrow(/allowed provider binary/);
   });
 
+  it('rejects unsafe consolidated provider commands before opening observer storage', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    const opts = makeOpts({
+      orchestratorConfig: {
+        consolidatedProviders: [
+          { name: 'unsafe-claude', type: 'claude-cli', cliPath: '/tmp/malicious-claude' },
+        ],
+      } as never,
+    });
+
+    await expect(createCliDeps(opts)).rejects.toThrow(/trustCommandOverride: true/);
+    expect(observerDepsMocks.enabled).toBeDefined();
+    expect((await import('../../../src/adapters/cli-observer-bridge.js')).CliObserverBridge).not.toHaveBeenCalled();
+  });
+
   it('applies trusted command override from providersConfig', async () => {
     const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
     const opts = makeOpts({

--- a/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/dep-factory-providers.test.ts
@@ -38,6 +38,7 @@ const traceViewerMocks = vi.hoisted(() => ({
 const observerDepsMocks = vi.hoisted(() => ({
   enabled: { kind: 'enabled-observer-deps' },
   disabled: { kind: 'disabled-observer-deps' },
+  close: vi.fn(async () => {}),
 }));
 
 vi.mock('../../../src/logging/beast-logger.js', () => ({
@@ -68,7 +69,7 @@ vi.mock('../../../src/adapters/cli-observer-bridge.js', () => ({
     this.getActiveSessionId = vi.fn(() => undefined);
     this.recordReplay = vi.fn();
     this.getReplayManifest = vi.fn(() => [...mockBridgeReplayManifest]);
-    this.close = vi.fn(async () => {});
+    this.close = observerDepsMocks.close;
     this.observerDeps = observerDepsMocks.enabled;
     this.disabledObserverDeps = observerDepsMocks.disabled;
   }),
@@ -262,6 +263,7 @@ describe('dep-factory provider wiring', () => {
     optionalModuleMocks.critiqueError = undefined;
     optionalModuleMocks.governorError = undefined;
     traceViewerMocks.stop.mockClear();
+    observerDepsMocks.close.mockClear();
     mockBridgeReplayManifest.length = 0;
   });
 
@@ -306,6 +308,16 @@ describe('dep-factory provider wiring', () => {
       expect.stringContaining('Compaction telemetry disabled: database is locked'),
       'dep-factory',
     );
+  });
+
+  it('closes compaction telemetry when trace viewer shutdown fails', async () => {
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+    traceViewerMocks.stop.mockRejectedValueOnce(new Error('trace viewer stop failed'));
+    const result = await createCliDeps(makeOpts({ verbose: true }));
+
+    await expect(result.finalize()).rejects.toThrow('trace viewer stop failed');
+
+    expect(observerDepsMocks.close).toHaveBeenCalledOnce();
   });
 
   it('throws descriptive error for unknown provider name', async () => {

--- a/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ChunkSessionCompactor } from '../../../src/session/chunk-session-compactor.js';
 import { createChunkSession } from '../../../src/session/chunk-session.js';
 
@@ -28,5 +28,37 @@ describe('ChunkSessionCompactor', () => {
 
     expect(compacted.compactionGeneration).toBe(1);
     expect(compacted.transcript.some((entry) => entry.kind === 'compaction_summary')).toBe(true);
+  });
+
+  it('records matching before and after token measurements after compaction is committed', async () => {
+    const onCompaction = vi.fn(async () => undefined);
+    const measureSessionTokens = vi.fn((session: ReturnType<typeof createChunkSession>) => (
+      session.compactionGeneration === 0 ? 950 : 125
+    ));
+    const compactor = new ChunkSessionCompactor({
+      summarize: async () => 'Compacted summary',
+      measureSessionTokens,
+      onCompaction,
+    });
+    const session = createChunkSession({
+      planName: 'telemetry-plan',
+      taskId: 'impl:telemetry',
+      chunkId: 'telemetry',
+      promiseTag: 'IMPL_TELEMETRY_DONE',
+      workingDir: '/tmp/telemetry',
+      provider: 'claude',
+      maxTokens: 200000,
+    });
+
+    const compacted = await compactor.compact(session);
+    await compactor.recordCompaction(session, compacted, 'threshold');
+
+    expect(measureSessionTokens).toHaveBeenNthCalledWith(1, session);
+    expect(measureSessionTokens).toHaveBeenNthCalledWith(2, compacted);
+    expect(onCompaction).toHaveBeenCalledWith(expect.objectContaining({
+      tokensBefore: 950,
+      tokensAfter: 125,
+      triggerReason: 'threshold',
+    }));
   });
 });

--- a/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
@@ -3,6 +3,13 @@ import { ChunkSessionCompactor } from '../../../src/session/chunk-session-compac
 import { createChunkSession } from '../../../src/session/chunk-session.js';
 
 describe('ChunkSessionCompactor', () => {
+  it('requires token measurement whenever compaction telemetry is enabled', () => {
+    expect(() => new ChunkSessionCompactor({
+      summarize: async () => 'Compacted summary',
+      onCompaction: async () => undefined,
+    })).toThrow('measureSessionTokens is required when onCompaction is configured');
+  });
+
   it('replaces old transcript entries with a compaction summary and increments generation', async () => {
     const compactor = new ChunkSessionCompactor({
       summarize: async () => 'Summary: files touched and remaining objective.',
@@ -67,6 +74,7 @@ describe('ChunkSessionCompactor', () => {
     const compactor = new ChunkSessionCompactor({
       summarize: async () => 'Compacted summary',
       onCompaction,
+      measureSessionTokens: () => 0,
     });
     const session = createChunkSession({
       planName: 'clock-plan',
@@ -101,6 +109,7 @@ describe('ChunkSessionCompactor', () => {
     const compactor = new ChunkSessionCompactor({
       summarize: async () => 'Compacted summary',
       onCompaction,
+      measureSessionTokens: () => 0,
     });
     const session = createChunkSession({
       planName: 'manual-plan',

--- a/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/session/chunk-session-compactor.test.ts
@@ -61,4 +61,65 @@ describe('ChunkSessionCompactor', () => {
       triggerReason: 'threshold',
     }));
   });
+
+  it('timestamps observations with the wall clock used by rate windows', async () => {
+    const onCompaction = vi.fn(async () => undefined);
+    const compactor = new ChunkSessionCompactor({
+      summarize: async () => 'Compacted summary',
+      onCompaction,
+    });
+    const session = createChunkSession({
+      planName: 'clock-plan',
+      taskId: 'impl:clock',
+      chunkId: 'clock',
+      promiseTag: 'IMPL_CLOCK_DONE',
+      workingDir: '/tmp/clock',
+      provider: 'claude',
+      maxTokens: 200000,
+    });
+    const compacted = {
+      ...await compactor.compact(session),
+      updatedAt: '2000-01-01T00:00:00.000Z',
+    };
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+
+    try {
+      await compactor.recordCompaction(session, compacted, 'threshold');
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(onCompaction).toHaveBeenCalledWith(expect.objectContaining({
+      timestamp: Date.parse('2030-01-01T00:00:00.000Z'),
+    }));
+  });
+
+  it('commits manual compaction before recording its trigger reason', async () => {
+    const order: string[] = [];
+    const onCompaction = vi.fn(async () => { order.push('observe'); });
+    const compactor = new ChunkSessionCompactor({
+      summarize: async () => 'Compacted summary',
+      onCompaction,
+    });
+    const session = createChunkSession({
+      planName: 'manual-plan',
+      taskId: 'impl:manual',
+      chunkId: 'manual',
+      promiseTag: 'IMPL_MANUAL_DONE',
+      workingDir: '/tmp/manual',
+      provider: 'claude',
+      maxTokens: 200000,
+    });
+
+    const compacted = await compactor.compactAndRecord(session, async () => {
+      order.push('persist');
+    });
+
+    expect(compacted.compactionGeneration).toBe(1);
+    expect(order).toEqual(['persist', 'observe']);
+    expect(onCompaction).toHaveBeenCalledWith(expect.objectContaining({
+      triggerReason: 'manual',
+    }));
+  });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -887,7 +887,7 @@ describe('MartinLoop', () => {
       renderer: new ChunkSessionRenderer(),
       compactor: new ChunkSessionCompactor({
         summarize: async () => 'Compacted summary',
-        measureCompactedTokens: () => 120,
+        measureSessionTokens: session => session.compactionGeneration === 0 ? 900 : 120,
         onCompaction: event => bridge.recordCompaction(event),
       }),
       contextUsage: () => ({
@@ -914,6 +914,82 @@ describe('MartinLoop', () => {
     ]);
 
     await bridge.close();
+  });
+
+  it('keeps a committed compaction when telemetry persistence fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'martin-compact-observer-failure-'));
+    tmpDirs.push(root);
+    const sessionStore = new FileChunkSessionStore(join(root, 'sessions'));
+    const snapshotStore = new FileChunkSessionSnapshotStore(join(root, 'snapshots'));
+
+    queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    await expect(loop.run(baseConfig({
+      planName: 'telemetry-failure-plan',
+      taskId: 'impl:telemetry-failure',
+      chunkId: 'telemetry-failure',
+      sessionStore,
+      snapshotStore,
+      renderer: new ChunkSessionRenderer(),
+      compactor: new ChunkSessionCompactor({
+        summarize: async () => 'Compacted summary',
+        onCompaction: async () => { throw new Error('traces database is locked'); },
+      }),
+      contextUsage: () => ({
+        usedTokens: 900,
+        maxTokens: 1000,
+        usageRatio: 0.9,
+        threshold: 0.85,
+        shouldCompact: true,
+      }),
+      maxIterations: 1,
+    }))).resolves.toMatchObject({ completed: true });
+
+    expect(sessionStore.load(
+      'telemetry-failure-plan',
+      'telemetry-failure',
+      'impl:telemetry-failure',
+    )?.compactionGeneration).toBe(1);
+  });
+
+  it('does not record telemetry when cancellation rolls back a compaction', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'martin-compact-observer-abort-'));
+    tmpDirs.push(root);
+    const sessionStore = new FileChunkSessionStore(join(root, 'sessions'));
+    const snapshotStore = new FileChunkSessionSnapshotStore(join(root, 'snapshots'));
+    const abortController = new AbortController();
+    const onCompaction = vi.fn(async () => undefined);
+
+    queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    await expect(loop.run(baseConfig({
+      planName: 'telemetry-abort-plan',
+      taskId: 'impl:telemetry-abort',
+      chunkId: 'telemetry-abort',
+      sessionStore,
+      snapshotStore,
+      renderer: new ChunkSessionRenderer(),
+      compactor: new ChunkSessionCompactor({
+        summarize: async () => {
+          abortController.abort('cancelled after compaction summary');
+          return 'Compacted summary';
+        },
+        onCompaction,
+      }),
+      contextUsage: () => ({
+        usedTokens: 900,
+        maxTokens: 1000,
+        usageRatio: 0.9,
+        threshold: 0.85,
+        shouldCompact: true,
+      }),
+      abortSignal: abortController.signal,
+      maxIterations: 1,
+    }))).rejects.toThrow('cancelled after compaction summary');
+
+    expect(onCompaction).not.toHaveBeenCalled();
   });
 
   it('falls back to replay when provider changes after a failure', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -934,6 +934,7 @@ describe('MartinLoop', () => {
       renderer: new ChunkSessionRenderer(),
       compactor: new ChunkSessionCompactor({
         summarize: async () => 'Compacted summary',
+        measureSessionTokens: () => 0,
         onCompaction: async () => { throw new Error('traces database is locked'); },
       }),
       contextUsage: () => ({
@@ -976,6 +977,7 @@ describe('MartinLoop', () => {
           abortController.abort('cancelled after compaction summary');
           return 'Compacted summary';
         },
+        measureSessionTokens: () => 0,
         onCompaction,
       }),
       contextUsage: () => ({

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -874,6 +874,7 @@ describe('MartinLoop', () => {
     const metrics = new CompactionMetrics(adapter);
     const bridge = new CliObserverBridge({ budgetLimitUsd: 1, compactionAdapter: adapter });
     bridge.startTrace('run-threshold');
+    const traceId = bridge.observerDeps.trace.id;
 
     queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
 
@@ -905,7 +906,7 @@ describe('MartinLoop', () => {
     await expect(metrics.query(stored!.sessionId)).resolves.toEqual([
       expect.objectContaining({
         sessionId: stored!.sessionId,
-        runId: 'run-threshold',
+        runId: traceId,
         generation: 1,
         triggerReason: 'threshold',
         tokensBefore: 900,

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -12,6 +12,8 @@ import { FileChunkSessionSnapshotStore } from '../../../src/session/chunk-sessio
 import { ChunkSessionRenderer } from '../../../src/session/chunk-session-renderer.js';
 import { ChunkSessionCompactor } from '../../../src/session/chunk-session-compactor.js';
 import { createChunkSession, createChunkTranscriptEntry } from '../../../src/session/chunk-session.js';
+import { CliObserverBridge } from '../../../src/adapters/cli-observer-bridge.js';
+import { CompactionMetrics, SQLiteAdapter } from '@franken/observer';
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
@@ -861,6 +863,57 @@ describe('MartinLoop', () => {
     expect(snapshotStore.list('demo-plan', '01_demo')).toHaveLength(1);
     const stored = sessionStore.load('demo-plan', '01_demo');
     expect(stored?.transcript.some((entry) => entry.kind === 'compaction_summary')).toBe(true);
+  });
+
+  it('persists threshold compaction telemetry through the observer bridge', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'martin-compact-observer-'));
+    tmpDirs.push(root);
+    const sessionStore = new FileChunkSessionStore(join(root, 'sessions'));
+    const snapshotStore = new FileChunkSessionSnapshotStore(join(root, 'snapshots'));
+    const adapter = new SQLiteAdapter(join(root, 'traces.db'), { useWorkerThread: false });
+    const metrics = new CompactionMetrics(adapter);
+    const bridge = new CliObserverBridge({ budgetLimitUsd: 1, compactionAdapter: adapter });
+    bridge.startTrace('run-threshold');
+
+    queueMock({ stdout: 'done\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    await loop.run(baseConfig({
+      planName: 'telemetry-plan',
+      taskId: 'impl:telemetry',
+      chunkId: 'telemetry',
+      sessionStore,
+      snapshotStore,
+      renderer: new ChunkSessionRenderer(),
+      compactor: new ChunkSessionCompactor({
+        summarize: async () => 'Compacted summary',
+        measureCompactedTokens: () => 120,
+        onCompaction: event => bridge.recordCompaction(event),
+      }),
+      contextUsage: () => ({
+        usedTokens: 900,
+        maxTokens: 1000,
+        usageRatio: 0.9,
+        threshold: 0.85,
+        shouldCompact: true,
+      }),
+      maxIterations: 1,
+    }));
+
+    const stored = sessionStore.load('telemetry-plan', 'telemetry', 'impl:telemetry');
+    expect(stored).toBeDefined();
+    await expect(metrics.query(stored!.sessionId)).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: stored!.sessionId,
+        runId: 'run-threshold',
+        generation: 1,
+        triggerReason: 'threshold',
+        tokensBefore: 900,
+        tokensAfter: 120,
+      }),
+    ]);
+
+    await bridge.close();
   });
 
   it('falls back to replay when provider changes after a failure', async () => {

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -8,7 +8,7 @@
 - [x] Document the compaction observer flow in `docs/ARCHITECTURE.md`.
 - [x] Run repository tests, lint, typecheck, and build.
 - [x] Audit the final diff against `origin/main`.
-- [ ] Commit, push, and open a PR linked to #3728.
+- [x] Commit, push, and open PR #3780 linked to #3728.
 - [ ] Run the GitHub Codex review loop until the current head is clean.
 - [ ] Hand off for human review without merging.
 

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -32,11 +32,7 @@
 - Round 4 focused verification: observer 25/25 passed; dependency-factory provider wiring 52/52 passed.
 - Round 4 package verification: observer 905/905 passed; orchestrator 4,507/4,507 passed.
 - Round 4 root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only).
-- Codex round 5 findings addressed with RED→GREEN coverage: compaction rows correlate to the persisted trace id, wall-clock retention is enforced on idle reads, rate windows cannot exceed retained history, and observer storage closes even when trace-viewer shutdown fails.
-- Round 5 focused RED evidence: the four regression tests failed for the expected stale run id, missing bridge close, idle retained row, and overlong-window resolution; the same four tests then passed after restoring the fixes.
-- Round 5 package verification: observer and orchestrator tests passed (observer cache replay plus focused observer execution; orchestrator 4,509/4,509 passed).
-- Round 5 scoped lint, typecheck, and build passed for observer and orchestrator (pre-existing lint warnings only).
 - Codex round 5 RED→GREEN remediation: compaction events use the persisted trace ID; wall-clock retention runs on writes, queries, and aggregates; rate windows are capped to the 24-hour retained history; and observer shutdown runs even when trace-viewer shutdown rejects.
-- Round 5 focused RED evidence: the new trace-correlation and shutdown-finalizer tests failed against the pre-remediation paths, then passed 75/75 after restoring the production fixes; observer compaction coverage passed 7/7.
+- Round 5 focused RED evidence: four regression tests failed for the expected stale run id, missing bridge close, idle retained row, and overlong-window resolution; the same four tests passed after restoring the production fixes, and complete observer compaction coverage passed 7/7.
 - Round 5 package verification: observer package passed; orchestrator passed 4,509/4,509 after aligning the Martin-loop integration expectation with persisted trace identity.
 - Round 5 root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only); `git diff --check` passed and the scope audit found no Hive Brain files.

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -24,3 +24,7 @@
 - Scope audit: branch is based directly on `origin/main`; no TokenCounter, CostCalculator, provider, Hive Brain, Brain Vitals API/UI, or #3727 cache-accounting changes are present.
 - Codex round 1 findings addressed with RED→GREEN coverage: telemetry is emitted only after canonical-session persistence, SQLite failures are best-effort, and before/after token estimates measure the same appended transcript boundary.
 - Codex round 2 findings addressed with RED→GREEN coverage: adapter shutdown is best-effort, event timestamps use the same wall clock as rate windows, and `compactAndRecord()` provides an explicit persisted manual-compaction path.
+- Codex round 3 findings addressed with RED→GREEN coverage: rate windows have an upper bound, trace deletion removes run compaction rows, telemetry requires post-compaction token measurement, and SQLite telemetry initialization is best-effort.
+- Final focused observer verification: 22/22 passed; focused orchestrator verification: 56/56 passed.
+- Final package verification: observer 902/902 passed; orchestrator 4,506/4,506 passed after adding required token-measurement fixtures to two existing Martin-loop telemetry tests.
+- Final root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only).

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -22,3 +22,4 @@
 - `npm run build`: passed.
 - `git diff --check`: passed.
 - Scope audit: branch is based directly on `origin/main`; no TokenCounter, CostCalculator, provider, Hive Brain, Brain Vitals API/UI, or #3727 cache-accounting changes are present.
+- Codex round 1 findings addressed with RED→GREEN coverage: telemetry is emitted only after canonical-session persistence, SQLite failures are best-effort, and before/after token estimates measure the same appended transcript boundary.

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -23,3 +23,4 @@
 - `git diff --check`: passed.
 - Scope audit: branch is based directly on `origin/main`; no TokenCounter, CostCalculator, provider, Hive Brain, Brain Vitals API/UI, or #3727 cache-accounting changes are present.
 - Codex round 1 findings addressed with RED→GREEN coverage: telemetry is emitted only after canonical-session persistence, SQLite failures are best-effort, and before/after token estimates measure the same appended transcript boundary.
+- Codex round 2 findings addressed with RED→GREEN coverage: adapter shutdown is best-effort, event timestamps use the same wall clock as rate windows, and `compactAndRecord()` provides an explicit persisted manual-compaction path.

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -32,3 +32,11 @@
 - Round 4 focused verification: observer 25/25 passed; dependency-factory provider wiring 52/52 passed.
 - Round 4 package verification: observer 905/905 passed; orchestrator 4,507/4,507 passed.
 - Round 4 root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only).
+- Codex round 5 findings addressed with RED→GREEN coverage: compaction rows correlate to the persisted trace id, wall-clock retention is enforced on idle reads, rate windows cannot exceed retained history, and observer storage closes even when trace-viewer shutdown fails.
+- Round 5 focused RED evidence: the four regression tests failed for the expected stale run id, missing bridge close, idle retained row, and overlong-window resolution; the same four tests then passed after restoring the fixes.
+- Round 5 package verification: observer and orchestrator tests passed (observer cache replay plus focused observer execution; orchestrator 4,509/4,509 passed).
+- Round 5 scoped lint, typecheck, and build passed for observer and orchestrator (pre-existing lint warnings only).
+- Codex round 5 RED→GREEN remediation: compaction events use the persisted trace ID; wall-clock retention runs on writes, queries, and aggregates; rate windows are capped to the 24-hour retained history; and observer shutdown runs even when trace-viewer shutdown rejects.
+- Round 5 focused RED evidence: the new trace-correlation and shutdown-finalizer tests failed against the pre-remediation paths, then passed 75/75 after restoring the production fixes; observer compaction coverage passed 7/7.
+- Round 5 package verification: observer package passed; orchestrator passed 4,509/4,509 after aligning the Martin-loop integration expectation with persisted trace identity.
+- Round 5 root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only); `git diff --check` passed and the scope audit found no Hive Brain files.

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -1,0 +1,24 @@
+# Issue #3728 — Compaction observer metric progress
+
+- [x] Confirm issue scope and start from a clean `origin/main` worktree.
+- [x] Add RED→GREEN SQLite persistence coverage for compaction events.
+- [x] Add RED→GREEN windowed `compactionRate()` aggregation coverage.
+- [x] Add RED→GREEN Martin-loop threshold compaction telemetry coverage.
+- [x] Add RED→GREEN production dependency wiring coverage for the canonical traces database.
+- [x] Document the compaction observer flow in `docs/ARCHITECTURE.md`.
+- [x] Run repository tests, lint, typecheck, and build.
+- [x] Audit the final diff against `origin/main`.
+- [ ] Commit, push, and open a PR linked to #3728.
+- [ ] Run the GitHub Codex review loop until the current head is clean.
+- [ ] Hand off for human review without merging.
+
+## Verification evidence
+
+- `npx vitest run src/compaction-metrics.test.ts src/adapters/sqlite/SQLiteAdapter.test.ts`: 21/21 passed.
+- Focused orchestrator run: 116/117 passed across Martin loop, dependency wiring, and bridge finalization; the sole unrelated CritiquePortAdapter assertion also passes in the full scoped run. A final five-test compaction/finalizer selection passed 5/5.
+- `npx turbo run test --filter=@franken/orchestrator --filter=@franken/observer`: observer passed; orchestrator reached 4,496/4,498 passing with two unrelated 5-second timeout failures. The cleanup timeout passes alone; the process-redaction timeout remains slow and is outside this diff.
+- `npm run lint`: passed (pre-existing warnings only).
+- `npm run typecheck`: passed.
+- `npm run build`: passed.
+- `git diff --check`: passed.
+- Scope audit: branch is based directly on `origin/main`; no TokenCounter, CostCalculator, provider, Hive Brain, Brain Vitals API/UI, or #3727 cache-accounting changes are present.

--- a/tasks/issue-3728-compaction-observer-progress.md
+++ b/tasks/issue-3728-compaction-observer-progress.md
@@ -28,3 +28,7 @@
 - Final focused observer verification: 22/22 passed; focused orchestrator verification: 56/56 passed.
 - Final package verification: observer 902/902 passed; orchestrator 4,506/4,506 passed after adding required token-measurement fixtures to two existing Martin-loop telemetry tests.
 - Final root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only).
+- Codex round 4 findings addressed: compaction rows are pruned outside a 24-hour window, run identity participates in the SQLite primary key with a legacy-schema migration, and consolidated provider overrides are validated before observer storage opens.
+- Round 4 focused verification: observer 25/25 passed; dependency-factory provider wiring 52/52 passed.
+- Round 4 package verification: observer 905/905 passed; orchestrator 4,507/4,507 passed.
+- Round 4 root `npm run lint`, `npm run typecheck`, and `npm run build`: passed (pre-existing lint warnings only).


### PR DESCRIPTION
## Summary
- emit threshold/manual context-compaction observations from `ChunkSessionCompactor`
- persist bounded compaction records in the canonical observer SQLite database
- expose query and windowed `compactionRate()` helpers for later Brain Vitals aggregation
- preserve the existing in-memory CLI compaction counter and document the export flow

## Test plan
- `npx vitest run src/compaction-metrics.test.ts src/adapters/sqlite/SQLiteAdapter.test.ts` (21 passed)
- focused orchestrator Martin-loop, dependency-wiring, and finalizer coverage (compaction selections pass)
- `npm run lint` (passes; pre-existing warnings only)
- `npm run typecheck` (passes)
- `npm run build` (passes)
- `git diff --check` (passes)

## Known unrelated test noise
The scoped observer/orchestrator suite reached 4,496/4,498 orchestrator tests passing; two unrelated tests exceeded the existing 5-second timeout under full-suite load. The cleanup test passes in isolation. The process-redaction test remains over 5 seconds and is outside this diff.

Closes #3728
