### PR TITLE
feat(observer): add cache-aware token accounting

### DIFF
--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -1154,8 +1154,8 @@ describe('GovernorAdapter', () => {
     db.close();
 
     await expect(governor.budgetStatus()).resolves.toEqual({
-      totalSpendUsd: 20,
-      byModel: [{ model: 'gpt-4o', costUsd: 20 }],
+      totalSpendUsd: 12.5,
+      byModel: [{ model: 'gpt-4o', costUsd: 12.5 }],
     });
   });
 
@@ -1175,9 +1175,9 @@ describe('GovernorAdapter', () => {
     db.close();
 
     await expect(governor.budgetStatus()).resolves.toEqual({
-      totalSpendUsd: 24.75,
+      totalSpendUsd: 17.25,
       byModel: [
-        { model: 'gpt-4o', costUsd: 23.5 },
+        { model: 'gpt-4o', costUsd: 16 },
         { model: 'new-model-not-in-pricing', costUsd: 1.25, unknownModel: true },
       ],
     });

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -1148,14 +1148,17 @@ describe('GovernorAdapter', () => {
 
     const db = new Database(dbPath);
     db.prepare(`
-      INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd)
-      VALUES (?, ?, ?, ?, ?)
-    `).run('sess-known', 'gpt-4o', 1_000_000, 1_000_000, 0);
+      INSERT INTO cost_ledger (
+        session_id, model, prompt_tokens, completion_tokens,
+        cache_read_tokens, cache_creation_tokens, cost_usd
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('sess-known', 'gpt-4o', 1_000_000, 1_000_000, 1_000_000, 1_000_000, 0);
     db.close();
 
     await expect(governor.budgetStatus()).resolves.toEqual({
-      totalSpendUsd: 12.5,
-      byModel: [{ model: 'gpt-4o', costUsd: 12.5 }],
+      totalSpendUsd: 16.25,
+      byModel: [{ model: 'gpt-4o', costUsd: 16.25 }],
     });
   });
 

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.test.ts
@@ -1162,6 +1162,26 @@ describe('GovernorAdapter', () => {
     });
   });
 
+  it('reprices one-hour cache creation in zero-cost ledger rows', async () => {
+    const dbPath = tracked(tmpDbPath());
+    const governor = createGovernorAdapter(dbPath);
+
+    const db = new Database(dbPath);
+    db.prepare(`
+      INSERT INTO cost_ledger (
+        session_id, model, prompt_tokens, completion_tokens,
+        cache_creation_tokens, cache_creation_1h_tokens, cost_usd
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('sess-one-hour', 'claude-sonnet-4-6', 0, 0, 1_000_000, 400_000, 0);
+    db.close();
+
+    await expect(governor.budgetStatus()).resolves.toEqual({
+      totalSpendUsd: 4.65,
+      byModel: [{ model: 'claude-sonnet-4-6', costUsd: 4.65 }],
+    });
+  });
+
   it('reprices zero-cost rows before grouping budget status by model', async () => {
     const dbPath = tracked(tmpDbPath());
     const governor = createGovernorAdapter(dbPath);

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -1129,7 +1129,8 @@ export function createGovernorAdapter(dbPath: string, configPath?: string): Gove
     async budgetStatus() {
       const rows = store.db.prepare(`
         SELECT model, prompt_tokens, completion_tokens,
-               cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
+               cache_read_tokens, cache_creation_tokens, cache_creation_1h_tokens,
+               cost_usd, cost_source
         FROM cost_ledger
       `).all() as Array<{
         model: string;
@@ -1137,6 +1138,7 @@ export function createGovernorAdapter(dbPath: string, configPath?: string): Gove
         completion_tokens: number;
         cache_read_tokens: number;
         cache_creation_tokens: number;
+        cache_creation_1h_tokens: number;
         cost_usd: number;
         cost_source: string;
       }>;
@@ -1152,6 +1154,7 @@ export function createGovernorAdapter(dbPath: string, configPath?: string): Gove
               completionTokens: row.completion_tokens,
               cacheReadTokens: row.cache_read_tokens,
               cacheCreationTokens: row.cache_creation_tokens,
+              cacheCreation1hTokens: row.cache_creation_1h_tokens,
             })
           : row.cost_usd;
         const current = grouped.get(row.model) ?? { model: row.model, costUsd: 0 };

--- a/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/governor-adapter.ts
@@ -1128,9 +1128,18 @@ export function createGovernorAdapter(dbPath: string, configPath?: string): Gove
 
     async budgetStatus() {
       const rows = store.db.prepare(`
-        SELECT model, prompt_tokens, completion_tokens, cost_usd, cost_source
+        SELECT model, prompt_tokens, completion_tokens,
+               cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
         FROM cost_ledger
-      `).all() as Array<{ model: string; prompt_tokens: number; completion_tokens: number; cost_usd: number; cost_source: string }>;
+      `).all() as Array<{
+        model: string;
+        prompt_tokens: number;
+        completion_tokens: number;
+        cache_read_tokens: number;
+        cache_creation_tokens: number;
+        cost_usd: number;
+        cost_source: string;
+      }>;
 
       const grouped = new Map<string, { model: string; costUsd: number; unknownModel?: boolean }>();
 
@@ -1141,6 +1150,8 @@ export function createGovernorAdapter(dbPath: string, configPath?: string): Gove
               model: row.model,
               promptTokens: row.prompt_tokens,
               completionTokens: row.completion_tokens,
+              cacheReadTokens: row.cache_read_tokens,
+              cacheCreationTokens: row.cache_creation_tokens,
             })
           : row.cost_usd;
         const current = grouped.get(row.model) ?? { model: row.model, costUsd: 0 };

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -746,6 +746,28 @@ describe('ObserverAdapter', () => {
     });
   });
 
+  it('rejects cache-token overflow while aggregating persisted rows', async () => {
+    const observer = createObserverAdapter(tracked(tmpDbPath()));
+
+    await observer.logCost({
+      sessionId: 'sess-cache-overflow',
+      model: 'claude-sonnet-4-6',
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: Number.MAX_SAFE_INTEGER,
+    });
+    await observer.logCost({
+      sessionId: 'sess-cache-overflow',
+      model: 'claude-sonnet-4-6',
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: 1,
+    });
+
+    await expect(observer.cost({ sessionId: 'sess-cache-overflow' }))
+      .rejects.toThrow(/cacheReadTokens.*Number\.MAX_SAFE_INTEGER/);
+  });
+
   it('preserves explicitly logged zero-cost rows in cost summaries', async () => {
     const dbPath = tracked(tmpDbPath());
     const observer = createObserverAdapter(dbPath);

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -722,23 +722,26 @@ describe('ObserverAdapter', () => {
       completionTokens: 1_000_000,
       cacheReadTokens: 1_000_000,
       cacheCreationTokens: 1_000_000,
+      cacheCreation1hTokens: 400_000,
     });
     const summary = await observer.cost({ sessionId: 'sess-cache' });
 
-    expect(logged).toEqual({ costUsd: 22.05, unknownModel: false });
+    expect(logged).toEqual({ costUsd: 22.95, unknownModel: false });
     expect(summary).toEqual({
       totalPromptTokens: 1_000_000,
       totalCompletionTokens: 1_000_000,
       totalCacheReadTokens: 1_000_000,
       totalCacheCreationTokens: 1_000_000,
-      totalCostUsd: 22.05,
+      totalCacheCreation1hTokens: 400_000,
+      totalCostUsd: 22.95,
       byModel: [{
         model: 'claude-sonnet-4-6',
         promptTokens: 1_000_000,
         completionTokens: 1_000_000,
         cacheReadTokens: 1_000_000,
         cacheCreationTokens: 1_000_000,
-        costUsd: 22.05,
+        cacheCreation1hTokens: 400_000,
+        costUsd: 22.95,
       }],
     });
   });

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.test.ts
@@ -712,6 +712,37 @@ describe('ObserverAdapter', () => {
     writeSpy.mockRestore();
   });
 
+  it('persists cache tiers and includes them in computed cost summaries', async () => {
+    const observer = createObserverAdapter(tracked(tmpDbPath()));
+
+    const logged = await observer.logCost({
+      sessionId: 'sess-cache',
+      model: 'claude-sonnet-4-6',
+      promptTokens: 1_000_000,
+      completionTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheCreationTokens: 1_000_000,
+    });
+    const summary = await observer.cost({ sessionId: 'sess-cache' });
+
+    expect(logged).toEqual({ costUsd: 22.05, unknownModel: false });
+    expect(summary).toEqual({
+      totalPromptTokens: 1_000_000,
+      totalCompletionTokens: 1_000_000,
+      totalCacheReadTokens: 1_000_000,
+      totalCacheCreationTokens: 1_000_000,
+      totalCostUsd: 22.05,
+      byModel: [{
+        model: 'claude-sonnet-4-6',
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+        costUsd: 22.05,
+      }],
+    });
+  });
+
   it('preserves explicitly logged zero-cost rows in cost summaries', async () => {
     const dbPath = tracked(tmpDbPath());
     const observer = createObserverAdapter(dbPath);

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -34,11 +34,15 @@ export class ObserverMetadataParseError extends Error {
 export interface ObserverCostSummary {
   totalPromptTokens: number;
   totalCompletionTokens: number;
+  totalCacheReadTokens?: number;
+  totalCacheCreationTokens?: number;
   totalCostUsd: number;
   byModel: Array<{
     model: string;
     promptTokens: number;
     completionTokens: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
     costUsd: number;
     unknownModel?: boolean;
   }>;
@@ -69,6 +73,8 @@ export interface ObserverCostInput {
   model: string;
   promptTokens: number;
   completionTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   costUsd?: number;
 }
 
@@ -162,18 +168,33 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         model: input.model,
         promptTokens: input.promptTokens,
         completionTokens: input.completionTokens,
+        cacheReadTokens: input.cacheReadTokens ?? 0,
+        cacheCreationTokens: input.cacheCreationTokens ?? 0,
       });
       store.db.prepare(`
-        INSERT INTO cost_ledger (session_id, model, prompt_tokens, completion_tokens, cost_usd, cost_source)
-        VALUES (?, ?, ?, ?, ?, ?)
-      `).run(input.sessionId, input.model, input.promptTokens, input.completionTokens, costUsd, input.costUsd === undefined ? 'computed' : 'explicit');
+        INSERT INTO cost_ledger (
+          session_id, model, prompt_tokens, completion_tokens,
+          cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        input.sessionId,
+        input.model,
+        input.promptTokens,
+        input.completionTokens,
+        input.cacheReadTokens ?? 0,
+        input.cacheCreationTokens ?? 0,
+        costUsd,
+        input.costUsd === undefined ? 'computed' : 'explicit',
+      );
 
       return { costUsd, unknownModel };
     },
 
     async cost(input) {
       let sql = `
-        SELECT model, prompt_tokens, completion_tokens, cost_usd, cost_source
+        SELECT model, prompt_tokens, completion_tokens,
+               cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
         FROM cost_ledger
       `;
       const params: unknown[] = [];
@@ -187,6 +208,8 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         model: string;
         prompt_tokens: number;
         completion_tokens: number;
+        cache_read_tokens: number;
+        cache_creation_tokens: number;
         cost_usd: number;
         cost_source: string;
       }>;
@@ -203,6 +226,12 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
 
         current.promptTokens += row.prompt_tokens;
         current.completionTokens += row.completion_tokens;
+        if (row.cache_read_tokens > 0) {
+          current.cacheReadTokens = (current.cacheReadTokens ?? 0) + row.cache_read_tokens;
+        }
+        if (row.cache_creation_tokens > 0) {
+          current.cacheCreationTokens = (current.cacheCreationTokens ?? 0) + row.cache_creation_tokens;
+        }
         if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
           current.unknownModel = true;
         }
@@ -211,6 +240,8 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
               model: row.model,
               promptTokens: row.prompt_tokens,
               completionTokens: row.completion_tokens,
+              cacheReadTokens: row.cache_read_tokens,
+              cacheCreationTokens: row.cache_creation_tokens,
             })
           : row.cost_usd;
 
@@ -218,9 +249,13 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
       }
 
       const byModel = [...grouped.values()];
