### PR TITLE
feat(observer): add brain health scoring

### DIFF
--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -18,6 +18,7 @@ npm install @franken/observer
 - [Quick start](#quick-start)
 - [Core tracing](#core-tracing)
 - [Token & cost tracking](#token--cost-tracking)
+- [Brain health scoring](#brain-health-scoring)
 - [Process resource telemetry](#process-resource-telemetry)
 - [Decision outcome attribution](#decision-outcome-attribution)
 - [Export backends](#export-backends)
@@ -294,6 +295,49 @@ attribution.report()
 //     { model: 'claude-opus-4-6',   totalCalls: 1, successfulCalls: 0, failedCalls: 1, successRate: 0.0, totalCostUsd: 0.0105 },
 //   ]
 ```
+
+---
+
+## Brain health scoring
+
+`calculateBrainHealthScore` combines six caller-normalized signals into a deterministic 0–100 score. Higher is healthier. V1 uses these replaceable defaults:
+
+| Signal | Weight | Healthy direction |
+|---|---:|---|
+| Task success rate | 30% | Higher |
+| Cache-hit ratio | 15% | Higher |
+| Compaction pressure | 15% | Lower |
+| Lifecycle churn/discard pressure | 15% | Lower |
+| Resource pressure | 10% | Lower |
+| Budget burn ratio | 15% | Lower |
+
+The formula is `100 × (0.30×success + 0.15×cache + 0.15×(1−compaction) + 0.15×(1−churn) + 0.10×(1−resource) + 0.15×(1−budget burn))`. Task outcomes receive the largest weight because completing useful work is the primary health signal. Resource pressure receives the smallest weight because the current power telemetry is estimated rather than hardware-measured. The remaining operational signals are balanced equally for a tuneable v1 baseline. Every signal must be normalized to `0..1`; operators define the unhealthy ceilings used to convert raw compactions/hour, CPU/RSS, orphan counts, and budget data into pressure ratios.
+
+`BrainHealthScorer` computes and persists snapshots on demand. This avoids a hidden background timer and lets the orchestrator choose a cadence that matches its task and telemetry windows. `brainId` accepts the current definition/agent identifier and can later carry a Brain Registry id without changing the score model.
+
+```ts
+import { BrainHealthScorer, SQLiteAdapter } from '@franken/observer'
+
+const db = new SQLiteAdapter('./traces.db')
+const health = new BrainHealthScorer(db)
+
+await health.computeAndPersist('definition-42', {
+  taskSuccessRate: 0.9,
+  cacheHitRatio: 0.7,
+  compactionPressure: 0.2,
+  churnRatio: 0.1,
+  resourcePressure: 0.4,
+  budgetBurnRatio: 0.5,
+})
+
+const latest = await health.getHealthScore('definition-42')
+const history = await health.getHealthHistory('definition-42', {
+  since: Date.now() - 24 * 60 * 60 * 1_000,
+  before: Date.now(),
+})
+```
+
+The SQLite history is indexed by brain id and timestamp. Query results are newest-first and include the exact normalized signals and weights used for each score.
 
 ---
 

--- a/packages/franken-observer/README.md
+++ b/packages/franken-observer/README.md
@@ -335,9 +335,12 @@ const history = await health.getHealthHistory('definition-42', {
   since: Date.now() - 24 * 60 * 60 * 1_000,
   before: Date.now(),
 })
+
+// Apply an operator-chosen retention window (for example, keep 30 days).
+await db.deleteHealthScoresBefore(Date.now() - 30 * 24 * 60 * 60 * 1_000)
 ```
 
-The SQLite history is indexed by brain id and timestamp. Query results are newest-first and include the exact normalized signals and weights used for each score.
+The SQLite history is indexed by brain id and timestamp. Query results are newest-first and include the exact normalized signals and weights used for each score. Snapshots are not pruned implicitly because retention needs vary by deployment; operators should schedule `deleteHealthScoresBefore()` with their chosen cutoff.
 
 ---
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.test.ts
@@ -51,6 +51,7 @@ describe('SQLiteAdapter', () => {
       'foreign_keys = ON',
       "index_list('compaction_events')",
       "table_info('process_resource_samples')",
+      "table_info('brain_health_scores')",
     ])
     expect(execMock).toHaveBeenCalledTimes(1)
 
@@ -65,6 +66,9 @@ describe('SQLiteAdapter', () => {
           : [{ name: 'idx_compaction_events_session_timestamp' }]
       }
       if (statement === "table_info('process_resource_samples')") {
+        return execMock.mock.calls.length === 0 ? [] : [{ name: 'id' }]
+      }
+      if (statement === "table_info('brain_health_scores')") {
         return execMock.mock.calls.length === 0 ? [] : [{ name: 'id' }]
       }
       return undefined

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -8,6 +8,12 @@ import { wallClockNow } from '@franken/types'
 import type { Trace, Span } from '../../core/types.js'
 import type { ExportAdapter, TraceSummary } from '../../export/ExportAdapter.js'
 import type {
+  BrainHealthSample,
+  BrainHealthSampleQuery,
+  BrainHealthSignals,
+  BrainHealthWeights,
+} from '../../brain-health.js'
+import type {
   ProcessResourceSample,
   ProcessResourceSampleQuery,
 } from '../../resource/ProcessResourceSampler.js'
@@ -38,6 +44,8 @@ import {
   SELECT_RESOURCE_SAMPLES_BY_AGENT,
   SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
   SELECT_RESOURCE_SAMPLES_BY_RUN,
+  INSERT_BRAIN_HEALTH_SCORE,
+  SELECT_BRAIN_HEALTH_SCORES,
 } from './schema.js'
 
 interface TraceRow {
@@ -70,6 +78,14 @@ interface TraceSummaryRow {
   spanCount: number
 }
 
+interface BrainHealthScoreRow {
+  brainId: string
+  score: number
+  signals: string
+  weights: string
+  timestamp: number
+}
+
 interface FlushedSpanState {
   status: Span['status']
   endedAt: number | undefined
@@ -92,6 +108,18 @@ function normalizeResourceSample(sample: ProcessResourceSample): ProcessResource
   if (agentId.length === 0) throw new TypeError('resource sample agentId must not be empty')
   if (runId.length === 0) throw new TypeError('resource sample runId must not be empty')
   return { ...sample, agentId, runId }
+}
+
+function normalizeBrainHealthSample(sample: BrainHealthSample): BrainHealthSample {
+  const brainId = sample.brainId.trim()
+  if (brainId.length === 0) throw new TypeError('health score brainId must not be empty')
+  if (!Number.isFinite(sample.score) || sample.score < 0 || sample.score > 100) {
+    throw new RangeError('health score must be between 0 and 100')
+  }
+  if (!Number.isSafeInteger(sample.timestamp) || sample.timestamp < 0) {
+    throw new RangeError('health score timestamp must be a non-negative safe integer')
+  }
+  return { ...sample, brainId }
 }
 
 export interface SQLiteAdapterOptions {
@@ -159,6 +187,8 @@ type SQLiteWorkerOperation =
   | 'recordResourceSample'
   | 'queryResourceSamples'
   | 'deleteResourceSamplesBefore'
+  | 'recordHealthScore'
+  | 'queryHealthScores'
 
 interface SQLiteWorkerResponse {
   id: number
@@ -265,6 +295,11 @@ function execute(operation, payload) {
           : sql.selectResourceSamplesByAgentAndRun
       return db.prepare(statement).all(query)
     }
+    case 'recordHealthScore':
+      db.prepare(sql.insertBrainHealthScore).run(payload.sample)
+      return undefined
+    case 'queryHealthScores':
+      return db.prepare(sql.selectBrainHealthScores).all(payload.query)
     default:
       throw new Error('Unknown SQLite worker operation: ' + operation)
   }
@@ -347,6 +382,8 @@ class SQLiteWorkerClient {
             selectResourceSamplesByAgent: SELECT_RESOURCE_SAMPLES_BY_AGENT,
             selectResourceSamplesByAgentAndRun: SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
             selectResourceSamplesByRun: SELECT_RESOURCE_SAMPLES_BY_RUN,
+            insertBrainHealthScore: INSERT_BRAIN_HEALTH_SCORE,
+            selectBrainHealthScores: SELECT_BRAIN_HEALTH_SCORES,
           },
         },
       },
@@ -640,6 +677,16 @@ function rowToSpan(row: SpanRow): Span {
   }
 }
 
+function rowToBrainHealthSample(row: BrainHealthScoreRow): BrainHealthSample {
+  return {
+    brainId: row.brainId,
+    score: row.score,
+    signals: safeParse<BrainHealthSignals>(row.signals, {} as BrainHealthSignals, `brain ${row.brainId} health signals`),
+    weights: safeParse<BrainHealthWeights>(row.weights, {} as BrainHealthWeights, `brain ${row.brainId} health weights`),
+    timestamp: row.timestamp,
+  }
+}
+
 /**
  * Persistent SQLite-backed export adapter.
  * Uses WAL journal mode for safe concurrent reads and batched
@@ -680,6 +727,9 @@ export class SQLiteAdapter implements ExportAdapter {
         const resourceTableInfo = this.db.pragma("table_info('process_resource_samples')") as Array<{ name?: unknown }>
         const resourceSchemaInitialized = Array.isArray(resourceTableInfo)
           && resourceTableInfo.some(column => column.name === 'id')
+        const healthTableInfo = this.db.pragma("table_info('brain_health_scores')") as Array<{ name?: unknown }>
+        const healthSchemaInitialized = Array.isArray(healthTableInfo)
+          && healthTableInfo.some(column => column.name === 'id')
         if (schemaInitialized) {
           const rawTableInfo = this.db.pragma("table_info('compaction_events')") as unknown
           const tableInfo = (Array.isArray(rawTableInfo) ? rawTableInfo : []) as Array<{
@@ -697,9 +747,9 @@ export class SQLiteAdapter implements ExportAdapter {
             this.db.exec(MIGRATE_COMPACTION_EVENT_IDENTITY)
           }
         }
-        if (!schemaInitialized || !resourceSchemaInitialized) {
+        if (!schemaInitialized || !resourceSchemaInitialized || !healthSchemaInitialized) {
           // CREATE TABLE IF NOT EXISTS also upgrades databases created before
-          // process resource telemetry was introduced.
+          // process resource telemetry or brain health scoring was introduced.
           this.db.exec(CREATE_TABLES)
         }
       })
@@ -1130,6 +1180,55 @@ export class SQLiteAdapter implements ExportAdapter {
       return this.withSqliteLockRetry('query process resource samples', () => (
         this.db.prepare(statement).all(params) as ProcessResourceSample[]
       ))
+    })
+  }
+
+  async recordHealthScore(sample: BrainHealthSample): Promise<void> {
+    const normalized = normalizeBrainHealthSample(sample)
+    const row = {
+      brainId: normalized.brainId,
+      score: normalized.score,
+      signals: JSON.stringify(normalized.signals),
+      weights: JSON.stringify(normalized.weights),
+      timestamp: normalized.timestamp,
+    }
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        await this.withSqliteLockRetry('record brain health score', () => (
+          this.workerClient!.request<void>('recordHealthScore', { sample: row })
+        ))
+        return
+      }
+      await this.withSqliteLockRetry('record brain health score', () => {
+        this.db.prepare(INSERT_BRAIN_HEALTH_SCORE).run(row)
+      })
+    })
+  }
+
+  async queryHealthScores(query: BrainHealthSampleQuery): Promise<BrainHealthSample[]> {
+    const brainId = query.brainId.trim()
+    if (brainId.length === 0) {
+      return Promise.reject(new TypeError('health score query brainId must not be empty'))
+    }
+    const since = query.since ?? 0
+    const before = query.before ?? Number.MAX_SAFE_INTEGER
+    if (!Number.isSafeInteger(since) || !Number.isSafeInteger(before) || since < 0 || before < since) {
+      return Promise.reject(new RangeError('health score time range must contain safe integers with before >= since'))
+    }
+    const requestedLimit = query.limit ?? 100
+    if (!Number.isSafeInteger(requestedLimit) || requestedLimit <= 0) {
+      return Promise.reject(new RangeError('health score limit must be a positive safe integer'))
+    }
+    const params = { brainId, since, before, limit: Math.min(1_000, requestedLimit) }
+    return this.enqueueSqliteOperation(async () => {
+      const rows = this.workerClient !== undefined
+        ? await this.withSqliteLockRetry('query brain health scores', () => (
+            this.workerClient!.request<BrainHealthScoreRow[]>('queryHealthScores', { query: params })
+          ))
+        : await this.withSqliteLockRetry('query brain health scores', () => (
+            this.db.prepare(SELECT_BRAIN_HEALTH_SCORES).all(params) as BrainHealthScoreRow[]
+          ))
+      return rows.map(rowToBrainHealthSample)
     })
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
+++ b/packages/franken-observer/src/adapters/sqlite/SQLiteAdapter.ts
@@ -36,6 +36,7 @@ import {
   DELETE_COMPACTIONS_BY_RUN,
   DELETE_COMPACTIONS_BEFORE,
   DELETE_RESOURCE_SAMPLES_BEFORE,
+  DELETE_BRAIN_HEALTH_SCORES_BEFORE,
   DELETE_TRACE,
   UPSERT_COMPACTION_EVENT,
   SELECT_COMPACTION_EVENTS,
@@ -189,6 +190,7 @@ type SQLiteWorkerOperation =
   | 'deleteResourceSamplesBefore'
   | 'recordHealthScore'
   | 'queryHealthScores'
+  | 'deleteHealthScoresBefore'
 
 interface SQLiteWorkerResponse {
   id: number
@@ -300,6 +302,8 @@ function execute(operation, payload) {
       return undefined
     case 'queryHealthScores':
       return db.prepare(sql.selectBrainHealthScores).all(payload.query)
+    case 'deleteHealthScoresBefore':
+      return db.prepare(sql.deleteBrainHealthScoresBefore).run(payload.before).changes
     default:
       throw new Error('Unknown SQLite worker operation: ' + operation)
   }
@@ -384,6 +388,7 @@ class SQLiteWorkerClient {
             selectResourceSamplesByRun: SELECT_RESOURCE_SAMPLES_BY_RUN,
             insertBrainHealthScore: INSERT_BRAIN_HEALTH_SCORE,
             selectBrainHealthScores: SELECT_BRAIN_HEALTH_SCORES,
+            deleteBrainHealthScoresBefore: DELETE_BRAIN_HEALTH_SCORES_BEFORE,
           },
         },
       },
@@ -1229,6 +1234,22 @@ export class SQLiteAdapter implements ExportAdapter {
             this.db.prepare(SELECT_BRAIN_HEALTH_SCORES).all(params) as BrainHealthScoreRow[]
           ))
       return rows.map(rowToBrainHealthSample)
+    })
+  }
+
+  async deleteHealthScoresBefore(before: number): Promise<number> {
+    if (!Number.isSafeInteger(before) || before < 0) {
+      return Promise.reject(new RangeError('health score retention cutoff must be a non-negative safe integer'))
+    }
+    return this.enqueueSqliteOperation(async () => {
+      if (this.workerClient !== undefined) {
+        return this.withSqliteLockRetry('delete old brain health scores', () => (
+          this.workerClient!.request<number>('deleteHealthScoresBefore', { before })
+        ))
+      }
+      return this.withSqliteLockRetry('delete old brain health scores', () => (
+        this.db.prepare(DELETE_BRAIN_HEALTH_SCORES_BEFORE).run(before).changes
+      ))
     })
   }
 

--- a/packages/franken-observer/src/adapters/sqlite/resource-schema.test.ts
+++ b/packages/franken-observer/src/adapters/sqlite/resource-schema.test.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 import {
   CREATE_TABLES,
+  SELECT_BRAIN_HEALTH_SCORES,
   SELECT_RESOURCE_SAMPLES_BY_AGENT,
   SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN,
   SELECT_RESOURCE_SAMPLES_BY_RUN,
@@ -19,6 +20,23 @@ describe('process resource sample query schema', () => {
     const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(params) as Array<{ detail: string }>;
 
     expect(plan.some(row => row.detail.includes(expectedIndex))).toBe(true);
+    db.close();
+  });
+});
+
+describe('brain health score query schema', () => {
+  it('uses the brain id and timestamp index for history queries', () => {
+    const db = new Database(':memory:');
+    db.exec(CREATE_TABLES);
+
+    const plan = db.prepare(`EXPLAIN QUERY PLAN ${SELECT_BRAIN_HEALTH_SCORES}`).all({
+      brainId: 'brain-1',
+      since: 0,
+      before: 2_000,
+      limit: 100,
+    }) as Array<{ detail: string }>;
+
+    expect(plan.some(row => row.detail.includes('idx_brain_health_scores_brain_timestamp'))).toBe(true);
     db.close();
   });
 });

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -144,6 +144,7 @@ export const DELETE_SPANS_BY_TRACE = `DELETE FROM spans WHERE traceId = ?`
 export const DELETE_COMPACTIONS_BY_RUN = `DELETE FROM compaction_events WHERE runId = ?`
 export const DELETE_COMPACTIONS_BEFORE = `DELETE FROM compaction_events WHERE timestamp < ?`
 export const DELETE_RESOURCE_SAMPLES_BEFORE = `DELETE FROM process_resource_samples WHERE timestamp < ?`
+export const DELETE_BRAIN_HEALTH_SCORES_BEFORE = `DELETE FROM brain_health_scores WHERE timestamp < ?`
 export const DELETE_TRACE = `DELETE FROM traces WHERE id = ?`
 
 export const UPSERT_COMPACTION_EVENT = `

--- a/packages/franken-observer/src/adapters/sqlite/schema.ts
+++ b/packages/franken-observer/src/adapters/sqlite/schema.ts
@@ -58,6 +58,18 @@ export const CREATE_TABLES = `
     ON process_resource_samples(agentId, timestamp);
   CREATE INDEX IF NOT EXISTS idx_process_resource_samples_run_timestamp
     ON process_resource_samples(runId, timestamp);
+
+  CREATE TABLE IF NOT EXISTS brain_health_scores (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    brainId    TEXT    NOT NULL,
+    score      REAL    NOT NULL CHECK (score >= 0 AND score <= 100),
+    signals    TEXT    NOT NULL,
+    weights    TEXT    NOT NULL,
+    timestamp  INTEGER NOT NULL CHECK (timestamp >= 0)
+  ) STRICT;
+
+  CREATE INDEX IF NOT EXISTS idx_brain_health_scores_brain_timestamp
+    ON brain_health_scores(brainId, timestamp);
 `
 
 export const MIGRATE_COMPACTION_EVENT_IDENTITY = `
@@ -195,4 +207,17 @@ export const SELECT_RESOURCE_SAMPLES_BY_AGENT_AND_RUN = `
   ${RESOURCE_SAMPLE_COLUMNS}
   WHERE agentId = @agentId AND runId = @runId
   ${RESOURCE_SAMPLE_RANGE_AND_ORDER}
+`
+
+export const INSERT_BRAIN_HEALTH_SCORE = `
+  INSERT INTO brain_health_scores (brainId, score, signals, weights, timestamp)
+  VALUES (@brainId, @score, @signals, @weights, @timestamp)
+`
+
+export const SELECT_BRAIN_HEALTH_SCORES = `
+  SELECT brainId, score, signals, weights, timestamp
+  FROM brain_health_scores
+  WHERE brainId = @brainId AND timestamp >= @since AND timestamp <= @before
+  ORDER BY timestamp DESC, id DESC
+  LIMIT @limit
 `

--- a/packages/franken-observer/src/brain-health.test.ts
+++ b/packages/franken-observer/src/brain-health.test.ts
@@ -87,6 +87,24 @@ describe('BrainHealthScorer', () => {
     await expect(scorer.getHealthHistory('brain-a', { since: 1_001, before: 1_999 }))
       .resolves.toEqual([]);
 
+    const widerWindow = { brainId: 'brain-b', since: 0 };
+    await expect(scorer.getHealthHistory('brain-a', widerWindow))
+      .resolves.toEqual([degraded, healthy]);
+
+    await adapter.close();
+  });
+
+  it('supports explicit retention pruning without deleting recent health scores', async () => {
+    const adapter = new SQLiteAdapter(':memory:', { useWorkerThread: false });
+    const scorer = new BrainHealthScorer(adapter);
+    await scorer.computeAndPersist('brain-a', HEALTHY_SIGNALS, 1_000);
+    await scorer.computeAndPersist('brain-a', HEALTHY_SIGNALS, 2_000);
+
+    await expect(adapter.deleteHealthScoresBefore(1_500)).resolves.toBe(1);
+    await expect(scorer.getHealthHistory('brain-a')).resolves.toEqual([
+      expect.objectContaining({ timestamp: 2_000 }),
+    ]);
+
     await adapter.close();
   });
 

--- a/packages/franken-observer/src/brain-health.test.ts
+++ b/packages/franken-observer/src/brain-health.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  BrainHealthScorer,
+  DEFAULT_BRAIN_HEALTH_WEIGHTS,
+  calculateBrainHealthScore,
+  type BrainHealthSignals,
+} from './brain-health.js';
+import { SQLiteAdapter } from './adapters/sqlite/SQLiteAdapter.js';
+
+const HEALTHY_SIGNALS: BrainHealthSignals = {
+  taskSuccessRate: 1,
+  cacheHitRatio: 1,
+  compactionPressure: 0,
+  churnRatio: 0,
+  resourcePressure: 0,
+  budgetBurnRatio: 0,
+};
+
+describe('calculateBrainHealthScore', () => {
+  it('returns the documented 0–100 endpoints for healthy and degraded signals', () => {
+    expect(calculateBrainHealthScore(HEALTHY_SIGNALS)).toBe(100);
+    expect(calculateBrainHealthScore({
+      taskSuccessRate: 0,
+      cacheHitRatio: 0,
+      compactionPressure: 1,
+      churnRatio: 1,
+      resourcePressure: 1,
+      budgetBurnRatio: 1,
+    })).toBe(0);
+  });
+
+  it.each([
+    ['task success', { taskSuccessRate: 0 }],
+    ['cache efficiency', { cacheHitRatio: 0 }],
+    ['compaction pressure', { compactionPressure: 1 }],
+    ['lifecycle churn', { churnRatio: 1 }],
+    ['resource pressure', { resourcePressure: 1 }],
+    ['budget burn', { budgetBurnRatio: 1 }],
+  ] as const)('moves lower when only %s degrades', (_name, degraded) => {
+    expect(calculateBrainHealthScore({ ...HEALTHY_SIGNALS, ...degraded }))
+      .toBeLessThan(calculateBrainHealthScore(HEALTHY_SIGNALS));
+  });
+
+  it('uses replaceable weights that must be finite, non-negative, and sum to one', () => {
+    expect(calculateBrainHealthScore(
+      { ...HEALTHY_SIGNALS, taskSuccessRate: 0 },
+      {
+        taskSuccessRate: 0.5,
+        cacheHitRatio: 0.1,
+        compactionPressure: 0.1,
+        churnRatio: 0.1,
+        resourcePressure: 0.05,
+        budgetBurnRatio: 0.15,
+      },
+    )).toBe(50);
+
+    expect(() => calculateBrainHealthScore(HEALTHY_SIGNALS, {
+      ...DEFAULT_BRAIN_HEALTH_WEIGHTS,
+      taskSuccessRate: 0.31,
+    })).toThrow('sum to 1');
+  });
+
+  it('rejects signal values outside the normalized range', () => {
+    expect(() => calculateBrainHealthScore({ ...HEALTHY_SIGNALS, churnRatio: 1.01 }))
+      .toThrow('churnRatio must be between 0 and 1');
+  });
+});
+
+describe('BrainHealthScorer', () => {
+  it('computes on demand and persists latest and ranged history by brain id', async () => {
+    const adapter = new SQLiteAdapter(':memory:', { useWorkerThread: false });
+    const scorer = new BrainHealthScorer(adapter);
+
+    const healthy = await scorer.computeAndPersist('brain-a', HEALTHY_SIGNALS, 1_000);
+    const degradedSignals = { ...HEALTHY_SIGNALS, churnRatio: 1 };
+    const degraded = await scorer.computeAndPersist('brain-a', degradedSignals, 2_000);
+    await scorer.computeAndPersist('brain-b', HEALTHY_SIGNALS, 1_500);
+
+    expect(healthy.score).toBe(100);
+    expect(degraded.score).toBeLessThan(healthy.score);
+    await expect(scorer.getHealthScore('brain-a')).resolves.toEqual(degraded);
+    await expect(scorer.getHealthHistory('brain-a', { since: 1_000, before: 2_000 }))
+      .resolves.toEqual([degraded, healthy]);
+    await expect(scorer.getHealthHistory('brain-a', { since: 1_001, before: 1_999 }))
+      .resolves.toEqual([]);
+
+    await adapter.close();
+  });
+
+  it('survives adapter restart through the worker-backed SQLite path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brain-health-'));
+    const dbPath = join(dir, 'observer.db');
+    try {
+      const writer = new SQLiteAdapter(dbPath);
+      const recorded = await new BrainHealthScorer(writer)
+        .computeAndPersist('definition-42', HEALTHY_SIGNALS, 3_000);
+      await writer.close();
+
+      const reader = new SQLiteAdapter(dbPath);
+      await expect(new BrainHealthScorer(reader).getHealthScore('definition-42'))
+        .resolves.toEqual(recorded);
+      await expect(new BrainHealthScorer(reader).getHealthScore('missing'))
+        .resolves.toBeNull();
+      await reader.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/franken-observer/src/brain-health.ts
+++ b/packages/franken-observer/src/brain-health.ts
@@ -118,8 +118,8 @@ export class BrainHealthScorer {
     window: BrainHealthHistoryWindow = {},
   ): Promise<BrainHealthSample[]> {
     return this.adapter.queryHealthScores({
-      brainId: requireBrainId(brainId),
       ...window,
+      brainId: requireBrainId(brainId),
     });
   }
 }

--- a/packages/franken-observer/src/brain-health.ts
+++ b/packages/franken-observer/src/brain-health.ts
@@ -1,0 +1,157 @@
+export interface BrainHealthSignals {
+  /** Fraction of completed tasks that succeeded. */
+  readonly taskSuccessRate: number;
+  /** Fraction of reusable input tokens served from cache. */
+  readonly cacheHitRatio: number;
+  /** Normalized context-compaction pressure; 1 is the configured unhealthy threshold. */
+  readonly compactionPressure: number;
+  /** Normalized lifecycle discard/retry/orphan pressure; 1 is fully degraded. */
+  readonly churnRatio: number;
+  /** Normalized CPU/RSS/power pressure; 1 is the configured resource ceiling. */
+  readonly resourcePressure: number;
+  /** Current spend divided by the configured budget, capped at 1 by callers. */
+  readonly budgetBurnRatio: number;
+}
+
+export type BrainHealthWeights = Readonly<Record<keyof BrainHealthSignals, number>>;
+
+export interface BrainHealthSample {
+  readonly brainId: string;
+  readonly score: number;
+  readonly signals: BrainHealthSignals;
+  readonly weights: BrainHealthWeights;
+  readonly timestamp: number;
+}
+
+export interface BrainHealthHistoryWindow {
+  readonly since?: number;
+  readonly before?: number;
+  readonly limit?: number;
+}
+
+export interface BrainHealthSampleQuery extends BrainHealthHistoryWindow {
+  readonly brainId: string;
+}
+
+export interface BrainHealthSampleAdapter {
+  recordHealthScore(sample: BrainHealthSample): Promise<void>;
+  queryHealthScores(query: BrainHealthSampleQuery): Promise<BrainHealthSample[]>;
+}
+
+/**
+ * Outcome quality receives the largest share. Cache efficiency, context
+ * stability, lifecycle stability, and budget headroom are equally weighted;
+ * resource pressure receives a smaller share because v1 power data is an
+ * estimate rather than a hardware measurement.
+ */
+export const DEFAULT_BRAIN_HEALTH_WEIGHTS: BrainHealthWeights = Object.freeze({
+  taskSuccessRate: 0.3,
+  cacheHitRatio: 0.15,
+  compactionPressure: 0.15,
+  churnRatio: 0.15,
+  resourcePressure: 0.1,
+  budgetBurnRatio: 0.15,
+});
+
+const SIGNAL_NAMES = Object.keys(DEFAULT_BRAIN_HEALTH_WEIGHTS) as Array<keyof BrainHealthSignals>;
+
+/** Returns a deterministic 0–100 score from caller-normalized health signals. */
+export function calculateBrainHealthScore(
+  signals: BrainHealthSignals,
+  weights: BrainHealthWeights = DEFAULT_BRAIN_HEALTH_WEIGHTS,
+): number {
+  validateWeights(weights);
+  for (const name of SIGNAL_NAMES) validateRatio(name, signals[name]);
+
+  const score = (
+    signals.taskSuccessRate * weights.taskSuccessRate
+    + signals.cacheHitRatio * weights.cacheHitRatio
+    + (1 - signals.compactionPressure) * weights.compactionPressure
+    + (1 - signals.churnRatio) * weights.churnRatio
+    + (1 - signals.resourcePressure) * weights.resourcePressure
+    + (1 - signals.budgetBurnRatio) * weights.budgetBurnRatio
+  ) * 100;
+
+  return Math.round(score * 100) / 100;
+}
+
+/**
+ * Computes and persists health snapshots on demand. Callers own cadence so the
+ * observer does not create a hidden timer or retain a second in-memory cache.
+ */
+export class BrainHealthScorer {
+  constructor(
+    private readonly adapter: BrainHealthSampleAdapter,
+    private readonly weights: BrainHealthWeights = DEFAULT_BRAIN_HEALTH_WEIGHTS,
+  ) {
+    validateWeights(weights);
+  }
+
+  async computeAndPersist(
+    brainId: string,
+    signals: BrainHealthSignals,
+    timestamp = Date.now(),
+  ): Promise<BrainHealthSample> {
+    const normalizedBrainId = requireBrainId(brainId);
+    validateTimestamp(timestamp);
+    const sample: BrainHealthSample = {
+      brainId: normalizedBrainId,
+      score: calculateBrainHealthScore(signals, this.weights),
+      signals: { ...signals },
+      weights: { ...this.weights },
+      timestamp,
+    };
+    await this.adapter.recordHealthScore(sample);
+    return sample;
+  }
+
+  async getHealthScore(brainId: string): Promise<BrainHealthSample | null> {
+    const [latest] = await this.adapter.queryHealthScores({
+      brainId: requireBrainId(brainId),
+      limit: 1,
+    });
+    return latest ?? null;
+  }
+
+  getHealthHistory(
+    brainId: string,
+    window: BrainHealthHistoryWindow = {},
+  ): Promise<BrainHealthSample[]> {
+    return this.adapter.queryHealthScores({
+      brainId: requireBrainId(brainId),
+      ...window,
+    });
+  }
+}
+
+function validateRatio(name: keyof BrainHealthSignals, value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(`${name} must be between 0 and 1`);
+  }
+}
+
+function validateWeights(weights: BrainHealthWeights): void {
+  let total = 0;
+  for (const name of SIGNAL_NAMES) {
+    const weight = weights[name];
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new RangeError(`${name} weight must be a non-negative finite number`);
+    }
+    total += weight;
+  }
+  if (Math.abs(total - 1) > 1e-9) {
+    throw new RangeError(`brain health weights must sum to 1, received ${total}`);
+  }
+}
+
+function requireBrainId(brainId: string): string {
+  const normalized = brainId.trim();
+  if (normalized.length === 0) throw new TypeError('brainId must not be empty');
+  return normalized;
+}
+
+function validateTimestamp(timestamp: number): void {
+  if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
+    throw new RangeError('health score timestamp must be a non-negative safe integer');
+  }
+}

--- a/packages/franken-observer/src/index.ts
+++ b/packages/franken-observer/src/index.ts
@@ -54,6 +54,11 @@ export { TraceServer } from './ui/TraceServer.js'
 export { generateGrafanaDashboard } from './grafana/GrafanaDashboard.js'
 export { CompactionMetrics } from './compaction-metrics.js'
 export {
+  BrainHealthScorer,
+  DEFAULT_BRAIN_HEALTH_WEIGHTS,
+  calculateBrainHealthScore,
+} from './brain-health.js'
+export {
   DEFAULT_IDLE_WATTS,
   DEFAULT_RESOURCE_SAMPLE_INTERVAL_MS,
   DEFAULT_TDP_WATTS,
@@ -79,6 +84,14 @@ export type {
   CompactionRate,
   CompactionTriggerReason,
 } from './compaction-metrics.js'
+export type {
+  BrainHealthHistoryWindow,
+  BrainHealthSample,
+  BrainHealthSampleAdapter,
+  BrainHealthSampleQuery,
+  BrainHealthSignals,
+  BrainHealthWeights,
+} from './brain-health.js'
 export type {
   ProcessPowerModel,
   ProcessResourceSample,

--- a/tasks/brain-vitals-3731-progress.md
+++ b/tasks/brain-vitals-3731-progress.md
@@ -7,7 +7,7 @@
 - [x] RED→GREEN: add latest-score and bounded time-range history queries for direct and worker-backed SQLite paths.
 - [x] Export the public API and document the v1 formula, weights, normalization, and on-demand rationale.
 - [x] Run focused tests plus `@franken/observer` test, lint, typecheck, and build gates.
-- [ ] Commit and push the unique issue branch; open exactly one PR closing #3731.
+- [x] Commit and push the unique issue branch; open exactly one PR closing #3731: https://github.com/djm204/frankenbeast/pull/3797.
 - [ ] Complete exact-head GitHub Codex review loops, resolve all threads, and verify exact-head CI.
 - [ ] Squash-merge, verify #3731 closed, and record merge/test/review evidence.
 

--- a/tasks/brain-vitals-3731-progress.md
+++ b/tasks/brain-vitals-3731-progress.md
@@ -1,0 +1,19 @@
+# Brain Vitals #3731 progress
+
+- [x] Verify #3727–#3730 are closed and their merge commits are present on fresh `origin/main`.
+- [x] Read #3731, parent handoffs, existing cache/compaction/lifecycle/resource APIs, and SQLite persistence conventions.
+- [x] RED→GREEN: add a pure, configurable 0–100 health-score formula with directionality and validation tests.
+- [x] RED→GREEN: add on-demand score computation/persistence keyed by brain id.
+- [x] RED→GREEN: add latest-score and bounded time-range history queries for direct and worker-backed SQLite paths.
+- [x] Export the public API and document the v1 formula, weights, normalization, and on-demand rationale.
+- [x] Run focused tests plus `@franken/observer` test, lint, typecheck, and build gates.
+- [ ] Commit and push the unique issue branch; open exactly one PR closing #3731.
+- [ ] Complete exact-head GitHub Codex review loops, resolve all threads, and verify exact-head CI.
+- [ ] Squash-merge, verify #3731 closed, and record merge/test/review evidence.
+
+## V1 decisions
+
+- Use six normalized inputs: task success, cache-hit ratio, compaction pressure, lifecycle churn/discard pressure, resource pressure, and budget burn ratio. This includes all four wave-one signals plus task outcomes and budget pressure.
+- Default weights prioritize outcome quality (30%), then cache efficiency, context stability, lifecycle stability, and budget headroom (15% each), with resource efficiency at 10%. The config remains replaceable and must sum to 1.
+- Compute and persist on demand rather than starting a hidden timer. Callers control sampling cadence, and each computation becomes an immutable time-series observation.
+- Keep `brainId` generic so callers can pass the current `definitionId`/`agentTypeId` and later re-key to Brain Registry ids without changing scoring semantics.


### PR DESCRIPTION
## Summary
- add a configurable 0–100 brain health model over task, cache, compaction, churn, resource, and budget signals
- persist on-demand snapshots in indexed SQLite history with latest and ranged query APIs
- document the v1 formula, weights, normalization, and scheduling decision

## Verification
- `npm test --workspace @franken/observer` (39 files, 959 tests)
- `npm run lint --workspace @franken/observer` (pass; 5 pre-existing warnings)
- `npm run typecheck --workspace @franken/observer`
- `npm run build --workspace @franken/observer`

Closes #3731