### PR TITLE
feat(web): add live Brain Pulse Map

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1077,6 +1077,19 @@ The stream sends a fresh snapshot every second and separate typed `activity`
 events for cache hits/misses, compaction completion, lifecycle churn,
 resource-threshold crossings, and budget-threshold crossings.
 
+`franken-web` uses those discrete events as the sole pulse-rate input for the
+Brain Vitals panel's primary Live Brain Pulse Map. Its five current nodes map
+directly to the `cache`, `compaction`, `churn`, `resource`, and `cost` event
+dimensions; a rolling one-minute client window controls pulse speed, each
+dimension's normalized health signal controls node state, and the aggregate
+health score controls the center ring. Selecting a node exposes the contributing
+events and their real run ids before the existing per-run telemetry drill-down.
+Hive Brain's memory/planning/reasoning/action/learning faculties stay visibly
+unavailable rather than borrowing vitals data: the read-only `/v1/brain/*`
+surface has faculty state, but no compatible live faculty activity-event stream
+yet. Adding those nodes is therefore an additive cross-epic follow-up, not a
+synthetic mapping in the Brain Vitals UI.
+
 | Route | Purpose and bounds |
 |-------|--------------------|
 | `GET /v1/brain-vitals/:brainId` | Current one-hour health and telemetry snapshot; health score is persisted for history |

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -74,14 +74,22 @@ operator credential.
 
 The sibling **Brain Vitals** panel is the operational view. It discovers brains
 from real Beast runs, reads aggregate health/history from `/v1/brain-vitals/*`,
-and uses the ticket-authenticated SSE stream to update health, CPU, memory,
-power, token, cost, cache, compaction, and churn charts without a refresh. Its
-run list opens a read-only slide-in drill-down backed by
+and uses the ticket-authenticated SSE stream to drive its primary **Live Brain
+Pulse Map** plus secondary health, CPU, memory, power, token, cost, cache,
+compaction, and churn charts without a refresh. The fixed, responsive map has
+one node for each live vitals dimension (`cache`, `compaction`, `churn`,
+`resource`, and `cost`). Node pulse rate comes only from typed activity events
+observed in the last minute; no event means an honest idle node. Node color is
+derived from that dimension's health signal, while the center ring reflects the
+aggregate health score. Selecting a node reveals its recent real events and run
+ids, and those run links open the read-only slide-in drill-down backed by
 `/v1/brain-vitals/:brainId/runs/:runId`, including per-run token/cache splits,
 cost, compactions, resource samples, churn classification, and activity events.
 The faculty **Brain** panel answers “what the brain knows”; **Brain Vitals**
-answers “how hard the brain is working.” The Pulse Map tracked by #3738 remains
-a follow-up entry visualization and is not fabricated before that route/UI ships.
+answers “how hard the brain is working.” Memory, planning, reasoning, action,
+and learning remain explicitly marked as coming soon in the map because the
+Brain routes do not yet expose a compatible live faculty activity-event feed;
+the UI never substitutes vitals or fabricated rates for those faculties.
 
 If you use a non-default backend port in local development, keep `VITE_API_URL` unset and set `VITE_API_PROXY_TARGET` so the Vite `/v1/chat` proxy keeps chat auth server-side. Beast routes (`/v1/beasts/*`) reuse that same target by default. Set `VITE_BEAST_API_PROXY_TARGET` only when Beast controls run on a different backend, for example a separate local orchestrator or daemon port:
 

--- a/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
@@ -20,9 +20,14 @@ const LABELS: Record<BrainVitalsDimension, string> = {
 type HealthState = 'healthy' | 'warning' | 'danger' | 'unavailable';
 type PulseState = 'idle' | 'low' | 'medium' | 'high';
 
+export interface BrainPulseActivity extends BrainVitalsActivity {
+  readonly receivedAt: number;
+  readonly sequence: number;
+}
+
 interface BrainPulseMapProps {
   snapshot: BrainVitalsSnapshot;
-  activities: readonly BrainVitalsActivity[];
+  activities: readonly BrainPulseActivity[];
   onOpenRun: (runId: string) => void;
 }
 
@@ -72,8 +77,8 @@ export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMap
   }, [activities]);
 
   const recentActivities = useMemo(() => activities.filter((activity) => (
-    activity.timestamp >= now - ACTIVITY_WINDOW_MS
-    && activity.timestamp <= now + 5_000
+    activity.receivedAt >= now - ACTIVITY_WINDOW_MS
+    && activity.receivedAt <= now + 5_000
   )), [activities, now]);
 
   const selectedActivities = selectedDimension