+      const totalCacheReadTokens = byModel.reduce((sum, row) => sum + (row.cacheReadTokens ?? 0), 0);
+      const totalCacheCreationTokens = byModel.reduce((sum, row) => sum + (row.cacheCreationTokens ?? 0), 0);
       return {
         totalPromptTokens: byModel.reduce((sum, row) => sum + row.promptTokens, 0),
         totalCompletionTokens: byModel.reduce((sum, row) => sum + row.completionTokens, 0),
+        ...(totalCacheReadTokens > 0 ? { totalCacheReadTokens } : {}),
+        ...(totalCacheCreationTokens > 0 ? { totalCacheCreationTokens } : {}),
         totalCostUsd: byModel.reduce((sum, row) => sum + row.costUsd, 0),
         byModel,
       };

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -36,6 +36,7 @@ export interface ObserverCostSummary {
   totalCompletionTokens: number;
   totalCacheReadTokens?: number;
   totalCacheCreationTokens?: number;
+  totalCacheCreation1hTokens?: number;
   totalCostUsd: number;
   byModel: Array<{
     model: string;
@@ -43,6 +44,7 @@ export interface ObserverCostSummary {
     completionTokens: number;
     cacheReadTokens?: number;
     cacheCreationTokens?: number;
+    cacheCreation1hTokens?: number;
     costUsd: number;
     unknownModel?: boolean;
   }>;
@@ -75,6 +77,7 @@ export interface ObserverCostInput {
   completionTokens: number;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
+  cacheCreation1hTokens?: number;
   costUsd?: number;
 }
 
@@ -170,13 +173,15 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         completionTokens: input.completionTokens,
         cacheReadTokens: input.cacheReadTokens ?? 0,
         cacheCreationTokens: input.cacheCreationTokens ?? 0,
+        cacheCreation1hTokens: input.cacheCreation1hTokens ?? 0,
       });
       store.db.prepare(`
         INSERT INTO cost_ledger (
           session_id, model, prompt_tokens, completion_tokens,
-          cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
+          cache_read_tokens, cache_creation_tokens, cache_creation_1h_tokens,
+          cost_usd, cost_source
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         input.sessionId,
         input.model,
@@ -184,6 +189,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         input.completionTokens,
         input.cacheReadTokens ?? 0,
         input.cacheCreationTokens ?? 0,
+        input.cacheCreation1hTokens ?? 0,
         costUsd,
         input.costUsd === undefined ? 'computed' : 'explicit',
       );
@@ -194,7 +200,8 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
     async cost(input) {
       let sql = `
         SELECT model, prompt_tokens, completion_tokens,
-               cache_read_tokens, cache_creation_tokens, cost_usd, cost_source
+               cache_read_tokens, cache_creation_tokens, cache_creation_1h_tokens,
+               cost_usd, cost_source
         FROM cost_ledger
       `;
       const params: unknown[] = [];
@@ -210,6 +217,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         completion_tokens: number;
         cache_read_tokens: number;
         cache_creation_tokens: number;
+        cache_creation_1h_tokens: number;
         cost_usd: number;
         cost_source: string;
       }>;
@@ -232,6 +240,9 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
         if (row.cache_creation_tokens > 0) {
           current.cacheCreationTokens = (current.cacheCreationTokens ?? 0) + row.cache_creation_tokens;
         }
+        if (row.cache_creation_1h_tokens > 0) {
+          current.cacheCreation1hTokens = (current.cacheCreation1hTokens ?? 0) + row.cache_creation_1h_tokens;
+        }
         if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
           current.unknownModel = true;
         }
@@ -242,6 +253,7 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
               completionTokens: row.completion_tokens,
               cacheReadTokens: row.cache_read_tokens,
               cacheCreationTokens: row.cache_creation_tokens,
+              cacheCreation1hTokens: row.cache_creation_1h_tokens,
             })
           : row.cost_usd;
 
@@ -251,11 +263,13 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
       const byModel = [...grouped.values()];
       const totalCacheReadTokens = byModel.reduce((sum, row) => sum + (row.cacheReadTokens ?? 0), 0);
       const totalCacheCreationTokens = byModel.reduce((sum, row) => sum + (row.cacheCreationTokens ?? 0), 0);
+      const totalCacheCreation1hTokens = byModel.reduce((sum, row) => sum + (row.cacheCreation1hTokens ?? 0), 0);
       return {
         totalPromptTokens: byModel.reduce((sum, row) => sum + row.promptTokens, 0),
         totalCompletionTokens: byModel.reduce((sum, row) => sum + row.completionTokens, 0),
         ...(totalCacheReadTokens > 0 ? { totalCacheReadTokens } : {}),
         ...(totalCacheCreationTokens > 0 ? { totalCacheCreationTokens } : {}),
+        ...(totalCacheCreation1hTokens > 0 ? { totalCacheCreation1hTokens } : {}),
         totalCostUsd: byModel.reduce((sum, row) => sum + row.costUsd, 0),
         byModel,
       };

--- a/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/observer-adapter.ts
@@ -110,6 +110,17 @@ function shouldRepriceStoredCost(row: { cost_source: string; cost_usd: number; m
   return true;
 }
 
+function addTokenCounts(left: number, right: number, label: string): number {
+  if (!Number.isSafeInteger(right) || right < 0) {
+    throw new RangeError(`${label} must contain non-negative safe integers`);
+  }
+  const sum = left + right;
+  if (!Number.isSafeInteger(sum)) {
+    throw new RangeError(`${label} total exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`);
+  }
+  return sum;
+}
+
 export function createObserverAdapter(dbPath: string): ObserverAdapter {
   const store = createSqliteStore(dbPath);
   let closed = false;
@@ -232,16 +243,16 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
           costUsd: 0,
         };
 
-        current.promptTokens += row.prompt_tokens;
-        current.completionTokens += row.completion_tokens;
+        current.promptTokens = addTokenCounts(current.promptTokens, row.prompt_tokens, 'promptTokens');
+        current.completionTokens = addTokenCounts(current.completionTokens, row.completion_tokens, 'completionTokens');
         if (row.cache_read_tokens > 0) {
-          current.cacheReadTokens = (current.cacheReadTokens ?? 0) + row.cache_read_tokens;
+          current.cacheReadTokens = addTokenCounts(current.cacheReadTokens ?? 0, row.cache_read_tokens, 'cacheReadTokens');
         }
         if (row.cache_creation_tokens > 0) {
-          current.cacheCreationTokens = (current.cacheCreationTokens ?? 0) + row.cache_creation_tokens;
+          current.cacheCreationTokens = addTokenCounts(current.cacheCreationTokens ?? 0, row.cache_creation_tokens, 'cacheCreationTokens');
         }
         if (row.cache_creation_1h_tokens > 0) {
-          current.cacheCreation1hTokens = (current.cacheCreation1hTokens ?? 0) + row.cache_creation_1h_tokens;
+          current.cacheCreation1hTokens = addTokenCounts(current.cacheCreation1hTokens ?? 0, row.cache_creation_1h_tokens, 'cacheCreation1hTokens');
         }
         if (row.cost_source !== 'explicit' && row.cost_usd <= 0 && !hasDefaultPricing(row.model)) {
           current.unknownModel = true;
@@ -261,12 +272,29 @@ export function createObserverAdapter(dbPath: string): ObserverAdapter {
       }
 
       const byModel = [...grouped.values()];
-      const totalCacheReadTokens = byModel.reduce((sum, row) => sum + (row.cacheReadTokens ?? 0), 0);
-      const totalCacheCreationTokens = byModel.reduce((sum, row) => sum + (row.cacheCreationTokens ?? 0), 0);
-      const totalCacheCreation1hTokens = byModel.reduce((sum, row) => sum + (row.cacheCreation1hTokens ?? 0), 0);
+      const totalPromptTokens = byModel.reduce(
+        (sum, row) => addTokenCounts(sum, row.promptTokens, 'totalPromptTokens'),
+        0,
+      );
+      const totalCompletionTokens = byModel.reduce(
+        (sum, row) => addTokenCounts(sum, row.completionTokens, 'totalCompletionTokens'),
+        0,
+      );
+      const totalCacheReadTokens = byModel.reduce(
+        (sum, row) => addTokenCounts(sum, row.cacheReadTokens ?? 0, 'totalCacheReadTokens'),
+        0,
+      );
+      const totalCacheCreationTokens = byModel.reduce(
+        (sum, row) => addTokenCounts(sum, row.cacheCreationTokens ?? 0, 'totalCacheCreationTokens'),
+        0,
+      );
+      const totalCacheCreation1hTokens = byModel.reduce(
+        (sum, row) => addTokenCounts(sum, row.cacheCreation1hTokens ?? 0, 'totalCacheCreation1hTokens'),
+        0,
+      );
       return {
-        totalPromptTokens: byModel.reduce((sum, row) => sum + row.promptTokens, 0),
-        totalCompletionTokens: byModel.reduce((sum, row) => sum + row.completionTokens, 0),
+        totalPromptTokens,
+        totalCompletionTokens,
         ...(totalCacheReadTokens > 0 ? { totalCacheReadTokens } : {}),
         ...(totalCacheCreationTokens > 0 ? { totalCacheCreationTokens } : {}),
         ...(totalCacheCreation1hTokens > 0 ? { totalCacheCreation1hTokens } : {}),

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -50,6 +50,7 @@ describe('Observer Server', () => {
         totalCompletionTokens: 1300,
         totalCacheReadTokens: 300,
         totalCacheCreationTokens: 100,
+        totalCacheCreation1hTokens: 40,
         totalCostUsd: 0.129,
         byModel: [
           {
@@ -58,6 +59,7 @@ describe('Observer Server', () => {
             completionTokens: 1300,
             cacheReadTokens: 300,
             cacheCreationTokens: 100,
+            cacheCreation1hTokens: 40,
             costUsd: 0.129,
           },
         ],
@@ -94,15 +96,16 @@ describe('Observer Server', () => {
 
     const logCostResult = await logCostTool.handler({
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
-      cacheReadTokens: 300, cacheCreationTokens: 100,
+      cacheReadTokens: 300, cacheCreationTokens: 100, cacheCreation1hTokens: 40,
     });
     expect(observer.logCost).toHaveBeenCalledWith({
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
-      cacheReadTokens: 300, cacheCreationTokens: 100,
+      cacheReadTokens: 300, cacheCreationTokens: 100, cacheCreation1hTokens: 40,
     });
     expect(logCostResult.content[0]!.text).toContain('1000 prompt');
     expect(logCostResult.content[0]!.text).toContain('300 cache read');
     expect(logCostResult.content[0]!.text).toContain('100 cache creation');
+    expect(logCostResult.content[0]!.text).toContain('40 one-hour cache creation');
     expect(logCostResult.content[0]!.text).toContain('$0.0000');
     expect(logCostResult.content[0]!.text).toContain('unknown model');
 
@@ -112,6 +115,7 @@ describe('Observer Server', () => {
     expect(costResult.content[0]!.text).toContain('1300');
     expect(costResult.content[0]!.text).toContain('300 cache read');
     expect(costResult.content[0]!.text).toContain('100 cache creation');
+    expect(costResult.content[0]!.text).toContain('40 one-hour cache creation');
 
     const trailResult = await trailTool.handler({ sessionId: 'sess-1' });
     expect(observer.trail).toHaveBeenCalledWith('sess-1');

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -104,8 +104,8 @@ describe('Observer Server', () => {
     });
     expect(logCostResult.content[0]!.text).toContain('1000 prompt');
     expect(logCostResult.content[0]!.text).toContain('300 cache read');
-    expect(logCostResult.content[0]!.text).toContain('100 cache creation');
-    expect(logCostResult.content[0]!.text).toContain('40 one-hour cache creation');
+    expect(logCostResult.content[0]!.text).toContain('100 cache creation (40 one-hour)');
+    expect(logCostResult.content[0]!.text).not.toContain('+ 40 one-hour cache creation');
     expect(logCostResult.content[0]!.text).toContain('$0.0000');
     expect(logCostResult.content[0]!.text).toContain('unknown model');
 
@@ -114,8 +114,8 @@ describe('Observer Server', () => {
     expect(costResult.content[0]!.text).toContain('3000');
     expect(costResult.content[0]!.text).toContain('1300');
     expect(costResult.content[0]!.text).toContain('300 cache read');
-    expect(costResult.content[0]!.text).toContain('100 cache creation');
-    expect(costResult.content[0]!.text).toContain('40 one-hour cache creation');
+    expect(costResult.content[0]!.text).toContain('100 cache creation (40 one-hour)');
+    expect(costResult.content[0]!.text).not.toContain('+ 40 one-hour cache creation');
 
     const trailResult = await trailTool.handler({ sessionId: 'sess-1' });
     expect(observer.trail).toHaveBeenCalledWith('sess-1');

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -85,9 +85,11 @@ describe('Observer Server', () => {
 
     const logCostResult = await logCostTool.handler({
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
+      cacheReadTokens: 300, cacheCreationTokens: 100,
     });
     expect(observer.logCost).toHaveBeenCalledWith({
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
+      cacheReadTokens: 300, cacheCreationTokens: 100,
     });
     expect(logCostResult.content[0]!.text).toContain('1000');
     expect(logCostResult.content[0]!.text).toContain('$0.0000');

--- a/packages/franken-mcp-suite/src/servers/observer.test.ts
+++ b/packages/franken-mcp-suite/src/servers/observer.test.ts
@@ -48,9 +48,18 @@ describe('Observer Server', () => {
       cost: vi.fn().mockResolvedValue({
         totalPromptTokens: 3000,
         totalCompletionTokens: 1300,
+        totalCacheReadTokens: 300,
+        totalCacheCreationTokens: 100,
         totalCostUsd: 0.129,
         byModel: [
-          { model: 'claude-opus-4', promptTokens: 3000, completionTokens: 1300, costUsd: 0.129 },
+          {
+            model: 'claude-opus-4',
+            promptTokens: 3000,
+            completionTokens: 1300,
+            cacheReadTokens: 300,
+            cacheCreationTokens: 100,
+            costUsd: 0.129,
+          },
         ],
       }),
       trail: vi.fn().mockResolvedValue([
@@ -91,7 +100,9 @@ describe('Observer Server', () => {
       sessionId: 'sess-1', model: 'gpt-4o', promptTokens: 1000, completionTokens: 200,
       cacheReadTokens: 300, cacheCreationTokens: 100,
     });
-    expect(logCostResult.content[0]!.text).toContain('1000');
+    expect(logCostResult.content[0]!.text).toContain('1000 prompt');
+    expect(logCostResult.content[0]!.text).toContain('300 cache read');
+    expect(logCostResult.content[0]!.text).toContain('100 cache creation');
     expect(logCostResult.content[0]!.text).toContain('$0.0000');
     expect(logCostResult.content[0]!.text).toContain('unknown model');
 
@@ -99,6 +110,8 @@ describe('Observer Server', () => {
     expect(observer.cost).toHaveBeenCalledWith({ sessionId: 'sess-1' });
     expect(costResult.content[0]!.text).toContain('3000');
     expect(costResult.content[0]!.text).toContain('1300');
+    expect(costResult.content[0]!.text).toContain('300 cache read');
+    expect(costResult.content[0]!.text).toContain('100 cache creation');
 
     const trailResult = await trailTool.handler({ sessionId: 'sess-1' });
     expect(observer.trail).toHaveBeenCalledWith('sess-1');

--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.test.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.test.ts
@@ -8,6 +8,8 @@ describe('observer cost validation', () => {
       model: 'gpt-4o',
       promptTokens: 0,
       completionTokens: '25',
+      cacheCreationTokens: '20',
+      cacheCreation1hTokens: '5',
       costUsd: '0.001',
     })).toEqual({
       ok: true,
@@ -16,6 +18,8 @@ describe('observer cost validation', () => {
         model: 'gpt-4o',
         promptTokens: 0,
         completionTokens: 25,
+        cacheCreationTokens: 20,
+        cacheCreation1hTokens: 5,
         costUsd: 0.001,
       },
     });
@@ -33,6 +37,7 @@ describe('observer cost validation', () => {
       { field: 'completionTokens', args: { promptTokens: 0, completionTokens: -1 } },
       { field: 'completionTokens', args: { promptTokens: 0, completionTokens: 1.5 } },
       { field: 'completionTokens', args: { promptTokens: 0, completionTokens: Number.MAX_SAFE_INTEGER + 1 } },
+      { field: 'cacheCreation1hTokens', args: { promptTokens: 0, completionTokens: 0, cacheCreationTokens: 1, cacheCreation1hTokens: 2 } },
       { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: 'NaN' } },
       { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: 'Infinity' } },
       { field: 'costUsd', args: { promptTokens: 0, completionTokens: 0, costUsd: -0.01 } },

--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
@@ -3,6 +3,7 @@ export interface ObserverCostNumbers {
   completionTokens: number;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
+  cacheCreation1hTokens?: number;
   costUsd?: number;
 }
 
@@ -69,6 +70,12 @@ export function validateObserverCostNumbers(input: ObserverCostNumbers): void {
   if (input.cacheCreationTokens !== undefined && (!Number.isFinite(input.cacheCreationTokens) || !Number.isSafeInteger(input.cacheCreationTokens) || input.cacheCreationTokens < 0)) {
     throw new Error('cacheCreationTokens must be a finite safe non-negative integer');
   }
+  if (input.cacheCreation1hTokens !== undefined && (!Number.isFinite(input.cacheCreation1hTokens) || !Number.isSafeInteger(input.cacheCreation1hTokens) || input.cacheCreation1hTokens < 0)) {
+    throw new Error('cacheCreation1hTokens must be a finite safe non-negative integer');
+  }
+  if ((input.cacheCreation1hTokens ?? 0) > (input.cacheCreationTokens ?? 0)) {
+    throw new Error('cacheCreation1hTokens must not exceed cacheCreationTokens');
+  }
   if (input.costUsd !== undefined && (!Number.isFinite(input.costUsd) || input.costUsd < 0)) {
     throw new Error('costUsd must be a finite non-negative number');
   }
@@ -91,6 +98,13 @@ export function parseObserverCostArgs(args: Record<string, unknown>): ParseResul
   if (!cacheCreationTokensArg.ok) {
     return { ok: false, message: 'cacheCreationTokens must be a finite safe non-negative integer' };
   }
+  const cacheCreation1hTokensArg = parseOptionalNonNegativeIntegerArg('cacheCreation1hTokens', args['cacheCreation1hTokens']);
+  if (!cacheCreation1hTokensArg.ok) {
+    return { ok: false, message: 'cacheCreation1hTokens must be a finite safe non-negative integer' };
+  }
+  if ((cacheCreation1hTokensArg.value ?? 0) > (cacheCreationTokensArg.value ?? 0)) {
+    return { ok: false, message: 'cacheCreation1hTokens must not exceed cacheCreationTokens' };
+  }
   const costUsdArg = parseOptionalNonNegativeNumberArg('costUsd', args['costUsd']);
   if (!costUsdArg.ok) {
     return { ok: false, message: 'costUsd must be a finite non-negative number' };
@@ -103,6 +117,7 @@ export function parseObserverCostArgs(args: Record<string, unknown>): ParseResul
     completionTokens: completionTokensArg.value,
     ...(cacheReadTokensArg.value !== undefined ? { cacheReadTokens: cacheReadTokensArg.value } : {}),
     ...(cacheCreationTokensArg.value !== undefined ? { cacheCreationTokens: cacheCreationTokensArg.value } : {}),
+    ...(cacheCreation1hTokensArg.value !== undefined ? { cacheCreation1hTokens: cacheCreation1hTokensArg.value } : {}),
     ...(costUsdArg.value !== undefined ? { costUsd: costUsdArg.value } : {}),
   };
   validateObserverCostNumbers(parsed);

--- a/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
+++ b/packages/franken-mcp-suite/src/shared/observer-cost-validation.ts
@@ -1,6 +1,8 @@
 export interface ObserverCostNumbers {
   promptTokens: number;
   completionTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   costUsd?: number;
 }
 
@@ -24,6 +26,16 @@ function parseNonNegativeIntegerArg(name: string, value: unknown): ParseResult<n
     return { ok: false, message: `${name} must be a finite safe non-negative integer` };
   }
   return { ok: true, value: parsed };
+}
+
+function parseOptionalNonNegativeIntegerArg(
+  name: string,
+  value: unknown,
+): ParseResult<number | undefined> {
+  if (value == null) {
+    return { ok: true, value: undefined };
+  }
+  return parseNonNegativeIntegerArg(name, value);
 }
 
 function parseOptionalNonNegativeNumberArg(name: string, value: unknown): ParseResult<number | undefined> {
@@ -51,6 +63,12 @@ export function validateObserverCostNumbers(input: ObserverCostNumbers): void {
   if (!Number.isFinite(input.completionTokens) || !Number.isSafeInteger(input.completionTokens) || input.completionTokens < 0) {
     throw new Error('completionTokens must be a finite safe non-negative integer');
   }
+  if (input.cacheReadTokens !== undefined && (!Number.isFinite(input.cacheReadTokens) || !Number.isSafeInteger(input.cacheReadTokens) || input.cacheReadTokens < 0)) {
+    throw new Error('cacheReadTokens must be a finite safe non-negative integer');
+  }
+  if (input.cacheCreationTokens !== undefined && (!Number.isFinite(input.cacheCreationTokens) || !Number.isSafeInteger(input.cacheCreationTokens) || input.cacheCreationTokens < 0)) {
+    throw new Error('cacheCreationTokens must be a finite safe non-negative integer');
+  }
   if (input.costUsd !== undefined && (!Number.isFinite(input.costUsd) || input.costUsd < 0)) {
     throw new Error('costUsd must be a finite non-negative number');
   }
@@ -65,6 +83,14 @@ export function parseObserverCostArgs(args: Record<string, unknown>): ParseResul
   if (!completionTokensArg.ok) {
     return { ok: false, message: 'completionTokens must be a finite safe non-negative integer' };
   }
+  const cacheReadTokensArg = parseOptionalNonNegativeIntegerArg('cacheReadTokens', args['cacheReadTokens']);
+  if (!cacheReadTokensArg.ok) {
+    return { ok: false, message: 'cacheReadTokens must be a finite safe non-negative integer' };
+  }
+  const cacheCreationTokensArg = parseOptionalNonNegativeIntegerArg('cacheCreationTokens', args['cacheCreationTokens']);
+  if (!cacheCreationTokensArg.ok) {
+    return { ok: false, message: 'cacheCreationTokens must be a finite safe non-negative integer' };
+  }
   const costUsdArg = parseOptionalNonNegativeNumberArg('costUsd', args['costUsd']);
   if (!costUsdArg.ok) {
     return { ok: false, message: 'costUsd must be a finite non-negative number' };
@@ -75,6 +101,8 @@ export function parseObserverCostArgs(args: Record<string, unknown>): ParseResul
     model: String(args['model']),
     promptTokens: promptTokensArg.value,
     completionTokens: completionTokensArg.value,
+    ...(cacheReadTokensArg.value !== undefined ? { cacheReadTokens: cacheReadTokensArg.value } : {}),
+    ...(cacheCreationTokensArg.value !== undefined ? { cacheCreationTokens: cacheCreationTokensArg.value } : {}),
     ...(costUsdArg.value !== undefined ? { costUsd: costUsdArg.value } : {}),
   };
   validateObserverCostNumbers(parsed);

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -48,6 +48,7 @@ const SCHEMA = `
     completion_tokens INTEGER NOT NULL DEFAULT 0,
     cache_read_tokens INTEGER NOT NULL DEFAULT 0,
     cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
     cost_usd REAL NOT NULL DEFAULT 0,
     cost_source TEXT NOT NULL DEFAULT 'computed',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -119,6 +120,7 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   ensureCostColumn('cost_source', "TEXT NOT NULL DEFAULT 'legacy'");
   ensureCostColumn('cache_read_tokens', 'INTEGER NOT NULL DEFAULT 0');
   ensureCostColumn('cache_creation_tokens', 'INTEGER NOT NULL DEFAULT 0');
+  ensureCostColumn('cache_creation_1h_tokens', 'INTEGER NOT NULL DEFAULT 0');
 
   return {
     db,

--- a/packages/franken-mcp-suite/src/shared/sqlite-store.ts
+++ b/packages/franken-mcp-suite/src/shared/sqlite-store.ts
@@ -46,6 +46,8 @@ const SCHEMA = `
     model TEXT NOT NULL,
     prompt_tokens INTEGER NOT NULL DEFAULT 0,
     completion_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
     cost_usd REAL NOT NULL DEFAULT 0,
     cost_source TEXT NOT NULL DEFAULT 'computed',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -104,15 +106,19 @@ export function createSqliteStore(dbPath: string): SqliteStore {
   `);
 
   const costColumns = db.pragma('table_info(cost_ledger)') as Array<{ name: string }>;
-  if (!costColumns.some((column) => column.name === 'cost_source')) {
+  const ensureCostColumn = (name: string, definition: string): void => {
+    if (costColumns.some((column) => column.name === name)) return;
     try {
-      db.exec("ALTER TABLE cost_ledger ADD COLUMN cost_source TEXT NOT NULL DEFAULT 'legacy'");
+      db.exec(`ALTER TABLE cost_ledger ADD COLUMN ${name} ${definition}`);
     } catch (error) {
-      if (!(error instanceof Error) || !/duplicate column name: cost_source/i.test(error.message)) {
+      if (!(error instanceof Error) || !new RegExp(`duplicate column name: ${name}`, 'i').test(error.message)) {
         throw error;
       }
     }
-  }
+  };
+  ensureCostColumn('cost_source', "TEXT NOT NULL DEFAULT 'legacy'");
+  ensureCostColumn('cache_read_tokens', 'INTEGER NOT NULL DEFAULT 0');
+  ensureCostColumn('cache_creation_tokens', 'INTEGER NOT NULL DEFAULT 0');
 
   return {
     db,

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -1166,7 +1166,7 @@ const TOOLS: ToolFull[] = [
       return {
         content: [{
           type: 'text',
-          text: `Logged cost: ${promptTokens} prompt + ${completionTokens} completion + ${cacheReadTokens} cache read + ${cacheCreationTokens} cache creation + ${cacheCreation1hTokens} one-hour cache creation tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}`,
+          text: `Logged cost: ${promptTokens} prompt + ${completionTokens} completion + ${cacheReadTokens} cache read + ${cacheCreationTokens} cache creation (${cacheCreation1hTokens} one-hour) tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}`,
         }],
       };
     },
@@ -1191,10 +1191,10 @@ const TOOLS: ToolFull[] = [
         `## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`,
         '',
         ...summary.byModel.map((row) =>
-          `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion + ${row.cacheReadTokens ?? 0} cache read + ${row.cacheCreationTokens ?? 0} cache creation + ${row.cacheCreation1hTokens ?? 0} one-hour cache creation = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`,
+          `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion + ${row.cacheReadTokens ?? 0} cache read + ${row.cacheCreationTokens ?? 0} cache creation (${row.cacheCreation1hTokens ?? 0} one-hour) = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`,
         ),
         '',
-        `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion + ${summary.totalCacheReadTokens ?? 0} cache read + ${summary.totalCacheCreationTokens ?? 0} cache creation + ${summary.totalCacheCreation1hTokens ?? 0} one-hour cache creation = $${summary.totalCostUsd.toFixed(4)}`,
+        `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion + ${summary.totalCacheReadTokens ?? 0} cache read + ${summary.totalCacheCreationTokens ?? 0} cache creation (${summary.totalCacheCreation1hTokens ?? 0} one-hour) = $${summary.totalCostUsd.toFixed(4)}`,
       ];
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -1152,10 +1152,21 @@ const TOOLS: ToolFull[] = [
       if (!parsedArgs.ok) {
         return { content: [{ type: 'text', text: `Error: fbeast_observer_log_cost ${parsedArgs.message}` }], isError: true };
       }
-      const { model, promptTokens, completionTokens } = parsedArgs.value;
+      const {
+        model,
+        promptTokens,
+        completionTokens,
+        cacheReadTokens = 0,
+        cacheCreationTokens = 0,
+      } = parsedArgs.value;
       const result = await observer.logCost(parsedArgs.value);
       const pricingNote = result.unknownModel ? ' (unknown model — not priced)' : '';
-      return { content: [{ type: 'text', text: `Logged cost: ${promptTokens}+${completionTokens} tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}` }] };
+      return {
+        content: [{
+          type: 'text',
+          text: `Logged cost: ${promptTokens} prompt + ${completionTokens} completion + ${cacheReadTokens} cache read + ${cacheCreationTokens} cache creation tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}`,
+        }],
+      };
     },
   },
   {
@@ -1174,7 +1185,15 @@ const TOOLS: ToolFull[] = [
       if (summary.byModel.length === 0) {
         return { content: [{ type: 'text', text: 'No cost data recorded.' }] };
       }
-      const lines = [`## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`, '', ...summary.byModel.map((row) => `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`), '', `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion = $${summary.totalCostUsd.toFixed(4)}`];
+      const lines = [
+        `## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`,
+        '',
+        ...summary.byModel.map((row) =>
+          `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion + ${row.cacheReadTokens ?? 0} cache read + ${row.cacheCreationTokens ?? 0} cache creation = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`,
+        ),
+        '',
+        `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion + ${summary.totalCacheReadTokens ?? 0} cache read + ${summary.totalCacheCreationTokens ?? 0} cache creation = $${summary.totalCostUsd.toFixed(4)}`,
+      ];
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },
   },

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -1159,13 +1159,14 @@ const TOOLS: ToolFull[] = [
         completionTokens,
         cacheReadTokens = 0,
         cacheCreationTokens = 0,
+        cacheCreation1hTokens = 0,
       } = parsedArgs.value;
       const result = await observer.logCost(parsedArgs.value);
       const pricingNote = result.unknownModel ? ' (unknown model — not priced)' : '';
       return {
         content: [{
           type: 'text',
-          text: `Logged cost: ${promptTokens} prompt + ${completionTokens} completion + ${cacheReadTokens} cache read + ${cacheCreationTokens} cache creation tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}`,
+          text: `Logged cost: ${promptTokens} prompt + ${completionTokens} completion + ${cacheReadTokens} cache read + ${cacheCreationTokens} cache creation + ${cacheCreation1hTokens} one-hour cache creation tokens for ${model} = $${result.costUsd.toFixed(4)}${pricingNote}`,
         }],
       };
     },
@@ -1190,10 +1191,10 @@ const TOOLS: ToolFull[] = [
         `## Cost Summary${sessionId ? ` (session: ${sessionId})` : ''}`,
         '',
         ...summary.byModel.map((row) =>
-          `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion + ${row.cacheReadTokens ?? 0} cache read + ${row.cacheCreationTokens ?? 0} cache creation = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`,
+          `- ${row.model}: ${row.promptTokens} prompt + ${row.completionTokens} completion + ${row.cacheReadTokens ?? 0} cache read + ${row.cacheCreationTokens ?? 0} cache creation + ${row.cacheCreation1hTokens ?? 0} one-hour cache creation = $${row.costUsd.toFixed(4)}${row.unknownModel ? ' (unknown model — not priced)' : ''}`,
         ),
         '',
-        `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion + ${summary.totalCacheReadTokens ?? 0} cache read + ${summary.totalCacheCreationTokens ?? 0} cache creation = $${summary.totalCostUsd.toFixed(4)}`,
+        `**Total:** ${summary.totalPromptTokens} prompt + ${summary.totalCompletionTokens} completion + ${summary.totalCacheReadTokens ?? 0} cache read + ${summary.totalCacheCreationTokens ?? 0} cache creation + ${summary.totalCacheCreation1hTokens ?? 0} one-hour cache creation = $${summary.totalCostUsd.toFixed(4)}`,
       ];
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     },

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -1141,6 +1141,8 @@ const TOOLS: ToolFull[] = [
         model: { type: 'string', description: 'Model name (e.g. gpt-4o, claude-opus-4-5)', minLength: 1, maxLength: 256 },
         promptTokens: { type: 'number', description: 'Input/prompt token count', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
         completionTokens: { type: 'number', description: 'Output/completion token count', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+        cacheReadTokens: { type: 'number', description: 'Input tokens read from provider cache', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+        cacheCreationTokens: { type: 'number', description: 'Input tokens written to provider cache', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
         costUsd: { type: 'number', description: 'Actual cost in USD if known — omit to auto-calculate from pricing table', minimum: 0 },
       },
       required: ['sessionId', 'model', 'promptTokens', 'completionTokens'],

--- a/packages/franken-mcp-suite/src/shared/tool-registry.ts
+++ b/packages/franken-mcp-suite/src/shared/tool-registry.ts
@@ -1143,6 +1143,7 @@ const TOOLS: ToolFull[] = [
         completionTokens: { type: 'number', description: 'Output/completion token count', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
         cacheReadTokens: { type: 'number', description: 'Input tokens read from provider cache', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
         cacheCreationTokens: { type: 'number', description: 'Input tokens written to provider cache', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+        cacheCreation1hTokens: { type: 'number', description: 'One-hour cache writes already included in cacheCreationTokens', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
         costUsd: { type: 'number', description: 'Actual cost in USD if known — omit to auto-calculate from pricing table', minimum: 0 },
       },
       required: ['sessionId', 'model', 'promptTokens', 'completionTokens'],

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -239,20 +239,20 @@ const customCalc = new CostCalculator(myPricing)
 
 `cacheHitRatio({ promptTokens, cacheReadTokens })` returns the fraction of reusable input served from cache. It returns `0` when both counts are zero.
 
-Default pricing (USD, verified 2026-07-25; cache creation uses Anthropic's 5-minute write tier):
+Default pricing (USD, verified 2026-07-25):
 
-| Model | Prompt / M | Completion / M | Cache read / M | Cache creation / M |
-|---|---:|---:|---:|---:|
-| `claude-opus-4-6` | $5.00 | $25.00 | $0.50 | $6.25 |
-| `claude-sonnet-4-6` | $3.00 | $15.00 | $0.30 | $3.75 |
-| `claude-haiku-4-5` | $1.00 | $5.00 | $0.10 | $1.25 |
-| `claude` (alias for sonnet) | $3.00 | $15.00 | $0.30 | $3.75 |
-| `gpt-4o` | $2.50 | $10.00 | $1.25 | prompt fallback |
-| `gpt-4o-mini` | $0.15 | $0.60 | $0.075 | prompt fallback |
-| `gemini-2.0-flash` | $0.10 | $0.40 | prompt fallback | prompt fallback |
-| `gemini` (alias for flash) | $0.10 | $0.40 | prompt fallback | prompt fallback |
-| `codex` | $5.00 | $15.00 | prompt fallback | prompt fallback |
-| `aider` (uses sonnet by default) | $3.00 | $15.00 | prompt fallback | prompt fallback |
+| Model | Prompt / M | Completion / M | Cache read / M | Cache creation 5m / M | Cache creation 1h / M |
+|---|---:|---:|---:|---:|---:|
+| `claude-opus-4-6` | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
+| `claude-sonnet-4-6` | $3.00 | $15.00 | $0.30 | $3.75 | $6.00 |
+| `claude-haiku-4-5` | $1.00 | $5.00 | $0.10 | $1.25 | $2.00 |
+| `claude` (alias for sonnet) | $3.00 | $15.00 | $0.30 | $3.75 | $6.00 |
+| `gpt-4o` | $2.50 | $10.00 | $1.25 | prompt fallback | prompt fallback |
+| `gpt-4o-mini` | $0.15 | $0.60 | $0.075 | prompt fallback | prompt fallback |
+| `gemini-2.0-flash` | $0.10 | $0.40 | prompt fallback | prompt fallback | prompt fallback |
+| `gemini` (alias for flash) | $0.10 | $0.40 | prompt fallback | prompt fallback | prompt fallback |
+| `codex` | $5.00 | $15.00 | prompt fallback | prompt fallback | prompt fallback |
+| `aider` (uses sonnet by default) | $3.00 | $15.00 | $0.30 | $3.75 | $6.00 |
 
 ### `CircuitBreaker`
 

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -161,15 +161,23 @@ import { TokenCounter } from '@franken/observer'
 
 const counter = new TokenCounter()
 
-counter.record({ model: 'claude-sonnet-4-6', promptTokens: 500, completionTokens: 200 })
+counter.record({
+  model: 'claude-sonnet-4-6',
+  promptTokens: 500,
+  completionTokens: 200,
+  cacheReadTokens: 1_000,
+  cacheCreationTokens: 100,
+})
 counter.record({ model: 'claude-sonnet-4-6', promptTokens: 300, completionTokens: 100 })
 counter.record({ model: 'claude-opus-4-6',   promptTokens: 100, completionTokens:  50 })
 
 counter.totalsFor('claude-sonnet-4-6')
-// → { promptTokens: 800, completionTokens: 300, totalTokens: 1100 }
+// → { promptTokens: 800, completionTokens: 300, cacheReadTokens: 1000,
+//     cacheCreationTokens: 100, totalTokens: 2200 }
 
 counter.grandTotal()
-// → { promptTokens: 900, completionTokens: 350, totalTokens: 1250 }
+// → { promptTokens: 900, completionTokens: 350, cacheReadTokens: 1000,
+//     cacheCreationTokens: 100, totalTokens: 2350 }
 
 counter.allModels()  // → ['claude-sonnet-4-6', 'claude-opus-4-6']
 counter.reset()
@@ -179,7 +187,13 @@ Pass a `TokenCounter` to `SpanLifecycle.recordTokenUsage` to feed it automatical
 
 ```ts
 const counter = new TokenCounter()
-SpanLifecycle.recordTokenUsage(span, { promptTokens: 500, completionTokens: 200, model: 'claude-sonnet-4-6' }, counter)
+SpanLifecycle.recordTokenUsage(span, {
+  promptTokens: 500,
+  completionTokens: 200,
+  cacheReadTokens: 1_000,
+  cacheCreationTokens: 100,
+  model: 'claude-sonnet-4-6',
+}, counter)
 ```
 
 ### `CostCalculator`
@@ -191,8 +205,14 @@ import { CostCalculator, DEFAULT_PRICING } from '@franken/observer'
 
 const calc = new CostCalculator(DEFAULT_PRICING)
 
-calc.calculate({ model: 'claude-sonnet-4-6', promptTokens: 1_000_000, completionTokens: 500_000 })
-// → 10.5  (1M × $3 + 0.5M × $15)
+calc.calculate({
+  model: 'claude-sonnet-4-6',
+  promptTokens: 1_000_000,
+  completionTokens: 500_000,
+  cacheReadTokens: 1_000_000,
+  cacheCreationTokens: 1_000_000,
+})
+// → 14.55  ($3 fresh input + $7.50 output + $0.30 cache read + $3.75 cache write)
 
 // Sum across all models from a TokenCounter snapshot.
 // totalCost expects per-model TokenRecord entries, not grandTotal().
@@ -200,6 +220,8 @@ const records = counter.allModels().map((model) => ({
   model,
   promptTokens: counter.totalsFor(model).promptTokens,
   completionTokens: counter.totalsFor(model).completionTokens,
+  cacheReadTokens: counter.totalsFor(model).cacheReadTokens,
+  cacheCreationTokens: counter.totalsFor(model).cacheCreationTokens,
 }))
 calc.totalCost(records)
 
@@ -215,20 +237,22 @@ const myPricing = { ...DEFAULT_PRICING, 'my-local-model': { promptPerMillion: 0,
 const customCalc = new CostCalculator(myPricing)
 ```
 
-Default pricing (USD, 2025-Q4):
+`cacheHitRatio({ promptTokens, cacheReadTokens })` returns the fraction of reusable input served from cache. It returns `0` when both counts are zero.
 
-| Model | Prompt / M | Completion / M |
-|---|---|---|
-| `claude-opus-4-6` | $15.00 | $75.00 |
-| `claude-sonnet-4-6` | $3.00 | $15.00 |
-| `claude-haiku-4-5` | $0.80 | $4.00 |
-| `claude` (alias for sonnet) | $3.00 | $15.00 |
-| `gpt-4o` | $5.00 | $15.00 |
-| `gpt-4o-mini` | $0.15 | $0.60 |
-| `gemini-2.0-flash` | $0.10 | $0.40 |
-| `gemini` (alias for flash) | $0.10 | $0.40 |
-| `codex` | $5.00 | $15.00 |
-| `aider` (uses sonnet by default) | $3.00 | $15.00 |
+Default pricing (USD, verified 2026-07-25; cache creation uses Anthropic's 5-minute write tier):
+
+| Model | Prompt / M | Completion / M | Cache read / M | Cache creation / M |
+|---|---:|---:|---:|---:|
+| `claude-opus-4-6` | $5.00 | $25.00 | $0.50 | $6.25 |
+| `claude-sonnet-4-6` | $3.00 | $15.00 | $0.30 | $3.75 |
+| `claude-haiku-4-5` | $1.00 | $5.00 | $0.10 | $1.25 |
+| `claude` (alias for sonnet) | $3.00 | $15.00 | $0.30 | $3.75 |
+| `gpt-4o` | $2.50 | $10.00 | $1.25 | prompt fallback |
+| `gpt-4o-mini` | $0.15 | $0.60 | $0.075 | prompt fallback |
+| `gemini-2.0-flash` | $0.10 | $0.40 | prompt fallback | prompt fallback |
+| `gemini` (alias for flash) | $0.10 | $0.40 | prompt fallback | prompt fallback |
+| `codex` | $5.00 | $15.00 | prompt fallback | prompt fallback |
+| `aider` (uses sonnet by default) | $3.00 | $15.00 | prompt fallback | prompt fallback |
 
 ### `CircuitBreaker`
 

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -308,6 +308,37 @@ describe('PrometheusAdapter', () => {
   })
 
   describe('scrape() — cost metrics', () => {
+    it('reports and prices cache-read and cache-creation tokens', async () => {
+      const adapter = new PrometheusAdapter({
+        pricingTable: {
+          'cache-model': {
+            promptPerMillion: 3,
+            completionPerMillion: 15,
+            cacheReadPerMillion: 0.3,
+            cacheCreationPerMillion: 3.75,
+          },
+        },
+      })
+      await adapter.flush(
+        makeTraceWithMetadata({
+          model: 'cache-model',
+          promptTokens: 1_000_000,
+          completionTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheCreationTokens: 1_000_000,
+        }),
+      )
+
+      const out = adapter.scrape()
+      expect(out).toContain(
+        'franken_observer_tokens_total{model="cache-model",type="cache_read"} 1000000',
+      )
+      expect(out).toContain(
+        'franken_observer_tokens_total{model="cache-model",type="cache_creation"} 1000000',
+      )
+      expect(out).toContain('franken_observer_cost_usd_total{model="cache-model"} 22.05')
+    })
+
     it('reports cost_usd_total when a pricingTable is provided', async () => {
       const adapter = new PrometheusAdapter({
         pricingTable: {

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -316,6 +316,7 @@ describe('PrometheusAdapter', () => {
             completionPerMillion: 15,
             cacheReadPerMillion: 0.3,
             cacheCreationPerMillion: 3.75,
+            cacheCreation1hPerMillion: 6,
           },
         },
       })
@@ -326,6 +327,7 @@ describe('PrometheusAdapter', () => {
           completionTokens: 1_000_000,
           cacheReadTokens: 1_000_000,
           cacheCreationTokens: 1_000_000,
+          cacheCreation1hTokens: 400_000,
         }),
       )
 
@@ -336,7 +338,7 @@ describe('PrometheusAdapter', () => {
       expect(out).toContain(
         'franken_observer_tokens_total{model="cache-model",type="cache_creation"} 1000000',
       )
-      expect(out).toContain('franken_observer_cost_usd_total{model="cache-model"} 22.05')
+      expect(out).toContain('franken_observer_cost_usd_total{model="cache-model"} 22.95')
     })
 
     it('reports cost_usd_total when a pricingTable is provided', async () => {

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.test.ts
@@ -308,39 +308,6 @@ describe('PrometheusAdapter', () => {
   })
 
   describe('scrape() — cost metrics', () => {
-    it('reports and prices cache-read and cache-creation tokens', async () => {
-      const adapter = new PrometheusAdapter({
-        pricingTable: {
-          'cache-model': {
-            promptPerMillion: 3,
-            completionPerMillion: 15,
-            cacheReadPerMillion: 0.3,
-            cacheCreationPerMillion: 3.75,
-            cacheCreation1hPerMillion: 6,
-          },
-        },
-      })
-      await adapter.flush(
-        makeTraceWithMetadata({
-          model: 'cache-model',
-          promptTokens: 1_000_000,
-          completionTokens: 1_000_000,
-          cacheReadTokens: 1_000_000,
-          cacheCreationTokens: 1_000_000,
-          cacheCreation1hTokens: 400_000,
-        }),
-      )
-
-      const out = adapter.scrape()
-      expect(out).toContain(
-        'franken_observer_tokens_total{model="cache-model",type="cache_read"} 1000000',
-      )
-      expect(out).toContain(
-        'franken_observer_tokens_total{model="cache-model",type="cache_creation"} 1000000',
-      )
-      expect(out).toContain('franken_observer_cost_usd_total{model="cache-model"} 22.95')
-    })
-
     it('reports cost_usd_total when a pricingTable is provided', async () => {
       const adapter = new PrometheusAdapter({
         pricingTable: {

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -13,6 +13,8 @@ export interface PrometheusAdapterOptions {
 interface TokenCounts {
   prompt: number
   completion: number
+  cacheRead: number
+  cacheCreation: number
 }
 
 interface FlushedSpanEntry {
@@ -87,25 +89,66 @@ export class PrometheusAdapter implements ExportAdapter {
 
       const promptTokens = span.metadata['promptTokens']
       const completionTokens = span.metadata['completionTokens']
+      const cacheReadTokens = span.metadata['cacheReadTokens']
+      const cacheCreationTokens = span.metadata['cacheCreationTokens']
       if (typeof promptTokens === 'number') {
         assertValidTokenDelta(promptTokens, 'promptTokens')
       }
       if (typeof completionTokens === 'number') {
         assertValidTokenDelta(completionTokens, 'completionTokens')
       }
-      if (typeof promptTokens !== 'number' && typeof completionTokens !== 'number') continue
+      if (typeof cacheReadTokens === 'number') {
+        assertValidTokenDelta(cacheReadTokens, 'cacheReadTokens')
+      }
+      if (typeof cacheCreationTokens === 'number') {
+        assertValidTokenDelta(cacheCreationTokens, 'cacheCreationTokens')
+      }
+      if (
+        typeof promptTokens !== 'number' &&
+        typeof completionTokens !== 'number' &&
+        typeof cacheReadTokens !== 'number' &&
+        typeof cacheCreationTokens !== 'number'
+      ) continue
 
       const prompt = typeof promptTokens === 'number' ? promptTokens : 0
       const completion = typeof completionTokens === 'number' ? completionTokens : 0
-      const existing = pendingTokenCounters.get(model) ?? { prompt: 0, completion: 0 }
+      const cacheRead = typeof cacheReadTokens === 'number' ? cacheReadTokens : 0
+      const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
+      const existing = pendingTokenCounters.get(model) ?? {
+        prompt: 0,
+        completion: 0,
+        cacheRead: 0,
+        cacheCreation: 0,
+      }
       const nextPrompt = safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`)
       const nextCompletion = safeAddTokenCounter(
         existing.completion,
         completion,
         `${model} completion`,
       )
-      safeAddTokenCounter(nextPrompt, nextCompletion, `${model} token`)
-      pendingTokenCounters.set(model, { prompt: nextPrompt, completion: nextCompletion })
+      const nextCacheRead = safeAddTokenCounter(
+        existing.cacheRead,
+        cacheRead,
+        `${model} cache read`,
+      )
+      const nextCacheCreation = safeAddTokenCounter(
+        existing.cacheCreation,
+        cacheCreation,
+        `${model} cache creation`,
+      )
+      const nextInput = safeAddTokenCounter(nextPrompt, nextCacheRead, `${model} input token`)
+      const nextReusableInput = safeAddTokenCounter(
+        nextInput,
+        nextCacheCreation,
+        `${model} input token`,
+      )
+      safeAddTokenCounter(nextReusableInput, nextCompletion, `${model} token`)
+      pendingTokenCounters.set(model, {
+        prompt: nextPrompt,
+        completion: nextCompletion,
+        cacheRead: nextCacheRead,
+        cacheCreation: nextCacheCreation,
+      })
     }
 
     const newlyFlushedSpanIds: string[] = []
@@ -119,18 +162,36 @@ export class PrometheusAdapter implements ExportAdapter {
       const model = span.metadata['model']
       const promptTokens = span.metadata['promptTokens']
       const completionTokens = span.metadata['completionTokens']
+      const cacheReadTokens = span.metadata['cacheReadTokens']
+      const cacheCreationTokens = span.metadata['cacheCreationTokens']
 
       if (
         typeof model === 'string' &&
-        (typeof promptTokens === 'number' || typeof completionTokens === 'number')
+        (typeof promptTokens === 'number' ||
+          typeof completionTokens === 'number' ||
+          typeof cacheReadTokens === 'number' ||
+          typeof cacheCreationTokens === 'number')
       ) {
         const prompt = typeof promptTokens === 'number' ? promptTokens : 0
         const completion = typeof completionTokens === 'number' ? completionTokens : 0
+        const cacheRead = typeof cacheReadTokens === 'number' ? cacheReadTokens : 0
+        const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
 
-        const existing = this.tokenCounters.get(model) ?? { prompt: 0, completion: 0 }
+        const existing = this.tokenCounters.get(model) ?? {
+          prompt: 0,
+          completion: 0,
+          cacheRead: 0,
+          cacheCreation: 0,
+        }
         this.tokenCounters.set(model, {
           prompt: safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`),
           completion: safeAddTokenCounter(existing.completion, completion, `${model} completion`),
+          cacheRead: safeAddTokenCounter(existing.cacheRead, cacheRead, `${model} cache read`),
+          cacheCreation: safeAddTokenCounter(
+            existing.cacheCreation,
+            cacheCreation,
+            `${model} cache creation`,
+          ),
         })
 
         // Cost counter — only when pricing table covers this model
@@ -138,7 +199,10 @@ export class PrometheusAdapter implements ExportAdapter {
           const pricing = this.pricingTable[model]
           const cost =
             (prompt * pricing.promptPerMillion) / 1_000_000 +
-            (completion * pricing.completionPerMillion) / 1_000_000
+            (completion * pricing.completionPerMillion) / 1_000_000 +
+            (cacheRead * (pricing.cacheReadPerMillion ?? pricing.promptPerMillion)) / 1_000_000 +
+            (cacheCreation * (pricing.cacheCreationPerMillion ?? pricing.promptPerMillion)) /
+              1_000_000
           this.costCounters.set(model, (this.costCounters.get(model) ?? 0) + cost)
         }
       }
@@ -213,6 +277,12 @@ export class PrometheusAdapter implements ExportAdapter {
         )
         lines.push(
           `franken_observer_tokens_total{model="${escapedModel}",type="completion"} ${counts.completion}`,
+        )
+        lines.push(
+          `franken_observer_tokens_total{model="${escapedModel}",type="cache_read"} ${counts.cacheRead}`,
+        )
+        lines.push(
+          `franken_observer_tokens_total{model="${escapedModel}",type="cache_creation"} ${counts.cacheCreation}`,
         )
       }
     }

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -13,8 +13,6 @@ export interface PrometheusAdapterOptions {
 interface TokenCounts {
   prompt: number
   completion: number
-  cacheRead: number
-  cacheCreation: number
 }
 
 interface FlushedSpanEntry {
@@ -89,76 +87,25 @@ export class PrometheusAdapter implements ExportAdapter {
 
       const promptTokens = span.metadata['promptTokens']
       const completionTokens = span.metadata['completionTokens']
-      const cacheReadTokens = span.metadata['cacheReadTokens']
-      const cacheCreationTokens = span.metadata['cacheCreationTokens']
-      const cacheCreation1hTokens = span.metadata['cacheCreation1hTokens']
       if (typeof promptTokens === 'number') {
         assertValidTokenDelta(promptTokens, 'promptTokens')
       }
       if (typeof completionTokens === 'number') {
         assertValidTokenDelta(completionTokens, 'completionTokens')
       }
-      if (typeof cacheReadTokens === 'number') {
-        assertValidTokenDelta(cacheReadTokens, 'cacheReadTokens')
-      }
-      if (typeof cacheCreationTokens === 'number') {
-        assertValidTokenDelta(cacheCreationTokens, 'cacheCreationTokens')
-      }
-      if (typeof cacheCreation1hTokens === 'number') {
-        assertValidTokenDelta(cacheCreation1hTokens, 'cacheCreation1hTokens')
-        const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
-        if (cacheCreation1hTokens > cacheCreation) {
-          throw new RangeError(
-            'PrometheusAdapter: cacheCreation1hTokens must not exceed cacheCreationTokens',
-          )
-        }
-      }
-      if (
-        typeof promptTokens !== 'number' &&
-        typeof completionTokens !== 'number' &&
-        typeof cacheReadTokens !== 'number' &&
-        typeof cacheCreationTokens !== 'number'
-      ) continue
+      if (typeof promptTokens !== 'number' && typeof completionTokens !== 'number') continue
 
       const prompt = typeof promptTokens === 'number' ? promptTokens : 0
       const completion = typeof completionTokens === 'number' ? completionTokens : 0
-      const cacheRead = typeof cacheReadTokens === 'number' ? cacheReadTokens : 0
-      const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
-      const existing = pendingTokenCounters.get(model) ?? {
-        prompt: 0,
-        completion: 0,
-        cacheRead: 0,
-        cacheCreation: 0,
-      }
+      const existing = pendingTokenCounters.get(model) ?? { prompt: 0, completion: 0 }
       const nextPrompt = safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`)
       const nextCompletion = safeAddTokenCounter(
         existing.completion,
         completion,
         `${model} completion`,
       )
-      const nextCacheRead = safeAddTokenCounter(
-        existing.cacheRead,
-        cacheRead,
-        `${model} cache read`,
-      )
-      const nextCacheCreation = safeAddTokenCounter(
-        existing.cacheCreation,
-        cacheCreation,
-        `${model} cache creation`,
-      )
-      const nextInput = safeAddTokenCounter(nextPrompt, nextCacheRead, `${model} input token`)
-      const nextReusableInput = safeAddTokenCounter(
-        nextInput,
-        nextCacheCreation,
-        `${model} input token`,
-      )
-      safeAddTokenCounter(nextReusableInput, nextCompletion, `${model} token`)
-      pendingTokenCounters.set(model, {
-        prompt: nextPrompt,
-        completion: nextCompletion,
-        cacheRead: nextCacheRead,
-        cacheCreation: nextCacheCreation,
-      })
+      safeAddTokenCounter(nextPrompt, nextCompletion, `${model} token`)
+      pendingTokenCounters.set(model, { prompt: nextPrompt, completion: nextCompletion })
     }
 
     const newlyFlushedSpanIds: string[] = []
@@ -172,39 +119,18 @@ export class PrometheusAdapter implements ExportAdapter {
       const model = span.metadata['model']
       const promptTokens = span.metadata['promptTokens']
       const completionTokens = span.metadata['completionTokens']
-      const cacheReadTokens = span.metadata['cacheReadTokens']
-      const cacheCreationTokens = span.metadata['cacheCreationTokens']
-      const cacheCreation1hTokens = span.metadata['cacheCreation1hTokens']
 
       if (
         typeof model === 'string' &&
-        (typeof promptTokens === 'number' ||
-          typeof completionTokens === 'number' ||
-          typeof cacheReadTokens === 'number' ||
-          typeof cacheCreationTokens === 'number')
+        (typeof promptTokens === 'number' || typeof completionTokens === 'number')
       ) {
         const prompt = typeof promptTokens === 'number' ? promptTokens : 0
         const completion = typeof completionTokens === 'number' ? completionTokens : 0
-        const cacheRead = typeof cacheReadTokens === 'number' ? cacheReadTokens : 0
-        const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
-        const cacheCreation1h =
-          typeof cacheCreation1hTokens === 'number' ? cacheCreation1hTokens : 0
 
-        const existing = this.tokenCounters.get(model) ?? {
-          prompt: 0,
-          completion: 0,
-          cacheRead: 0,
-          cacheCreation: 0,
-        }
+        const existing = this.tokenCounters.get(model) ?? { prompt: 0, completion: 0 }
         this.tokenCounters.set(model, {
           prompt: safeAddTokenCounter(existing.prompt, prompt, `${model} prompt`),
           completion: safeAddTokenCounter(existing.completion, completion, `${model} completion`),
-          cacheRead: safeAddTokenCounter(existing.cacheRead, cacheRead, `${model} cache read`),
-          cacheCreation: safeAddTokenCounter(
-            existing.cacheCreation,
-            cacheCreation,
-            `${model} cache creation`,
-          ),
         })
 
         // Cost counter — only when pricing table covers this model
@@ -212,16 +138,7 @@ export class PrometheusAdapter implements ExportAdapter {
           const pricing = this.pricingTable[model]
           const cost =
             (prompt * pricing.promptPerMillion) / 1_000_000 +
-            (completion * pricing.completionPerMillion) / 1_000_000 +
-            (cacheRead * (pricing.cacheReadPerMillion ?? pricing.promptPerMillion)) / 1_000_000 +
-            ((cacheCreation - cacheCreation1h) *
-              (pricing.cacheCreationPerMillion ?? pricing.promptPerMillion)) /
-              1_000_000 +
-            (cacheCreation1h *
-              (pricing.cacheCreation1hPerMillion ??
-                pricing.cacheCreationPerMillion ??
-                pricing.promptPerMillion)) /
-              1_000_000
+            (completion * pricing.completionPerMillion) / 1_000_000
           this.costCounters.set(model, (this.costCounters.get(model) ?? 0) + cost)
         }
       }
@@ -296,12 +213,6 @@ export class PrometheusAdapter implements ExportAdapter {
         )
         lines.push(
           `franken_observer_tokens_total{model="${escapedModel}",type="completion"} ${counts.completion}`,
-        )
-        lines.push(
-          `franken_observer_tokens_total{model="${escapedModel}",type="cache_read"} ${counts.cacheRead}`,
-        )
-        lines.push(
-          `franken_observer_tokens_total{model="${escapedModel}",type="cache_creation"} ${counts.cacheCreation}`,
         )
       }
     }

--- a/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
+++ b/packages/franken-observer/src/adapters/prometheus/PrometheusAdapter.ts
@@ -91,6 +91,7 @@ export class PrometheusAdapter implements ExportAdapter {
       const completionTokens = span.metadata['completionTokens']
       const cacheReadTokens = span.metadata['cacheReadTokens']
       const cacheCreationTokens = span.metadata['cacheCreationTokens']
+      const cacheCreation1hTokens = span.metadata['cacheCreation1hTokens']
       if (typeof promptTokens === 'number') {
         assertValidTokenDelta(promptTokens, 'promptTokens')
       }
@@ -102,6 +103,15 @@ export class PrometheusAdapter implements ExportAdapter {
       }
       if (typeof cacheCreationTokens === 'number') {
         assertValidTokenDelta(cacheCreationTokens, 'cacheCreationTokens')
+      }
+      if (typeof cacheCreation1hTokens === 'number') {
+        assertValidTokenDelta(cacheCreation1hTokens, 'cacheCreation1hTokens')
+        const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
+        if (cacheCreation1hTokens > cacheCreation) {
+          throw new RangeError(
+            'PrometheusAdapter: cacheCreation1hTokens must not exceed cacheCreationTokens',
+          )
+        }
       }
       if (
         typeof promptTokens !== 'number' &&
@@ -164,6 +174,7 @@ export class PrometheusAdapter implements ExportAdapter {
       const completionTokens = span.metadata['completionTokens']
       const cacheReadTokens = span.metadata['cacheReadTokens']
       const cacheCreationTokens = span.metadata['cacheCreationTokens']
+      const cacheCreation1hTokens = span.metadata['cacheCreation1hTokens']
 
       if (
         typeof model === 'string' &&
@@ -176,6 +187,8 @@ export class PrometheusAdapter implements ExportAdapter {
         const completion = typeof completionTokens === 'number' ? completionTokens : 0
         const cacheRead = typeof cacheReadTokens === 'number' ? cacheReadTokens : 0
         const cacheCreation = typeof cacheCreationTokens === 'number' ? cacheCreationTokens : 0
+        const cacheCreation1h =
+          typeof cacheCreation1hTokens === 'number' ? cacheCreation1hTokens : 0
 
         const existing = this.tokenCounters.get(model) ?? {
           prompt: 0,
@@ -201,7 +214,13 @@ export class PrometheusAdapter implements ExportAdapter {
             (prompt * pricing.promptPerMillion) / 1_000_000 +
             (completion * pricing.completionPerMillion) / 1_000_000 +
             (cacheRead * (pricing.cacheReadPerMillion ?? pricing.promptPerMillion)) / 1_000_000 +
-            (cacheCreation * (pricing.cacheCreationPerMillion ?? pricing.promptPerMillion)) /
+            ((cacheCreation - cacheCreation1h) *
+              (pricing.cacheCreationPerMillion ?? pricing.promptPerMillion)) /
+              1_000_000 +
+            (cacheCreation1h *
+              (pricing.cacheCreation1hPerMillion ??
+                pricing.cacheCreationPerMillion ??
+                pricing.promptPerMillion)) /
               1_000_000
           this.costCounters.set(model, (this.costCounters.get(model) ?? 0) + cost)
         }

--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -108,6 +108,29 @@ describe('SpanLifecycle', () => {
       })
     })
 
+    it('forwards one-hour cache creation to metadata and the counter', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'one-hour-cached-llm-call' })
+      const counter = new TokenCounter()
+
+      SpanLifecycle.recordTokenUsage(span, {
+        promptTokens: 0,
+        completionTokens: 0,
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+        model: 'claude-sonnet-4-6',
+      }, counter)
+
+      expect(span.metadata).toMatchObject({
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+      })
+      expect(counter.totalsFor('claude-sonnet-4-6')).toMatchObject({
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+      })
+    })
+
     it('rejects atomically: a counter validation throw leaves the span unmutated', () => {
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'llm-call' })

--- a/packages/franken-observer/src/core/SpanLifecycle.test.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.test.ts
@@ -81,6 +81,33 @@ describe('SpanLifecycle', () => {
       expect(counter.totalsFor('claude-sonnet-4-6').totalTokens).toBe(400)
     })
 
+    it('records cache usage in span metadata and the provided counter', () => {
+      const trace = TraceContext.createTrace('goal')
+      const span = TraceContext.startSpan(trace, { name: 'cached-llm-call' })
+      const counter = new TokenCounter()
+
+      SpanLifecycle.recordTokenUsage(span, {
+        promptTokens: 100,
+        completionTokens: 50,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        model: 'claude-sonnet-4-6',
+      }, counter)
+
+      expect(span.metadata).toMatchObject({
+        promptTokens: 100,
+        completionTokens: 50,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        totalTokens: 250,
+      })
+      expect(counter.totalsFor('claude-sonnet-4-6')).toMatchObject({
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        totalTokens: 250,
+      })
+    })
+
     it('rejects atomically: a counter validation throw leaves the span unmutated', () => {
       const trace = TraceContext.createTrace('goal')
       const span = TraceContext.startSpan(trace, { name: 'llm-call' })

--- a/packages/franken-observer/src/core/SpanLifecycle.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.ts
@@ -6,6 +6,7 @@ export interface TokenUsage {
   completionTokens: number
   cacheReadTokens?: number
   cacheCreationTokens?: number
+  cacheCreation1hTokens?: number
   model?: string
 }
 
@@ -51,10 +52,15 @@ export const SpanLifecycle = {
     }
     const cacheReadTokens = usage.cacheReadTokens ?? 0
     const cacheCreationTokens = usage.cacheCreationTokens ?? 0
+    const cacheCreation1hTokens = usage.cacheCreation1hTokens ?? 0
     assertValidTokenDelta(usage.promptTokens, 'promptTokens')
     assertValidTokenDelta(usage.completionTokens, 'completionTokens')
     assertValidTokenDelta(cacheReadTokens, 'cacheReadTokens')
     assertValidTokenDelta(cacheCreationTokens, 'cacheCreationTokens')
+    assertValidTokenDelta(cacheCreation1hTokens, 'cacheCreation1hTokens')
+    if (cacheCreation1hTokens > cacheCreationTokens) {
+      throw new RangeError('SpanLifecycle: cacheCreation1hTokens must not exceed cacheCreationTokens')
+    }
     const uncachedTokens = safeAddTokenCounts(usage.promptTokens, usage.completionTokens)
     const cachedTokens = safeAddTokenCounts(cacheReadTokens, cacheCreationTokens)
     const totalTokens = safeAddTokenCounts(uncachedTokens, cachedTokens)
@@ -69,6 +75,7 @@ export const SpanLifecycle = {
         completionTokens: usage.completionTokens,
         cacheReadTokens,
         cacheCreationTokens,
+        ...(usage.cacheCreation1hTokens !== undefined ? { cacheCreation1hTokens } : {}),
       })
     }
     const data: Record<string, unknown> = {
@@ -81,6 +88,9 @@ export const SpanLifecycle = {
     }
     if (usage.cacheCreationTokens !== undefined) {
       data['cacheCreationTokens'] = cacheCreationTokens
+    }
+    if (usage.cacheCreation1hTokens !== undefined) {
+      data['cacheCreation1hTokens'] = cacheCreation1hTokens
     }
     if (usage.model !== undefined) {
       data['model'] = usage.model

--- a/packages/franken-observer/src/core/SpanLifecycle.ts
+++ b/packages/franken-observer/src/core/SpanLifecycle.ts
@@ -4,6 +4,8 @@ import type { TokenCounter } from '../cost/TokenCounter.js'
 export interface TokenUsage {
   promptTokens: number
   completionTokens: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
   model?: string
 }
 
@@ -47,9 +49,15 @@ export const SpanLifecycle = {
     if (span.status !== 'active') {
       throw new Error(`Cannot record token usage on a ${span.status} span (id: ${span.id})`)
     }
+    const cacheReadTokens = usage.cacheReadTokens ?? 0
+    const cacheCreationTokens = usage.cacheCreationTokens ?? 0
     assertValidTokenDelta(usage.promptTokens, 'promptTokens')
     assertValidTokenDelta(usage.completionTokens, 'completionTokens')
-    const totalTokens = safeAddTokenCounts(usage.promptTokens, usage.completionTokens)
+    assertValidTokenDelta(cacheReadTokens, 'cacheReadTokens')
+    assertValidTokenDelta(cacheCreationTokens, 'cacheCreationTokens')
+    const uncachedTokens = safeAddTokenCounts(usage.promptTokens, usage.completionTokens)
+    const cachedTokens = safeAddTokenCounts(cacheReadTokens, cacheCreationTokens)
+    const totalTokens = safeAddTokenCounts(uncachedTokens, cachedTokens)
 
     // Record to the counter next: it may throw if the new model/global totals
     // would overflow. Doing it before mutating the span keeps the rejection
@@ -59,12 +67,20 @@ export const SpanLifecycle = {
         model: usage.model,
         promptTokens: usage.promptTokens,
         completionTokens: usage.completionTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
       })
     }
     const data: Record<string, unknown> = {
       promptTokens: usage.promptTokens,
       completionTokens: usage.completionTokens,
       totalTokens,
+    }
+    if (usage.cacheReadTokens !== undefined) {
+      data['cacheReadTokens'] = cacheReadTokens
+    }
+    if (usage.cacheCreationTokens !== undefined) {
+      data['cacheCreationTokens'] = cacheCreationTokens
     }
     if (usage.model !== undefined) {
       data['model'] = usage.model

--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -6,8 +6,47 @@ describe('CostCalculator', () => {
   describe('with default pricing', () => {
     const calc = new CostCalculator(DEFAULT_PRICING)
 
+    it('matches published Anthropic cache pricing for listed Claude models', () => {
+      expect(DEFAULT_PRICING['claude-opus-4-6']).toEqual({
+        promptPerMillion: 5,
+        completionPerMillion: 25,
+        cacheReadPerMillion: 0.5,
+        cacheCreationPerMillion: 6.25,
+      })
+      expect(DEFAULT_PRICING['claude-sonnet-4-6']).toMatchObject({
+        cacheReadPerMillion: 0.3,
+        cacheCreationPerMillion: 3.75,
+      })
+      expect(DEFAULT_PRICING['claude-haiku-4-5']).toMatchObject({
+        cacheReadPerMillion: 0.1,
+        cacheCreationPerMillion: 1.25,
+      })
+    })
+
+    it('matches published OpenAI cached-input pricing for listed GPT-4o models', () => {
+      expect(DEFAULT_PRICING['gpt-4o']).toMatchObject({
+        promptPerMillion: 2.5,
+        completionPerMillion: 10,
+        cacheReadPerMillion: 1.25,
+      })
+      expect(DEFAULT_PRICING['gpt-4o-mini']).toMatchObject({
+        promptPerMillion: 0.15,
+        completionPerMillion: 0.6,
+        cacheReadPerMillion: 0.075,
+      })
+    })
+
+    it('uses Sonnet cache pricing for the Aider alias', () => {
+      expect(DEFAULT_PRICING['aider']).toMatchObject({
+        promptPerMillion: 3,
+        completionPerMillion: 15,
+        cacheReadPerMillion: 0.3,
+        cacheCreationPerMillion: 3.75,
+      })
+    })
+
     it('calculates cost for claude-opus-4-6 using per-million token rates', () => {
-      // Opus 4: $15/M prompt, $75/M completion (example rates)
+      // Opus 4.6: $5/M prompt, $25/M completion.
       const cost = calc.calculate({
         model: 'claude-opus-4-6',
         promptTokens: 1_000_000,
@@ -27,6 +66,39 @@ describe('CostCalculator', () => {
         (500_000 / 1_000_000) * pricing.promptPerMillion +
         (250_000 / 1_000_000) * pricing.completionPerMillion
       expect(cost).toBeCloseTo(expected, 8)
+    })
+
+    it('prices cache reads and cache creation at their configured rates', () => {
+      const calc = new CostCalculator({
+        cached: {
+          promptPerMillion: 4,
+          completionPerMillion: 8,
+          cacheReadPerMillion: 0.4,
+          cacheCreationPerMillion: 5,
+        },
+      })
+
+      expect(calc.calculate({
+        model: 'cached',
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+      })).toBe(17.4)
+    })
+
+    it('falls back to prompt pricing when cache-specific rates are unset', () => {
+      const calc = new CostCalculator({
+        fallback: { promptPerMillion: 4, completionPerMillion: 8 },
+      })
+
+      expect(calc.calculate({
+        model: 'fallback',
+        promptTokens: 0,
+        completionTokens: 0,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+      })).toBe(8)
     })
 
     it('multiplies small token counts by the rate before scaling to millions', () => {

--- a/packages/franken-observer/src/cost/CostCalculator.test.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.test.ts
@@ -12,14 +12,17 @@ describe('CostCalculator', () => {
         completionPerMillion: 25,
         cacheReadPerMillion: 0.5,
         cacheCreationPerMillion: 6.25,
+        cacheCreation1hPerMillion: 10,
       })
       expect(DEFAULT_PRICING['claude-sonnet-4-6']).toMatchObject({
         cacheReadPerMillion: 0.3,
         cacheCreationPerMillion: 3.75,
+        cacheCreation1hPerMillion: 6,
       })
       expect(DEFAULT_PRICING['claude-haiku-4-5']).toMatchObject({
         cacheReadPerMillion: 0.1,
         cacheCreationPerMillion: 1.25,
+        cacheCreation1hPerMillion: 2,
       })
     })
 
@@ -85,6 +88,16 @@ describe('CostCalculator', () => {
         cacheReadTokens: 1_000_000,
         cacheCreationTokens: 1_000_000,
       })).toBe(17.4)
+    })
+
+    it('prices one-hour Anthropic cache creation separately from five-minute creation', () => {
+      expect(calc.calculate({
+        model: 'claude-sonnet-4-6',
+        promptTokens: 0,
+        completionTokens: 0,
+        cacheCreationTokens: 1_000_000,
+        cacheCreation1hTokens: 400_000,
+      })).toBeCloseTo((600_000 * 3.75 + 400_000 * 6) / 1_000_000, 8)
     })
 
     it('falls back to prompt pricing when cache-specific rates are unset', () => {

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -52,13 +52,23 @@ export class CostCalculator {
   private static assertValidTokenAggregates(entries: TokenRecord[]): void {
     let promptTokens = 0
     let completionTokens = 0
+    let cacheReadTokens = 0
+    let cacheCreationTokens = 0
 
     for (const entry of entries) {
+      const cacheRead = entry.cacheReadTokens ?? 0
+      const cacheCreation = entry.cacheCreationTokens ?? 0
       CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
       CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
+      CostCalculator.assertValidTokenCount(cacheRead, 'cacheReadTokens')
+      CostCalculator.assertValidTokenCount(cacheCreation, 'cacheCreationTokens')
       promptTokens = CostCalculator.safeAddTokenCounts(promptTokens, entry.promptTokens)
       completionTokens = CostCalculator.safeAddTokenCounts(completionTokens, entry.completionTokens)
-      CostCalculator.safeAddTokenCounts(promptTokens, completionTokens)
+      cacheReadTokens = CostCalculator.safeAddTokenCounts(cacheReadTokens, cacheRead)
+      cacheCreationTokens = CostCalculator.safeAddTokenCounts(cacheCreationTokens, cacheCreation)
+      const uncached = CostCalculator.safeAddTokenCounts(promptTokens, completionTokens)
+      const cached = CostCalculator.safeAddTokenCounts(cacheReadTokens, cacheCreationTokens)
+      CostCalculator.safeAddTokenCounts(uncached, cached)
     }
   }
 
@@ -67,8 +77,12 @@ export class CostCalculator {
   }
 
   calculateWithAttribution(entry: TokenRecord): CostCalculation {
+    const cacheReadTokens = entry.cacheReadTokens ?? 0
+    const cacheCreationTokens = entry.cacheCreationTokens ?? 0
     CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
     CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
+    CostCalculator.assertValidTokenCount(cacheReadTokens, 'cacheReadTokens')
+    CostCalculator.assertValidTokenCount(cacheCreationTokens, 'cacheCreationTokens')
 
     const model = this.pricing[entry.model]
     if (model === undefined) {
@@ -81,7 +95,10 @@ export class CostCalculator {
     return {
       costUsd:
         (entry.promptTokens * model.promptPerMillion) / 1_000_000 +
-        (entry.completionTokens * model.completionPerMillion) / 1_000_000,
+        (entry.completionTokens * model.completionPerMillion) / 1_000_000 +
+        (cacheReadTokens * (model.cacheReadPerMillion ?? model.promptPerMillion)) / 1_000_000 +
+        (cacheCreationTokens * (model.cacheCreationPerMillion ?? model.promptPerMillion)) /
+          1_000_000,
       unknownModel: false,
     }
   }

--- a/packages/franken-observer/src/cost/CostCalculator.ts
+++ b/packages/franken-observer/src/cost/CostCalculator.ts
@@ -54,18 +54,28 @@ export class CostCalculator {
     let completionTokens = 0
     let cacheReadTokens = 0
     let cacheCreationTokens = 0
+    let cacheCreation1hTokens = 0
 
     for (const entry of entries) {
       const cacheRead = entry.cacheReadTokens ?? 0
       const cacheCreation = entry.cacheCreationTokens ?? 0
+      const cacheCreation1h = entry.cacheCreation1hTokens ?? 0
       CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
       CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
       CostCalculator.assertValidTokenCount(cacheRead, 'cacheReadTokens')
       CostCalculator.assertValidTokenCount(cacheCreation, 'cacheCreationTokens')
+      CostCalculator.assertValidTokenCount(cacheCreation1h, 'cacheCreation1hTokens')
+      if (cacheCreation1h > cacheCreation) {
+        throw new RangeError('CostCalculator: cacheCreation1hTokens must not exceed cacheCreationTokens')
+      }
       promptTokens = CostCalculator.safeAddTokenCounts(promptTokens, entry.promptTokens)
       completionTokens = CostCalculator.safeAddTokenCounts(completionTokens, entry.completionTokens)
       cacheReadTokens = CostCalculator.safeAddTokenCounts(cacheReadTokens, cacheRead)
       cacheCreationTokens = CostCalculator.safeAddTokenCounts(cacheCreationTokens, cacheCreation)
+      cacheCreation1hTokens = CostCalculator.safeAddTokenCounts(
+        cacheCreation1hTokens,
+        cacheCreation1h,
+      )
       const uncached = CostCalculator.safeAddTokenCounts(promptTokens, completionTokens)
       const cached = CostCalculator.safeAddTokenCounts(cacheReadTokens, cacheCreationTokens)
       CostCalculator.safeAddTokenCounts(uncached, cached)
@@ -79,10 +89,15 @@ export class CostCalculator {
   calculateWithAttribution(entry: TokenRecord): CostCalculation {
     const cacheReadTokens = entry.cacheReadTokens ?? 0
     const cacheCreationTokens = entry.cacheCreationTokens ?? 0
+    const cacheCreation1hTokens = entry.cacheCreation1hTokens ?? 0
     CostCalculator.assertValidTokenCount(entry.promptTokens, 'promptTokens')
     CostCalculator.assertValidTokenCount(entry.completionTokens, 'completionTokens')
     CostCalculator.assertValidTokenCount(cacheReadTokens, 'cacheReadTokens')
     CostCalculator.assertValidTokenCount(cacheCreationTokens, 'cacheCreationTokens')
+    CostCalculator.assertValidTokenCount(cacheCreation1hTokens, 'cacheCreation1hTokens')
+    if (cacheCreation1hTokens > cacheCreationTokens) {
+      throw new RangeError('CostCalculator: cacheCreation1hTokens must not exceed cacheCreationTokens')
+    }
 
     const model = this.pricing[entry.model]
     if (model === undefined) {
@@ -97,7 +112,13 @@ export class CostCalculator {
         (entry.promptTokens * model.promptPerMillion) / 1_000_000 +
         (entry.completionTokens * model.completionPerMillion) / 1_000_000 +
         (cacheReadTokens * (model.cacheReadPerMillion ?? model.promptPerMillion)) / 1_000_000 +
-        (cacheCreationTokens * (model.cacheCreationPerMillion ?? model.promptPerMillion)) /
+        ((cacheCreationTokens - cacheCreation1hTokens) *
+          (model.cacheCreationPerMillion ?? model.promptPerMillion)) /
+          1_000_000 +
+        (cacheCreation1hTokens *
+          (model.cacheCreation1hPerMillion ??
+            model.cacheCreationPerMillion ??
+            model.promptPerMillion)) /
           1_000_000,
       unknownModel: false,
     }

--- a/packages/franken-observer/src/cost/ModelAttribution.test.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.test.ts
@@ -123,6 +123,27 @@ describe('ModelAttribution', () => {
       expect(row.totalCostUsd).toBeCloseTo(DEFAULT_PRICING['claude-opus-4-6']!.promptPerMillion, 6)
     })
 
+    it('includes cache-read and cache-creation tiers in attributed cost', () => {
+      const attr = new ModelAttribution({
+        cached: {
+          promptPerMillion: 10,
+          completionPerMillion: 20,
+          cacheReadPerMillion: 1,
+          cacheCreationPerMillion: 12.5,
+        },
+      })
+      attr.record({
+        model: 'cached',
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+        success: true,
+      })
+
+      expect(attr.report()[0]!.totalCostUsd).toBe(43.5)
+    })
+
     it('returns an empty array when nothing has been recorded', () => {
       const attr = new ModelAttribution(DEFAULT_PRICING)
       expect(attr.report()).toEqual([])

--- a/packages/franken-observer/src/cost/ModelAttribution.test.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.test.ts
@@ -130,6 +130,7 @@ describe('ModelAttribution', () => {
           completionPerMillion: 20,
           cacheReadPerMillion: 1,
           cacheCreationPerMillion: 12.5,
+          cacheCreation1hPerMillion: 20,
         },
       })
       attr.record({
@@ -138,10 +139,11 @@ describe('ModelAttribution', () => {
         completionTokens: 1_000_000,
         cacheReadTokens: 1_000_000,
         cacheCreationTokens: 1_000_000,
+        cacheCreation1hTokens: 400_000,
         success: true,
       })
 
-      expect(attr.report()[0]!.totalCostUsd).toBe(43.5)
+      expect(attr.report()[0]!.totalCostUsd).toBe(46.5)
     })
 
     it('returns an empty array when nothing has been recorded', () => {

--- a/packages/franken-observer/src/cost/ModelAttribution.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.ts
@@ -7,6 +7,7 @@ export interface AttributionEntry {
   completionTokens: number
   cacheReadTokens?: number
   cacheCreationTokens?: number
+  cacheCreation1hTokens?: number
   success: boolean
 }
 
@@ -26,6 +27,7 @@ interface ModelState {
   completionTokens: number
   cacheReadTokens: number
   cacheCreationTokens: number
+  cacheCreation1hTokens: number
 }
 
 export interface ModelAttributionOptions {
@@ -43,6 +45,7 @@ export class ModelAttribution {
   private totalCompletionTokens = 0
   private totalCacheReadTokens = 0
   private totalCacheCreationTokens = 0
+  private totalCacheCreation1hTokens = 0
 
   constructor(pricing: PricingTable, options: ModelAttributionOptions = {}) {
     const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
@@ -80,8 +83,15 @@ export class ModelAttribution {
     ModelAttribution.assertValidDelta(entry.completionTokens, 'completionTokens')
     const cacheReadDelta = entry.cacheReadTokens ?? 0
     const cacheCreationDelta = entry.cacheCreationTokens ?? 0
+    const cacheCreation1hDelta = entry.cacheCreation1hTokens ?? 0
     ModelAttribution.assertValidDelta(cacheReadDelta, 'cacheReadTokens')
     ModelAttribution.assertValidDelta(cacheCreationDelta, 'cacheCreationTokens')
+    ModelAttribution.assertValidDelta(cacheCreation1hDelta, 'cacheCreation1hTokens')
+    if (cacheCreation1hDelta > cacheCreationDelta) {
+      throw new RangeError(
+        'ModelAttribution: cacheCreation1hTokens must not exceed cacheCreationTokens',
+      )
+    }
     if (!this.state.has(entry.model) && this.state.size >= this.maxModels) {
       throw new RangeError(
         `ModelAttribution: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
@@ -95,6 +105,7 @@ export class ModelAttribution {
       completionTokens: 0,
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
+      cacheCreation1hTokens: 0,
     }
     const promptTokens = ModelAttribution.safeAdd(existing.promptTokens, entry.promptTokens)
     const completionTokens = ModelAttribution.safeAdd(existing.completionTokens, entry.completionTokens)
@@ -102,6 +113,10 @@ export class ModelAttribution {
     const cacheCreationTokens = ModelAttribution.safeAdd(
       existing.cacheCreationTokens,
       cacheCreationDelta,
+    )
+    const cacheCreation1hTokens = ModelAttribution.safeAdd(
+      existing.cacheCreation1hTokens,
+      cacheCreation1hDelta,
     )
     const inputTokens = ModelAttribution.safeAdd(promptTokens, cacheReadTokens)
     const reusableInputTokens = ModelAttribution.safeAdd(inputTokens, cacheCreationTokens)
@@ -117,6 +132,10 @@ export class ModelAttribution {
       this.totalCacheCreationTokens,
       cacheCreationDelta,
     )
+    const totalCacheCreation1hTokens = ModelAttribution.safeAdd(
+      this.totalCacheCreation1hTokens,
+      cacheCreation1hDelta,
+    )
     const totalInputTokens = ModelAttribution.safeAdd(totalPromptTokens, totalCacheReadTokens)
     const totalReusableInputTokens = ModelAttribution.safeAdd(
       totalInputTokens,
@@ -131,11 +150,13 @@ export class ModelAttribution {
       completionTokens,
       cacheReadTokens,
       cacheCreationTokens,
+      cacheCreation1hTokens,
     })
     this.totalPromptTokens = totalPromptTokens
     this.totalCompletionTokens = totalCompletionTokens
     this.totalCacheReadTokens = totalCacheReadTokens
     this.totalCacheCreationTokens = totalCacheCreationTokens
+    this.totalCacheCreation1hTokens = totalCacheCreation1hTokens
   }
 
   report(): AttributionRow[] {
@@ -151,6 +172,7 @@ export class ModelAttribution {
         completionTokens: s.completionTokens,
         cacheReadTokens: s.cacheReadTokens,
         cacheCreationTokens: s.cacheCreationTokens,
+        cacheCreation1hTokens: s.cacheCreation1hTokens,
       }),
     }))
   }

--- a/packages/franken-observer/src/cost/ModelAttribution.ts
+++ b/packages/franken-observer/src/cost/ModelAttribution.ts
@@ -5,6 +5,8 @@ export interface AttributionEntry {
   model: string
   promptTokens: number
   completionTokens: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
   success: boolean
 }
 
@@ -22,6 +24,8 @@ interface ModelState {
   successfulCalls: number
   promptTokens: number
   completionTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
 }
 
 export interface ModelAttributionOptions {
@@ -37,6 +41,8 @@ export class ModelAttribution {
   private readonly maxModels: number
   private totalPromptTokens = 0
   private totalCompletionTokens = 0
+  private totalCacheReadTokens = 0
+  private totalCacheCreationTokens = 0
 
   constructor(pricing: PricingTable, options: ModelAttributionOptions = {}) {
     const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
@@ -72,6 +78,10 @@ export class ModelAttribution {
   record(entry: AttributionEntry): void {
     ModelAttribution.assertValidDelta(entry.promptTokens, 'promptTokens')
     ModelAttribution.assertValidDelta(entry.completionTokens, 'completionTokens')
+    const cacheReadDelta = entry.cacheReadTokens ?? 0
+    const cacheCreationDelta = entry.cacheCreationTokens ?? 0
+    ModelAttribution.assertValidDelta(cacheReadDelta, 'cacheReadTokens')
+    ModelAttribution.assertValidDelta(cacheCreationDelta, 'cacheCreationTokens')
     if (!this.state.has(entry.model) && this.state.size >= this.maxModels) {
       throw new RangeError(
         `ModelAttribution: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
@@ -83,23 +93,49 @@ export class ModelAttribution {
       successfulCalls: 0,
       promptTokens: 0,
       completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
     }
     const promptTokens = ModelAttribution.safeAdd(existing.promptTokens, entry.promptTokens)
     const completionTokens = ModelAttribution.safeAdd(existing.completionTokens, entry.completionTokens)
-    ModelAttribution.safeAdd(promptTokens, completionTokens)
+    const cacheReadTokens = ModelAttribution.safeAdd(existing.cacheReadTokens, cacheReadDelta)
+    const cacheCreationTokens = ModelAttribution.safeAdd(
+      existing.cacheCreationTokens,
+      cacheCreationDelta,
+    )
+    const inputTokens = ModelAttribution.safeAdd(promptTokens, cacheReadTokens)
+    const reusableInputTokens = ModelAttribution.safeAdd(inputTokens, cacheCreationTokens)
+    ModelAttribution.safeAdd(reusableInputTokens, completionTokens)
 
     const totalPromptTokens = ModelAttribution.safeAdd(this.totalPromptTokens, entry.promptTokens)
     const totalCompletionTokens = ModelAttribution.safeAdd(this.totalCompletionTokens, entry.completionTokens)
-    ModelAttribution.safeAdd(totalPromptTokens, totalCompletionTokens)
+    const totalCacheReadTokens = ModelAttribution.safeAdd(
+      this.totalCacheReadTokens,
+      cacheReadDelta,
+    )
+    const totalCacheCreationTokens = ModelAttribution.safeAdd(
+      this.totalCacheCreationTokens,
+      cacheCreationDelta,
+    )
+    const totalInputTokens = ModelAttribution.safeAdd(totalPromptTokens, totalCacheReadTokens)
+    const totalReusableInputTokens = ModelAttribution.safeAdd(
+      totalInputTokens,
+      totalCacheCreationTokens,
+    )
+    ModelAttribution.safeAdd(totalReusableInputTokens, totalCompletionTokens)
 
     this.state.set(entry.model, {
       totalCalls: existing.totalCalls + 1,
       successfulCalls: existing.successfulCalls + (entry.success ? 1 : 0),
       promptTokens,
       completionTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
     })
     this.totalPromptTokens = totalPromptTokens
     this.totalCompletionTokens = totalCompletionTokens
+    this.totalCacheReadTokens = totalCacheReadTokens
+    this.totalCacheCreationTokens = totalCacheCreationTokens
   }
 
   report(): AttributionRow[] {
@@ -113,6 +149,8 @@ export class ModelAttribution {
         model,
         promptTokens: s.promptTokens,
         completionTokens: s.completionTokens,
+        cacheReadTokens: s.cacheReadTokens,
+        cacheCreationTokens: s.cacheCreationTokens,
       }),
     }))
   }

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -237,4 +237,20 @@ describe('cacheHitRatio()', () => {
   ] as const)('returns the expected ratio for %s', (_name, record, expected) => {
     expect(cacheHitRatio(record)).toBe(expected)
   })
+
+  it.each([
+    ['negative', { promptTokens: -1, cacheReadTokens: 1 }],
+    ['fractional', { promptTokens: 1.5, cacheReadTokens: 1 }],
+    ['non-finite', { promptTokens: Number.POSITIVE_INFINITY, cacheReadTokens: 1 }],
+    ['unsafe', { promptTokens: Number.MAX_SAFE_INTEGER + 1, cacheReadTokens: 0 }],
+  ])('rejects %s token counts', (_name, record) => {
+    expect(() => cacheHitRatio(record)).toThrow(RangeError)
+  })
+
+  it('rejects a denominator outside the safe-integer range', () => {
+    expect(() => cacheHitRatio({
+      promptTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 1,
+    })).toThrow(RangeError)
+  })
 })

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { TokenCounter } from './TokenCounter.js'
+import { cacheHitRatio, TokenCounter } from './TokenCounter.js'
 
 describe('TokenCounter', () => {
   let counter: TokenCounter
@@ -26,6 +26,25 @@ describe('TokenCounter', () => {
       expect(totals.totalTokens).toBe(600)
     })
 
+    it('accumulates cache-read and cache-creation tokens and defaults missing cache fields to zero', () => {
+      counter.record({
+        model: 'claude-sonnet-4-6',
+        promptTokens: 100,
+        completionTokens: 25,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+      })
+      counter.record({ model: 'claude-sonnet-4-6', promptTokens: 50, completionTokens: 10 })
+
+      expect(counter.totalsFor('claude-sonnet-4-6')).toEqual({
+        promptTokens: 150,
+        completionTokens: 35,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        totalTokens: 285,
+      })
+    })
+
     it('tracks multiple models independently', () => {
       counter.record({ model: 'claude-opus-4-6', promptTokens: 100, completionTokens: 50 })
       counter.record({ model: 'gpt-4o', promptTokens: 200, completionTokens: 80 })
@@ -45,6 +64,8 @@ describe('TokenCounter', () => {
       expect(boundedCounter.grandTotal()).toEqual({
         promptTokens: 30,
         completionTokens: 15,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: 45,
       })
     })
@@ -59,6 +80,8 @@ describe('TokenCounter', () => {
       expect(boundedCounter.totalsFor('model-a')).toEqual({
         promptTokens: 30,
         completionTokens: 15,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: 45,
       })
     })
@@ -96,6 +119,8 @@ describe('TokenCounter', () => {
       expect(counter.grandTotal()).toEqual({
         promptTokens: 2_000,
         completionTokens: 3_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: 5_000,
       })
 
@@ -104,6 +129,8 @@ describe('TokenCounter', () => {
       expect(counter.grandTotal()).toEqual({
         promptTokens: 0,
         completionTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: 0,
       })
     })
@@ -161,6 +188,8 @@ describe('TokenCounter', () => {
       expect(counter.totalsFor('m')).toEqual({
         promptTokens: 0,
         completionTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: 0,
       })
     })
@@ -176,8 +205,21 @@ describe('TokenCounter', () => {
       expect(counter.grandTotal()).toEqual({
         promptTokens: Number.MAX_SAFE_INTEGER,
         completionTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
         totalTokens: Number.MAX_SAFE_INTEGER,
       })
     })
+  })
+})
+
+describe('cacheHitRatio()', () => {
+  it.each([
+    ['no prompt activity', { promptTokens: 0, cacheReadTokens: 0 }, 0],
+    ['all cached', { promptTokens: 0, cacheReadTokens: 100 }, 1],
+    ['all fresh', { promptTokens: 100, cacheReadTokens: 0 }, 0],
+    ['mixed', { promptTokens: 25, cacheReadTokens: 75 }, 0.75],
+  ] as const)('returns the expected ratio for %s', (_name, record, expected) => {
+    expect(cacheHitRatio(record)).toBe(expected)
   })
 })

--- a/packages/franken-observer/src/cost/TokenCounter.test.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.test.ts
@@ -45,6 +45,21 @@ describe('TokenCounter', () => {
       })
     })
 
+    it('preserves the one-hour cache-creation subset for cost calculation', () => {
+      counter.record({
+        model: 'claude-sonnet-4-6',
+        promptTokens: 0,
+        completionTokens: 0,
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+      })
+
+      expect(counter.totalsFor('claude-sonnet-4-6')).toMatchObject({
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+      })
+    })
+
     it('tracks multiple models independently', () => {
       counter.record({ model: 'claude-opus-4-6', promptTokens: 100, completionTokens: 50 })
       counter.record({ model: 'gpt-4o', promptTokens: 200, completionTokens: 80 })

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -23,7 +23,22 @@ export interface CacheHitRatioInput {
 }
 
 export function cacheHitRatio(record: CacheHitRatioInput): number {
+  for (const [label, value] of [
+    ['promptTokens', record.promptTokens],
+    ['cacheReadTokens', record.cacheReadTokens],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(
+        `cacheHitRatio: ${label} must be a non-negative safe integer, received ${value}`,
+      )
+    }
+  }
   const denominator = record.promptTokens + record.cacheReadTokens
+  if (!Number.isSafeInteger(denominator)) {
+    throw new RangeError(
+      `cacheHitRatio: input token total ${denominator} exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+    )
+  }
   return denominator === 0 ? 0 : record.cacheReadTokens / denominator
 }
 

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -4,6 +4,8 @@ export interface TokenRecord {
   completionTokens: number
   cacheReadTokens?: number
   cacheCreationTokens?: number
+  /** One-hour cache writes, already included in cacheCreationTokens. */
+  cacheCreation1hTokens?: number
 }
 
 export interface TokenTotals {
@@ -11,6 +13,7 @@ export interface TokenTotals {
   completionTokens: number
   cacheReadTokens: number
   cacheCreationTokens: number
+  cacheCreation1hTokens?: number
   totalTokens: number
 }
 
@@ -37,12 +40,14 @@ export class TokenCounter {
     completion: number
     cacheRead: number
     cacheCreation: number
+    cacheCreation1h: number
   }>()
   private readonly maxModels: number
   private totalPromptTokens = 0
   private totalCompletionTokens = 0
   private totalCacheReadTokens = 0
   private totalCacheCreationTokens = 0
+  private totalCacheCreation1hTokens = 0
 
   constructor(options: TokenCounterOptions = {}) {
     const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
@@ -77,10 +82,15 @@ export class TokenCounter {
   record(entry: TokenRecord): void {
     const cacheReadTokens = entry.cacheReadTokens ?? 0
     const cacheCreationTokens = entry.cacheCreationTokens ?? 0
+    const cacheCreation1hTokens = entry.cacheCreation1hTokens ?? 0
     TokenCounter.assertValidDelta(entry.promptTokens, 'promptTokens')
     TokenCounter.assertValidDelta(entry.completionTokens, 'completionTokens')
     TokenCounter.assertValidDelta(cacheReadTokens, 'cacheReadTokens')
     TokenCounter.assertValidDelta(cacheCreationTokens, 'cacheCreationTokens')
+    TokenCounter.assertValidDelta(cacheCreation1hTokens, 'cacheCreation1hTokens')
+    if (cacheCreation1hTokens > cacheCreationTokens) {
+      throw new RangeError('TokenCounter: cacheCreation1hTokens must not exceed cacheCreationTokens')
+    }
     if (!this.counts.has(entry.model) && this.counts.size >= this.maxModels) {
       throw new RangeError(
         `TokenCounter: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
@@ -91,11 +101,13 @@ export class TokenCounter {
       completion: 0,
       cacheRead: 0,
       cacheCreation: 0,
+      cacheCreation1h: 0,
     }
     const prompt = TokenCounter.safeAdd(existing.prompt, entry.promptTokens)
     const completion = TokenCounter.safeAdd(existing.completion, entry.completionTokens)
     const cacheRead = TokenCounter.safeAdd(existing.cacheRead, cacheReadTokens)
     const cacheCreation = TokenCounter.safeAdd(existing.cacheCreation, cacheCreationTokens)
+    const cacheCreation1h = TokenCounter.safeAdd(existing.cacheCreation1h, cacheCreation1hTokens)
     // Validate the combined per-model total up-front so a record whose
     // prompt+completion overflows the safe-integer range is rejected here,
     // atomically, instead of poisoning later totalsFor() reads.
@@ -113,14 +125,19 @@ export class TokenCounter {
       this.totalCacheCreationTokens,
       cacheCreationTokens,
     )
+    const globalCacheCreation1h = TokenCounter.safeAdd(
+      this.totalCacheCreation1hTokens,
+      cacheCreation1hTokens,
+    )
     const globalUncached = TokenCounter.safeAdd(globalPrompt, globalCompletion)
     const globalCached = TokenCounter.safeAdd(globalCacheRead, globalCacheCreation)
     TokenCounter.safeAdd(globalUncached, globalCached)
-    this.counts.set(entry.model, { prompt, completion, cacheRead, cacheCreation })
+    this.counts.set(entry.model, { prompt, completion, cacheRead, cacheCreation, cacheCreation1h })
     this.totalPromptTokens = globalPrompt
     this.totalCompletionTokens = globalCompletion
     this.totalCacheReadTokens = globalCacheRead
     this.totalCacheCreationTokens = globalCacheCreation
+    this.totalCacheCreation1hTokens = globalCacheCreation1h
   }
 
   totalsFor(model: string): TokenTotals {
@@ -129,6 +146,7 @@ export class TokenCounter {
       completion: 0,
       cacheRead: 0,
       cacheCreation: 0,
+      cacheCreation1h: 0,
     }
     const uncached = TokenCounter.safeAdd(entry.prompt, entry.completion)
     const cached = TokenCounter.safeAdd(entry.cacheRead, entry.cacheCreation)
@@ -137,6 +155,7 @@ export class TokenCounter {
       completionTokens: entry.completion,
       cacheReadTokens: entry.cacheRead,
       cacheCreationTokens: entry.cacheCreation,
+      ...(entry.cacheCreation1h > 0 ? { cacheCreation1hTokens: entry.cacheCreation1h } : {}),
       totalTokens: TokenCounter.safeAdd(uncached, cached),
     }
   }
@@ -152,6 +171,9 @@ export class TokenCounter {
       completionTokens: this.totalCompletionTokens,
       cacheReadTokens: this.totalCacheReadTokens,
       cacheCreationTokens: this.totalCacheCreationTokens,
+      ...(this.totalCacheCreation1hTokens > 0
+        ? { cacheCreation1hTokens: this.totalCacheCreation1hTokens }
+        : {}),
       totalTokens: TokenCounter.safeAdd(uncached, cached),
     }
   }
@@ -166,5 +188,6 @@ export class TokenCounter {
     this.totalCompletionTokens = 0
     this.totalCacheReadTokens = 0
     this.totalCacheCreationTokens = 0
+    this.totalCacheCreation1hTokens = 0
   }
 }

--- a/packages/franken-observer/src/cost/TokenCounter.ts
+++ b/packages/franken-observer/src/cost/TokenCounter.ts
@@ -2,12 +2,26 @@ export interface TokenRecord {
   model: string
   promptTokens: number
   completionTokens: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
 }
 
 export interface TokenTotals {
   promptTokens: number
   completionTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
   totalTokens: number
+}
+
+export interface CacheHitRatioInput {
+  promptTokens: number
+  cacheReadTokens: number
+}
+
+export function cacheHitRatio(record: CacheHitRatioInput): number {
+  const denominator = record.promptTokens + record.cacheReadTokens
+  return denominator === 0 ? 0 : record.cacheReadTokens / denominator
 }
 
 export interface TokenCounterOptions {
@@ -18,10 +32,17 @@ export interface TokenCounterOptions {
 const DEFAULT_MAX_MODELS = 1_000
 
 export class TokenCounter {
-  private readonly counts = new Map<string, { prompt: number; completion: number }>()
+  private readonly counts = new Map<string, {
+    prompt: number
+    completion: number
+    cacheRead: number
+    cacheCreation: number
+  }>()
   private readonly maxModels: number
   private totalPromptTokens = 0
   private totalCompletionTokens = 0
+  private totalCacheReadTokens = 0
+  private totalCacheCreationTokens = 0
 
   constructor(options: TokenCounterOptions = {}) {
     const maxModels = options.maxModels ?? DEFAULT_MAX_MODELS
@@ -54,46 +75,84 @@ export class TokenCounter {
   }
 
   record(entry: TokenRecord): void {
+    const cacheReadTokens = entry.cacheReadTokens ?? 0
+    const cacheCreationTokens = entry.cacheCreationTokens ?? 0
     TokenCounter.assertValidDelta(entry.promptTokens, 'promptTokens')
     TokenCounter.assertValidDelta(entry.completionTokens, 'completionTokens')
+    TokenCounter.assertValidDelta(cacheReadTokens, 'cacheReadTokens')
+    TokenCounter.assertValidDelta(cacheCreationTokens, 'cacheCreationTokens')
     if (!this.counts.has(entry.model) && this.counts.size >= this.maxModels) {
       throw new RangeError(
         `TokenCounter: model cardinality limit of ${this.maxModels} reached; rejected model "${entry.model}"`,
       )
     }
-    const existing = this.counts.get(entry.model) ?? { prompt: 0, completion: 0 }
+    const existing = this.counts.get(entry.model) ?? {
+      prompt: 0,
+      completion: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+    }
     const prompt = TokenCounter.safeAdd(existing.prompt, entry.promptTokens)
     const completion = TokenCounter.safeAdd(existing.completion, entry.completionTokens)
+    const cacheRead = TokenCounter.safeAdd(existing.cacheRead, cacheReadTokens)
+    const cacheCreation = TokenCounter.safeAdd(existing.cacheCreation, cacheCreationTokens)
     // Validate the combined per-model total up-front so a record whose
     // prompt+completion overflows the safe-integer range is rejected here,
     // atomically, instead of poisoning later totalsFor() reads.
-    TokenCounter.safeAdd(prompt, completion)
+    const modelUncached = TokenCounter.safeAdd(prompt, completion)
+    const modelCached = TokenCounter.safeAdd(cacheRead, cacheCreation)
+    TokenCounter.safeAdd(modelUncached, modelCached)
     // Also validate the new global totals: a second model could otherwise push
     // grandTotal() past the safe-integer range even when every per-model total
     // is safe (e.g. model A with MAX_SAFE_INTEGER prompt, model B with 1). The
     // current stored state is always valid, so grandTotal() will not throw here.
     const globalPrompt = TokenCounter.safeAdd(this.totalPromptTokens, entry.promptTokens)
     const globalCompletion = TokenCounter.safeAdd(this.totalCompletionTokens, entry.completionTokens)
-    TokenCounter.safeAdd(globalPrompt, globalCompletion)
-    this.counts.set(entry.model, { prompt, completion })
+    const globalCacheRead = TokenCounter.safeAdd(this.totalCacheReadTokens, cacheReadTokens)
+    const globalCacheCreation = TokenCounter.safeAdd(
+      this.totalCacheCreationTokens,
+      cacheCreationTokens,
+    )
+    const globalUncached = TokenCounter.safeAdd(globalPrompt, globalCompletion)
+    const globalCached = TokenCounter.safeAdd(globalCacheRead, globalCacheCreation)
+    TokenCounter.safeAdd(globalUncached, globalCached)
+    this.counts.set(entry.model, { prompt, completion, cacheRead, cacheCreation })
     this.totalPromptTokens = globalPrompt
     this.totalCompletionTokens = globalCompletion
+    this.totalCacheReadTokens = globalCacheRead
+    this.totalCacheCreationTokens = globalCacheCreation
   }
 
   totalsFor(model: string): TokenTotals {
-    const entry = this.counts.get(model) ?? { prompt: 0, completion: 0 }
+    const entry = this.counts.get(model) ?? {
+      prompt: 0,
+      completion: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+    }
+    const uncached = TokenCounter.safeAdd(entry.prompt, entry.completion)
+    const cached = TokenCounter.safeAdd(entry.cacheRead, entry.cacheCreation)
     return {
       promptTokens: entry.prompt,
       completionTokens: entry.completion,
-      totalTokens: TokenCounter.safeAdd(entry.prompt, entry.completion),
+      cacheReadTokens: entry.cacheRead,
+      cacheCreationTokens: entry.cacheCreation,
+      totalTokens: TokenCounter.safeAdd(uncached, cached),
     }
   }
 
   grandTotal(): TokenTotals {
+    const uncached = TokenCounter.safeAdd(this.totalPromptTokens, this.totalCompletionTokens)
+    const cached = TokenCounter.safeAdd(
+      this.totalCacheReadTokens,
+      this.totalCacheCreationTokens,
+    )
     return {
       promptTokens: this.totalPromptTokens,
       completionTokens: this.totalCompletionTokens,
-      totalTokens: TokenCounter.safeAdd(this.totalPromptTokens, this.totalCompletionTokens),
+      cacheReadTokens: this.totalCacheReadTokens,
+      cacheCreationTokens: this.totalCacheCreationTokens,
+      totalTokens: TokenCounter.safeAdd(uncached, cached),
     }
   }
 
@@ -105,5 +164,7 @@ export class TokenCounter {
     this.counts.clear()
     this.totalPromptTokens = 0
     this.totalCompletionTokens = 0
+    this.totalCacheReadTokens = 0
+    this.totalCacheCreationTokens = 0
   }
 }

--- a/packages/franken-observer/src/cost/defaultPricing.ts
+++ b/packages/franken-observer/src/cost/defaultPricing.ts
@@ -3,28 +3,68 @@ export interface ModelPricing {
   promptPerMillion: number
   /** USD per 1,000,000 completion tokens */
   completionPerMillion: number
+  /** USD per 1,000,000 prompt-cache read tokens; defaults to prompt pricing. */
+  cacheReadPerMillion?: number
+  /** USD per 1,000,000 prompt-cache creation tokens; defaults to prompt pricing. */
+  cacheCreationPerMillion?: number
 }
 
 export type PricingTable = Record<string, ModelPricing>
 
 /**
- * Default pricing table (USD, as of 2025-Q4).
+ * Default pricing table (USD, verified 2026-07-25).
  * Override by passing your own PricingTable to CostCalculator.
  */
 export const DEFAULT_PRICING: PricingTable = {
-  // Anthropic Claude
-  'claude-opus-4-6': { promptPerMillion: 15.0, completionPerMillion: 75.0 },
-  'claude-sonnet-4-6': { promptPerMillion: 3.0, completionPerMillion: 15.0 },
-  'claude-haiku-4-5': { promptPerMillion: 0.8, completionPerMillion: 4.0 },
-  'claude': { promptPerMillion: 3.0, completionPerMillion: 15.0 }, // Alias for sonnet
-  // OpenAI
-  'gpt-4o': { promptPerMillion: 5.0, completionPerMillion: 15.0 },
-  'gpt-4o-mini': { promptPerMillion: 0.15, completionPerMillion: 0.6 },
+  // Anthropic first-party pricing, including 5-minute cache writes and reads:
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  'claude-opus-4-6': {
+    promptPerMillion: 5.0,
+    completionPerMillion: 25.0,
+    cacheReadPerMillion: 0.5,
+    cacheCreationPerMillion: 6.25,
+  },
+  'claude-sonnet-4-6': {
+    promptPerMillion: 3.0,
+    completionPerMillion: 15.0,
+    cacheReadPerMillion: 0.3,
+    cacheCreationPerMillion: 3.75,
+  },
+  'claude-haiku-4-5': {
+    promptPerMillion: 1.0,
+    completionPerMillion: 5.0,
+    cacheReadPerMillion: 0.1,
+    cacheCreationPerMillion: 1.25,
+  },
+  'claude': {
+    promptPerMillion: 3.0,
+    completionPerMillion: 15.0,
+    cacheReadPerMillion: 0.3,
+    cacheCreationPerMillion: 3.75,
+  }, // Alias for sonnet
+  // OpenAI first-party model pricing, including cached input:
+  // https://developers.openai.com/api/docs/models/gpt-4o
+  // https://developers.openai.com/api/docs/models/gpt-4o-mini
+  'gpt-4o': {
+    promptPerMillion: 2.5,
+    completionPerMillion: 10.0,
+    cacheReadPerMillion: 1.25,
+  },
+  'gpt-4o-mini': {
+    promptPerMillion: 0.15,
+    completionPerMillion: 0.6,
+    cacheReadPerMillion: 0.075,
+  },
   // Google Gemini
   'gemini-2.0-flash': { promptPerMillion: 0.1, completionPerMillion: 0.4 },
   'gemini': { promptPerMillion: 0.1, completionPerMillion: 0.4 }, // Alias for flash
   // Codex CLI (override if your billing differs)
   'codex': { promptPerMillion: 5.0, completionPerMillion: 15.0 },
   // Aider (uses sonnet by default)
-  'aider': { promptPerMillion: 3.0, completionPerMillion: 15.0 },
+  'aider': {
+    promptPerMillion: 3.0,
+    completionPerMillion: 15.0,
+    cacheReadPerMillion: 0.3,
+    cacheCreationPerMillion: 3.75,
+  },
 }

--- a/packages/franken-observer/src/cost/defaultPricing.ts
+++ b/packages/franken-observer/src/cost/defaultPricing.ts
@@ -7,6 +7,8 @@ export interface ModelPricing {
   cacheReadPerMillion?: number
   /** USD per 1,000,000 prompt-cache creation tokens; defaults to prompt pricing. */
   cacheCreationPerMillion?: number
+  /** USD per 1,000,000 one-hour prompt-cache creation tokens; defaults to cache creation pricing. */
+  cacheCreation1hPerMillion?: number
 }
 
 export type PricingTable = Record<string, ModelPricing>
@@ -16,31 +18,35 @@ export type PricingTable = Record<string, ModelPricing>
  * Override by passing your own PricingTable to CostCalculator.
  */
 export const DEFAULT_PRICING: PricingTable = {
-  // Anthropic first-party pricing, including 5-minute cache writes and reads:
+  // Anthropic first-party pricing, including 5-minute/1-hour cache writes and reads:
   // https://platform.claude.com/docs/en/about-claude/pricing
   'claude-opus-4-6': {
     promptPerMillion: 5.0,
     completionPerMillion: 25.0,
     cacheReadPerMillion: 0.5,
     cacheCreationPerMillion: 6.25,
+    cacheCreation1hPerMillion: 10,
   },
   'claude-sonnet-4-6': {
     promptPerMillion: 3.0,
     completionPerMillion: 15.0,
     cacheReadPerMillion: 0.3,
     cacheCreationPerMillion: 3.75,
+    cacheCreation1hPerMillion: 6,
   },
   'claude-haiku-4-5': {
     promptPerMillion: 1.0,
     completionPerMillion: 5.0,
     cacheReadPerMillion: 0.1,
     cacheCreationPerMillion: 1.25,
+    cacheCreation1hPerMillion: 2,
   },
   'claude': {
     promptPerMillion: 3.0,
     completionPerMillion: 15.0,
     cacheReadPerMillion: 0.3,
     cacheCreationPerMillion: 3.75,
+    cacheCreation1hPerMillion: 6,
   }, // Alias for sonnet
   // OpenAI first-party model pricing, including cached input:
   // https://developers.openai.com/api/docs/models/gpt-4o
@@ -66,5 +72,6 @@ export const DEFAULT_PRICING: PricingTable = {
     completionPerMillion: 15.0,
     cacheReadPerMillion: 0.3,
     cacheCreationPerMillion: 3.75,
+    cacheCreation1hPerMillion: 6,
   },
 }

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -3,7 +3,7 @@
 export { TraceContext } from './core/TraceContext.js'
 export { SpanLifecycle } from './core/SpanLifecycle.js'
 export { OTELSerializer } from './export/OTELSerializer.js'
-export { TokenCounter } from './cost/TokenCounter.js'
+export { cacheHitRatio, TokenCounter } from './cost/TokenCounter.js'
 export { CostCalculator } from './cost/CostCalculator.js'
 export { CircuitBreaker } from './cost/CircuitBreaker.js'
 export { ModelAttribution } from './cost/ModelAttribution.js'
@@ -120,7 +120,12 @@ export type {
   TraceValidationResult,
 } from './core/types.js'
 export type { TokenUsage } from './core/SpanLifecycle.js'
-export type { TokenRecord, TokenTotals, TokenCounterOptions } from './cost/TokenCounter.js'
+export type {
+  CacheHitRatioInput,
+  TokenRecord,
+  TokenTotals,
+  TokenCounterOptions,
+} from './cost/TokenCounter.js'
 export type {
   CostCalculation,
   CostCalculatorOptions,

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -36,11 +36,23 @@ export interface IAdapter {
 
 export interface ILlmObserver {
   counter: {
-    record(entry: { model: string; promptTokens: number; completionTokens: number }): void;
+    record(entry: {
+      model: string;
+      promptTokens: number;
+      completionTokens: number;
+      cacheReadTokens?: number;
+      cacheCreationTokens?: number;
+    }): void;
   };
   startSpan(trace: any, opts: { name: string }): any;
   endSpan(span: any, opts: { status: string }): void;
-  recordTokenUsage(span: any, usage: { promptTokens: number; completionTokens: number; model: string }, counter: any): void;
+  recordTokenUsage(span: any, usage: {
+    promptTokens: number;
+    completionTokens: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+    model: string;
+  }, counter: any): void;
   trace: any;
 }
 
@@ -145,6 +157,12 @@ export class AdapterLlmClient implements ILlmClient {
             model,
             promptTokens,
             completionTokens,
+            ...(usage?.cacheReadTokens !== undefined
+              ? { cacheReadTokens: usage.cacheReadTokens }
+              : {}),
+            ...(usage?.cacheCreationTokens !== undefined
+              ? { cacheCreationTokens: usage.cacheCreationTokens }
+              : {}),
           },
           this.observer.counter,
         );

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -42,6 +42,7 @@ export interface ILlmObserver {
       completionTokens: number;
       cacheReadTokens?: number;
       cacheCreationTokens?: number;
+      cacheCreation1hTokens?: number;
     }): void;
   };
   startSpan(trace: any, opts: { name: string }): any;
@@ -51,6 +52,7 @@ export interface ILlmObserver {
     completionTokens: number;
     cacheReadTokens?: number;
     cacheCreationTokens?: number;
+    cacheCreation1hTokens?: number;
     model: string;
   }, counter: any): void;
   trace: any;
@@ -162,6 +164,9 @@ export class AdapterLlmClient implements ILlmClient {
               : {}),
             ...(usage?.cacheCreationTokens !== undefined
               ? { cacheCreationTokens: usage.cacheCreationTokens }
+              : {}),
+            ...(usage?.cacheCreation1hTokens !== undefined
+              ? { cacheCreation1hTokens: usage.cacheCreation1hTokens }
               : {}),
           },
           this.observer.counter,

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -100,6 +100,9 @@ export class CliObserverBridge implements IObserverModule {
         completionTokens: t.completionTokens,
         cacheReadTokens: t.cacheReadTokens,
         cacheCreationTokens: t.cacheCreationTokens,
+        ...(t.cacheCreation1hTokens !== undefined
+          ? { cacheCreation1hTokens: t.cacheCreation1hTokens }
+          : {}),
       };
     });
     const estimatedCostUsd = this.costCalc.totalCost(entries);
@@ -142,7 +145,7 @@ export class CliObserverBridge implements IObserverModule {
         TraceContext.startSpan(t, opts),
       endSpan: (span: Span, opts?: { status?: string; errorMessage?: string }, loopDetector?: LoopDetector) =>
         TraceContext.endSpan(span, opts as { status?: 'completed' | 'error'; errorMessage?: string }, loopDetector),
-      recordTokenUsage: (span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; model?: string }, counter?: TokenCounter) =>
+      recordTokenUsage: (span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; cacheCreation1hTokens?: number; model?: string }, counter?: TokenCounter) =>
         SpanLifecycle.recordTokenUsage(span, usage, counter),
       setMetadata: (span: Span, data: Record<string, unknown>) =>
         SpanLifecycle.setMetadata(span, data),
@@ -164,7 +167,7 @@ export class CliObserverBridge implements IObserverModule {
       startSpan: (_t: Trace, opts: { name: string; parentSpanId?: string }) =>
         createDisabledSpan(traceId, opts),
       endSpan: () => {},
-      recordTokenUsage: (_span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; model?: string }, counter?: TokenCounter) => {
+      recordTokenUsage: (_span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; cacheCreation1hTokens?: number; model?: string }, counter?: TokenCounter) => {
         (counter ?? this.counter).record({
           model: usage.model ?? 'unknown',
           promptTokens: usage.promptTokens,
@@ -174,6 +177,9 @@ export class CliObserverBridge implements IObserverModule {
             : {}),
           ...(usage.cacheCreationTokens !== undefined
             ? { cacheCreationTokens: usage.cacheCreationTokens }
+            : {}),
+          ...(usage.cacheCreation1hTokens !== undefined
+            ? { cacheCreation1hTokens: usage.cacheCreation1hTokens }
             : {}),
         });
       },

--- a/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-observer-bridge.ts
@@ -94,12 +94,19 @@ export class CliObserverBridge implements IObserverModule {
     const totals = this.counter.grandTotal();
     const entries = this.counter.allModels().map((m) => {
       const t = this.counter.totalsFor(m);
-      return { model: m, promptTokens: t.promptTokens, completionTokens: t.completionTokens };
+      return {
+        model: m,
+        promptTokens: t.promptTokens,
+        completionTokens: t.completionTokens,
+        cacheReadTokens: t.cacheReadTokens,
+        cacheCreationTokens: t.cacheCreationTokens,
+      };
     });
     const estimatedCostUsd = this.costCalc.totalCost(entries);
     // Route through the validating factory so the orchestrator boundary rejects
     // negative/unsafe totals instead of forwarding poisoned spend downstream.
-    return makeTokenSpend(totals.promptTokens, totals.completionTokens, estimatedCostUsd);
+    const totalInputTokens = totals.totalTokens - totals.completionTokens;
+    return makeTokenSpend(totalInputTokens, totals.completionTokens, estimatedCostUsd);
   }
 
   estimateContextWindow(input: {
@@ -135,7 +142,7 @@ export class CliObserverBridge implements IObserverModule {
         TraceContext.startSpan(t, opts),
       endSpan: (span: Span, opts?: { status?: string; errorMessage?: string }, loopDetector?: LoopDetector) =>
         TraceContext.endSpan(span, opts as { status?: 'completed' | 'error'; errorMessage?: string }, loopDetector),
-      recordTokenUsage: (span: Span, usage: { promptTokens: number; completionTokens: number; model?: string }, counter?: TokenCounter) =>
+      recordTokenUsage: (span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; model?: string }, counter?: TokenCounter) =>
         SpanLifecycle.recordTokenUsage(span, usage, counter),
       setMetadata: (span: Span, data: Record<string, unknown>) =>
         SpanLifecycle.setMetadata(span, data),
@@ -157,11 +164,17 @@ export class CliObserverBridge implements IObserverModule {
       startSpan: (_t: Trace, opts: { name: string; parentSpanId?: string }) =>
         createDisabledSpan(traceId, opts),
       endSpan: () => {},
-      recordTokenUsage: (_span: Span, usage: { promptTokens: number; completionTokens: number; model?: string }, counter?: TokenCounter) => {
+      recordTokenUsage: (_span: Span, usage: { promptTokens: number; completionTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number; model?: string }, counter?: TokenCounter) => {
         (counter ?? this.counter).record({
           model: usage.model ?? 'unknown',
           promptTokens: usage.promptTokens,
           completionTokens: usage.completionTokens,
+          ...(usage.cacheReadTokens !== undefined
+            ? { cacheReadTokens: usage.cacheReadTokens }
+            : {}),
+          ...(usage.cacheCreationTokens !== undefined
+            ? { cacheCreationTokens: usage.cacheCreationTokens }
+            : {}),
         });
       },
       setMetadata: () => {},

--- a/packages/franken-orchestrator/src/adapters/observer-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/observer-adapter.ts
@@ -14,6 +14,7 @@ export interface CostCalculatorPort {
     completionTokens: number;
     cacheReadTokens?: number;
     cacheCreationTokens?: number;
+    cacheCreation1hTokens?: number;
   }): number;
 }
 

--- a/packages/franken-orchestrator/src/adapters/observer-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/observer-adapter.ts
@@ -117,12 +117,23 @@ export class ObserverPortAdapter implements IObserverModule {
       const completionTokens = tokenCountFromMetadata(span.metadata.completionTokens, 'completionTokens', span.id);
       const hasCacheReadTokens = typeof span.metadata.cacheReadTokens === 'number';
       const hasCacheCreationTokens = typeof span.metadata.cacheCreationTokens === 'number';
+      const hasCacheCreation1hTokens = typeof span.metadata.cacheCreation1hTokens === 'number';
       const cacheReadTokens = tokenCountFromMetadata(span.metadata.cacheReadTokens, 'cacheReadTokens', span.id);
       const cacheCreationTokens = tokenCountFromMetadata(
         span.metadata.cacheCreationTokens,
         'cacheCreationTokens',
         span.id,
       );
+      const cacheCreation1hTokens = tokenCountFromMetadata(
+        span.metadata.cacheCreation1hTokens,
+        'cacheCreation1hTokens',
+        span.id,
+      );
+      if (cacheCreation1hTokens > cacheCreationTokens) {
+        throw new RangeError(
+          `ObserverPortAdapter: span ${span.id} cacheCreation1hTokens must not exceed cacheCreationTokens`,
+        );
+      }
       inputTokens += promptTokens + cacheReadTokens + cacheCreationTokens;
       outputTokens += completionTokens;
 
@@ -137,6 +148,7 @@ export class ObserverPortAdapter implements IObserverModule {
           completionTokens,
           ...(hasCacheReadTokens ? { cacheReadTokens } : {}),
           ...(hasCacheCreationTokens ? { cacheCreationTokens } : {}),
+          ...(hasCacheCreation1hTokens ? { cacheCreation1hTokens } : {}),
         });
       }
     }

--- a/packages/franken-orchestrator/src/adapters/observer-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/observer-adapter.ts
@@ -8,7 +8,13 @@ export interface TraceContextPort<Trace = TracePort, Span = SpanPort> {
 }
 
 export interface CostCalculatorPort {
-  calculate(entry: { model: string; promptTokens: number; completionTokens: number }): number;
+  calculate(entry: {
+    model: string;
+    promptTokens: number;
+    completionTokens: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+  }): number;
 }
 
 export interface TracePort {
@@ -109,15 +115,28 @@ export class ObserverPortAdapter implements IObserverModule {
       // tokens/cost. Missing/non-numeric metadata is treated as zero.
       const promptTokens = tokenCountFromMetadata(span.metadata.promptTokens, 'promptTokens', span.id);
       const completionTokens = tokenCountFromMetadata(span.metadata.completionTokens, 'completionTokens', span.id);
-      inputTokens += promptTokens;
+      const hasCacheReadTokens = typeof span.metadata.cacheReadTokens === 'number';
+      const hasCacheCreationTokens = typeof span.metadata.cacheCreationTokens === 'number';
+      const cacheReadTokens = tokenCountFromMetadata(span.metadata.cacheReadTokens, 'cacheReadTokens', span.id);
+      const cacheCreationTokens = tokenCountFromMetadata(
+        span.metadata.cacheCreationTokens,
+        'cacheCreationTokens',
+        span.id,
+      );
+      inputTokens += promptTokens + cacheReadTokens + cacheCreationTokens;
       outputTokens += completionTokens;
 
       const model = span.metadata.model;
-      if (typeof model === 'string' && (promptTokens > 0 || completionTokens > 0)) {
+      if (
+        typeof model === 'string' &&
+        (promptTokens > 0 || completionTokens > 0 || cacheReadTokens > 0 || cacheCreationTokens > 0)
+      ) {
         estimatedCostUsd += this.costCalculator.calculate({
           model,
           promptTokens,
           completionTokens,
+          ...(hasCacheReadTokens ? { cacheReadTokens } : {}),
+          ...(hasCacheCreationTokens ? { cacheCreationTokens } : {}),
         });
       }
     }

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -10,7 +10,7 @@ import {
   CHAT_SOCKET_PROTOCOL,
   CHAT_SOCKET_TOKEN_PROTOCOL_PREFIX,
 } from '../http/ws-chat-server.js';
-import { deterministicUuid, type ProviderContext, type TokenUsage } from '@franken/types';
+import { deterministicUuid, TokenUsageSchema, type ProviderContext, type TokenUsage } from '@franken/types';
 import { assertLocalPlaintextOrSecureHttpUrl, localPlaintextOrSecureEndpoint } from './network-url.js';
 
 const ZERO_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -269,25 +269,17 @@ export interface RemoteReplyOutcome {
 }
 
 function parseTokenUsage(value: unknown): TokenUsage | undefined {
-  if (typeof value !== 'object' || value === null) return undefined;
-  const usage = value as Record<string, unknown>;
-  const inputTokens = usage['inputTokens'];
-  const outputTokens = usage['outputTokens'];
-  const totalTokens = usage['totalTokens'];
-  if (typeof inputTokens === 'number' && typeof outputTokens === 'number' && typeof totalTokens === 'number') {
-    const cacheReadTokens = usage['cacheReadTokens'];
-    const cacheCreationTokens = usage['cacheCreationTokens'];
-    const cacheCreation1hTokens = usage['cacheCreation1hTokens'];
-    return {
-      inputTokens,
-      outputTokens,
-      ...(typeof cacheReadTokens === 'number' ? { cacheReadTokens } : {}),
-      ...(typeof cacheCreationTokens === 'number' ? { cacheCreationTokens } : {}),
-      ...(typeof cacheCreation1hTokens === 'number' ? { cacheCreation1hTokens } : {}),
-      totalTokens,
-    };
-  }
-  return undefined;
+  const parsed = TokenUsageSchema.safeParse(value);
+  if (!parsed.success) return undefined;
+  const usage = parsed.data;
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    ...(usage.cacheReadTokens !== undefined ? { cacheReadTokens: usage.cacheReadTokens } : {}),
+    ...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: usage.cacheCreationTokens } : {}),
+    ...(usage.cacheCreation1hTokens !== undefined ? { cacheCreation1hTokens: usage.cacheCreation1hTokens } : {}),
+    totalTokens: usage.totalTokens,
+  };
 }
 
 function parseProviderContext(value: unknown): ProviderContext | undefined {

--- a/packages/franken-orchestrator/src/network/chat-attach.ts
+++ b/packages/franken-orchestrator/src/network/chat-attach.ts
@@ -19,6 +19,21 @@ function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
   return {
     inputTokens: a.inputTokens + b.inputTokens,
     outputTokens: a.outputTokens + b.outputTokens,
+    ...(
+      a.cacheReadTokens !== undefined || b.cacheReadTokens !== undefined
+        ? { cacheReadTokens: (a.cacheReadTokens ?? 0) + (b.cacheReadTokens ?? 0) }
+        : {}
+    ),
+    ...(
+      a.cacheCreationTokens !== undefined || b.cacheCreationTokens !== undefined
+        ? { cacheCreationTokens: (a.cacheCreationTokens ?? 0) + (b.cacheCreationTokens ?? 0) }
+        : {}
+    ),
+    ...(
+      a.cacheCreation1hTokens !== undefined || b.cacheCreation1hTokens !== undefined
+        ? { cacheCreation1hTokens: (a.cacheCreation1hTokens ?? 0) + (b.cacheCreation1hTokens ?? 0) }
+        : {}
+    ),
     totalTokens: a.totalTokens + b.totalTokens,
   };
 }
@@ -260,7 +275,17 @@ function parseTokenUsage(value: unknown): TokenUsage | undefined {
   const outputTokens = usage['outputTokens'];
   const totalTokens = usage['totalTokens'];
   if (typeof inputTokens === 'number' && typeof outputTokens === 'number' && typeof totalTokens === 'number') {
-    return { inputTokens, outputTokens, totalTokens };
+    const cacheReadTokens = usage['cacheReadTokens'];
+    const cacheCreationTokens = usage['cacheCreationTokens'];
+    const cacheCreation1hTokens = usage['cacheCreation1hTokens'];
+    return {
+      inputTokens,
+      outputTokens,
+      ...(typeof cacheReadTokens === 'number' ? { cacheReadTokens } : {}),
+      ...(typeof cacheCreationTokens === 'number' ? { cacheCreationTokens } : {}),
+      ...(typeof cacheCreation1hTokens === 'number' ? { cacheCreation1hTokens } : {}),
+      totalTokens,
+    };
   }
   return undefined;
 }
@@ -375,6 +400,7 @@ function sendManagedChatInput(socket: WebSocket, input: string): void {
 }
 
 export const __chatAttachTestHooks = {
+  addUsage,
   awaitRemoteReply,
   createRemoteSession,
   parseManagedChatMessage,

--- a/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
@@ -9,7 +9,9 @@ import type {
   ProviderAuthMethod,
   ToolDefinition,
   BrainSnapshot,
+  TokenUsage,
 } from '@franken/types';
+import { TokenUsageSchema } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
 import { createEgressGuardedFetch, type EgressAuditSink, type EgressPolicyConfig } from '../network/egress-policy.js';
 
@@ -80,13 +82,7 @@ export class AnthropicApiAdapter implements ILlmProvider {
       const finalMessage = await stream.finalMessage();
       yield {
         type: 'done',
-        usage: {
-          inputTokens: finalMessage.usage.input_tokens,
-          outputTokens: finalMessage.usage.output_tokens,
-          totalTokens:
-            finalMessage.usage.input_tokens +
-            finalMessage.usage.output_tokens,
-        },
+        usage: this.translateUsage(finalMessage.usage),
       };
     } catch (error) {
       if (error instanceof Anthropic.RateLimitError) {
@@ -145,6 +141,24 @@ export class AnthropicApiAdapter implements ILlmProvider {
       description: t.description,
       input_schema: t.inputSchema as Anthropic.Tool['input_schema'],
     }));
+  }
+
+  translateUsage(usage: Anthropic.Usage): TokenUsage {
+    const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+    const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+    const translated: TokenUsage = {
+      inputTokens: usage.input_tokens,
+      outputTokens: usage.output_tokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      totalTokens:
+        usage.input_tokens +
+        usage.output_tokens +
+        cacheReadTokens +
+        cacheCreationTokens,
+    };
+    TokenUsageSchema.parse(translated);
+    return translated;
   }
 
   /**

--- a/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
@@ -146,11 +146,13 @@ export class AnthropicApiAdapter implements ILlmProvider {
   translateUsage(usage: Anthropic.Usage): TokenUsage {
     const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
     const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+    const cacheCreation1hTokens = usage.cache_creation?.ephemeral_1h_input_tokens ?? 0;
     const translated: TokenUsage = {
       inputTokens: usage.input_tokens,
       outputTokens: usage.output_tokens,
       cacheReadTokens,
       cacheCreationTokens,
+      ...(cacheCreation1hTokens > 0 ? { cacheCreation1hTokens } : {}),
       totalTokens:
         usage.input_tokens +
         usage.output_tokens +

--- a/packages/franken-orchestrator/src/providers/openai-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/openai-api-adapter.ts
@@ -9,7 +9,9 @@ import type {
   ProviderAuthMethod,
   ToolDefinition,
   BrainSnapshot,
+  TokenUsage,
 } from '@franken/types';
+import { TokenUsageSchema } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
 import { createEgressGuardedFetch, type EgressAuditSink, type EgressPolicyConfig } from '../network/egress-policy.js';
 
@@ -135,11 +137,7 @@ export class OpenAiApiAdapter implements ILlmProvider {
         if (chunk.usage) {
           yield {
             type: 'done',
-            usage: {
-              inputTokens: chunk.usage.prompt_tokens ?? 0,
-              outputTokens: chunk.usage.completion_tokens ?? 0,
-              totalTokens: chunk.usage.total_tokens ?? 0,
-            },
+            usage: this.translateUsage(chunk.usage),
           };
           return;
         }
@@ -224,5 +222,26 @@ export class OpenAiApiAdapter implements ILlmProvider {
         parameters: t.inputSchema,
       },
     }));
+  }
+
+  translateUsage(usage: NonNullable<OpenAI.ChatCompletionChunk['usage']>): TokenUsage {
+    const promptTokens = usage.prompt_tokens ?? 0;
+    const outputTokens = usage.completion_tokens ?? 0;
+    const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+    if (cacheReadTokens > promptTokens) {
+      throw new RangeError('OpenAI cached prompt tokens cannot exceed total prompt tokens');
+    }
+    const parsed = TokenUsageSchema.parse({
+      inputTokens: promptTokens - cacheReadTokens,
+      outputTokens,
+      cacheReadTokens,
+      totalTokens: usage.total_tokens ?? promptTokens + outputTokens,
+    });
+    return {
+      inputTokens: parsed.inputTokens,
+      outputTokens: parsed.outputTokens,
+      cacheReadTokens,
+      totalTokens: parsed.totalTokens,
+    };
   }
 }

--- a/packages/franken-orchestrator/src/providers/token-aggregator.ts
+++ b/packages/franken-orchestrator/src/providers/token-aggregator.ts
@@ -1,8 +1,10 @@
-import type { TokenUsage } from '@franken/types';
+import { TokenUsageSchema, type TokenUsage } from '@franken/types';
 
 export interface AggregatedTokenUsage {
   totalInputTokens: number;
   totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreationTokens: number;
   totalTokens: number;
   byProvider: Map<string, TokenUsage>;
 }
@@ -10,33 +12,61 @@ export interface AggregatedTokenUsage {
 export class TokenAggregator {
   private readonly usage = new Map<string, TokenUsage>();
 
-  record(providerName: string, usage: TokenUsage): void {
+  private static safeAdd(a: number, b: number): number {
+    const sum = a + b;
+    if (!Number.isSafeInteger(sum)) {
+      throw new RangeError('TokenAggregator token total exceeds Number.MAX_SAFE_INTEGER');
+    }
+    return sum;
+  }
+
+  record(providerName: string, usageInput: TokenUsage): void {
+    const usage = TokenUsageSchema.parse(usageInput);
     const existing = this.usage.get(providerName) ?? {
       inputTokens: 0,
       outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
       totalTokens: 0,
     };
     this.usage.set(providerName, {
-      inputTokens: existing.inputTokens + usage.inputTokens,
-      outputTokens: existing.outputTokens + usage.outputTokens,
-      totalTokens: existing.totalTokens + usage.totalTokens,
+      inputTokens: TokenAggregator.safeAdd(existing.inputTokens, usage.inputTokens),
+      outputTokens: TokenAggregator.safeAdd(existing.outputTokens, usage.outputTokens),
+      cacheReadTokens: TokenAggregator.safeAdd(
+        existing.cacheReadTokens ?? 0,
+        usage.cacheReadTokens ?? 0,
+      ),
+      cacheCreationTokens: TokenAggregator.safeAdd(
+        existing.cacheCreationTokens ?? 0,
+        usage.cacheCreationTokens ?? 0,
+      ),
+      totalTokens: TokenAggregator.safeAdd(existing.totalTokens, usage.totalTokens),
     });
   }
 
   getTotalUsage(): AggregatedTokenUsage {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let totalCacheReadTokens = 0;
+    let totalCacheCreationTokens = 0;
     let totalTokens = 0;
 
     for (const u of this.usage.values()) {
-      totalInputTokens += u.inputTokens;
-      totalOutputTokens += u.outputTokens;
-      totalTokens += u.totalTokens;
+      totalInputTokens = TokenAggregator.safeAdd(totalInputTokens, u.inputTokens);
+      totalOutputTokens = TokenAggregator.safeAdd(totalOutputTokens, u.outputTokens);
+      totalCacheReadTokens = TokenAggregator.safeAdd(totalCacheReadTokens, u.cacheReadTokens ?? 0);
+      totalCacheCreationTokens = TokenAggregator.safeAdd(
+        totalCacheCreationTokens,
+        u.cacheCreationTokens ?? 0,
+      );
+      totalTokens = TokenAggregator.safeAdd(totalTokens, u.totalTokens);
     }
 
     return {
       totalInputTokens,
       totalOutputTokens,
+      totalCacheReadTokens,
+      totalCacheCreationTokens,
       totalTokens,
       byProvider: new Map(this.usage),
     };

--- a/packages/franken-orchestrator/src/providers/token-aggregator.ts
+++ b/packages/franken-orchestrator/src/providers/token-aggregator.ts
@@ -5,6 +5,7 @@ export interface AggregatedTokenUsage {
   totalOutputTokens: number;
   totalCacheReadTokens: number;
   totalCacheCreationTokens: number;
+  totalCacheCreation1hTokens: number;
   totalTokens: number;
   byProvider: Map<string, TokenUsage>;
 }
@@ -29,6 +30,10 @@ export class TokenAggregator {
       cacheCreationTokens: 0,
       totalTokens: 0,
     };
+    const cacheCreation1hTokens = TokenAggregator.safeAdd(
+      existing.cacheCreation1hTokens ?? 0,
+      usage.cacheCreation1hTokens ?? 0,
+    );
     this.usage.set(providerName, {
       inputTokens: TokenAggregator.safeAdd(existing.inputTokens, usage.inputTokens),
       outputTokens: TokenAggregator.safeAdd(existing.outputTokens, usage.outputTokens),
@@ -40,6 +45,7 @@ export class TokenAggregator {
         existing.cacheCreationTokens ?? 0,
         usage.cacheCreationTokens ?? 0,
       ),
+      ...(cacheCreation1hTokens > 0 ? { cacheCreation1hTokens } : {}),
       totalTokens: TokenAggregator.safeAdd(existing.totalTokens, usage.totalTokens),
     });
   }
@@ -49,15 +55,28 @@ export class TokenAggregator {
     let totalOutputTokens = 0;
     let totalCacheReadTokens = 0;
     let totalCacheCreationTokens = 0;
+    let totalCacheCreation1hTokens = 0;
     let totalTokens = 0;
 
     for (const u of this.usage.values()) {
-      totalInputTokens = TokenAggregator.safeAdd(totalInputTokens, u.inputTokens);
+      const freshAndReadInput = TokenAggregator.safeAdd(
+        u.inputTokens,
+        u.cacheReadTokens ?? 0,
+      );
+      const providerInputTokens = TokenAggregator.safeAdd(
+        freshAndReadInput,
+        u.cacheCreationTokens ?? 0,
+      );
+      totalInputTokens = TokenAggregator.safeAdd(totalInputTokens, providerInputTokens);
       totalOutputTokens = TokenAggregator.safeAdd(totalOutputTokens, u.outputTokens);
       totalCacheReadTokens = TokenAggregator.safeAdd(totalCacheReadTokens, u.cacheReadTokens ?? 0);
       totalCacheCreationTokens = TokenAggregator.safeAdd(
         totalCacheCreationTokens,
         u.cacheCreationTokens ?? 0,
+      );
+      totalCacheCreation1hTokens = TokenAggregator.safeAdd(
+        totalCacheCreation1hTokens,
+        u.cacheCreation1hTokens ?? 0,
       );
       totalTokens = TokenAggregator.safeAdd(totalTokens, u.totalTokens);
     }
@@ -67,6 +86,7 @@ export class TokenAggregator {
       totalOutputTokens,
       totalCacheReadTokens,
       totalCacheCreationTokens,
+      totalCacheCreation1hTokens,
       totalTokens,
       byProvider: new Map(this.usage),
     };

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -77,6 +77,7 @@ export interface TokenTotals {
   readonly completionTokens: number;
   readonly cacheReadTokens: number;
   readonly cacheCreationTokens: number;
+  readonly cacheCreation1hTokens?: number;
   readonly totalTokens: number;
 }
 
@@ -897,6 +898,9 @@ export class CliSkillExecutor {
         completionTokens: t.completionTokens,
         cacheReadTokens: t.cacheReadTokens,
         cacheCreationTokens: t.cacheCreationTokens,
+        ...(t.cacheCreation1hTokens !== undefined
+          ? { cacheCreation1hTokens: t.cacheCreation1hTokens }
+          : {}),
       };
     });
     return this.observer.costCalc.totalCost(entries);

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -75,6 +75,8 @@ export interface Trace {
 export interface TokenTotals {
   readonly promptTokens: number;
   readonly completionTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
   readonly totalTokens: number;
 }
 
@@ -82,11 +84,15 @@ export interface TokenRecord {
   readonly model: string;
   readonly promptTokens: number;
   readonly completionTokens: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheCreationTokens?: number;
 }
 
 export interface TokenUsage {
   readonly promptTokens: number;
   readonly completionTokens: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheCreationTokens?: number;
   readonly model?: string;
 }
 
@@ -885,7 +891,13 @@ export class CliSkillExecutor {
   private computeCurrentCost(): number {
     const entries = this.observer.counter.allModels().map((m) => {
       const t = this.observer.counter.totalsFor(m);
-      return { model: m, promptTokens: t.promptTokens, completionTokens: t.completionTokens };
+      return {
+        model: m,
+        promptTokens: t.promptTokens,
+        completionTokens: t.completionTokens,
+        cacheReadTokens: t.cacheReadTokens,
+        cacheCreationTokens: t.cacheCreationTokens,
+      };
     });
     return this.observer.costCalc.totalCost(entries);
   }

--- a/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
+++ b/packages/franken-orchestrator/src/skills/cli-skill-executor.ts
@@ -87,6 +87,7 @@ export interface TokenRecord {
   readonly completionTokens: number;
   readonly cacheReadTokens?: number;
   readonly cacheCreationTokens?: number;
+  readonly cacheCreation1hTokens?: number;
 }
 
 export interface TokenUsage {
@@ -94,6 +95,7 @@ export interface TokenUsage {
   readonly completionTokens: number;
   readonly cacheReadTokens?: number;
   readonly cacheCreationTokens?: number;
+  readonly cacheCreation1hTokens?: number;
   readonly model?: string;
 }
 

--- a/packages/franken-orchestrator/test/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/test/adapters/cli-observer-bridge.test.ts
@@ -97,8 +97,30 @@ describe('CliObserverBridge', () => {
       deps.endSpan(span);
 
       const spend = await bridge.getTokenSpend('session-cost');
-      // gpt-4o: promptPerMillion = 5.0, so 1M prompt tokens = $5.00
-      expect(spend.estimatedCostUsd).toBeCloseTo(5.0, 2);
+      // gpt-4o: promptPerMillion = 2.5, so 1M prompt tokens = $2.50
+      expect(spend.estimatedCostUsd).toBeCloseTo(2.5, 2);
+    });
+
+    it('includes cache tokens in total input and prices each cache tier', async () => {
+      const bridge = createBridge();
+      bridge.startTrace('session-cache-cost');
+      const deps = bridge.observerDeps;
+      const span = deps.startSpan(deps.trace, { name: 'cached-cost-test' });
+
+      deps.recordTokenUsage(span, {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+        model: 'claude-sonnet-4-6',
+      }, deps.counter);
+      deps.endSpan(span);
+
+      const spend = await bridge.getTokenSpend('session-cache-cost');
+      expect(spend.inputTokens).toBe(3_000_000);
+      expect(spend.outputTokens).toBe(1_000_000);
+      expect(spend.totalTokens).toBe(4_000_000);
+      expect(spend.estimatedCostUsd).toBeCloseTo(22.05, 8);
     });
 
     it('returns zeros when startTrace has not been called', async () => {
@@ -210,8 +232,8 @@ describe('CliObserverBridge', () => {
       const spend = await bridge.getTokenSpend('session-1000-tokens');
       expect(spend.totalTokens).toBe(1000);
       expect(spend.estimatedCostUsd).toBeGreaterThan(0);
-      // gpt-4o: (500/1M)*5 + (500/1M)*15 = 0.0025 + 0.0075 = 0.01
-      expect(spend.estimatedCostUsd).toBeCloseTo(0.01, 4);
+      // gpt-4o: (500/1M)*2.5 + (500/1M)*10 = 0.00125 + 0.005 = 0.00625
+      expect(spend.estimatedCostUsd).toBeCloseTo(0.00625, 5);
     });
 
     it('record tokens exceeding budget, breaker.check() returns tripped: true', async () => {

--- a/packages/franken-orchestrator/test/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/test/adapters/cli-observer-bridge.test.ts
@@ -112,6 +112,7 @@ describe('CliObserverBridge', () => {
         completionTokens: 1_000_000,
         cacheReadTokens: 1_000_000,
         cacheCreationTokens: 1_000_000,
+        cacheCreation1hTokens: 400_000,
         model: 'claude-sonnet-4-6',
       }, deps.counter);
       deps.endSpan(span);
@@ -120,7 +121,7 @@ describe('CliObserverBridge', () => {
       expect(spend.inputTokens).toBe(3_000_000);
       expect(spend.outputTokens).toBe(1_000_000);
       expect(spend.totalTokens).toBe(4_000_000);
-      expect(spend.estimatedCostUsd).toBeCloseTo(22.05, 8);
+      expect(spend.estimatedCostUsd).toBeCloseTo(22.95, 8);
     });
 
     it('returns zeros when startTrace has not been called', async () => {

--- a/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
+++ b/packages/franken-orchestrator/test/cli/budget-enforcement.test.ts
@@ -47,13 +47,13 @@ function provider(name: string, script: string): ICliProvider {
 
 describe('Budget enforcement integration', () => {
   it('trips the circuit breaker when recorded cost exceeds budget', async () => {
-    // Budget: $0.01, record tokens costing $0.02
+    // Budget: $0.01, record tokens costing $0.0125
     const bridge = new CliObserverBridge({ budgetLimitUsd: 0.01 });
     bridge.startTrace('budget-trip-test');
     const deps = bridge.observerDeps;
 
     // Record 1000 prompt + 1000 completion tokens as gpt-4o
-    // gpt-4o: (1000/1M)*5 + (1000/1M)*15 = $0.005 + $0.015 = $0.02
+    // gpt-4o: (1000/1M)*2.5 + (1000/1M)*10 = $0.0025 + $0.01 = $0.0125
     const span = deps.startSpan(deps.trace, { name: 'expensive-call' });
     deps.recordTokenUsage(
       span,
@@ -69,21 +69,21 @@ describe('Budget enforcement integration', () => {
     });
     const spendUsd = deps.costCalc.totalCost(entries);
 
-    expect(spendUsd).toBeCloseTo(0.02, 4);
+    expect(spendUsd).toBeCloseTo(0.0125, 5);
 
     const result = deps.breaker.check(spendUsd);
     expect(result.tripped).toBe(true);
-    expect(result.spendUsd).toBeCloseTo(0.02, 4);
+    expect(result.spendUsd).toBeCloseTo(0.0125, 5);
     expect(result.limitUsd).toBe(0.01);
   });
 
   it('does not trip the circuit breaker when usage is within budget', async () => {
-    // Budget: $100, record tokens costing $0.02
+    // Budget: $100, record tokens costing $0.0125
     const bridge = new CliObserverBridge({ budgetLimitUsd: 100 });
     bridge.startTrace('budget-safe-test');
     const deps = bridge.observerDeps;
 
-    // Record 1000 prompt + 1000 completion tokens as gpt-4o = $0.02
+    // Record 1000 prompt + 1000 completion tokens as gpt-4o = $0.0125
     const span = deps.startSpan(deps.trace, { name: 'cheap-call' });
     deps.recordTokenUsage(
       span,
@@ -99,7 +99,7 @@ describe('Budget enforcement integration', () => {
     });
     const spendUsd = deps.costCalc.totalCost(entries);
 
-    expect(spendUsd).toBeCloseTo(0.02, 4);
+    expect(spendUsd).toBeCloseTo(0.0125, 5);
 
     const result = deps.breaker.check(spendUsd);
     expect(result.tripped).toBe(false);

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -125,6 +125,29 @@ describe('AdapterLlmClient', () => {
     );
   });
 
+  it('forwards provider cache usage when recording observer usage', async () => {
+    const observer = makeObserver();
+    const usage = {
+      inputTokens: 600,
+      outputTokens: 100,
+      cacheReadTokens: 300,
+      cacheCreationTokens: 100,
+      totalTokens: 1100,
+    };
+    const client = new AdapterLlmClient(
+      makeAdapter({ transformResponse: vi.fn(() => ({ content: 'hi', usage })) }),
+      observer,
+    );
+
+    await client.complete('prompt');
+
+    expect(observer.recordTokenUsage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ cacheReadTokens: 300, cacheCreationTokens: 100 }),
+      expect.anything(),
+    );
+  });
+
   it('completeWithUsage returns providerContext when the adapter reports a fallback', async () => {
     const providerContext = { provider: 'claude', switchedFrom: 'codex', switchReason: 'rate_limited' };
     const client = new AdapterLlmClient(

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -132,6 +132,7 @@ describe('AdapterLlmClient', () => {
       outputTokens: 100,
       cacheReadTokens: 300,
       cacheCreationTokens: 100,
+      cacheCreation1hTokens: 40,
       totalTokens: 1100,
     };
     const client = new AdapterLlmClient(
@@ -143,7 +144,11 @@ describe('AdapterLlmClient', () => {
 
     expect(observer.recordTokenUsage).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ cacheReadTokens: 300, cacheCreationTokens: 100 }),
+      expect.objectContaining({
+        cacheReadTokens: 300,
+        cacheCreationTokens: 100,
+        cacheCreation1hTokens: 40,
+      }),
       expect.anything(),
     );
   });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-observer-bridge.test.ts
@@ -279,6 +279,24 @@ describe('CliObserverBridge', () => {
       expect(source).not.toContain('as unknown as Trace');
       expect(source).not.toContain('as unknown as Span');
     });
+
+    it('preserves one-hour cache writes when tracing is disabled', async () => {
+      const bridge = new CliObserverBridge(defaultConfig);
+      bridge.startTrace('session-disabled-cache');
+      const deps = bridge.disabledObserverDeps;
+
+      deps.recordTokenUsage(deps.startSpan(deps.trace, { name: 'disabled-cache' }), {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheCreationTokens: 1_000_000,
+        cacheCreation1hTokens: 400_000,
+        model: 'claude-sonnet-4-6',
+      }, deps.counter);
+
+      const spend = await bridge.getTokenSpend('session-disabled-cache');
+      expect(spend.estimatedCostUsd).toBeCloseTo(22.95, 8);
+    });
   });
 
   // ── Integration (chunk 05) ──

--- a/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
@@ -83,6 +83,43 @@ describe('ObserverPortAdapter', () => {
     });
   });
 
+  it('includes cache metadata in token spend and cost calculation', async () => {
+    const trace = makeTrace();
+    const traceContext = {
+      createTrace: vi.fn().mockReturnValue(trace),
+      startSpan: vi.fn().mockImplementation((_trace: any, options: any) => {
+        const span = makeSpan(trace.id, options.name);
+        trace.spans.push(span);
+        return span;
+      }),
+      endSpan: vi.fn(),
+    };
+    const costCalculator = { calculate: vi.fn().mockReturnValue(0.5) };
+    const adapter = new ObserverPortAdapter({ traceContext, costCalculator });
+    adapter.startTrace('session-1');
+    adapter.startSpan('task:1').end({
+      promptTokens: 10,
+      completionTokens: 5,
+      cacheReadTokens: 8,
+      cacheCreationTokens: 2,
+      model: 'claude-sonnet-4-6',
+    });
+
+    await expect(adapter.getTokenSpend('session-1')).resolves.toEqual({
+      inputTokens: 20,
+      outputTokens: 5,
+      totalTokens: 25,
+      estimatedCostUsd: 0.5,
+    });
+    expect(costCalculator.calculate).toHaveBeenCalledWith({
+      model: 'claude-sonnet-4-6',
+      promptTokens: 10,
+      completionTokens: 5,
+      cacheReadTokens: 8,
+      cacheCreationTokens: 2,
+    });
+  });
+
   it('rejects a span with negative token metadata instead of letting it cancel', async () => {
     const trace = makeTrace();
     const traceContext = {

--- a/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
@@ -102,6 +102,7 @@ describe('ObserverPortAdapter', () => {
       completionTokens: 5,
       cacheReadTokens: 8,
       cacheCreationTokens: 2,
+      cacheCreation1hTokens: 1,
       model: 'claude-sonnet-4-6',
     });
 
@@ -117,6 +118,7 @@ describe('ObserverPortAdapter', () => {
       completionTokens: 5,
       cacheReadTokens: 8,
       cacheCreationTokens: 2,
+      cacheCreation1hTokens: 1,
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/observer-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ObserverPortAdapter } from '../../../src/adapters/observer-adapter.js';
+import {
+  ObserverPortAdapter,
+  type CostCalculatorPort,
+} from '../../../src/adapters/observer-adapter.js';
 
 const makeTrace = () => ({
   id: 'trace-1',
@@ -94,7 +97,13 @@ describe('ObserverPortAdapter', () => {
       }),
       endSpan: vi.fn(),
     };
-    const costCalculator = { calculate: vi.fn().mockReturnValue(0.5) };
+    const calculate = vi.fn<(entry: Parameters<CostCalculatorPort['calculate']>[0]) => number>();
+    const costCalculator: CostCalculatorPort = {
+      calculate(entry) {
+        calculate(entry);
+        return entry.cacheCreation1hTokens ?? 0;
+      },
+    };
     const adapter = new ObserverPortAdapter({ traceContext, costCalculator });
     adapter.startTrace('session-1');
     adapter.startSpan('task:1').end({
@@ -110,9 +119,9 @@ describe('ObserverPortAdapter', () => {
       inputTokens: 20,
       outputTokens: 5,
       totalTokens: 25,
-      estimatedCostUsd: 0.5,
+      estimatedCostUsd: 1,
     });
-    expect(costCalculator.calculate).toHaveBeenCalledWith({
+    expect(calculate).toHaveBeenCalledWith({
       model: 'claude-sonnet-4-6',
       promptTokens: 10,
       completionTokens: 5,

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -319,7 +319,7 @@ describe('resolveManagedChatAttachment', () => {
       usage: {
         inputTokens: 15,
         outputTokens: 10,
-        totalTokens: 30,
+        totalTokens: 34,
         cacheReadTokens: 5,
         cacheCreationTokens: 4,
         cacheCreation1hTokens: 2,
@@ -331,12 +331,35 @@ describe('resolveManagedChatAttachment', () => {
       usage: {
         inputTokens: 15,
         outputTokens: 10,
-        totalTokens: 30,
+        totalTokens: 34,
         cacheReadTokens: 5,
         cacheCreationTokens: 4,
         cacheCreation1hTokens: 2,
       },
     });
+  });
+
+  it('rejects cache-aware managed-chat usage with an inconsistent total', async () => {
+    stubManagedChatWebSocket();
+    const socket = new MockManagedChatWebSocket('ws://127.0.0.1:4242/v1/chat/ws');
+
+    const reply = __chatAttachTestHooks.awaitRemoteReply(socket as unknown as WebSocket, false);
+    socket.emitMessage(JSON.stringify({
+      type: 'assistant.message.complete',
+      messageId: 'm1',
+      content: 'hello',
+      usage: {
+        inputTokens: 15,
+        outputTokens: 10,
+        totalTokens: 30,
+        cacheReadTokens: 5,
+        cacheCreationTokens: 4,
+        cacheCreation1hTokens: 2,
+      },
+      timestamp: new Date().toISOString(),
+    }));
+
+    await expect(reply).resolves.toEqual({});
   });
 
   it('accumulates managed-chat cache usage across turns', () => {

--- a/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/chat-attach.test.ts
@@ -307,6 +307,66 @@ describe('resolveManagedChatAttachment', () => {
     });
   });
 
+  it('preserves cache token usage reported by managed chat', async () => {
+    stubManagedChatWebSocket();
+    const socket = new MockManagedChatWebSocket('ws://127.0.0.1:4242/v1/chat/ws');
+
+    const reply = __chatAttachTestHooks.awaitRemoteReply(socket as unknown as WebSocket, false);
+    socket.emitMessage(JSON.stringify({
+      type: 'assistant.message.complete',
+      messageId: 'm1',
+      content: 'hello',
+      usage: {
+        inputTokens: 15,
+        outputTokens: 10,
+        totalTokens: 30,
+        cacheReadTokens: 5,
+        cacheCreationTokens: 4,
+        cacheCreation1hTokens: 2,
+      },
+      timestamp: new Date().toISOString(),
+    }));
+
+    await expect(reply).resolves.toEqual({
+      usage: {
+        inputTokens: 15,
+        outputTokens: 10,
+        totalTokens: 30,
+        cacheReadTokens: 5,
+        cacheCreationTokens: 4,
+        cacheCreation1hTokens: 2,
+      },
+    });
+  });
+
+  it('accumulates managed-chat cache usage across turns', () => {
+    expect(__chatAttachTestHooks.addUsage(
+      {
+        inputTokens: 15,
+        outputTokens: 10,
+        totalTokens: 30,
+        cacheReadTokens: 5,
+        cacheCreationTokens: 4,
+        cacheCreation1hTokens: 2,
+      },
+      {
+        inputTokens: 20,
+        outputTokens: 8,
+        totalTokens: 35,
+        cacheReadTokens: 7,
+        cacheCreationTokens: 3,
+        cacheCreation1hTokens: 1,
+      },
+    )).toEqual({
+      inputTokens: 35,
+      outputTokens: 18,
+      totalTokens: 65,
+      cacheReadTokens: 12,
+      cacheCreationTokens: 7,
+      cacheCreation1hTokens: 3,
+    });
+  });
+
   it('resolves with an empty outcome when the server has not opted the peer into usage-stats', async () => {
     stubManagedChatWebSocket();
     const socket = new MockManagedChatWebSocket('ws://127.0.0.1:4242/v1/chat/ws');

--- a/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
@@ -99,20 +99,25 @@ describe('AnthropicApiAdapter', () => {
   });
 
   describe('translateUsage()', () => {
-    it('preserves Anthropic cache-read and cache-creation usage', () => {
+    it('preserves Anthropic cache-read and cache-creation usage by TTL', () => {
       const adapter = new AnthropicApiAdapter({ apiKey: 'test-...ure' });
 
       expect(adapter.translateUsage({
         input_tokens: 100,
         output_tokens: 50,
         cache_read_input_tokens: 80,
-        cache_creation_input_tokens: 20,
+        cache_creation_input_tokens: 50,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 20,
+          ephemeral_1h_input_tokens: 30,
+        },
       } as any)).toEqual({
         inputTokens: 100,
         outputTokens: 50,
         cacheReadTokens: 80,
-        cacheCreationTokens: 20,
-        totalTokens: 250,
+        cacheCreationTokens: 50,
+        cacheCreation1hTokens: 30,
+        totalTokens: 280,
       });
     });
 

--- a/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/anthropic-api-adapter.test.ts
@@ -98,6 +98,36 @@ describe('AnthropicApiAdapter', () => {
     });
   });
 
+  describe('translateUsage()', () => {
+    it('preserves Anthropic cache-read and cache-creation usage', () => {
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-...ure' });
+
+      expect(adapter.translateUsage({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 80,
+        cache_creation_input_tokens: 20,
+      } as any)).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        totalTokens: 250,
+      });
+    });
+
+    it('rejects cache usage whose combined total is unsafe', () => {
+      const adapter = new AnthropicApiAdapter({ apiKey: 'test-...ure' });
+
+      expect(() => adapter.translateUsage({
+        input_tokens: Number.MAX_SAFE_INTEGER,
+        output_tokens: 0,
+        cache_read_input_tokens: 1,
+        cache_creation_input_tokens: 0,
+      } as any)).toThrow();
+    });
+  });
+
   describe('createEventTranslator()', () => {
     it('translates text_delta events', () => {
       const adapter = new AnthropicApiAdapter({ apiKey: 'test-api-key-fixture' });

--- a/packages/franken-orchestrator/tests/unit/providers/openai-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/openai-api-adapter.test.ts
@@ -143,6 +143,18 @@ describe('OpenAiApiAdapter', () => {
     });
   });
 
+  describe('translateUsage()', () => {
+    it('rejects usage whose combined token count is unsafe', () => {
+      const adapter = new OpenAiApiAdapter({ apiKey: 'test-...ure' });
+
+      expect(() => adapter.translateUsage({
+        prompt_tokens: Number.MAX_SAFE_INTEGER,
+        completion_tokens: 1,
+        total_tokens: Number.MAX_SAFE_INTEGER,
+      } as any)).toThrow();
+    });
+  });
+
   describe('execute()', () => {
     it('translates text stream chunks and emits done with usage', async () => {
       const adapter = new OpenAiApiAdapter({ apiKey: 'test-api-key-fixture' });
@@ -150,7 +162,15 @@ describe('OpenAiApiAdapter', () => {
       const mockChunks = [
         { choices: [{ delta: { content: 'Hello' }, finish_reason: null }], usage: null },
         { choices: [{ delta: { content: ' world' }, finish_reason: 'stop' }], usage: null },
-        { choices: [], usage: { prompt_tokens: 20, completion_tokens: 10, total_tokens: 30 } },
+        {
+          choices: [],
+          usage: {
+            prompt_tokens: 20,
+            completion_tokens: 10,
+            total_tokens: 30,
+            prompt_tokens_details: { cached_tokens: 5 },
+          },
+        },
       ];
       (adapter as any).client = {
         chat: {
@@ -169,7 +189,16 @@ describe('OpenAiApiAdapter', () => {
 
       expect(events[0]).toEqual({ type: 'text', content: 'Hello' });
       expect(events[1]).toEqual({ type: 'text', content: ' world' });
-      expect(events[2]).toEqual({ type: 'done', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } });
+      expect(events[2]).toEqual({
+        type: 'done',
+        usage: {
+          inputTokens: 15,
+          outputTokens: 10,
+          cacheReadTokens: 5,
+          totalTokens: 30,
+        },
+      });
+
     });
 
     it('emits retryable error on rate limit', async () => {

--- a/packages/franken-orchestrator/tests/unit/providers/token-aggregator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/token-aggregator.test.ts
@@ -49,7 +49,7 @@ describe('TokenAggregator', () => {
     });
 
     expect(aggregator.getTotalUsage()).toMatchObject({
-      totalInputTokens: 110,
+      totalInputTokens: 210,
       totalOutputTokens: 55,
       totalCacheReadTokens: 80,
       totalCacheCreationTokens: 20,

--- a/packages/franken-orchestrator/tests/unit/providers/token-aggregator.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/token-aggregator.test.ts
@@ -34,6 +34,58 @@ describe('TokenAggregator', () => {
     expect(usage.totalOutputTokens).toBe(50);
   });
 
+  it('aggregates cache usage while defaulting omitted cache fields to zero', () => {
+    aggregator.record('anthropic-api', {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+      totalTokens: 250,
+    });
+    aggregator.record('anthropic-api', {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+
+    expect(aggregator.getTotalUsage()).toMatchObject({
+      totalInputTokens: 110,
+      totalOutputTokens: 55,
+      totalCacheReadTokens: 80,
+      totalCacheCreationTokens: 20,
+      totalTokens: 265,
+    });
+    expect(aggregator.getTotalUsage().byProvider.get('anthropic-api')).toEqual({
+      inputTokens: 110,
+      outputTokens: 55,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+      totalTokens: 265,
+    });
+  });
+
+  it('rejects cumulative overflow without mutating provider totals', () => {
+    aggregator.record('anthropic-api', {
+      inputTokens: Number.MAX_SAFE_INTEGER,
+      outputTokens: 0,
+      totalTokens: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(() => aggregator.record('anthropic-api', {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1,
+      totalTokens: 1,
+    })).toThrow(RangeError);
+    expect(aggregator.getTotalUsage().byProvider.get('anthropic-api')).toEqual({
+      inputTokens: Number.MAX_SAFE_INTEGER,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalTokens: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
   it('accumulates multiple calls to the same provider', () => {
     aggregator.record('claude-cli', {
       inputTokens: 100,

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -322,6 +322,7 @@ describe('CliSkillExecutor', () => {
       completionTokens: 50,
       cacheReadTokens: 80,
       cacheCreationTokens: 20,
+      cacheCreation1hTokens: 5,
       totalTokens: 250,
     });
     observer.costCalc.totalCost.mockReturnValue(0.001);
@@ -334,6 +335,7 @@ describe('CliSkillExecutor', () => {
       completionTokens: 50,
       cacheReadTokens: 80,
       cacheCreationTokens: 20,
+      cacheCreation1hTokens: 5,
     }]);
   });
 

--- a/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/cli-skill-executor.test.ts
@@ -179,9 +179,9 @@ function makeMockObserver(): MockObserver {
   return {
     trace: { id: 'trace-1' },
     counter: {
-      grandTotal: vi.fn<ObserverDeps['counter']['grandTotal']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
+      grandTotal: vi.fn<ObserverDeps['counter']['grandTotal']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, totalTokens: 0 }),
       allModels: vi.fn<ObserverDeps['counter']['allModels']>().mockReturnValue([]),
-      totalsFor: vi.fn<ObserverDeps['counter']['totalsFor']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
+      totalsFor: vi.fn<ObserverDeps['counter']['totalsFor']>().mockReturnValue({ promptTokens: 0, completionTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, totalTokens: 0 }),
     },
     costCalc: {
       totalCost: vi.fn<ObserverDeps['costCalc']['totalCost']>().mockReturnValue(0),
@@ -314,6 +314,28 @@ describe('CliSkillExecutor', () => {
   ) {
     return harness.execute(skillId, input, config, checkpoint, taskId, sanitizeResponse);
   }
+
+  it('includes cache tiers when computing current budget spend', () => {
+    observer.counter.allModels.mockReturnValue(['claude-sonnet-4-6']);
+    observer.counter.totalsFor.mockReturnValue({
+      promptTokens: 100,
+      completionTokens: 50,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+      totalTokens: 250,
+    });
+    observer.costCalc.totalCost.mockReturnValue(0.001);
+    const executor = harness.executor() as unknown as { computeCurrentCost(): number };
+
+    expect(executor.computeCurrentCost()).toBe(0.001);
+    expect(observer.costCalc.totalCost).toHaveBeenCalledWith([{
+      model: 'claude-sonnet-4-6',
+      promptTokens: 100,
+      completionTokens: 50,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+    }]);
+  });
 
   describe('successful execution (promise detected)', () => {
     it('records tool.call and tool.result replay records for the CLI skill execution', async () => {

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -105,6 +105,8 @@ export type LlmStreamEvent =
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   totalTokens: number;
 }
 
@@ -189,15 +191,21 @@ export const TokenUsageSchema = z
   .object({
     inputTokens: TokenCountSchema,
     outputTokens: TokenCountSchema,
+    cacheReadTokens: TokenCountSchema.optional(),
+    cacheCreationTokens: TokenCountSchema.optional(),
     totalTokens: TokenCountSchema,
   })
   .superRefine((usage, ctx) => {
-    const expectedTotal = usage.inputTokens + usage.outputTokens;
+    const expectedTotal =
+      usage.inputTokens +
+      usage.outputTokens +
+      (usage.cacheReadTokens ?? 0) +
+      (usage.cacheCreationTokens ?? 0);
     if (!Number.isSafeInteger(expectedTotal)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['totalTokens'],
-        message: `inputTokens + outputTokens must not exceed Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
+        message: `combined token counts must not exceed Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER})`,
       });
       return;
     }
@@ -206,7 +214,7 @@ export const TokenUsageSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['totalTokens'],
-        message: 'totalTokens must equal inputTokens + outputTokens',
+        message: 'totalTokens must equal inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens',
       });
     }
   });

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -107,6 +107,8 @@ export interface TokenUsage {
   outputTokens: number;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
+  /** One-hour cache writes, already included in cacheCreationTokens. */
+  cacheCreation1hTokens?: number;
   totalTokens: number;
 }
 
@@ -193,9 +195,17 @@ export const TokenUsageSchema = z
     outputTokens: TokenCountSchema,
     cacheReadTokens: TokenCountSchema.optional(),
     cacheCreationTokens: TokenCountSchema.optional(),
+    cacheCreation1hTokens: TokenCountSchema.optional(),
     totalTokens: TokenCountSchema,
   })
   .superRefine((usage, ctx) => {
+    if ((usage.cacheCreation1hTokens ?? 0) > (usage.cacheCreationTokens ?? 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['cacheCreation1hTokens'],
+        message: 'cacheCreation1hTokens must not exceed cacheCreationTokens',
+      });
+    }
     const expectedTotal =
       usage.inputTokens +
       usage.outputTokens +

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -31,6 +31,18 @@ describe('TokenUsageSchema', () => {
     expect(TokenUsageSchema.parse(usage)).toEqual(usage);
   });
 
+  it('preserves provider-reported cache token counts', () => {
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+      totalTokens: 250,
+    };
+
+    expect(TokenUsageSchema.parse(usage)).toEqual(usage);
+  });
+
   it('rejects negative inputTokens', () => {
     expect(() =>
       TokenUsageSchema.parse({ inputTokens: -1, outputTokens: 0, totalTokens: 0 }),

--- a/packages/franken-types/tests/provider.test.ts
+++ b/packages/franken-types/tests/provider.test.ts
@@ -26,6 +26,27 @@ import {
 } from '../src/index.js';
 
 describe('TokenUsageSchema', () => {
+  it('preserves the Anthropic one-hour cache-creation subset', () => {
+    expect(TokenUsageSchema.parse({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 50,
+      cacheCreation1hTokens: 30,
+      totalTokens: 280,
+    })).toMatchObject({ cacheCreationTokens: 50, cacheCreation1hTokens: 30 })
+  })
+
+  it('rejects a one-hour cache-creation subset larger than total cache creation', () => {
+    expect(() => TokenUsageSchema.parse({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 10,
+      cacheCreation1hTokens: 11,
+      totalTokens: 10,
+    })).toThrow()
+  })
+
   it('validates well-formed usage', () => {
     const usage: TokenUsage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
     expect(TokenUsageSchema.parse(usage)).toEqual(usage);

--- a/tasks/3727-codex-remediation-progress.md
+++ b/tasks/3727-codex-remediation-progress.md
@@ -13,3 +13,9 @@
 - [ ] Route exact-head Codex trigger through Approval Cop tier 12 and obtain clean result.
 - [ ] Verify exact-head green CI and fully paginated zero unresolved Codex threads.
 - [ ] Record terminal Kanban handoff; do not merge.
+
+## Current-head Codex round (0314063e10)
+- [x] RED→GREEN: render one-hour cache creation as a subset of aggregate cache creation in MCP observer output (focused test failed on additive wording, then passed 5/5).
+- [x] RED→GREEN: preserve and accumulate all cache token fields through managed-chat attachment usage (focused tests failed on dropped fields/missing accumulator, then passed 18/18).
+- [ ] Run focused and package verification, commit/push normally, reply/resolve both threads, and obtain a fresh exact-head Codex clean result.
+- [ ] Reverify exact-head CI, fully paginated zero unresolved threads, isolation, and no merge.

--- a/tasks/3727-codex-remediation-progress.md
+++ b/tasks/3727-codex-remediation-progress.md
@@ -1,0 +1,15 @@
+# #3727 Codex Remediation Progress
+
+- [x] Read live issue #3727, task t_707101f6 comments, PR #3781 state, and all four accepted Codex threads.
+- [x] Confirm issue-defined cacheHitRatio remains cacheReadTokens / (cacheReadTokens + promptTokens).
+- [x] RED→GREEN: preserve and price Anthropic 1-hour versus 5-minute cache creation.
+- [x] RED→GREEN: include cache read/creation in aggregated input totals.
+- [x] RED→GREEN: include cache tiers in governor historical repricing.
+- [x] RED→GREEN: render cache tiers in MCP observer log and summary responses.
+- [x] Run focused tests for types, observer, orchestrator, and MCP suite.
+- [x] Run required package verification, lint, typecheck, build, and diff/scope review.
+- [ ] Commit as David Mendez <me@davidmendez.dev> and push PR #3781 branch.
+- [ ] Reply to and resolve accepted Codex threads.
+- [ ] Route exact-head Codex trigger through Approval Cop tier 12 and obtain clean result.
+- [ ] Verify exact-head green CI and fully paginated zero unresolved Codex threads.
+- [ ] Record terminal Kanban handoff; do not merge.


### PR DESCRIPTION
## Summary
- add cache-read and cache-creation token fields across shared provider usage, observer counters, span metadata, and orchestrator aggregation
- translate real Anthropic and OpenAI SDK cache usage without estimating unsupported fields
- price cache tiers with prompt-rate fallback, export a cache-hit ratio helper, and document the accounting model
- preserve safe-integer validation and atomic overflow rejection across counters and aggregators

## Test plan
- `npm --workspace @franken/orchestrator test -- tests/unit/providers/anthropic-api-adapter.test.ts tests/unit/providers/openai-api-adapter.test.ts tests/unit/providers/token-aggregator.test.ts tests/unit/adapters/observer-adapter.test.ts tests/unit/skills/cli-skill-executor.test.ts test/adapters/cli-observer-bridge.test.ts`
- `npm --workspace @franken/observer test -- src/cost/TokenCounter.test.ts src/cost/CostCalculator.test.ts src/core/SpanLifecycle.test.ts`
- `npm --workspace @franken/types test -- tests/provider.test.ts`
- `npx turbo run typecheck --filter=@franken/types --filter=@franken/observer --filter=@franken/orchestrator`
- `npx turbo run lint --filter=@franken/types --filter=@franken/observer --filter=@franken/orchestrator`
- `npx turbo run build --filter=@franken/types --filter=@franken/observer --filter=@franken/orchestrator`

Closes #3727
