### PR TITLE
fix(orchestrator): expose trusted CLI paths to managed services

### DIFF
--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, realpathSync } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { Socket } from 'node:net';
-import { dirname, delimiter, join, sep } from 'node:path';
+import { dirname, delimiter, isAbsolute, join, sep } from 'node:path';
 import type { ManagedNetworkServiceState } from './network-state-store.js';
 import type { ResolvedNetworkService } from './network-registry.js';
 import type { PreflightServiceResult, StartServiceOptions } from './network-supervisor.js';
@@ -266,11 +266,15 @@ function allowlistedNetworkProcessEnv(
 }
 
 function buildNetworkProcessPath(): string {
+  const operatorHome = process.env.HOME;
+  const operatorBin = operatorHome && isAbsolute(operatorHome) && !operatorHome.includes(delimiter)
+    ? join(operatorHome, '.local', 'bin')
+    : undefined;
   const pathEntries = process.platform === 'win32'
     ? [dirname(process.execPath)]
     : [
         dirname(process.execPath),
-        ...(process.env.HOME ? [join(process.env.HOME, '.local', 'bin')] : []),
+        ...(operatorBin ? [operatorBin] : []),
         '/usr/local/bin',
         '/usr/bin',
         '/bin',
@@ -306,9 +310,19 @@ function buildValidatedProcessSpec(service: ResolvedNetworkService): ValidatedPr
     };
   }
   if (processSpec.command === 'node' || processSpec.command === 'node.exe') {
+    const args = [...processSpec.args];
+    if (service.id === 'dashboard-web') {
+      const buildCommandIndex = args.indexOf('--build-command');
+      const buildArgsIndex = args.indexOf('--build-args');
+      if (buildCommandIndex < 0 || buildArgsIndex < 0) {
+        throw new Error(`Unsafe network service arguments for ${service.id}`);
+      }
+      args[buildCommandIndex + 1] = process.execPath;
+      args.splice(buildArgsIndex + 1, 0, resolveNpmCliPath());
+    }
     return {
       command: process.execPath,
-      args: processSpec.args,
+      args,
       cwd: processSpec.cwd,
       env,
     };

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -149,13 +149,13 @@ function validateNetworkServiceEnv(service: ResolvedNetworkService): void {
   }
 }
 
