### PR TITLE
feat(observer): sample process resource usage

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -18,6 +18,7 @@ npm install @franken/observer
 - [Quick start](#quick-start)
 - [Core tracing](#core-tracing)
 - [Token & cost tracking](#token--cost-tracking)
+- [Process resource telemetry](#process-resource-telemetry)
 - [Decision outcome attribution](#decision-outcome-attribution)
 - [Export backends](#export-backends)
 - [OTEL serialisation](#otel-serialisation)
@@ -293,6 +294,41 @@ attribution.report()
 //     { model: 'claude-opus-4-6',   totalCalls: 1, successfulCalls: 0, failedCalls: 1, successRate: 0.0, totalCostUsd: 0.0105 },
 //   ]
 ```
+
+---
+
+## Process resource telemetry
+
+`ProcessResourceSampler` records real CPU utilization and RSS memory for a PID and attaches every sample to the caller's existing agent and run identifiers. Passing a `SQLiteAdapter` persists the time series in the same database used for traces; `queryResourceSamples` filters by agent or run and an inclusive timestamp range.
+
+```ts
+import { ProcessResourceSampler, SQLiteAdapter } from '@franken/observer'
+
+const db = new SQLiteAdapter('./traces.db')
+const sampler = new ProcessResourceSampler({
+  pid: spawnedProcess.pid,
+  agentId: beastAgentId,
+  runId: beastRunId,
+  adapter: db,
+  intervalMs: 5_000, // optional; 5 seconds is the default
+  idleWatts: 10,
+  tdpWatts: 65,
+})
+
+sampler.start()
+// Later, after the process exits:
+await sampler.stop() // drains an in-flight sample before returning
+
+const history = await db.queryResourceSamples({
+  runId: beastRunId,
+  since: Date.now() - 60_000,
+  before: Date.now(),
+})
+```
+
+Current-process sampling uses Node's built-in CPU and memory APIs. Child-PID sampling uses `ps`, avoiding a native addon for v1 and working on Linux/macOS; Windows child-PID sampling is explicitly unsupported. `ps` reports a lifetime-average CPU percentage rather than a hardware-counter interval, so precision varies by platform.
+
+`estimatedWatts` and `estimatedEnergyWh` are **best-effort estimates, not measurements**. The configurable linear model is `idleWatts + min(cpuPercent, 100) / 100 × tdpWatts`; it does not read RAPL, IPMI, battery, or other hardware sensors. Configure the values per host and do not use them for billing-grade energy accounting.
 
 ---
 

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -324,11 +324,16 @@ const history = await db.queryResourceSamples({
   since: Date.now() - 60_000,
   before: Date.now(),
 })
+
+// Apply an operator-chosen retention policy (for example, keep 30 days).
+const deleted = await db.deleteResourceSamplesBefore(Date.now() - 30 * 24 * 60 * 60 * 1_000)
 ```
 
 Current-process sampling uses Node's built-in CPU and memory APIs. Child-PID sampling uses `ps`, avoiding a native addon for v1 and working on Linux/macOS; Windows child-PID sampling is explicitly unsupported. `ps` reports a lifetime-average CPU percentage rather than a hardware-counter interval, so precision varies by platform.
 
-`estimatedWatts` and `estimatedEnergyWh` are **best-effort estimates, not measurements**. The configurable linear model is `idleWatts + min(cpuPercent, 100) / 100 × tdpWatts`; it does not read RAPL, IPMI, battery, or other hardware sensors. Configure the values per host and do not use them for billing-grade energy accounting.
+`estimatedWatts` and `estimatedEnergyWh` are **best-effort estimates, not measurements**. The configurable linear model is `idleWatts + min(cpuPercent, 100) / 100 × tdpWatts`; elapsed energy uses a monotonic clock so wall-clock corrections do not distort intervals. It does not read RAPL, IPMI, battery, or other hardware sensors. Configure the values per host and do not use them for billing-grade energy accounting.
+
+Periodic samples are not pruned implicitly because retention requirements vary by deployment. Long-running operators should schedule `deleteResourceSamplesBefore()` with an explicit cutoff; it returns the number of deleted rows.
 
 ---
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -50,6 +50,7 @@ describe('SQLiteAdapter', () => {
       'journal_mode = WAL',
       'foreign_keys = ON',
       "index_list('compaction_events')",
+      "table_info('process_resource_samples')",
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
@@ -62,6 +63,9 @@ describe('SQLiteAdapter', () => {
         return execMock.mock.calls.length === 0
           ? []
           : [{ name: 'idx_compaction_events_session_timestamp' }]
+      }
+      if (statement === "table_info('process_resource_samples')") {
+        return execMock.mock.calls.length === 0 ? [] : [{ name: 'id' }]
       }
       return undefined
     })

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -7,6 +7,10 @@ import { Worker } from 'node:worker_threads'
 import { wallClockNow } from '@franken/types'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
+import type {
+  ProcessResourceSample,
+  ProcessResourceSampleQuery,
+} from '../../resource/ProcessResourceSampler.js'
 import {
   COMPACTION_RETENTION_MS,
   type CompactionEvent,
@@ -24,11 +28,16 @@ import {
   SELECT_TRACE_SUMMARIES,
   DELETE_SPANS_BY_TRACE,
   DELETE_COMPACTIONS_BY_RUN,
+  DELETE_RESOURCE_SAMPLES_BY_RUN,
   DELETE_COMPACTIONS_BEFORE,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
   SELECT_COMPACTION_EVENTS,
   SELECT_COMPACTION_AGGREGATE,
+  INSERT_RESOURCE_SAMPLE,
+  SELECT_RESOURCE_SAMPLES_BY_AGENT,
+  SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
+  SELECT_RESOURCE_SAMPLES_BY_RUN,
 } from './schema.js'
 
 interface TraceRow {
@@ -139,6 +148,8 @@ type SQLiteWorkerOperation =
   | 'recordCompaction'
   | 'queryCompactions'
   | 'aggregateCompactions'
+  | 'recordResourceSample'
+  | 'queryResourceSamples'
 
 interface SQLiteWorkerResponse {
   id: number
@@ -207,10 +218,12 @@ function execute(operation, payload) {
     case 'deleteTrace': {
       const deleteSpans = db.prepare(sql.deleteSpansByTrace)
       const deleteCompactions = db.prepare(sql.deleteCompactionsByRun)
+      const deleteResourceSamples = db.prepare(sql.deleteResourceSamplesByRun)
       const deleteTrace = db.prepare(sql.deleteTrace)
       db.transaction((traceId) => {
         deleteSpans.run(traceId)
         deleteCompactions.run(traceId)
+        deleteResourceSamples.run(traceId)
         deleteTrace.run(traceId)
       })(payload.traceId)
       return undefined
@@ -231,6 +244,18 @@ function execute(operation, payload) {
         db.prepare(sql.deleteCompactionsBefore).run(retentionCutoff)
         return db.prepare(sql.selectCompactionAggregate).get(query)
       })(payload.query, payload.retentionCutoff)
+    case 'recordResourceSample':
+      db.prepare(sql.insertResourceSample).run(payload.sample)
+      return undefined
+    case 'queryResourceSamples': {
+      const query = payload.query
+      const statement = query.agentId === null
+        ? sql.selectResourceSamplesByRun
+        : query.runId === null
+          ? sql.selectResourceSamplesByAgent
+          : sql.selectResourceSamplesByAgentAndRun
+      return db.prepare(statement).all(query)
+    }
     default:
       throw new Error('Unknown SQLite worker operation: ' + operation)
   }
@@ -303,11 +328,16 @@ class SQLiteWorkerClient {
             selectTraceSummaries: SELECT_TRACE_SUMMARIES,
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
             deleteCompactionsByRun: DELETE_COMPACTIONS_BY_RUN,
+            deleteResourceSamplesByRun: DELETE_RESOURCE_SAMPLES_BY_RUN,
             deleteCompactionsBefore: DELETE_COMPACTIONS_BEFORE,
             deleteTrace: DELETE_TRACE,
             upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
             selectCompactionEvents: SELECT_COMPACTION_EVENTS,
             selectCompactionAggregate: SELECT_COMPACTION_AGGREGATE,
+            insertResourceSample: INSERT_RESOURCE_SAMPLE,
+            selectResourceSamplesByAgent: SELECT_RESOURCE_SAMPLES_BY_AGENT,
+            selectResourceSamplesByAgentAndRun: SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
+            selectResourceSamplesByRun: SELECT_RESOURCE_SAMPLES_BY_RUN,
           },
         },
       },
@@ -638,9 +668,10 @@ export class SQLiteAdapter implements ExportAdapter {
         const compactionIndexes = this.db.pragma("index_list('compaction_events')") as Array<{ name?: unknown }>
         const schemaInitialized = Array.isArray(compactionIndexes)
           && compactionIndexes.some(index => index.name === SQLITE_SCHEMA_SENTINEL_INDEX)
-        if (!schemaInitialized) {
-          this.db.exec(CREATE_TABLES)
-        } else {
+        const resourceTableInfo = this.db.pragma("table_info('process_resource_samples')") as Array<{ name?: unknown }>
+        const resourceSchemaInitialized = Array.isArray(resourceTableInfo)
+          && resourceTableInfo.some(column => column.name === 'id')
+        if (schemaInitialized) {
           const rawTableInfo = this.db.pragma("table_info('compaction_events')") as unknown
           const tableInfo = (Array.isArray(rawTableInfo) ? rawTableInfo : []) as Array<{
             name?: unknown
@@ -656,6 +687,11 @@ export class SQLiteAdapter implements ExportAdapter {
           )) {
             this.db.exec(MIGRATE_COMPACTION_EVENT_IDENTITY)
           }
+        }
+        if (!schemaInitialized || !resourceSchemaInitialized) {
+          // CREATE TABLE IF NOT EXISTS also upgrades databases created before
+          // process resource telemetry was introduced.
+          this.db.exec(CREATE_TABLES)
         }
       })
       const isTransientDatabase = databasePath === ':memory:' || databasePath === ''
@@ -931,10 +967,12 @@ export class SQLiteAdapter implements ExportAdapter {
       await this.withSqliteLockRetry('delete trace transaction', () => {
         const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
         const deleteCompactions = this.db.prepare(DELETE_COMPACTIONS_BY_RUN)
+        const deleteResourceSamples = this.db.prepare(DELETE_RESOURCE_SAMPLES_BY_RUN)
         const deleteTrace = this.db.prepare(DELETE_TRACE)
         const transaction = this.db.transaction((id: string) => {
           deleteSpans.run(id)
           deleteCompactions.run(id)
+          deleteResourceSamples.run(id)
           deleteTrace.run(id)
         })
 
@@ -1014,6 +1052,60 @@ export class SQLiteAdapter implements ExportAdapter {
           latestAt: number | null
         }
       })())
+    })
+  }
+
+  async recordResourceSample(sample: ProcessResourceSample): Promise<void> {
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        await this.withSqliteLockRetry('record process resource sample', () => (
+          this.workerClient!.request<void>('recordResourceSample', { sample })
+        ))
+        return
+      }
+      await this.withSqliteLockRetry('record process resource sample', () => {
+        this.db.prepare(INSERT_RESOURCE_SAMPLE).run(sample)
+      })
+    })
+  }
+
+  async queryResourceSamples(query: ProcessResourceSampleQuery): Promise<ProcessResourceSample[]> {
+    const agentId = query.agentId?.trim()
+    const runId = query.runId?.trim()
+    if (!agentId && !runId) {
+      return Promise.reject(new TypeError('queryResourceSamples requires agentId or runId'))
+    }
+    const since = query.since ?? 0
+    const before = query.before ?? Number.MAX_SAFE_INTEGER
+    if (!Number.isSafeInteger(since) || !Number.isSafeInteger(before) || since < 0 || before < since) {
+      return Promise.reject(new RangeError('resource sample time range must contain safe integers with before >= since'))
+    }
+    const requestedLimit = query.limit ?? 100
+    if (!Number.isSafeInteger(requestedLimit) || requestedLimit <= 0) {
+      return Promise.reject(new RangeError('resource sample limit must be a positive safe integer'))
+    }
+    const limit = Math.min(1_000, requestedLimit)
+    const params = {
+      agentId: agentId ?? null,
+      runId: runId ?? null,
+      since,
+      before,
+      limit,
+    }
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        return this.withSqliteLockRetry('query process resource samples', () => (
+          this.workerClient!.request<ProcessResourceSample[]>('queryResourceSamples', { query: params })
+        ))
+      }
+      const statement = params.agentId === null
+        ? SELECT_RESOURCE_SAMPLES_BY_RUN
+        : params.runId === null
+          ? SELECT_RESOURCE_SAMPLES_BY_AGENT
+          : SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN
+      return this.withSqliteLockRetry('query process resource samples', () => (
+        this.db.prepare(statement).all(params) as ProcessResourceSample[]
+      ))
     })
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -28,7 +28,6 @@ import {
   SELECT_TRACE_SUMMARIES,
   DELETE_SPANS_BY_TRACE,
   DELETE_COMPACTIONS_BY_RUN,
-  DELETE_RESOURCE_SAMPLES_BY_RUN,
   DELETE_COMPACTIONS_BEFORE,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
@@ -85,6 +84,14 @@ interface FlushedSpanState {
 
 const SQLITE_SCHEMA_SENTINEL_INDEX = 'idx_compaction_events_session_timestamp'
 const COMPACTION_PRIMARY_KEY = ['runId', 'sessionId', 'generation']
+
+function normalizeResourceSample(sample: ProcessResourceSample): ProcessResourceSample {
+  const agentId = sample.agentId.trim()
+  const runId = sample.runId.trim()
+  if (agentId.length === 0) throw new TypeError('resource sample agentId must not be empty')
+  if (runId.length === 0) throw new TypeError('resource sample runId must not be empty')
+  return { ...sample, agentId, runId }
+}
 
 export interface SQLiteAdapterOptions {
   /** Maximum flushed-span snapshots retained for repeated-flush dirty checks. */
@@ -218,12 +225,10 @@ function execute(operation, payload) {
     case 'deleteTrace': {
       const deleteSpans = db.prepare(sql.deleteSpansByTrace)
       const deleteCompactions = db.prepare(sql.deleteCompactionsByRun)
-      const deleteResourceSamples = db.prepare(sql.deleteResourceSamplesByRun)
       const deleteTrace = db.prepare(sql.deleteTrace)
       db.transaction((traceId) => {
         deleteSpans.run(traceId)
         deleteCompactions.run(traceId)
-        deleteResourceSamples.run(traceId)
         deleteTrace.run(traceId)
       })(payload.traceId)
       return undefined
@@ -328,7 +333,6 @@ class SQLiteWorkerClient {
             selectTraceSummaries: SELECT_TRACE_SUMMARIES,
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
             deleteCompactionsByRun: DELETE_COMPACTIONS_BY_RUN,
-            deleteResourceSamplesByRun: DELETE_RESOURCE_SAMPLES_BY_RUN,
             deleteCompactionsBefore: DELETE_COMPACTIONS_BEFORE,
             deleteTrace: DELETE_TRACE,
             upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
@@ -967,12 +971,10 @@ export class SQLiteAdapter implements ExportAdapter {
       await this.withSqliteLockRetry('delete trace transaction', () => {
         const deleteSpans = this.db.prepare(DELETE_SPANS_BY_TRACE)
         const deleteCompactions = this.db.prepare(DELETE_COMPACTIONS_BY_RUN)
-        const deleteResourceSamples = this.db.prepare(DELETE_RESOURCE_SAMPLES_BY_RUN)
         const deleteTrace = this.db.prepare(DELETE_TRACE)
         const transaction = this.db.transaction((id: string) => {
           deleteSpans.run(id)
           deleteCompactions.run(id)
-          deleteResourceSamples.run(id)
           deleteTrace.run(id)
         })
 
@@ -1056,15 +1058,16 @@ export class SQLiteAdapter implements ExportAdapter {
   }
 
   async recordResourceSample(sample: ProcessResourceSample): Promise<void> {
+    const normalizedSample = normalizeResourceSample(sample)
     return this.enqueueSqliteOperation(async () => {
       if (this.workerClient !== undefined) {
         await this.withSqliteLockRetry('record process resource sample', () => (
-          this.workerClient!.request<void>('recordResourceSample', { sample })
+          this.workerClient!.request<void>('recordResourceSample', { sample: normalizedSample })
         ))
         return
       }
       await this.withSqliteLockRetry('record process resource sample', () => {
-        this.db.prepare(INSERT_RESOURCE_SAMPLE).run(sample)
+        this.db.prepare(INSERT_RESOURCE_SAMPLE).run(normalizedSample)
       })
     })
   }

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -29,6 +29,7 @@ import {
   DELETE_SPANS_BY_TRACE,
   DELETE_COMPACTIONS_BY_RUN,
   DELETE_COMPACTIONS_BEFORE,
+  DELETE_RESOURCE_SAMPLES_BEFORE,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
   SELECT_COMPACTION_EVENTS,
@@ -157,6 +158,7 @@ type SQLiteWorkerOperation =
   | 'aggregateCompactions'
   | 'recordResourceSample'
   | 'queryResourceSamples'
+  | 'deleteResourceSamplesBefore'
 
 interface SQLiteWorkerResponse {
   id: number
@@ -252,6 +254,8 @@ function execute(operation, payload) {
     case 'recordResourceSample':
       db.prepare(sql.insertResourceSample).run(payload.sample)
       return undefined
+    case 'deleteResourceSamplesBefore':
+      return db.prepare(sql.deleteResourceSamplesBefore).run(payload.before).changes
     case 'queryResourceSamples': {
       const query = payload.query
       const statement = query.agentId === null
@@ -334,6 +338,7 @@ class SQLiteWorkerClient {
             deleteSpansByTrace: DELETE_SPANS_BY_TRACE,
             deleteCompactionsByRun: DELETE_COMPACTIONS_BY_RUN,
             deleteCompactionsBefore: DELETE_COMPACTIONS_BEFORE,
+            deleteResourceSamplesBefore: DELETE_RESOURCE_SAMPLES_BEFORE,
             deleteTrace: DELETE_TRACE,
             upsertCompactionEvent: UPSERT_COMPACTION_EVENT,
             selectCompactionEvents: SELECT_COMPACTION_EVENTS,
@@ -1072,9 +1077,25 @@ export class SQLiteAdapter implements ExportAdapter {
     })
   }
 
+  async deleteResourceSamplesBefore(before: number): Promise<number> {
+    if (!Number.isSafeInteger(before) || before < 0) {
+      return Promise.reject(new RangeError('resource sample retention cutoff must be a non-negative safe integer'))
+    }
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        return this.withSqliteLockRetry('delete old process resource samples', () => (
+          this.workerClient!.request<number>('deleteResourceSamplesBefore', { before })
+        ))
+      }
+      return this.withSqliteLockRetry('delete old process resource samples', () => (
+        this.db.prepare(DELETE_RESOURCE_SAMPLES_BEFORE).run(before).changes
+      ))
+    })
+  }
+
   async queryResourceSamples(query: ProcessResourceSampleQuery): Promise<ProcessResourceSample[]> {
-    const agentId = query.agentId?.trim()
-    const runId = query.runId?.trim()
+    const agentId = query.agentId?.trim() || undefined
+    const runId = query.runId?.trim() || undefined
     if (!agentId && !runId) {
       return Promise.reject(new TypeError('queryResourceSamples requires agentId or runId'))
     }

--- a/packages/franken-observer/src/adapters/sqlite/resource-schema.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/resource-schema.test.ts
@@ -1,0 +1,24 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import {
+  CREATE_TABLES,
+  SELECT_RESOURCE_SAMPLES_BY_AGENT,
+  SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
+  SELECT_RESOURCE_SAMPLES_BY_RUN,
+} from './schema.js';
+
+describe('process resource sample query schema', () => {
+  it.each([
+    ['agent', SELECT_RESOURCE_SAMPLES_BY_AGENT, { agentId: 'agent-1', since: 0, before: 2_000, limit: 100 }, 'idx_process_resource_samples_agent_timestamp'],
+    ['run', SELECT_RESOURCE_SAMPLES_BY_RUN, { runId: 'run-1', since: 0, before: 2_000, limit: 100 }, 'idx_process_resource_samples_run_timestamp'],
+    ['agent and run', SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN, { agentId: 'agent-1', runId: 'run-1', since: 0, before: 2_000, limit: 100 }, 'idx_process_resource_samples_run_timestamp'],
+  ])('uses an identifier/time index for %s queries', (_scope, sql, params, expectedIndex) => {
+    const db = new Database(':memory:');
+    db.exec(CREATE_TABLES);
+
+    const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(params) as Array<{ detail: string }>;
+
+    expect(plan.some(row => row.detail.includes(expectedIndex))).toBe(true);
+    db.close();
+  });
+});

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -131,6 +131,7 @@ export const SELECT_TRACE_SUMMARIES = `
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
 export const DELETE_COMPACTIONS_BEFORE = `DELETE FROM compaction_events WHERE timestamp < ?`
+export const DELETE_RESOURCE_SAMPLES_BEFORE = `DELETE FROM process_resource_samples WHERE timestamp < ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 
 export const UPSERT_COMPACTION_EVENT = `

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -130,7 +130,6 @@ export const SELECT_TRACE_SUMMARIES = `
 
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
-export const DELETE_RESOURCE_SAMPLES_BY_RUN = `DELETE FROM process_resource_samples WHERE runId = ?`
 export const DELETE_COMPACTIONS_BEFORE = `DELETE FROM compaction_events WHERE timestamp < ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -41,6 +41,23 @@ export const CREATE_TABLES = `
     ON compaction_events(sessionId, timestamp);
   CREATE INDEX IF NOT EXISTS idx_compaction_events_timestamp
     ON compaction_events(timestamp);
+
+  CREATE TABLE IF NOT EXISTS process_resource_samples (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    agentId            TEXT    NOT NULL,
+    runId              TEXT    NOT NULL,
+    pid                INTEGER NOT NULL CHECK (pid > 0),
+    cpuPercent         REAL    NOT NULL CHECK (cpuPercent >= 0),
+    rssBytes           INTEGER NOT NULL CHECK (rssBytes >= 0),
+    estimatedWatts     REAL    NOT NULL CHECK (estimatedWatts >= 0),
+    estimatedEnergyWh  REAL    NOT NULL CHECK (estimatedEnergyWh >= 0),
+    timestamp          INTEGER NOT NULL
+  ) STRICT;
+
+  CREATE INDEX IF NOT EXISTS idx_process_resource_samples_agent_timestamp
+    ON process_resource_samples(agentId, timestamp);
+  CREATE INDEX IF NOT EXISTS idx_process_resource_samples_run_timestamp
+    ON process_resource_samples(runId, timestamp);
 `
 
 export const MIGRATE_COMPACTION_EVENT_IDENTITY = `
@@ -113,6 +130,7 @@ export const SELECT_TRACE_SUMMARIES = `
 
 export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
+export const DELETE_RESOURCE_SAMPLES_BY_RUN = `DELETE FROM process_resource_samples WHERE runId = ?`
 export const DELETE_COMPACTIONS_BEFORE = `DELETE FROM compaction_events WHERE timestamp < ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 
@@ -140,4 +158,41 @@ export const SELECT_COMPACTION_AGGREGATE = `
   SELECT COUNT(*) AS count, MAX(timestamp) AS latestAt
   FROM compaction_events
   WHERE sessionId = @sessionId AND timestamp >= @since AND timestamp <= @before
+`
+
+export const INSERT_RESOURCE_SAMPLE = `
+  INSERT INTO process_resource_samples
+    (agentId, runId, pid, cpuPercent, rssBytes, estimatedWatts, estimatedEnergyWh, timestamp)
+  VALUES
+    (@agentId, @runId, @pid, @cpuPercent, @rssBytes, @estimatedWatts, @estimatedEnergyWh, @timestamp)
+`
+
+const RESOURCE_SAMPLE_COLUMNS = `
+  SELECT agentId, runId, pid, cpuPercent, rssBytes, estimatedWatts, estimatedEnergyWh, timestamp
+  FROM process_resource_samples
+`
+
+const RESOURCE_SAMPLE_RANGE_AND_ORDER = `
+    AND timestamp >= @since
+    AND timestamp <= @before
+  ORDER BY timestamp DESC, id DESC
+  LIMIT @limit
+`
+
+export const SELECT_RESOURCE_SAMPLES_BY_AGENT = `
+  ${RESOURCE_SAMPLE_COLUMNS}
+  WHERE agentId = @agentId
+  ${RESOURCE_SAMPLE_RANGE_AND_ORDER}
+`
+
+export const SELECT_RESOURCE_SAMPLES_BY_RUN = `
+  ${RESOURCE_SAMPLE_COLUMNS}
+  WHERE runId = @runId
+  ${RESOURCE_SAMPLE_RANGE_AND_ORDER}
+`
+
+export const SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN = `
+  ${RESOURCE_SAMPLE_COLUMNS}
+  WHERE agentId = @agentId AND runId = @runId
+  ${RESOURCE_SAMPLE_RANGE_AND_ORDER}
 `

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -53,6 +53,13 @@ export {
 export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 export { CompactionMetrics } from './compaction-metrics.js'
+export {
+  DEFAULT_IDLE_WATTS,
+  DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS,
+  DEFAULT_TDP_WATTS,
+  ProcessResourceSampler,
+  estimateProcessPower,
+} from './resource/ProcessResourceSampler.js'
 
 export type { ExportAdapter, TraceSummary } from './export/ExportAdapter.js'
 export type { MultiAdapterOptions } from './adapters/multi/MultiAdapter.js'
@@ -72,6 +79,13 @@ export type {
   CompactionRate,
   CompactionTriggerReason,
 } from './compaction-metrics.js'
+export type {
+  ProcessPowerModel,
+  ProcessResourceSample,
+  ProcessResourceSampleAdapter,
+  ProcessResourceSampleQuery,
+  ProcessResourceSamplerOptions,
+} from './resource/ProcessResourceSampler.js'
 export type { PrometheusAdapterOptions } from './adapters/prometheus/PrometheusAdapter.js'
 export type { TempoAdapterOptions, TempoBasicAuth } from './adapters/tempo/TempoAdapter.js'
 export type {

--- a/packages/franken-observer/src/process-resource-sampler.test.ts
+++ b/packages/franken-observer/src/process-resource-sampler.test.ts
@@ -1,0 +1,203 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js';
+import {
+  DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS,
+  ProcessResourceSampler,
+  estimateProcessPower,
+  type ProcessResourceSample,
+} from './resource/ProcessResourceSampler.js';
+
+const tempDirs: string[] = [];
+const children: ChildProcess[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function spawnIdleChild(): Promise<ChildProcess & { pid: number }> {
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)'], {
+    stdio: 'ignore',
+  });
+  children.push(child);
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', resolve);
+    child.once('error', reject);
+  });
+  if (child.pid === undefined) throw new Error('Child process did not expose a PID');
+  return child as ChildProcess & { pid: number };
+}
+
+function persistedSample(overrides: Partial<ProcessResourceSample> = {}): ProcessResourceSample {
+  return {
+    agentId: 'agent-1',
+    runId: 'run-1',
+    pid: 123,
+    cpuPercent: 25,
+    rssBytes: 4_096,
+    estimatedWatts: 26.25,
+    estimatedEnergyWh: 0.01,
+    timestamp: 1_000,
+    ...overrides,
+  };
+}
+
+describe('ProcessResourceSampler', () => {
+  it('samples CPU and RSS from a real child process', async () => {
+    const child = await spawnIdleChild();
+    const sampler = new ProcessResourceSampler({
+      pid: child.pid,
+      agentId: 'agent-real',
+      runId: 'run-real',
+    });
+
+    const sample = await sampler.sample();
+
+    expect(sample).toMatchObject({
+      pid: child.pid,
+      agentId: 'agent-real',
+      runId: 'run-real',
+    });
+    expect(sample.cpuPercent).toBeGreaterThanOrEqual(0);
+    expect(sample.rssBytes).toBeGreaterThan(0);
+    expect(sample.estimatedWatts).toBeGreaterThan(0);
+    expect(sample.timestamp).toBeGreaterThan(0);
+  });
+
+  it('uses a documented default interval and accepts a configured interval', () => {
+    const defaultSampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-default',
+      runId: 'run-default',
+    });
+    const configuredSampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-configured',
+      runId: 'run-configured',
+      intervalMs: 9_000,
+    });
+
+    expect(defaultSampler.intervalMs).toBe(DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS);
+    expect(configuredSampler.intervalMs).toBe(9_000);
+  });
+
+  it('serializes interval writes and drains the active sample before stopping', async () => {
+    vi.useFakeTimers();
+    let releaseWrite: (() => void) | undefined;
+    let activeWrites = 0;
+    let maxActiveWrites = 0;
+    let writeCount = 0;
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-interval',
+      runId: 'run-interval',
+      intervalMs: 100,
+      adapter: {
+        async recordResourceSample() {
+          writeCount += 1;
+          activeWrites += 1;
+          maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+          await new Promise<void>(resolve => { releaseWrite = resolve; });
+          activeWrites -= 1;
+        },
+      },
+    });
+
+    sampler.start();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(writeCount).toBe(1);
+    expect(maxActiveWrites).toBe(1);
+
+    let stopped = false;
+    const stopping = sampler.stop().then(() => { stopped = true; });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    releaseWrite?.();
+    await stopping;
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(stopped).toBe(true);
+    expect(writeCount).toBe(1);
+  });
+
+  it('normalizes agent and run identifiers before returning or persisting samples', async () => {
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: '  agent-normalized  ',
+      runId: '  run-normalized  ',
+    });
+
+    await expect(sampler.sample()).resolves.toMatchObject({
+      agentId: 'agent-normalized',
+      runId: 'run-normalized',
+    });
+  });
+
+  it('persists sampled runtime data through SQLite', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'resource-sampler-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'));
+    const child = await spawnIdleChild();
+    const sampler = new ProcessResourceSampler({
+      pid: child.pid,
+      agentId: 'agent-persisted',
+      runId: 'run-persisted',
+      adapter,
+    });
+
+    const sample = await sampler.sample();
+
+    await expect(adapter.queryResourceSamples({ runId: 'run-persisted' })).resolves.toEqual([sample]);
+    await adapter.close();
+  });
+});
+
+describe('estimateProcessPower', () => {
+  it.each([
+    [0, 10],
+    [50, 35],
+    [100, 60],
+    [250, 60],
+  ])('estimates watts for %s%% CPU utilization', (cpuPercent, expectedWatts) => {
+    expect(estimateProcessPower(cpuPercent, { idleWatts: 10, tdpWatts: 50 })).toBe(expectedWatts);
+  });
+});
+
+describe('SQLiteAdapter resource samples', () => {
+  it('queries samples by agent or run within an inclusive time range', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'resource-query-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'), { useWorkerThread: false });
+    await adapter.recordResourceSample(persistedSample({ timestamp: 999 }));
+    await adapter.recordResourceSample(persistedSample({ timestamp: 1_000 }));
+    await adapter.recordResourceSample(persistedSample({ timestamp: 1_500, runId: 'run-2' }));
+    await adapter.recordResourceSample(persistedSample({ timestamp: 2_000 }));
+    await adapter.recordResourceSample(persistedSample({ timestamp: 2_001 }));
+    await adapter.recordResourceSample(persistedSample({ timestamp: 1_750, agentId: 'agent-2' }));
+
+    await expect(adapter.queryResourceSamples({
+      agentId: 'agent-1',
+      runId: 'run-1',
+      since: 1_000,
+      before: 2_000,
+    })).resolves.toEqual([
+      persistedSample({ timestamp: 2_000 }),
+      persistedSample({ timestamp: 1_000 }),
+    ]);
+    await expect(adapter.queryResourceSamples({ agentId: 'agent-1' })).resolves.toHaveLength(5);
+    await expect(adapter.queryResourceSamples({ runId: 'run-2' })).resolves.toEqual([
+      persistedSample({ timestamp: 1_500, runId: 'run-2' }),
+    ]);
+
+    await adapter.close();
+  });
+});