@@ -143,8 +148,8 @@ export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMap
             <p>No real {LABELS[selectedDimension]!.toLowerCase()} activity events were observed in the last minute.</p>
           ) : (
             <ol>
-              {[...selectedActivities].sort((left, right) => right.timestamp - left.timestamp).map((activity) => (
-                <li key={`${activity.dimension}:${activity.kind}:${activity.runId}:${activity.timestamp}`}>
+              {[...selectedActivities].sort((left, right) => right.receivedAt - left.receivedAt).map((activity) => (
+                <li key={activity.sequence}>
                   <span><strong>{activity.kind}</strong><small>{new Date(activity.timestamp).toLocaleTimeString()}</small></span>
                   <button
                     type="button"

--- a/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
@@ -39,7 +39,9 @@ function healthValue(snapshot: BrainVitalsSnapshot, dimension: BrainVitalsDimens
     case 'resource': return snapshot.resource.availability === 'available'
       ? 1 - snapshot.health.signals.resourcePressure
       : null;
-    case 'cost': return 1 - snapshot.health.signals.budgetBurnRatio;
+    case 'cost': return snapshot.cost.budgetUsd === null
+      ? null
+      : 1 - snapshot.health.signals.budgetBurnRatio;
   }
 }
 

--- a/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
@@ -25,9 +25,12 @@ export interface BrainPulseActivity extends BrainVitalsActivity {
   readonly sequence: number;
 }
 
+export type BrainPulseActivityReceipts = Readonly<Record<BrainVitalsDimension, readonly number[]>>;
+
 interface BrainPulseMapProps {
   snapshot: BrainVitalsSnapshot;
   activities: readonly BrainPulseActivity[];
+  activityReceipts: BrainPulseActivityReceipts;
   onOpenRun: (runId: string) => void;
 }
 
@@ -65,7 +68,7 @@ function aggregateHealthState(score: number): Exclude<HealthState, 'unavailable'
   return 'danger';
 }
 
-export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMapProps) {
+export function BrainPulseMap({ snapshot, activities, activityReceipts, onOpenRun }: BrainPulseMapProps) {
   const [now, setNow] = useState(() => Date.now());
   const [selectedDimension, setSelectedDimension] = useState<BrainVitalsDimension | null>(null);
 
@@ -76,12 +79,21 @@ export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMap
 
   useEffect(() => {
     setNow(Date.now());
-  }, [activities]);
+  }, [activityReceipts]);
 
   const recentActivities = useMemo(() => activities.filter((activity) => (
     activity.receivedAt >= now - ACTIVITY_WINDOW_MS
     && activity.receivedAt <= now + 5_000
   )), [activities, now]);
+  const recentActivityCounts = useMemo(() => Object.fromEntries(DIMENSIONS.map((dimension) => [
+    dimension,
+    activityReceipts[dimension].filter((receivedAt) => (
+      receivedAt >= now - ACTIVITY_WINDOW_MS && receivedAt <= now + 5_000
+    )).length,
+  ])) as Record<BrainVitalsDimension, number>, [activityReceipts, now]);
+  const recentActivityCount = DIMENSIONS.reduce((total, dimension) => (
+    total + recentActivityCounts[dimension]
+  ), 0);
 
   const selectedActivities = selectedDimension
     ? recentActivities.filter((activity) => activity.dimension === selectedDimension)
@@ -94,7 +106,7 @@ export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMap
           <h4>Live Brain Pulse Map</h4>
           <p>Pulse rate reflects real activity events observed in the last minute.</p>
         </div>
-        <small>{recentActivities.length} recent {recentActivities.length === 1 ? 'event' : 'events'}</small>
+        <small>{recentActivityCount} recent {recentActivityCount === 1 ? 'event' : 'events'}</small>
       </header>
 
       {/* A fixed grid keeps all dimensions legible and keyboard reachable at narrow dashboard widths. */}
@@ -107,7 +119,7 @@ export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMap
           <strong>{Math.round(snapshot.health.score)}</strong>
         </div>
         {DIMENSIONS.map((dimension) => {
-          const count = recentActivities.filter((activity) => activity.dimension === dimension).length;
+          const count = recentActivityCounts[dimension];
           const value = healthValue(snapshot, dimension);
           const state = healthState(value);
           const activityState = pulseState(count);

--- a/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  BrainVitalsActivity,
+  BrainVitalsDimension,
+  BrainVitalsSnapshot,
+} from '../../lib/brain-vitals-api';
+
+const ACTIVITY_WINDOW_MS = 60_000;
+const DIMENSIONS: readonly BrainVitalsDimension[] = ['cache', 'compaction', 'churn', 'resource', 'cost'];
+const FACULTIES = ['memory', 'planning', 'reasoning', 'action', 'learning'] as const;
+
+const LABELS: Record<BrainVitalsDimension, string> = {
+  cache: 'Cache',
+  compaction: 'Compaction',
+  churn: 'Churn',
+  resource: 'Resource',
+  cost: 'Cost',
+};
+
+type HealthState = 'healthy' | 'warning' | 'danger' | 'unavailable';
+type PulseState = 'idle' | 'low' | 'medium' | 'high';
+
+interface BrainPulseMapProps {
+  snapshot: BrainVitalsSnapshot;
+  activities: readonly BrainVitalsActivity[];
+  onOpenRun: (runId: string) => void;
+}
+
+function healthValue(snapshot: BrainVitalsSnapshot, dimension: BrainVitalsDimension): number | null {
+  switch (dimension) {
+    case 'cache': return snapshot.health.signals.cacheHitRatio;
+    case 'compaction': return 1 - snapshot.health.signals.compactionPressure;
+    case 'churn': return 1 - snapshot.health.signals.churnRatio;
+    case 'resource': return snapshot.resource.availability === 'available'
+      ? 1 - snapshot.health.signals.resourcePressure
+      : null;
+    case 'cost': return 1 - snapshot.health.signals.budgetBurnRatio;
+  }
+}
+
+function healthState(value: number | null): HealthState {
+  if (value === null) return 'unavailable';
+  if (value >= 0.75) return 'healthy';
+  if (value >= 0.45) return 'warning';
+  return 'danger';
+}
+
+function pulseState(count: number): PulseState {
+  if (count === 0) return 'idle';
+  if (count <= 2) return 'low';
+  if (count <= 5) return 'medium';
+  return 'high';
+}
+
+function aggregateHealthState(score: number): Exclude<HealthState, 'unavailable'> {
+  if (score >= 75) return 'healthy';
+  if (score >= 45) return 'warning';
+  return 'danger';
+}
+
+export function BrainPulseMap({ snapshot, activities, onOpenRun }: BrainPulseMapProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const [selectedDimension, setSelectedDimension] = useState<BrainVitalsDimension | null>(null);
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    setNow(Date.now());
+  }, [activities]);
+
+  const recentActivities = useMemo(() => activities.filter((activity) => (
+    activity.timestamp >= now - ACTIVITY_WINDOW_MS
+    && activity.timestamp <= now + 5_000
+  )), [activities, now]);
+
+  const selectedActivities = selectedDimension
+    ? recentActivities.filter((activity) => activity.dimension === selectedDimension)
+    : [];
+
+  return (
+    <section className="brain-pulse-map" role="region" aria-label="Brain pulse map">
+      <header>
+        <div>
+          <h4>Live Brain Pulse Map</h4>
+          <p>Pulse rate reflects real activity events observed in the last minute.</p>
+        </div>
+        <small>{recentActivities.length} recent {recentActivities.length === 1 ? 'event' : 'events'}</small>
+      </header>
+
+      {/* A fixed grid keeps all dimensions legible and keyboard reachable at narrow dashboard widths. */}
+      <div className="brain-pulse-map__grid">
+        <div
+          className={`brain-pulse-map__core brain-pulse-map--${aggregateHealthState(snapshot.health.score)}`}
+          aria-label={`Overall brain health ${Math.round(snapshot.health.score)}`}
+        >
+          <span>Overall</span>
+          <strong>{Math.round(snapshot.health.score)}</strong>
+        </div>
+        {DIMENSIONS.map((dimension) => {
+          const count = recentActivities.filter((activity) => activity.dimension === dimension).length;
+          const value = healthValue(snapshot, dimension);
+          const state = healthState(value);
+          const activityState = pulseState(count);
+          return (
+            <button
+              key={dimension}
+              type="button"
+              className={`brain-pulse-map__node brain-pulse-map__node--${dimension} brain-pulse-map--${state} brain-pulse-map__node--${activityState}`}
+              aria-label={`${LABELS[dimension]} activity: ${state}, ${count} ${count === 1 ? 'event' : 'events'} in the last minute`}
+              aria-pressed={selectedDimension === dimension}
+              data-activity-count={count}
+              data-pulse-state={activityState === 'idle' ? 'idle' : 'active'}
+              onClick={() => setSelectedDimension(dimension)}
+            >
+              <span>{LABELS[dimension]}</span>
+              <strong>{count}/min</strong>
+              <small>{value === null ? 'Telemetry unavailable' : `Health signal ${Math.round(value * 100)}%`}</small>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="brain-pulse-map__faculties" aria-label="Faculty pulse map availability">
+        {FACULTIES.map((faculty) => (
+          <span key={faculty}><strong>{faculty}</strong><small>Coming soon — no live faculty event feed</small></span>
+        ))}
+      </div>
+
+      {selectedDimension && (
+        <section
+          className="brain-pulse-map__detail"
+          role="region"
+          aria-label={`${LABELS[selectedDimension]} pulse detail`}
+        >
+          <div>
+            <h5>{LABELS[selectedDimension]} activity</h5>
+            <button type="button" onClick={() => setSelectedDimension(null)}>Close detail</button>
+          </div>
+          {selectedActivities.length === 0 ? (
+            <p>No real {LABELS[selectedDimension]!.toLowerCase()} activity events were observed in the last minute.</p>
+          ) : (
+            <ol>
+              {[...selectedActivities].sort((left, right) => right.timestamp - left.timestamp).map((activity) => (
+                <li key={`${activity.dimension}:${activity.kind}:${activity.runId}:${activity.timestamp}`}>
+                  <span><strong>{activity.kind}</strong><small>{new Date(activity.timestamp).toLocaleTimeString()}</small></span>
+                  <button
+                    type="button"
+                    aria-label={`Open run ${activity.runId} from ${activity.dimension} activity`}
+                    onClick={() => onOpenRun(activity.runId)}
+                  >
+                    {activity.runId}
+                  </button>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      )}
+    </section>
+  );
+}

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -155,6 +155,44 @@ describe('BrainVitalsPanel', () => {
     expect(api.fetchBrainVitalsRun).toHaveBeenCalledWith('reviewer', 'run-1');
   });
 
+  it('uses real activity events to pulse a vitals node and expose its run drill-down', async () => {
+    let pushActivity!: (activity: BrainVitalsActivity) => void;
+    const api = client({
+      subscribeToBrainVitals: vi.fn((_brainId, _onSnapshot, _onError, onActivity) => {
+        pushActivity = onActivity!;
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+
+    expect(await screen.findByRole('region', { name: 'Brain pulse map' })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /activity:/ })).toHaveLength(5);
+    const compactionNode = screen.getByRole('button', { name: /Compaction activity:/ });
+    expect(compactionNode.getAttribute('data-activity-count')).toBe('0');
+    expect(compactionNode.getAttribute('data-pulse-state')).toBe('idle');
+
+    act(() => pushActivity({
+      dimension: 'compaction',
+      kind: 'compaction.completed',
+      runId: 'run-1',
+      timestamp: Date.now(),
+    }));
+
+    await waitFor(() => {
+      expect(compactionNode.getAttribute('data-activity-count')).toBe('1');
+      expect(compactionNode.getAttribute('data-pulse-state')).toBe('active');
+    });
+
+    fireEvent.click(compactionNode);
+    expect(screen.getByRole('region', { name: 'Compaction pulse detail' })).toBeTruthy();
+    expect(screen.getByText('compaction.completed')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Open run run-1 from compaction activity' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Run run-1 vitals' })).toBeTruthy();
+    expect(api.fetchBrainVitalsRun).toHaveBeenCalledWith('reviewer', 'run-1');
+  });
+
   it('offers a selector when multiple brain definitions have runs', async () => {
     const api = client({
       listBrainVitalsRuns: vi.fn().mockResolvedValue({

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -193,6 +193,20 @@ describe('BrainVitalsPanel', () => {
     expect(api.fetchBrainVitalsRun).toHaveBeenCalledWith('reviewer', 'run-1');
   });
 
+  it('marks cost health unavailable when the brain has no budget', async () => {
+    const api = client({
+      fetchBrainVitalsSnapshot: vi.fn().mockResolvedValue({
+        ...snapshot,
+        cost: { ...snapshot.cost, budgetUsd: null },
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+
+    const costNode = await screen.findByRole('button', { name: /Cost activity: unavailable/ });
+    expect(costNode.textContent).toContain('Telemetry unavailable');
+  });
+
   it('does not truncate a real one-minute activity rate at an arbitrary buffer size', async () => {
     let pushActivity!: (activity: BrainVitalsActivity) => void;
     const api = client({

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -231,6 +231,8 @@ describe('BrainVitalsPanel', () => {
     });
 
     await waitFor(() => expect(cacheNode.getAttribute('data-activity-count')).toBe('201'));
+    fireEvent.click(cacheNode);
+    expect(screen.getAllByRole('button', { name: /Open run run-1 from cache activity/ })).toHaveLength(200);
   });
 
   it('counts every delivered event on the local receipt clock', async () => {

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -193,6 +193,64 @@ describe('BrainVitalsPanel', () => {
     expect(api.fetchBrainVitalsRun).toHaveBeenCalledWith('reviewer', 'run-1');
   });
 
+  it('does not truncate a real one-minute activity rate at an arbitrary buffer size', async () => {
+    let pushActivity!: (activity: BrainVitalsActivity) => void;
+    const api = client({
+      subscribeToBrainVitals: vi.fn((_brainId, _onSnapshot, _onError, onActivity) => {
+        pushActivity = onActivity!;
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+    const cacheNode = await screen.findByRole('button', { name: /Cache activity:/ });
+    const now = Date.now();
+    act(() => {
+      for (let index = 0; index < 201; index += 1) {
+        pushActivity({
+          dimension: 'cache',
+          kind: 'cache.hit',
+          runId: 'run-1',
+          timestamp: now - index,
+        });
+      }
+    });
+
+    await waitFor(() => expect(cacheNode.getAttribute('data-activity-count')).toBe('201'));
+  });
+
+  it('ignores activity callbacks from a superseded brain subscription', async () => {
+    const activityCallbacks = new Map<string, (activity: BrainVitalsActivity) => void>();
+    const reviewerRun = detail.run;
+    const workerRun = { ...detail.run, id: 'run-2', definitionId: 'worker' };
+    const api = client({
+      listBrainVitalsRuns: vi.fn().mockResolvedValue({
+        runs: [reviewerRun, workerRun],
+        nextCursor: undefined,
+      }),
+      subscribeToBrainVitals: vi.fn((brainId, _onSnapshot, _onError, onActivity) => {
+        activityCallbacks.set(brainId, onActivity!);
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+    const selector = await screen.findByRole('combobox', { name: 'Brain' });
+    await waitFor(() => expect(activityCallbacks.has('reviewer')).toBe(true));
+    fireEvent.change(selector, { target: { value: 'worker' } });
+    await waitFor(() => expect(activityCallbacks.has('worker')).toBe(true));
+
+    act(() => activityCallbacks.get('reviewer')!({
+      dimension: 'compaction',
+      kind: 'compaction.completed',
+      runId: 'run-1',
+      timestamp: Date.now(),
+    }));
+
+    const compactionNode = await screen.findByRole('button', { name: /Compaction activity:/ });
+    expect(compactionNode.getAttribute('data-activity-count')).toBe('0');
+  });
+
   it('offers a selector when multiple brain definitions have runs', async () => {
     const api = client({
       listBrainVitalsRuns: vi.fn().mockResolvedValue({

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -219,6 +219,31 @@ describe('BrainVitalsPanel', () => {
     await waitFor(() => expect(cacheNode.getAttribute('data-activity-count')).toBe('201'));
   });
 
+  it('counts every delivered event on the local receipt clock', async () => {
+    let pushActivity!: (activity: BrainVitalsActivity) => void;
+    const api = client({
+      subscribeToBrainVitals: vi.fn((_brainId, _onSnapshot, _onError, onActivity) => {
+        pushActivity = onActivity!;
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+    const cacheNode = await screen.findByRole('button', { name: /Cache activity:/ });
+    const samePayload: BrainVitalsActivity = {
+      dimension: 'cache',
+      kind: 'cache.hit',
+      runId: 'run-1',
+      timestamp: Date.now() + 3_600_000,
+    };
+    act(() => {
+      pushActivity(samePayload);
+      pushActivity(samePayload);
+    });
+
+    await waitFor(() => expect(cacheNode.getAttribute('data-activity-count')).toBe('2'));
+  });
+
   it('ignores activity callbacks from a superseded brain subscription', async () => {
     const activityCallbacks = new Map<string, (activity: BrainVitalsActivity) => void>();
     const reviewerRun = detail.run;

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -6,7 +6,7 @@ import type {
   DashboardApiClient,
 } from '../../lib/dashboard-api';
 import type { BrainVitalsActivity } from '../../lib/brain-vitals-api';
-import { BrainVitalsPanel } from './brain-vitals-panel';
+import { BrainVitalsPanel, pruneActivityReceipts } from './brain-vitals-panel';
 
 const snapshot: BrainVitalsSnapshot = {
   brainId: 'reviewer',
@@ -233,6 +233,46 @@ describe('BrainVitalsPanel', () => {
     await waitFor(() => expect(cacheNode.getAttribute('data-activity-count')).toBe('201'));
     fireEvent.click(cacheNode);
     expect(screen.getAllByRole('button', { name: /Open run run-1 from cache activity/ })).toHaveLength(200);
+  });
+
+  it('retains bounded drill-down detail independently for each pulse dimension', async () => {
+    let pushActivity!: (activity: BrainVitalsActivity) => void;
+    const api = client({
+      subscribeToBrainVitals: vi.fn((_brainId, _onSnapshot, _onError, onActivity) => {
+        pushActivity = onActivity!;
+        return Promise.resolve(() => undefined);
+      }),
+    });
+
+    render(<BrainVitalsPanel client={api} />);
+    const cacheNode = await screen.findByRole('button', { name: /Cache activity:/ });
+    act(() => {
+      pushActivity({ dimension: 'cache', kind: 'cache.hit', runId: 'run-1', timestamp: Date.now() });
+      for (let index = 0; index < 200; index += 1) {
+        pushActivity({ dimension: 'cost', kind: 'cost.updated', runId: 'run-1', timestamp: Date.now() });
+      }
+    });
+
+    fireEvent.click(cacheNode);
+    expect(screen.getByRole('button', { name: 'Open run run-1 from cache activity' })).toBeTruthy();
+  });
+
+  it('prunes expired receipt history for inactive dimensions', () => {
+    const receipts = {
+      cache: [1, 70_000],
+      compaction: [2],
+      churn: [],
+      resource: [],
+      cost: [],
+    };
+
+    expect(pruneActivityReceipts(receipts, 60_000)).toEqual({
+      cache: [70_000],
+      compaction: [],
+      churn: [],
+      resource: [],
+      cost: [],
+    });
   });
 
   it('counts every delivered event on the local receipt clock', async () => {

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { BeastRunSummary } from '@franken/types';
 import type {
   BrainHealthSample,
+  BrainVitalsDimension,
   BrainVitalsRunDetail,
   BrainVitalsSnapshot,
   DashboardApiClient,
@@ -30,8 +31,43 @@ interface AggregatePoint {
   estimatedUsd: number;
 }
 
+const PULSE_DIMENSIONS: readonly BrainVitalsDimension[] = ['cache', 'compaction', 'churn', 'resource', 'cost'];
+const MAX_ACTIVITY_DETAILS_PER_DIMENSION = 200;
+
 function emptyActivityReceipts(): BrainPulseActivityReceipts {
   return { cache: [], compaction: [], churn: [], resource: [], cost: [] };
+}
+
+export function pruneActivityReceipts(
+  current: BrainPulseActivityReceipts,
+  cutoff: number,
+): BrainPulseActivityReceipts {
+  const next: BrainPulseActivityReceipts = {
+    cache: current.cache.filter((receivedAt: number) => receivedAt >= cutoff),
+    compaction: current.compaction.filter((receivedAt: number) => receivedAt >= cutoff),
+    churn: current.churn.filter((receivedAt: number) => receivedAt >= cutoff),
+    resource: current.resource.filter((receivedAt: number) => receivedAt >= cutoff),
+    cost: current.cost.filter((receivedAt: number) => receivedAt >= cutoff),
+  };
+  const changed = PULSE_DIMENSIONS.some((dimension) => (
+    next[dimension].length !== current[dimension].length
+  ));
+  return changed ? next : current;
+}
+
+function appendActivityDetail(
+  current: BrainPulseActivity[],
+  activity: BrainPulseActivity,
+): BrainPulseActivity[] {
+  const recent = current.filter((candidate) => candidate.receivedAt >= activity.receivedAt - 60_000);
+  const dimensionCount = recent.filter((candidate) => candidate.dimension === activity.dimension).length;
+  let toDrop = Math.max(0, dimensionCount + 1 - MAX_ACTIVITY_DETAILS_PER_DIMENSION);
+  const retained = recent.filter((candidate) => {
+    if (candidate.dimension !== activity.dimension || toDrop === 0) return true;
+    toDrop -= 1;
+    return false;
+  });
+  return [...retained, activity];
 }
 
 function describeError(error: unknown): string {
@@ -141,6 +177,18 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
   const [runDetail, setRunDetail] = useState<BrainVitalsRunDetail | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [runLoading, setRunLoading] = useState(false);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const cutoff = Date.now() - 60_000;
+      setActivityReceipts((current: BrainPulseActivityReceipts) => pruneActivityReceipts(current, cutoff));
+      setActivities((current) => {
+        const recent = current.filter((activity) => activity.receivedAt >= cutoff);
+        return recent.length === current.length ? current : recent;
+      });
+    }, 5_000);
+    return () => clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     const generation = generationRef.current + 1;
@@ -287,23 +335,20 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
       (activity) => {
         if (!active || generationRef.current !== generation) return;
         const receivedAt = Date.now();
-        setActivityReceipts((current) => ({
-          ...current,
-          [activity.dimension]: [
-            ...current[activity.dimension].filter((timestamp) => timestamp >= receivedAt - 60_000),
-            receivedAt,
-          ],
-        }));
+        setActivityReceipts((current: BrainPulseActivityReceipts) => {
+          const recent = pruneActivityReceipts(current, receivedAt - 60_000);
+          return {
+            ...recent,
+            [activity.dimension]: [...recent[activity.dimension], receivedAt],
+          };
+        });
         setActivities((current) => {
-          const recent = current.filter((candidate) => (
-            candidate.receivedAt >= receivedAt - 60_000
-          ));
           activitySequenceRef.current += 1;
-          return [...recent, {
+          return appendActivityDetail(current, {
             ...activity,
             receivedAt,
             sequence: activitySequenceRef.current,
-          }].slice(-200);
+          });
         });
         if (
           activity.dimension !== 'churn'

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
@@ -274,14 +274,24 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
         setStreamError(describeError(subscriptionError));
       },
       (activity) => {
+        if (!active || generationRef.current !== generation) return;
+        const receivedAt = Date.now();
         setActivities((current) => {
-          const duplicate = current.some((candidate) => (
+          const recent = current.filter((candidate) => (
+            candidate.timestamp >= receivedAt - 60_000
+            && candidate.timestamp <= receivedAt + 5_000
+          ));
+          if (
+            activity.timestamp < receivedAt - 60_000
+            || activity.timestamp > receivedAt + 5_000
+          ) return recent;
+          const duplicate = recent.some((candidate) => (
             candidate.dimension === activity.dimension
             && candidate.kind === activity.kind
             && candidate.runId === activity.runId
             && candidate.timestamp === activity.timestamp
           ));
-          return duplicate ? current : [...current, activity].slice(-200);
+          return duplicate ? recent : [...recent, activity];
         });
         if (
           activity.dimension !== 'churn'

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { BeastRunSummary } from '@franken/types';
 import type {
   BrainHealthSample,
+  BrainVitalsActivity,
   BrainVitalsRunDetail,
   BrainVitalsSnapshot,
   DashboardApiClient,
 } from '../../lib/dashboard-api';
 import { SlideInPanel } from '../beasts/slide-in-panel';
+import { BrainPulseMap } from './brain-pulse-map';
 
 interface BrainVitalsPanelProps {
   client: DashboardApiClient;
@@ -120,6 +122,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
   const [history, setHistory] = useState<BrainHealthSample[]>([]);
   const [resourcePoints, setResourcePoints] = useState<ResourcePoint[]>([]);
   const [aggregatePoints, setAggregatePoints] = useState<AggregatePoint[]>([]);
+  const [activities, setActivities] = useState<BrainVitalsActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
@@ -144,6 +147,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
     setHistory([]);
     setResourcePoints([]);
     setAggregatePoints([]);
+    setActivities([]);
     runCacheRef.current.clear();
     nextRunCursorRef.current = undefined;
 
@@ -215,6 +219,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
     setHistory([]);
     setResourcePoints([]);
     setAggregatePoints([]);
+    setActivities([]);
     latestSnapshotTimestampRef.current = 0;
     setSelectedRunId(null);
     setRunDetail(null);
@@ -269,6 +274,15 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
         setStreamError(describeError(subscriptionError));
       },
       (activity) => {
+        setActivities((current) => {
+          const duplicate = current.some((candidate) => (
+            candidate.dimension === activity.dimension
+            && candidate.kind === activity.kind
+            && candidate.runId === activity.runId
+            && candidate.timestamp === activity.timestamp
+          ));
+          return duplicate ? current : [...current, activity].slice(-200);
+        });
         if (
           activity.dimension !== 'churn'
           || runDiscoveryInFlightRef.current
@@ -372,6 +386,8 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
 
       {snapshot && (
         <>
+          <BrainPulseMap snapshot={snapshot} activities={activities} onOpenRun={(runId) => void openRun(runId)} />
+
           <div className="brain-vitals-panel__metrics">
             <article className="brain-vitals-panel__score" aria-label={`Health score ${snapshot.health.score}`}>
               <span>Health score</span>

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
@@ -7,7 +7,11 @@ import type {
   DashboardApiClient,
 } from '../../lib/dashboard-api';
 import { SlideInPanel } from '../beasts/slide-in-panel';
-import { BrainPulseMap, type BrainPulseActivity } from './brain-pulse-map';
+import {
+  BrainPulseMap,
+  type BrainPulseActivity,
+  type BrainPulseActivityReceipts,
+} from './brain-pulse-map';
 
 interface BrainVitalsPanelProps {
   client: DashboardApiClient;
@@ -24,6 +28,10 @@ interface AggregatePoint {
   timestamp: number;
   totalTokens: number;
   estimatedUsd: number;
+}
+
+function emptyActivityReceipts(): BrainPulseActivityReceipts {
+  return { cache: [], compaction: [], churn: [], resource: [], cost: [] };
 }
 
 function describeError(error: unknown): string {
@@ -123,6 +131,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
   const [resourcePoints, setResourcePoints] = useState<ResourcePoint[]>([]);
   const [aggregatePoints, setAggregatePoints] = useState<AggregatePoint[]>([]);
   const [activities, setActivities] = useState<BrainPulseActivity[]>([]);
+  const [activityReceipts, setActivityReceipts] = useState(emptyActivityReceipts);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
@@ -148,6 +157,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
     setResourcePoints([]);
     setAggregatePoints([]);
     setActivities([]);
+    setActivityReceipts(emptyActivityReceipts());
     runCacheRef.current.clear();
     nextRunCursorRef.current = undefined;
 
@@ -220,6 +230,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
     setResourcePoints([]);
     setAggregatePoints([]);
     setActivities([]);
+    setActivityReceipts(emptyActivityReceipts());
     latestSnapshotTimestampRef.current = 0;
     setSelectedRunId(null);
     setRunDetail(null);
@@ -276,6 +287,13 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
       (activity) => {
         if (!active || generationRef.current !== generation) return;
         const receivedAt = Date.now();
+        setActivityReceipts((current) => ({
+          ...current,
+          [activity.dimension]: [
+            ...current[activity.dimension].filter((timestamp) => timestamp >= receivedAt - 60_000),
+            receivedAt,
+          ],
+        }));
         setActivities((current) => {
           const recent = current.filter((candidate) => (
             candidate.receivedAt >= receivedAt - 60_000
@@ -285,7 +303,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
             ...activity,
             receivedAt,
             sequence: activitySequenceRef.current,
-          }];
+          }].slice(-200);
         });
         if (
           activity.dimension !== 'churn'
@@ -390,7 +408,12 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
 
       {snapshot && (
         <>
-          <BrainPulseMap snapshot={snapshot} activities={activities} onOpenRun={(runId) => void openRun(runId)} />
+          <BrainPulseMap
+            snapshot={snapshot}
+            activities={activities}
+            activityReceipts={activityReceipts}
+            onOpenRun={(runId) => void openRun(runId)}
+          />
 
           <div className="brain-vitals-panel__metrics">
             <article className="brain-vitals-panel__score" aria-label={`Health score ${snapshot.health.score}`}>

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.tsx
@@ -2,13 +2,12 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { BeastRunSummary } from '@franken/types';
 import type {
   BrainHealthSample,
-  BrainVitalsActivity,
   BrainVitalsRunDetail,
   BrainVitalsSnapshot,
   DashboardApiClient,
 } from '../../lib/dashboard-api';
 import { SlideInPanel } from '../beasts/slide-in-panel';
-import { BrainPulseMap } from './brain-pulse-map';
+import { BrainPulseMap, type BrainPulseActivity } from './brain-pulse-map';
 
 interface BrainVitalsPanelProps {
   client: DashboardApiClient;
@@ -109,6 +108,7 @@ function TrendChart({
 export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
   const generationRef = useRef(0);
   const runRequestRef = useRef(0);
+  const activitySequenceRef = useRef(0);
   const runCacheRef = useRef(new Map<string, BeastRunSummary>());
   const nextRunCursorRef = useRef<string | undefined>(undefined);
   const runDiscoveryInFlightRef = useRef(false);
@@ -122,7 +122,7 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
   const [history, setHistory] = useState<BrainHealthSample[]>([]);
   const [resourcePoints, setResourcePoints] = useState<ResourcePoint[]>([]);
   const [aggregatePoints, setAggregatePoints] = useState<AggregatePoint[]>([]);
-  const [activities, setActivities] = useState<BrainVitalsActivity[]>([]);
+  const [activities, setActivities] = useState<BrainPulseActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
@@ -278,20 +278,14 @@ export function BrainVitalsPanel({ client }: BrainVitalsPanelProps) {
         const receivedAt = Date.now();
         setActivities((current) => {
           const recent = current.filter((candidate) => (
-            candidate.timestamp >= receivedAt - 60_000
-            && candidate.timestamp <= receivedAt + 5_000
+            candidate.receivedAt >= receivedAt - 60_000
           ));
-          if (
-            activity.timestamp < receivedAt - 60_000
-            || activity.timestamp > receivedAt + 5_000
-          ) return recent;
-          const duplicate = recent.some((candidate) => (
-            candidate.dimension === activity.dimension
-            && candidate.kind === activity.kind
-            && candidate.runId === activity.runId
-            && candidate.timestamp === activity.timestamp
-          ));
-          return duplicate ? recent : [...recent, activity];
+          activitySequenceRef.current += 1;
+          return [...recent, {
+            ...activity,
+            receivedAt,
+            sequence: activitySequenceRef.current,
+          }];
         });
         if (
           activity.dimension !== 'churn'

--- a/packages/franken-web/src/lib/brain-vitals-api.ts
+++ b/packages/franken-web/src/lib/brain-vitals-api.ts
@@ -97,8 +97,10 @@ export interface BrainVitalsRunDetail {
   eventsTruncated: boolean;
 }
 
+export type BrainVitalsDimension = 'cache' | 'compaction' | 'churn' | 'resource' | 'cost';
+
 export interface BrainVitalsActivity {
-  dimension: 'cache' | 'compaction' | 'churn' | 'resource' | 'cost';
+  dimension: BrainVitalsDimension;
   kind: string;
   runId: string;
   timestamp: number;

--- a/packages/franken-web/src/lib/dashboard-api.ts
+++ b/packages/franken-web/src/lib/dashboard-api.ts
@@ -10,6 +10,8 @@ import {
 
 export type {
   BrainHealthSample,
+  BrainVitalsActivity,
+  BrainVitalsDimension,
   BrainVitalsRunDetail,
   BrainVitalsSnapshot,
   BrainVitalsWindow,

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -820,6 +820,174 @@ button {
   min-width: 12rem;
 }
 
+.brain-pulse-map {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 1rem;
+  background: radial-gradient(circle at center, rgba(134, 228, 95, 0.08), transparent 52%), var(--bg-panel-strong);
+}
+
+.brain-pulse-map > header,
+.brain-pulse-map__detail > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brain-pulse-map h4,
+.brain-pulse-map h5,
+.brain-pulse-map p {
+  margin: 0;
+}
+
+.brain-pulse-map header p,
+.brain-pulse-map header small,
+.brain-pulse-map__node small,
+.brain-pulse-map__faculties small,
+.brain-pulse-map__detail small {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
+
+.brain-pulse-map__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-areas:
+    "cache core compaction"
+    "churn core resource"
+    ". cost .";
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.brain-pulse-map__core {
+  grid-area: core;
+  display: grid;
+  place-content: center;
+  min-height: 9rem;
+  text-align: center;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  box-shadow: 0 0 22px color-mix(in srgb, currentColor 45%, transparent);
+}
+
+.brain-pulse-map__core strong {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 2rem;
+}
+
+.brain-pulse-map__node {
+  display: grid;
+  gap: 0.25rem;
+  min-height: 5.5rem;
+  padding: 0.75rem;
+  color: currentColor;
+  text-align: left;
+  border: 1px solid currentColor;
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, currentColor 7%, var(--bg-panel-strong));
+  box-shadow: 0 0 8px color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.brain-pulse-map__node--cache { grid-area: cache; }
+.brain-pulse-map__node--compaction { grid-area: compaction; }
+.brain-pulse-map__node--churn { grid-area: churn; }
+.brain-pulse-map__node--resource { grid-area: resource; }
+.brain-pulse-map__node--cost { grid-area: cost; }
+
+.brain-pulse-map__node strong {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 1.15rem;
+}
+
+.brain-pulse-map--healthy { color: var(--accent-strong); }
+.brain-pulse-map--warning,
+.brain-pulse-map--unavailable { color: var(--text-muted); }
+.brain-pulse-map--danger { color: var(--danger); }
+
+.brain-pulse-map__node--low { animation: brain-vitals-pulse 2.4s ease-in-out infinite; }
+.brain-pulse-map__node--medium { animation: brain-vitals-pulse 1.4s ease-in-out infinite; }
+.brain-pulse-map__node--high { animation: brain-vitals-pulse 0.8s ease-in-out infinite; }
+
+@keyframes brain-vitals-pulse {
+  50% {
+    filter: brightness(1.5);
+    box-shadow: 0 0 16px color-mix(in srgb, currentColor 65%, transparent);
+    transform: scale(1.025);
+  }
+}
+
+.brain-pulse-map__faculties {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.5rem;
+}
+
+.brain-pulse-map__faculties > span {
+  display: grid;
+  padding: 0.55rem;
+  color: var(--text-subtle);
+  border: 1px dashed var(--border);
+  border-radius: 0.65rem;
+}
+
+.brain-pulse-map__detail {
+  display: grid;
+  gap: 0.65rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+.brain-pulse-map__detail button {
+  padding: 0.4rem 0.6rem;
+  color: var(--accent-strong);
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  background: var(--surface-soft);
+}
+
+.brain-pulse-map__detail ol {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.brain-pulse-map__detail li,
+.brain-pulse-map__detail li span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+@media (max-width: 700px) {
+  .brain-pulse-map__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "core core"
+      "cache compaction"
+      "churn resource"
+      "cost cost";
+  }
+
+  .brain-pulse-map__core {
+    width: 8rem;
+    min-height: 8rem;
+    margin: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brain-pulse-map__node {
+    animation: none;
+  }
+}
+
 .brain-vitals-panel__metrics,
 .brain-vitals-panel__trends {
   display: grid;

--- a/tasks/brain-vitals-3738-progress.md
+++ b/tasks/brain-vitals-3738-progress.md
@@ -10,7 +10,7 @@
 - [x] Update franken-web README and architecture documentation.
 - [x] Run focused tests, @franken/web typecheck, lint, full tests, and production build.
 - [x] Run the real persisted-data browser golden path and trigger a real activity pulse.
-- [ ] Commit/push the unique exact-origin/main branch and open one PR closing #3738.
+- [x] Commit/push the unique exact-origin/main branch and open one PR closing #3738 (#3807).
 - [ ] Run bounded exact-head GitHub Codex review tiers; reply to and resolve every finding.
 - [ ] Verify exact-head CI and zero unresolved threads; merge.
 - [ ] Verify issue closure and record the final Kanban handoff.

--- a/tasks/brain-vitals-3738-progress.md
+++ b/tasks/brain-vitals-3738-progress.md
@@ -1,0 +1,16 @@
+# Brain Vitals #3738 Progress
+
+- [x] Confirm #3733 dependency is terminal and fetch exact current origin/main.
+- [x] Read #3738 and dependency comments; validate that the five vitals dimensions have real snapshot/activity/drill-down data.
+- [x] Inspect the existing Brain Vitals panel, SSE activity contract, run detail UI, styles, and tests.
+- [x] Add focused failing Pulse Map component tests and capture RED evidence.
+- [x] Implement the five-dimension real-data Brain Pulse Map as the panel entry visualization.
+- [x] Derive node health color from health signals and pulse intensity from recent SSE activity only.
+- [x] Scope node clicks to the matching real run and signal-specific drill-down.
+- [x] Update franken-web README and architecture documentation.
+- [x] Run focused tests, @franken/web typecheck, lint, full tests, and production build.
+- [x] Run the real persisted-data browser golden path and trigger a real activity pulse.
+- [ ] Commit/push the unique exact-origin/main branch and open one PR closing #3738.
+- [ ] Run bounded exact-head GitHub Codex review tiers; reply to and resolve every finding.
+- [ ] Verify exact-head CI and zero unresolved threads; merge.
+- [ ] Verify issue closure and record the final Kanban handoff.


### PR DESCRIPTION
## Summary
- add the Live Brain Pulse Map as the primary Brain Vitals visualization
- derive five vitals-node pulse rates from typed SSE activity in a rolling one-minute window and node health states from real snapshot signals
- add signal-scoped event/run drill-downs, explicit faculty-data placeholders, responsive/reduced-motion styling, and architecture docs

## Verification
- `npm --workspace @franken/web test`
- `npm run typecheck`
- `npm run lint` (passes; pre-existing warnings only)
- `npm run build`
- real persisted SQLite browser golden path against the Beast daemon: observed a live `cache.hit` pulse, opened its run-scoped drill-down, and confirmed zero browser JavaScript errors

Closes #3738