-// Resolve the `npm` binary on PATH to its real target. Distro packages that
+// Resolve the `npm` binary on the trusted managed PATH to its real target. Distro packages that
 // ship npm separately from node (e.g. Debian's /usr/bin/npm) symlink the
 // launcher to the real `npm-cli.js`, so following the link yields a trusted
 // CLI script we can run directly with node — without spawning a shell or an
 // npm shim. Returns null if npm is absent or does not resolve to an npm-cli.js.
 function resolveNpmCliFromPath(): string | null {
-  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  const pathDirs = buildNetworkProcessPath().split(delimiter).filter(Boolean);
   for (const dir of pathDirs) {
     const candidate = join(dir, 'npm');
     if (!existsSync(candidate)) continue;

--- a/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
+++ b/packages/franken-orchestrator/src/network/network-supervisor-runtime.ts
@@ -268,8 +268,14 @@ function allowlistedNetworkProcessEnv(
 function buildNetworkProcessPath(): string {
   const pathEntries = process.platform === 'win32'
     ? [dirname(process.execPath)]
-    : [dirname(process.execPath), '/usr/bin', '/bin'];
-  return pathEntries.join(delimiter);
+    : [
+        dirname(process.execPath),
+        ...(process.env.HOME ? [join(process.env.HOME, '.local', 'bin')] : []),
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
+      ];
+  return [...new Set(pathEntries)].join(delimiter);
 }
 
 function buildNetworkProcessEnv(

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
+import { delimiter, join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import {
   healthcheckNetworkService,
@@ -223,6 +224,29 @@ describe('startNetworkService', () => {
     ]);
     expect(Object.keys(spawnedEnv).every((key) => permittedKeys.has(key))).toBe(true);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'exposes conventional operator CLI directories without inheriting arbitrary PATH entries',
+    async () => {
+      const operatorHome = '/home/network-operator';
+      const untrustedDirectory = '/tmp/network-untrusted-bin';
+      vi.stubEnv('HOME', operatorHome);
+      vi.stubEnv('PATH', [untrustedDirectory, '/another/untrusted-bin'].join(delimiter));
+
+      await expect(startNetworkService(makeService('npm'), {
+        detached: false,
+      })).resolves.toEqual({ pid: 4242 });
+
+      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      const pathEntries = (spawnOptions?.env?.PATH ?? '').split(delimiter);
+      expect(pathEntries).toEqual(expect.arrayContaining([
+        join(operatorHome, '.local', 'bin'),
+        '/usr/local/bin',
+      ]));
+      expect(pathEntries).not.toContain(untrustedDirectory);
+      expect(pathEntries).not.toContain('/another/untrusted-bin');
+    },
+  );
 
   it('inherits only credentials required by the managed service', async () => {
     vi.stubEnv('FRANKENBEAST_BEAST_OPERATOR_TOKEN', 'operator-token-for-test');

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import { delimiter, join } from 'node:path';
+import { delimiter, isAbsolute, join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import {
   healthcheckNetworkService,
@@ -248,6 +248,23 @@ describe('startNetworkService', () => {
     },
   );
 
+  it.skipIf(process.platform === 'win32').each([
+    'relative/network-home',
+    `/safe${delimiter}/tmp/network-attacker`,
+  ])('excludes an unsafe HOME value from the managed PATH: %s', async (operatorHome) => {
+    vi.stubEnv('HOME', operatorHome);
+
+    await expect(startNetworkService(makeService('npm'), {
+      detached: false,
+    })).resolves.toEqual({ pid: 4242 });
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    const pathEntries = (spawnOptions?.env?.PATH ?? '').split(delimiter);
+    for (const injectedEntry of join(operatorHome, '.local', 'bin').split(delimiter)) {
+      expect(pathEntries).not.toContain(injectedEntry);
+    }
+  });
+
   it('inherits only credentials required by the managed service', async () => {
     vi.stubEnv('FRANKENBEAST_BEAST_OPERATOR_TOKEN', 'operator-token-for-test');
     vi.stubEnv('FRANKENBEAST_PASSPHRASE', 'vault-passphrase-for-test');
@@ -367,6 +384,21 @@ describe('startNetworkService', () => {
     })).resolves.toEqual({ pid: 4242 });
 
     expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it('pins the nested dashboard build to the resolved npm CLI', async () => {
+    await expect(startNetworkService(makeService('node', {
+      args: DASHBOARD_ARGS,
+    }, { id: 'dashboard-web' }), {
+      detached: false,
+    })).resolves.toEqual({ pid: 4242 });
+
+    const spawnedArgs = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
+    const buildCommandIndex = spawnedArgs?.indexOf('--build-command') ?? -1;
+    const buildArgsIndex = spawnedArgs?.indexOf('--build-args') ?? -1;
+    expect(spawnedArgs?.[buildCommandIndex + 1]).toBe(process.execPath);
+    expect(isAbsolute(spawnedArgs?.[buildArgsIndex + 1] ?? '')).toBe(true);
+    expect(spawnedArgs?.[buildArgsIndex + 1]).toMatch(/npm-cli\.js$/);
   });
 
   it('rejects dashboard build commands outside the nested build allowlist', async () => {

--- a/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-supervisor-runtime.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { delimiter, isAbsolute, join } from 'node:path';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
@@ -21,6 +22,18 @@ const spawnMock = vi.hoisted(() => vi.fn(() => ({
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
 }));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(actual.existsSync),
+    realpathSync: vi.fn(actual.realpathSync),
+  };
+});
+
+const existsSyncMock = vi.mocked(existsSync);
+const realpathSyncMock = vi.mocked(realpathSync);
 
 const CHAT_SERVER_ARGS = [
   '--silent',
@@ -399,6 +412,30 @@ describe('startNetworkService', () => {
     expect(spawnedArgs?.[buildCommandIndex + 1]).toBe(process.execPath);
     expect(isAbsolute(spawnedArgs?.[buildArgsIndex + 1] ?? '')).toBe(true);
     expect(spawnedArgs?.[buildArgsIndex + 1]).toMatch(/npm-cli\.js$/);
+  });
+
+  it('does not resolve the dashboard npm CLI from an arbitrary inherited PATH entry', async () => {
+    const attackerDirectory = '/tmp/network-attacker';
+    const attackerNpm = join(attackerDirectory, 'npm');
+    const attackerNpmCli = join(attackerDirectory, 'npm-cli.js');
+    const originalExistsSync = existsSyncMock.getMockImplementation();
+    const originalRealpathSync = realpathSyncMock.getMockImplementation();
+    vi.stubEnv('PATH', attackerDirectory);
+    existsSyncMock.mockImplementation((candidate) => [attackerNpm, attackerNpmCli].includes(String(candidate)));
+    realpathSyncMock.mockImplementation((candidate) => (
+      String(candidate) === attackerNpm ? attackerNpmCli : String(candidate)
+    ));
+
+    try {
+      await expect(startNetworkService(makeService('node', {
+        args: DASHBOARD_ARGS,
+      }, { id: 'dashboard-web' }), {
+        detached: false,
+      })).rejects.toThrow('Unable to locate a trusted npm CLI');
+    } finally {
+      existsSyncMock.mockImplementation(originalExistsSync!);
+      realpathSyncMock.mockImplementation(originalRealpathSync!);
+    }
   });
 
   it('rejects dashboard build commands outside the nested build allowlist', async () => {

--- a/tasks/issue-3864-managed-service-path-progress.md
+++ b/tasks/issue-3864-managed-service-path-progress.md
@@ -12,7 +12,7 @@
 - [x] Verify the actual managed-service dependency snapshot without exposing credentials.
 - [x] Record reusable findings in `tasks/resolve-issues-shared-lessons.md`.
 - [x] Inspect the staged diff and commit with the configured David Mendez identity.
-- [ ] Push one issue branch and open one linked pull request.
+- [x] Push one issue branch and open one linked pull request (#3868).
 - [ ] Run the bounded exact-current-head GitHub Codex review/remediation loop.
 - [ ] Verify green CI and zero unresolved review threads.
 - [ ] Leave an immutable merge-ready Kanban handoff without merging.

--- a/tasks/issue-3864-managed-service-path-progress.md
+++ b/tasks/issue-3864-managed-service-path-progress.md
@@ -1,0 +1,18 @@
+# Issue #3864 Managed-Service PATH Progress
+
+- [x] Create a clean isolated worktree on current `origin/main` (`715da9d456d9a883aa96d85f53cbefca832da1c1`).
+- [x] Confirm no existing remote branch or pull request owns `fix/issue-3864-managed-service-path`.
+- [x] Trace managed-service environment construction and executable availability checks.
+- [x] Reproduce the managed-service false-unavailable state before production edits.
+- [x] Add a failing regression for conventional trusted operator CLI paths.
+- [x] Add/confirm regression coverage proving arbitrary inherited `PATH` entries remain excluded.
+- [x] Implement the minimal trusted-path change.
+- [x] Run focused orchestrator tests.
+- [x] Run package/root typecheck, lint, test, and build gates required by the issue (tests pass in an isolated network namespace; host default ports are owned by unrelated managed services).
+- [x] Verify the actual managed-service dependency snapshot without exposing credentials.
+- [x] Record reusable findings in `tasks/resolve-issues-shared-lessons.md`.
+- [x] Inspect the staged diff and commit with the configured David Mendez identity.
+- [ ] Push one issue branch and open one linked pull request.
+- [ ] Run the bounded exact-current-head GitHub Codex review/remediation loop.
+- [ ] Verify green CI and zero unresolved review threads.
+- [ ] Leave an immutable merge-ready Kanban handoff without merging.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,8 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-27 — Managed-service CLI visibility must use explicit operator paths
-- A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation.
+- A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation. Validate home-derived entries as absolute and delimiter-free before adding them.
+- Audit nested child launchers after widening a managed PATH. Bare commands that were safe only under the old restricted PATH (such as a dashboard process spawning `npm`) must be replaced with already-resolved trusted executable/CLI paths.
 - Verify this boundary from the real detached child rather than only the launching shell: inspect only the child `PATH` from `/proc/<pid>/environ`, resolve required CLI names against that exact value, and query the authenticated managed dashboard health snapshot while keeping all credential values out of output.
 
 ## 2026-07-25 — Cross-agent hive activity needs explicit attribution truth

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-27 — Managed-service CLI visibility must use explicit operator paths
+- A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation.
+- Verify this boundary from the real detached child rather than only the launching shell: inspect only the child `PATH` from `/proc/<pid>/environ`, resolve required CLI names against that exact value, and query the authenticated managed dashboard health snapshot while keeping all credential values out of output.
+
 ## 2026-07-25 — Cross-agent hive activity needs explicit attribution truth
 - A workspace-wide status query may use agent-type hive activity for a subject only when the bounded tracked-agent scan proves that type belongs to one subject, or when the publisher id matches that subject's tracked agent/run directly. If the scan is incomplete or the type is shared, omit generic activity and expose a stable partial/error marker instead of guessing ownership.
 - Count soft-deleted agents when proving agent-type ownership; persisted hive episodes can outlive the tracked-agent row's active lifecycle.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-27 — Managed-service CLI visibility must use explicit operator paths
 - A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation. Validate home-derived entries as absolute and delimiter-free before adding them.
-- Audit nested child launchers after widening a managed PATH. Bare commands that were safe only under the old restricted PATH (such as a dashboard process spawning `npm`) must be replaced with already-resolved trusted executable/CLI paths.
+- Audit nested child launchers after widening a managed PATH. Bare commands that were safe only under the old restricted PATH (such as a dashboard process spawning `npm`) must be replaced with already-resolved trusted executable/CLI paths, and fallback resolution must search the sanitized managed PATH rather than the parent process PATH.
 - Verify this boundary from the real detached child rather than only the launching shell: inspect only the child `PATH` from `/proc/<pid>/environ`, resolve required CLI names against that exact value, and query the authenticated managed dashboard health snapshot while keeping all credential values out of output.
 
 ## 2026-07-25 — Cross-agent hive activity needs explicit attribution truth


### PR DESCRIPTION
## Summary
- add explicit `$HOME/.local/bin` and `/usr/local/bin` entries to managed-service PATH construction
- preserve isolation by excluding arbitrary inherited PATH entries
- add regression coverage and live detached-child verification guidance

## Verification
- `npm run test --workspace @franken/orchestrator -- tests/unit/network/network-supervisor-runtime.test.ts`
- `bwrap --unshare-net --dev-bind / / --proc /proc -- npm run test --workspace @franken/orchestrator`
- `bwrap --unshare-net --dev-bind / / --proc /proc -- npx turbo run test --concurrency=1`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- live detached managed services: Codex, Claude, and GitHub CLI healthy; arbitrary credential values never printed

Closes #3864