--- a/packages/franken-observer/src/process-resource-sampler.test.ts
+++ b/packages/franken-observer/src/process-resource-sampler.test.ts
@@ -142,6 +142,44 @@ describe('ProcessResourceSampler', () => {
     });
   });
 
+  it('drains a manual sample before stopping', async () => {
+    let releaseWrite: (() => void) | undefined;
+    let writeCompleted = false;
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-manual',
+      runId: 'run-manual',
+      adapter: {
+        async recordResourceSample() {
+          await new Promise<void>(resolve => { releaseWrite = resolve; });
+          writeCompleted = true;
+        },
+      },
+    });
+
+    const sampling = sampler.sample();
+    setTimeout(() => releaseWrite?.(), 10);
+    const writeCompletedWhenStopped = await sampler.stop().then(() => writeCompleted);
+    await sampling;
+
+    expect(writeCompletedWhenStopped).toBe(true);
+  });
+
+  it('contains rejections from the background error callback', async () => {
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-error',
+      runId: 'run-error',
+      adapter: {
+        async recordResourceSample() { throw new Error('write failed'); },
+      },
+      async onError() { throw new Error('reporting failed'); },
+    });
+
+    sampler.start();
+    await expect(sampler.stop()).resolves.toBeUndefined();
+  });
+
   it('persists sampled runtime data through SQLite', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'resource-sampler-'));
     tempDirs.push(dir);
@@ -198,6 +236,29 @@ describe('SQLiteAdapter resource samples', () => {
       persistedSample({ timestamp: 1_500, runId: 'run-2' }),
     ]);
 
+    await adapter.close();
+  });
+
+  it('normalizes direct-write identifiers and rejects empty identifiers', async () => {
+    const adapter = new SQLiteAdapter(':memory:', { useWorkerThread: false });
+    const sample = persistedSample({ agentId: '  agent-direct  ', runId: '  run-direct  ' });
+
+    await adapter.recordResourceSample(sample);
+    await expect(adapter.queryResourceSamples({ agentId: 'agent-direct' })).resolves.toEqual([
+      { ...sample, agentId: 'agent-direct', runId: 'run-direct' },
+    ]);
+    await expect(adapter.recordResourceSample({ ...sample, agentId: '   ' })).rejects.toThrow(TypeError);
+
+    await adapter.close();
+  });
+
+  it('does not treat an independent resource run ID as a trace ID during deletion', async () => {
+    const adapter = new SQLiteAdapter(':memory:', { useWorkerThread: false });
+    await adapter.recordResourceSample(persistedSample({ runId: 'shared-id' }));
+
+    await adapter.deleteTrace('shared-id');
+
+    await expect(adapter.queryResourceSamples({ runId: 'shared-id' })).resolves.toHaveLength(1);
     await adapter.close();
   });
 });

--- a/packages/franken-observer/src/process-resource-sampler.test.ts
+++ b/packages/franken-observer/src/process-resource-sampler.test.ts
@@ -16,6 +16,7 @@ const children: ChildProcess[] = [];
 
 afterEach(async () => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   for (const child of children.splice(0)) {
     if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
   }
@@ -142,6 +143,23 @@ describe('ProcessResourceSampler', () => {
     });
   });
 
+  it('uses monotonic elapsed time when the wall clock moves backward', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(10_000)
+      .mockReturnValueOnce(1);
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-clock',
+      runId: 'run-clock',
+    });
+
+    await sampler.sample();
+    const second = await sampler.sample();
+
+    expect(second.timestamp).toBe(1);
+    expect(second.estimatedEnergyWh).toBeGreaterThan(0);
+  });
+
   it('drains a manual sample before stopping', async () => {
     let releaseWrite: (() => void) | undefined;
     let writeCompleted = false;
@@ -178,6 +196,27 @@ describe('ProcessResourceSampler', () => {
 
     sampler.start();
     await expect(sampler.stop()).resolves.toBeUndefined();
+  });
+
+  it('awaits asynchronous sample callbacks before stopping', async () => {
+    let releaseCallback: (() => void) | undefined;
+    let callbackCompleted = false;
+    const sampler = new ProcessResourceSampler({
+      pid: process.pid,
+      agentId: 'agent-callback',
+      runId: 'run-callback',
+      async onSample() {
+        await new Promise<void>(resolve => { releaseCallback = resolve; });
+        callbackCompleted = true;
+      },
+    });
+
+    const sampling = sampler.sample();
+    setTimeout(() => releaseCallback?.(), 10);
+    const callbackCompletedWhenStopped = await sampler.stop().then(() => callbackCompleted);
+    await sampling;
+
+    expect(callbackCompletedWhenStopped).toBe(true);
   });
 
   it('persists sampled runtime data through SQLite', async () => {
@@ -235,6 +274,7 @@ describe('SQLiteAdapter resource samples', () => {
     await expect(adapter.queryResourceSamples({ runId: 'run-2' })).resolves.toEqual([
       persistedSample({ timestamp: 1_500, runId: 'run-2' }),
     ]);
+    await expect(adapter.queryResourceSamples({ agentId: ' ', runId: 'run-1' })).resolves.toHaveLength(5);
 
     await adapter.close();
   });
@@ -259,6 +299,21 @@ describe('SQLiteAdapter resource samples', () => {
     await adapter.deleteTrace('shared-id');
 
     await expect(adapter.queryResourceSamples({ runId: 'shared-id' })).resolves.toHaveLength(1);
+    await adapter.close();
+  });
+
+  it('supports explicit retention pruning without deleting recent samples', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'resource-retention-'));
+    tempDirs.push(dir);
+    const adapter = new SQLiteAdapter(join(dir, 'traces.db'));
+    await adapter.recordResourceSample(persistedSample({ runId: 'run-retention', timestamp: 1_000 }));
+    await adapter.recordResourceSample(persistedSample({ runId: 'run-retention', timestamp: 2_000 }));
+
+    await expect(adapter.deleteResourceSamplesBefore(1_500)).resolves.toBe(1);
+    await expect(adapter.queryResourceSamples({ runId: 'run-retention' })).resolves.toEqual([
+      persistedSample({ runId: 'run-retention', timestamp: 2_000 }),
+    ]);
+
     await adapter.close();
   });
 });

--- a/packages/franken-observer/src/resource/ProcessResourceSampler.ts
+++ b/packages/franken-observer/src/resource/ProcessResourceSampler.ts
@@ -44,7 +44,7 @@ export interface ProcessResourceSamplerOptions extends ProcessPowerModel {
   /** Sampling cadence in milliseconds. Default: 5000. */
   readonly intervalMs?: number;
   readonly adapter?: ProcessResourceSampleAdapter;
-  readonly onSample?: (sample: ProcessResourceSample) => void;
+  readonly onSample?: (sample: ProcessResourceSample) => void | Promise<void>;
   readonly onError?: (error: Error) => void | Promise<void>;
 }
 
@@ -96,12 +96,12 @@ export class ProcessResourceSampler {
   private readonly idleWatts: number;
   private readonly tdpWatts: number;
   private readonly adapter: ProcessResourceSampleAdapter | undefined;
-  private readonly onSample: ((sample: ProcessResourceSample) => void) | undefined;
+  private readonly onSample: ((sample: ProcessResourceSample) => void | Promise<void>) | undefined;
   private readonly onError: ((error: Error) => void | Promise<void>) | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
   private inFlight: Promise<void> | undefined;
   private sampleQueue: Promise<void> = Promise.resolve();
-  private previousTimestamp: number | undefined;
+  private previousSampleAt: bigint | undefined;
   private previousCpuUsage = process.cpuUsage();
   private previousCpuAt = process.hrtime.bigint();
 
@@ -139,13 +139,14 @@ export class ProcessResourceSampler {
       ? this.sampleCurrentProcess()
       : await this.sampleChildProcess();
     const timestamp = wallClockNow();
+    const sampledAt = process.hrtime.bigint();
     const estimatedWatts = estimateProcessPower(usage.cpuPercent, {
       idleWatts: this.idleWatts,
       tdpWatts: this.tdpWatts,
     });
-    const elapsedMs = this.previousTimestamp === undefined
+    const elapsedHours = this.previousSampleAt === undefined
       ? 0
-      : Math.max(0, timestamp - this.previousTimestamp);
+      : Number(sampledAt - this.previousSampleAt) / 3_600_000_000_000;
     const sample: ProcessResourceSample = {
       agentId: this.agentId,
       runId: this.runId,
@@ -153,12 +154,12 @@ export class ProcessResourceSampler {
       cpuPercent: usage.cpuPercent,
       rssBytes: usage.rssBytes,
       estimatedWatts,
-      estimatedEnergyWh: estimatedWatts * (elapsedMs / 3_600_000),
+      estimatedEnergyWh: estimatedWatts * elapsedHours,
       timestamp,
     };
-    this.previousTimestamp = timestamp;
+    this.previousSampleAt = sampledAt;
     await this.adapter?.recordResourceSample(sample);
-    this.onSample?.(sample);
+    await this.onSample?.(sample);
     return sample;
   }
 

--- a/packages/franken-observer/src/resource/ProcessResourceSampler.ts
+++ b/packages/franken-observer/src/resource/ProcessResourceSampler.ts
@@ -45,7 +45,7 @@ export interface ProcessResourceSamplerOptions extends ProcessPowerModel {
   readonly intervalMs?: number;
   readonly adapter?: ProcessResourceSampleAdapter;
   readonly onSample?: (sample: ProcessResourceSample) => void;
-  readonly onError?: (error: Error) => void;
+  readonly onError?: (error: Error) => void | Promise<void>;
 }
 
 interface RawProcessUsage {
@@ -97,9 +97,10 @@ export class ProcessResourceSampler {
   private readonly tdpWatts: number;
   private readonly adapter: ProcessResourceSampleAdapter | undefined;
   private readonly onSample: ((sample: ProcessResourceSample) => void) | undefined;
-  private readonly onError: ((error: Error) => void) | undefined;
+  private readonly onError: ((error: Error) => void | Promise<void>) | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
   private inFlight: Promise<void> | undefined;
+  private sampleQueue: Promise<void> = Promise.resolve();
   private previousTimestamp: number | undefined;
   private previousCpuUsage = process.cpuUsage();
   private previousCpuAt = process.hrtime.bigint();
@@ -127,7 +128,13 @@ export class ProcessResourceSampler {
     return this.timer !== undefined;
   }
 
-  async sample(): Promise<ProcessResourceSample> {
+  sample(): Promise<ProcessResourceSample> {
+    const operation = this.sampleQueue.then(() => this.collectSample());
+    this.sampleQueue = operation.then(() => undefined, () => undefined);
+    return operation;
+  }
+
+  private async collectSample(): Promise<ProcessResourceSample> {
     const usage = this.pid === process.pid
       ? this.sampleCurrentProcess()
       : await this.sampleChildProcess();
@@ -167,21 +174,28 @@ export class ProcessResourceSampler {
       clearInterval(this.timer);
       this.timer = undefined;
     }
-    await this.inFlight;
+    await Promise.all([this.inFlight, this.sampleQueue]);
   }
 
   private async tick(): Promise<void> {
     if (this.inFlight !== undefined) return this.inFlight;
     const operation = this.sample()
       .then(() => undefined)
-      .catch(error => {
-        this.onError?.(error instanceof Error ? error : new Error(String(error)));
-      });
+      .catch(error => this.reportError(error instanceof Error ? error : new Error(String(error))));
     this.inFlight = operation;
     try {
       await operation;
     } finally {
       if (this.inFlight === operation) this.inFlight = undefined;
+    }
+  }
+
+  private async reportError(error: Error): Promise<void> {
+    try {
+      await this.onError?.(error);
+    } catch {
+      // Error reporting must not turn a recoverable background failure into an
+      // unhandled rejection. Callers can instrument the callback independently.
     }
   }
 

--- a/packages/franken-observer/src/resource/ProcessResourceSampler.ts
+++ b/packages/franken-observer/src/resource/ProcessResourceSampler.ts
@@ -1,0 +1,228 @@
+import { promisify } from 'node:util';
+import { wallClockNow } from '@franken/types';
+
+export const DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS = 5_000;
+export const DEFAULT_IDLE_WATTS = 10;
+export const DEFAULT_TDP_WATTS = 65;
+
+export interface ProcessResourceSample {
+  readonly agentId: string;
+  readonly runId: string;
+  readonly pid: number;
+  readonly cpuPercent: number;
+  readonly rssBytes: number;
+  /** Best-effort model output, not a hardware power measurement. */
+  readonly estimatedWatts: number;
+  /** Estimated energy consumed since this sampler's previous sample. */
+  readonly estimatedEnergyWh: number;
+  readonly timestamp: number;
+}
+
+export interface ProcessResourceSampleQuery {
+  readonly agentId?: string;
+  readonly runId?: string;
+  readonly since?: number;
+  readonly before?: number;
+  readonly limit?: number;
+}
+
+export interface ProcessResourceSampleAdapter {
+  recordResourceSample(sample: ProcessResourceSample): Promise<void>;
+}
+
+export interface ProcessPowerModel {
+  /** Host baseline power assigned to the process estimate. Default: 10 W. */
+  readonly idleWatts?: number;
+  /** Additional power at 100% process CPU utilization. Default: 65 W. */
+  readonly tdpWatts?: number;
+}
+
+export interface ProcessResourceSamplerOptions extends ProcessPowerModel {
+  readonly pid: number;
+  readonly agentId: string;
+  readonly runId: string;
+  /** Sampling cadence in milliseconds. Default: 5000. */
+  readonly intervalMs?: number;
+  readonly adapter?: ProcessResourceSampleAdapter;
+  readonly onSample?: (sample: ProcessResourceSample) => void;
+  readonly onError?: (error: Error) => void;
+}
+
+interface RawProcessUsage {
+  readonly cpuPercent: number;
+  readonly rssBytes: number;
+}
+
+function requireNonEmpty(value: string, name: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) throw new TypeError(`${name} must not be empty`);
+  return normalized;
+}
+
+function requireNonNegativeFinite(value: number, name: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+/**
+ * Estimates process-attributed power using a configurable linear host model.
+ * This is intentionally a coarse estimate, not a sensor measurement. CPU above
+ * 100% (possible for multi-threaded processes in `ps`) is capped for the model.
+ */
+export function estimateProcessPower(
+  cpuPercent: number,
+  model: ProcessPowerModel = {},
+): number {
+  const normalizedCpu = Math.min(100, requireNonNegativeFinite(cpuPercent, 'cpuPercent'));
+  const idleWatts = requireNonNegativeFinite(model.idleWatts ?? DEFAULT_IDLE_WATTS, 'idleWatts');
+  const tdpWatts = requireNonNegativeFinite(model.tdpWatts ?? DEFAULT_TDP_WATTS, 'tdpWatts');
+  return idleWatts + ((normalizedCpu / 100) * tdpWatts);
+}
+
+/**
+ * Samples one OS process. The current Node process uses built-in CPU/RSS APIs;
+ * child PIDs use the widely available Unix `ps` command. The latter is a v1
+ * portability tradeoff: Linux/macOS are supported without a native addon,
+ * while Windows child-PID sampling fails with an explicit unsupported error.
+ */
+export class ProcessResourceSampler {
+  readonly intervalMs: number;
+
+  private readonly pid: number;
+  private readonly agentId: string;
+  private readonly runId: string;
+  private readonly idleWatts: number;
+  private readonly tdpWatts: number;
+  private readonly adapter: ProcessResourceSampleAdapter | undefined;
+  private readonly onSample: ((sample: ProcessResourceSample) => void) | undefined;
+  private readonly onError: ((error: Error) => void) | undefined;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private inFlight: Promise<void> | undefined;
+  private previousTimestamp: number | undefined;
+  private previousCpuUsage = process.cpuUsage();
+  private previousCpuAt = process.hrtime.bigint();
+
+  constructor(options: ProcessResourceSamplerOptions) {
+    if (!Number.isSafeInteger(options.pid) || options.pid <= 0) {
+      throw new RangeError('pid must be a positive safe integer');
+    }
+    const intervalMs = options.intervalMs ?? DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS;
+    if (!Number.isSafeInteger(intervalMs) || intervalMs < 100) {
+      throw new RangeError('intervalMs must be a safe integer of at least 100');
+    }
+    this.pid = options.pid;
+    this.agentId = requireNonEmpty(options.agentId, 'agentId');
+    this.runId = requireNonEmpty(options.runId, 'runId');
+    this.intervalMs = intervalMs;
+    this.idleWatts = requireNonNegativeFinite(options.idleWatts ?? DEFAULT_IDLE_WATTS, 'idleWatts');
+    this.tdpWatts = requireNonNegativeFinite(options.tdpWatts ?? DEFAULT_TDP_WATTS, 'tdpWatts');
+    this.adapter = options.adapter;
+    this.onSample = options.onSample;
+    this.onError = options.onError;
+  }
+
+  get running(): boolean {
+    return this.timer !== undefined;
+  }
+
+  async sample(): Promise<ProcessResourceSample> {
+    const usage = this.pid === process.pid
+      ? this.sampleCurrentProcess()
+      : await this.sampleChildProcess();
+    const timestamp = wallClockNow();
+    const estimatedWatts = estimateProcessPower(usage.cpuPercent, {
+      idleWatts: this.idleWatts,
+      tdpWatts: this.tdpWatts,
+    });
+    const elapsedMs = this.previousTimestamp === undefined
+      ? 0
+      : Math.max(0, timestamp - this.previousTimestamp);
+    const sample: ProcessResourceSample = {
+      agentId: this.agentId,
+      runId: this.runId,
+      pid: this.pid,
+      cpuPercent: usage.cpuPercent,
+      rssBytes: usage.rssBytes,
+      estimatedWatts,
+      estimatedEnergyWh: estimatedWatts * (elapsedMs / 3_600_000),
+      timestamp,
+    };
+    this.previousTimestamp = timestamp;
+    await this.adapter?.recordResourceSample(sample);
+    this.onSample?.(sample);
+    return sample;
+  }
+
+  start(): void {
+    if (this.timer !== undefined) return;
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+    this.timer.unref?.();
+    void this.tick();
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    await this.inFlight;
+  }
+
+  private async tick(): Promise<void> {
+    if (this.inFlight !== undefined) return this.inFlight;
+    const operation = this.sample()
+      .then(() => undefined)
+      .catch(error => {
+        this.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+    this.inFlight = operation;
+    try {
+      await operation;
+    } finally {
+      if (this.inFlight === operation) this.inFlight = undefined;
+    }
+  }
+
+  private sampleCurrentProcess(): RawProcessUsage {
+    const now = process.hrtime.bigint();
+    const elapsedMicros = Number(now - this.previousCpuAt) / 1_000;
+    const delta = process.cpuUsage(this.previousCpuUsage);
+    this.previousCpuAt = now;
+    this.previousCpuUsage = process.cpuUsage();
+    return {
+      cpuPercent: elapsedMicros <= 0 ? 0 : ((delta.user + delta.system) / elapsedMicros) * 100,
+      rssBytes: process.memoryUsage().rss,
+    };
+  }
+
+  private async sampleChildProcess(): Promise<RawProcessUsage> {
+    if (process.platform === 'win32') {
+      throw new Error('Child-process resource sampling is unsupported on Windows; sample the current process or use a host-specific collector');
+    }
+    // Keep this import lazy so consumers that mock child_process for their own
+    // process execution do not need to provide execFile just to import observer.
+    const { execFile } = await import('node:child_process');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('ps', [
+      '-o',
+      '%cpu=,rss=',
+      '-p',
+      String(this.pid),
+    ], { encoding: 'utf8', maxBuffer: 16 * 1_024 });
+    const fields = stdout.trim().split(/\s+/);
+    if (fields.length < 2) {
+      throw new Error(`Process ${this.pid} is not running or did not return resource data`);
+    }
+    const cpuPercent = Number(fields[0]);
+    const rssKilobytes = Number(fields[1]);
+    if (!Number.isFinite(cpuPercent) || !Number.isFinite(rssKilobytes)) {
+      throw new Error(`Process ${this.pid} returned invalid resource data`);
+    }
+    return {
+      cpuPercent: Math.max(0, cpuPercent),
+      rssBytes: Math.max(0, rssKilobytes) * 1_024,
+    };
+  }
+}

--- a/tasks/brain-vitals-3730-progress.md
+++ b/tasks/brain-vitals-3730-progress.md
@@ -1,0 +1,22 @@
+# Brain Vitals #3730 progress
+
+- [x] Fetch issue #3730, comments, and parent #3726 from live GitHub.
+- [x] Confirm issue is open, still missing on fresh `origin/main`, and within Brain Vitals scope.
+- [x] Confirm isolated clean worktree at fresh `origin/main` with required git identity.
+- [x] Inspect observer SQLite and process-supervisor integration patterns.
+- [x] RED: add and run a real child-process sampling test.
+- [x] RED: add and run deterministic power-estimate tests.
+- [x] RED: add and run SQLite persistence/time-range query tests.
+- [x] GREEN: implement the minimal sampler, estimator, interval lifecycle, and SQLite persistence.
+- [x] Export and document the public resource telemetry API and caveats.
+- [x] Run focused observer tests, typecheck, build, lint, and relevant repository gates.
+- [ ] Commit and push the issue branch; open one PR closing #3730.
+- [ ] Obtain exact-head CI success and a clean Codex review with zero unresolved threads.
+- [ ] Merge, verify issue closure and clean worktree, and record the final handoff.
+
+## Verification notes
+
+- Focused resource tests: 13 passed, covering a real spawned process, CPU/RSS, estimates, configurable intervals, serialized writes, persistence, and indexed queries.
+- Observer package: 38 files / 940 tests passed; lint, typecheck, and build passed.
+- Repository lint, typecheck, and build passed. Full concurrent repository test runs exposed unrelated orchestrator timing flakes; every reported failing file passed in isolation while the observer package remained green.
+- Independent review findings on lifecycle overlap, query-plan index use, identifier normalization, and import-time child-process mocking were resolved; the second pass reported no additional findings.

--- a/tasks/brain-vitals-3730-progress.md
+++ b/tasks/brain-vitals-3730-progress.md
@@ -16,7 +16,7 @@
 
 ## Verification notes
 
-- Focused resource tests: 17 passed, covering a real spawned process, CPU/RSS, estimates, configurable intervals, serialized/manual drain semantics, persistence, and indexed queries.
-- Observer package: 38 files / 944 tests passed; lint, typecheck, and build passed.
+- Focused resource tests: 20 passed, covering a real spawned process, CPU/RSS, estimates, configurable intervals, monotonic energy, async lifecycle draining, persistence, indexed queries, and explicit retention pruning.
+- Observer package: 38 files / 947 tests passed; lint, typecheck, and build passed.
 - Repository lint, typecheck, and build passed. Full concurrent repository test runs exposed unrelated orchestrator timing flakes; every reported failing file passed in isolation while the observer package remained green.
 - Independent review findings on lifecycle overlap, query-plan index use, identifier normalization, and import-time child-process mocking were resolved; the second pass reported no additional findings.

--- a/tasks/brain-vitals-3730-progress.md
+++ b/tasks/brain-vitals-3730-progress.md
@@ -16,7 +16,7 @@
 
 ## Verification notes
 
-- Focused resource tests: 13 passed, covering a real spawned process, CPU/RSS, estimates, configurable intervals, serialized writes, persistence, and indexed queries.
-- Observer package: 38 files / 940 tests passed; lint, typecheck, and build passed.
+- Focused resource tests: 17 passed, covering a real spawned process, CPU/RSS, estimates, configurable intervals, serialized/manual drain semantics, persistence, and indexed queries.
+- Observer package: 38 files / 944 tests passed; lint, typecheck, and build passed.
 - Repository lint, typecheck, and build passed. Full concurrent repository test runs exposed unrelated orchestrator timing flakes; every reported failing file passed in isolation while the observer package remained green.
 - Independent review findings on lifecycle overlap, query-plan index use, identifier normalization, and import-time child-process mocking were resolved; the second pass reported no additional findings.


### PR DESCRIPTION
## Summary

- add a configurable `ProcessResourceSampler` for real PID CPU and RSS telemetry
- estimate process power and interval energy with explicit tunable assumptions and caveats
- persist/query resource time series in observer SQLite using agent/run timestamp indexes
- serialize periodic writes, drain in-flight sampling on stop, and expose the public API

## Verification

- `npm --workspace @franken/observer test` — 38 files, 940 tests passed
- `npm --workspace @franken/observer run lint -- --quiet` — passed
- `npm --workspace @franken/observer run typecheck` — passed
- `npm --workspace @franken/observer run build` — passed
- `npm run lint` — passed (existing warnings only)
- `npm run typecheck` — passed
- `npm run build` — passed
- full concurrent `npm run test` exposed unrelated orchestrator timing flakes; every reported failing test file passed when rerun in isolation

Closes #3730
