### PR TITLE
test(web): add live Hermes smart-swarm E2E

### DIFF
--- a/docs/runbooks/smart-swarm-hermes-live-e2e.md
+++ b/docs/runbooks/smart-swarm-hermes-live-e2e.md
@@ -71,7 +71,6 @@ Terminal 2, also from the repository root:
 ```bash
 source /tmp/franken-smart-swarm-manual.env
 VITE_API_PROXY_TARGET=http://127.0.0.1:3737 \
-VITE_PROXY_OPERATOR_TOKEN="$FRANKENBEAST_BEAST_OPERATOR_TOKEN" \
 npm --workspace @franken/web run dev -- --host 127.0.0.1 --port 5173
 ```
 

--- a/docs/runbooks/smart-swarm-hermes-live-e2e.md
+++ b/docs/runbooks/smart-swarm-hermes-live-e2e.md
@@ -28,7 +28,7 @@ The script installs the pinned Playwright Chromium binary if absent, builds the 
 - a fresh Hermes comment reaches the dashboard over live SSE;
 - an interrupted dashboard proxy reconnects, obtains a new one-time stream ticket, and returns to connected state;
 - the dashboard resolves a real blocked Hermes task and verifies its CLI-visible postcondition;
-- a governed promote action is rejected without a governor and the task remains ready;
+- a governed promote action is rejected without a governor and the blocked task remains blocked;
 - an approval decision exercises Hermes' truthful typed `unsupported` result without mutating task state;
 - an initialized empty board renders the explicit empty state;
 - an incompatible board exercises degraded provider discovery while a compatible selected board remains usable;
@@ -53,16 +53,17 @@ Terminal 1, from the repository root:
 rm -f /tmp/franken-smart-swarm-manual.env
 umask 077
 HERMES_HOME="$(mktemp -d /tmp/franken-smart-swarm-manual.XXXXXX)"
+FRANKENBEAST_BASE_DIR="$(mktemp -d /tmp/franken-smart-swarm-state.XXXXXX)"
 OPERATOR_TOKEN="$(node -e "console.log(require('node:crypto').randomBytes(24).toString('hex'))")"
-printf 'export HERMES_HOME=%q\nexport HERMES_KANBAN_DB=%q\nexport FRANKENBEAST_BEAST_OPERATOR_TOKEN=%q\n' \
-  "$HERMES_HOME" "$HERMES_HOME/kanban.db" "$OPERATOR_TOKEN" > /tmp/franken-smart-swarm-manual.env
+printf 'export HERMES_HOME=%q\nexport HERMES_KANBAN_DB=%q\nexport FRANKENBEAST_BASE_DIR=%q\nexport FRANKENBEAST_BEAST_OPERATOR_TOKEN=%q\n' \
+  "$HERMES_HOME" "$HERMES_HOME/kanban.db" "$FRANKENBEAST_BASE_DIR" "$OPERATOR_TOKEN" > /tmp/franken-smart-swarm-manual.env
 source /tmp/franken-smart-swarm-manual.env
 hermes kanban init
 TASK_JSON="$(hermes kanban create 'Manual smart-swarm worker' --assignee default --workspace scratch --json)"
 TASK_ID="$(node -e 'console.log(JSON.parse(process.argv[1]).id)' "$TASK_JSON")"
 hermes kanban block --kind needs_input "$TASK_ID" 'Waiting for manual operator verification'
 printf 'export TASK_ID=%q\n' "$TASK_ID" >> /tmp/franken-smart-swarm-manual.env
-npm --workspace @franken/orchestrator run chat-server -- --port 3737
+npm --workspace @franken/orchestrator run chat-server -- --base-dir "$FRANKENBEAST_BASE_DIR" --port 3737
 ```
 
 Terminal 2, also from the repository root:
@@ -86,6 +87,7 @@ Confirm `Manual live SSE evidence` appears without refreshing. Stop both servers
 ```bash
 source /tmp/franken-smart-swarm-manual.env
 rm -rf "$HERMES_HOME"
+rm -rf "$FRANKENBEAST_BASE_DIR"
 rm -f /tmp/franken-smart-swarm-manual.env
-unset HERMES_HOME HERMES_KANBAN_DB FRANKENBEAST_BEAST_OPERATOR_TOKEN TASK_ID
+unset HERMES_HOME HERMES_KANBAN_DB FRANKENBEAST_BASE_DIR FRANKENBEAST_BEAST_OPERATOR_TOKEN TASK_ID
 ```

--- a/docs/runbooks/smart-swarm-hermes-live-e2e.md
+++ b/docs/runbooks/smart-swarm-hermes-live-e2e.md
@@ -1,0 +1,91 @@
+# Live smart-swarm Hermes E2E runbook
+
+Use this gate when changing the provider-neutral smart-swarm API, Hermes adapter, SSE transport, authenticated Vite proxy, or dashboard controls.
+
+## Prerequisites
+
+- Node.js and npm versions accepted by the root `package.json`.
+- An installed `hermes` CLI available on `PATH`.
+- Linux/macOS with permission to download Playwright Chromium on the first run.
+
+No existing Hermes board, operator credential, gateway, dispatcher, or external LLM is used. The test creates its own operator token and isolated temporary Hermes home.
+
+## Run
+
+From the repository root:
+
+```bash
+npm ci
+npm run test:e2e:smart-swarm:hermes
+```
+
+The script installs the pinned Playwright Chromium binary if absent, builds the production workspaces, and runs only `packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts` with the explicit live-test gate enabled.
+
+## What the gate proves
+
+- unauthenticated smart-swarm HTTP is rejected and the authenticated Vite proxy succeeds;
+- the browser selects Hermes and renders real CLI-created PM/worker/dependency/blocker/event evidence;
+- a fresh Hermes comment reaches the dashboard over live SSE;
+- an interrupted dashboard proxy reconnects, obtains a new one-time stream ticket, and returns to connected state;
+- the dashboard resolves a real blocked Hermes task and verifies its CLI-visible postcondition;
+- a governed promote action is rejected without a governor and the task remains ready;
+- an approval decision exercises Hermes' truthful typed `unsupported` result without mutating task state;
+- an initialized empty board renders the explicit empty state;
+- an incompatible board exercises degraded provider discovery while a compatible selected board remains usable;
+- unique secret-bearing task input is absent from the authenticated normalized response;
+- the production web bundle contains none of the dashboard unit-test fixture markers;
+- browser runtime errors and unexpected smart-swarm resource failures are absent;
+- the temporary Hermes home, action/session state, browser, Vite server, backend, and generated credentials are removed/restored on success or failure.
+
+The intentionally forced SSE interruption may emit aborted/incomplete stream-resource diagnostics. Existing unrelated `/v1/network/*` 404 responses are excluded from this smart-swarm-specific gate; JavaScript console exceptions and all other unexpected failures still fail the test.
+
+## Failure recovery
+
+The harness cleans up in `finally`, so rerunning the command is safe. If Chromium installation is unavailable, run `npx playwright install chromium` after restoring network access. If `hermes` is not on `PATH`, set `HERMES_COMMAND` to its executable path for the command invocation.
+
+## Manual live-event verification
+
+The automated gate is authoritative. For operator diagnosis, the following exact local-only flow starts the same authenticated backend/proxy pair against an isolated Hermes home.
+
+Terminal 1, from the repository root:
+
+```bash
+rm -f /tmp/franken-smart-swarm-manual.env
+umask 077
+HERMES_HOME="$(mktemp -d /tmp/franken-smart-swarm-manual.XXXXXX)"
+OPERATOR_TOKEN="$(node -e "console.log(require('node:crypto').randomBytes(24).toString('hex'))")"
+printf 'export HERMES_HOME=%q\nexport HERMES_KANBAN_DB=%q\nexport FRANKENBEAST_BEAST_OPERATOR_TOKEN=%q\n' \
+  "$HERMES_HOME" "$HERMES_HOME/kanban.db" "$OPERATOR_TOKEN" > /tmp/franken-smart-swarm-manual.env
+source /tmp/franken-smart-swarm-manual.env
+hermes kanban init
+TASK_JSON="$(hermes kanban create 'Manual smart-swarm worker' --assignee default --workspace scratch --json)"
+TASK_ID="$(node -e 'console.log(JSON.parse(process.argv[1]).id)' "$TASK_JSON")"
+hermes kanban block --kind needs_input "$TASK_ID" 'Waiting for manual operator verification'
+printf 'export TASK_ID=%q\n' "$TASK_ID" >> /tmp/franken-smart-swarm-manual.env
+npm --workspace @franken/orchestrator run chat-server -- --port 3737
+```
+
+Terminal 2, also from the repository root:
+
+```bash
+source /tmp/franken-smart-swarm-manual.env
+VITE_API_PROXY_TARGET=http://127.0.0.1:3737 \
+VITE_PROXY_OPERATOR_TOKEN="$FRANKENBEAST_BEAST_OPERATOR_TOKEN" \
+npm --workspace @franken/web run dev -- --host 127.0.0.1 --port 5173
+```
+
+Open the exact dashboard link `http://127.0.0.1:5173/#/smart-swarm`, select **Hermes**, and confirm the blocked worker appears. In Terminal 3, emit fresh evidence:
+
+```bash
+source /tmp/franken-smart-swarm-manual.env
+hermes kanban comment "$TASK_ID" 'Manual live SSE evidence' --author operator
+```
+
+Confirm `Manual live SSE evidence` appears without refreshing. Stop both servers, then remove all test state and generated credentials:
+
+```bash
+source /tmp/franken-smart-swarm-manual.env
+rm -rf "$HERMES_HOME"
+rm -f /tmp/franken-smart-swarm-manual.env
+unset HERMES_HOME HERMES_KANBAN_DB FRANKENBEAST_BEAST_OPERATOR_TOKEN TASK_ID
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@playwright/test": "^1.62.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
@@ -884,6 +885,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5507,6 +5524,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:eval": "turbo run test:eval --filter=@franken/observer",
     "test:ci": "npm run build --workspace @franken/types && npm run ci:test:root && npm run ci:test:packages && npm run ci:test:mcp-suite-integration && npm run ci:test:planner-integration && npm run ci:test:observer-eval",
     "test:e2e": "npm run test:e2e --workspace @franken/orchestrator --",
+    "test:e2e:smart-swarm:hermes": "playwright install chromium && npm run build && LIVE_SMART_SWARM_E2E=1 vitest run packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts --config packages/franken-orchestrator/vitest.config.ts",
     "test:live:bench": "turbo run test:live --filter=@franken/live-bench",
     "ci:test:root": "node scripts/retry-ci-command.mjs -- npm run test:root",
     "ci:test:packages": "node scripts/retry-ci-command.mjs -- npx turbo run test",
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@playwright/test": "^1.62.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.10",

--- a/packages/franken-orchestrator/src/http/chat-server.ts
+++ b/packages/franken-orchestrator/src/http/chat-server.ts
@@ -21,6 +21,7 @@ import { createChatApp } from './chat-app.js';
 import type { RuntimeActionAuditEvent } from './routes/runtime-routes.js';
 import type { IGovernorModule } from '../deps.js';
 import { RuntimeActionStore } from '../runtime/runtime-action-store.js';
+import type { RuntimeAdapterRegistry } from '../runtime/runtime-adapter-registry.js';
 import { attachChatWebSocketServer, type AttachChatWebSocketServerOptions, type ChatSocketMessageRateLimitOptions } from './ws-chat-server.js';
 import { createSessionTokenSecret } from './ws-chat-auth.js';
 import type { OrchestratorConfig } from '../config/orchestrator-config.js';
@@ -82,6 +83,7 @@ export interface StartChatServerOptions {
   runtimeActionGovernor?: IGovernorModule;
   runtimeActionAudit?: (event: RuntimeActionAuditEvent) => void | Promise<void>;
   runtimeActionStore?: RuntimeActionStore;
+  runtimeRegistry?: RuntimeAdapterRegistry;
 }
 
 export interface ChatServerHandle {
@@ -425,6 +427,7 @@ export async function startChatServer(options: StartChatServerOptions): Promise<
       ...(options.runtimeActionGovernor ? { runtimeActionGovernor: options.runtimeActionGovernor } : {}),
       ...(options.runtimeActionAudit ? { runtimeActionAudit: options.runtimeActionAudit } : {}),
       ...(runtimeActionStore ? { runtimeActionStore } : {}),
+      ...(options.runtimeRegistry ? { runtimeRegistry: options.runtimeRegistry } : {}),
       chatRateLimiter,
       chatMutationAdmission,
       approvalAuditLog,

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -9,7 +9,7 @@ import { chromium, expect as expectBrowser, type Browser, type BrowserContext } 
 import { createServer as createViteServer, type ViteDevServer } from 'vite';
 import { describe, expect, it } from 'vitest';
 import { startChatServer, type ChatServerHandle } from '../../src/http/chat-server.js';
-import { createDefaultRuntimeAdapterRegistry } from '../../src/runtime/index.js';
+import { HermesRuntimeAdapter, RuntimeAdapterRegistry } from '../../src/runtime/index.js';
 
 const execFileAsync = promisify(execFile);
 const enabled = process.env['LIVE_SMART_SWARM_E2E'] === '1';
@@ -151,16 +151,18 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
         llm: { complete: async () => 'unused in smart-swarm E2E' },
         projectName: 'smart-swarm-e2e',
         operatorToken,
-        runtimeRegistry: createDefaultRuntimeAdapterRegistry({
-          command: hermesCommand,
-          hermesHome,
-          kanbanDbPath: join(hermesHome, 'kanban.db'),
-          env: {
-            ...process.env,
-            HERMES_HOME: hermesHome,
-            HERMES_KANBAN_DB: join(hermesHome, 'kanban.db'),
-          },
-        }),
+        runtimeRegistry: new RuntimeAdapterRegistry([
+          new HermesRuntimeAdapter({
+            command: hermesCommand,
+            hermesHome,
+            kanbanDbPath: join(hermesHome, 'kanban.db'),
+            env: {
+              ...process.env,
+              HERMES_HOME: hermesHome,
+              HERMES_KANBAN_DB: join(hermesHome, 'kanban.db'),
+            },
+          }),
+        ]),
       });
       process.env['VITE_API_PROXY_TARGET'] = backend.url;
 

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -84,6 +84,21 @@ async function productionBundleText(): Promise<string> {
   return (await Promise.all(files.map((file) => readFile(join(assetsDir, file), 'utf8')))).join('\n');
 }
 
+function isExpectedResourceFailure(failure: string): boolean {
+  if (failure.startsWith('404 ') && failure.includes('/v1/network/')) return true;
+  return failure.includes('/events/') && (
+    failure.includes('ERR_ABORTED') || failure.includes('ERR_INCOMPLETE_CHUNKED_ENCODING')
+  );
+}
+
+describe('smart-swarm browser resource failure classification', () => {
+  it('exempts only 404 responses from the unrelated network API', () => {
+    expect(isExpectedResourceFailure('404 http://127.0.0.1/v1/network/status')).toBe(true);
+    expect(isExpectedResourceFailure('500 http://127.0.0.1/v1/network/status')).toBe(false);
+    expect(isExpectedResourceFailure('net::ERR_FAILED http://127.0.0.1/v1/network/status')).toBe(false);
+  });
+});
+
 describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', () => {
   it('proves authenticated HTTP/SSE, real browser topology, governed actions, recovery, and cleanup', async () => {
     const marker = `live-e2e-${Date.now()}`;
@@ -290,13 +305,7 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       await page.getByLabel('Workspace').selectOption({ label: 'empty-e2e' });
       await expectBrowser(page.getByText('No runtime work in empty-e2e')).toBeVisible({ timeout: 10_000 });
       expect(browserErrors).toEqual([]);
-      const unexpectedResourceFailures = resourceFailures.filter((failure) => {
-        if (failure.includes('/v1/network/')) return false;
-        if (failure.includes('/events/') && (
-          failure.includes('ERR_ABORTED') || failure.includes('ERR_INCOMPLETE_CHUNKED_ENCODING')
-        )) return false;
-        return true;
-      });
+      const unexpectedResourceFailures = resourceFailures.filter((failure) => !isExpectedResourceFailure(failure));
       expect(unexpectedResourceFailures).toEqual([]);
 
       const bundle = await productionBundleText();

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -1,0 +1,322 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import Database from 'better-sqlite3';
+import { chromium, expect as expectBrowser, type Browser, type BrowserContext } from '@playwright/test';
+import { createServer as createViteServer, type ViteDevServer } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { startChatServer, type ChatServerHandle } from '../../src/http/chat-server.js';
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env['LIVE_SMART_SWARM_E2E'] === '1';
+const repoRoot = resolve(import.meta.dirname, '../../../..');
+const webRoot = join(repoRoot, 'packages/franken-web');
+const hermesCommand = process.env['HERMES_COMMAND'] ?? 'hermes';
+const ambientHermesEnvKeys = [
+  'HERMES_DELEGATED_CHILD_CONTEXT',
+  'HERMES_KANBAN_BOARD',
+  'HERMES_KANBAN_BRANCH',
+  'HERMES_KANBAN_TASK',
+  'HERMES_KANBAN_WORKSPACE',
+  'HERMES_SESSION_ID',
+  'HERMES_TENANT',
+] as const;
+
+interface HermesTask {
+  id: string;
+  status: string;
+}
+
+async function runHermes(
+  hermesHome: string,
+  args: string[],
+  options: { board?: string; databasePath?: string } = {},
+): Promise<string> {
+  const boardArgs = options.board ? ['--board', options.board] : [];
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of ambientHermesEnvKeys) delete childEnv[key];
+  const { stdout } = await execFileAsync(
+    hermesCommand,
+    ['kanban', ...boardArgs, ...args],
+    {
+      cwd: repoRoot,
+      env: {
+        ...childEnv,
+        HERMES_HOME: hermesHome,
+        HERMES_KANBAN_DB: options.databasePath ?? join(hermesHome, 'kanban.db'),
+        HERMES_PROFILE: 'default',
+      },
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  return stdout;
+}
+
+async function createTask(
+  hermesHome: string,
+  title: string,
+  extraArgs: string[] = [],
+): Promise<HermesTask> {
+  return JSON.parse(await runHermes(hermesHome, [
+    'create', title,
+    '--assignee', 'default',
+    '--workspace', 'scratch',
+    ...extraArgs,
+    '--json',
+  ])) as HermesTask;
+}
+
+async function readTask(hermesHome: string, taskId: string): Promise<HermesTask> {
+  const result = JSON.parse(await runHermes(hermesHome, ['show', taskId, '--json'])) as {
+    task: HermesTask;
+  };
+  return result.task;
+}
+
+async function productionBundleText(): Promise<string> {
+  const assetsDir = join(webRoot, 'dist/assets');
+  const files = (await readdir(assetsDir)).filter((file) => file.endsWith('.js'));
+  return (await Promise.all(files.map((file) => readFile(join(assetsDir, file), 'utf8')))).join('\n');
+}
+
+describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', () => {
+  it('proves authenticated HTTP/SSE, real browser topology, governed actions, recovery, and cleanup', async () => {
+    const marker = `live-e2e-${Date.now()}`;
+    const secretMarker = `secret-${crypto.randomUUID()}`;
+    const workerTitle = `${marker} Worker token=${secretMarker}`;
+    const operatorToken = `operator-${crypto.randomUUID()}`;
+    const hermesHome = await mkdtemp(join(tmpdir(), 'franken-smart-swarm-hermes-'));
+    const sessionDir = await mkdtemp(join(tmpdir(), 'franken-smart-swarm-session-'));
+    const previousEnv = {
+      hermesHome: process.env['HERMES_HOME'],
+      kanbanDb: process.env['HERMES_KANBAN_DB'],
+      operatorToken: process.env['FRANKENBEAST_BEAST_OPERATOR_TOKEN'],
+      proxyTarget: process.env['VITE_API_PROXY_TARGET'],
+      ambientHermes: Object.fromEntries(ambientHermesEnvKeys.map((key) => [key, process.env[key]])),
+    };
+    let backend: ChatServerHandle | undefined;
+    let vite: ViteDevServer | undefined;
+    let browser: Browser | undefined;
+    let context: BrowserContext | undefined;
+    let caught: unknown;
+
+    try {
+      await runHermes(hermesHome, ['init']);
+      await runHermes(hermesHome, ['boards', 'create', 'empty-e2e', '--name', 'Empty E2E']);
+      await runHermes(hermesHome, ['init'], {
+        databasePath: join(hermesHome, 'kanban', 'boards', 'empty-e2e', 'kanban.db'),
+      });
+
+      const pm = await createTask(hermesHome, `${marker} PM`);
+      const worker = await createTask(hermesHome, workerTitle, [
+        '--parent', pm.id,
+        '--body', `private ${secretMarker}`,
+      ]);
+      await runHermes(hermesHome, [
+        'complete', pm.id,
+        '--summary', `${marker} dependency satisfied`,
+      ]);
+      await runHermes(hermesHome, [
+        'block', '--kind', 'needs_input', worker.id, `${marker} operator input required`,
+      ]);
+      await runHermes(hermesHome, [
+        'comment', worker.id, `${marker} initial live log evidence`, '--author', 'e2e-worker',
+      ]);
+      expect((await readTask(hermesHome, worker.id)).status).toBe('blocked');
+
+      const incompatibleDir = join(hermesHome, 'kanban', 'boards', 'incompatible-e2e');
+      await mkdir(incompatibleDir, { recursive: true });
+      const incompatibleDb = new Database(join(incompatibleDir, 'kanban.db'));
+      incompatibleDb.exec('CREATE TABLE incompatible_schema (id TEXT PRIMARY KEY)');
+      incompatibleDb.close();
+
+      for (const key of ambientHermesEnvKeys) delete process.env[key];
+      process.env['HERMES_HOME'] = hermesHome;
+      process.env['HERMES_KANBAN_DB'] = join(hermesHome, 'kanban.db');
+      process.env['FRANKENBEAST_BEAST_OPERATOR_TOKEN'] = operatorToken;
+
+      backend = await startChatServer({
+        host: '127.0.0.1',
+        port: 0,
+        sessionStoreDir: sessionDir,
+        llm: { complete: async () => 'unused in smart-swarm E2E' },
+        projectName: 'smart-swarm-e2e',
+        operatorToken,
+      });
+      process.env['VITE_API_PROXY_TARGET'] = backend.url;
+
+      const unauthenticated = await fetch(`${backend.url}/v1/smart-swarm/providers`);
+      expect(unauthenticated.status).toBe(401);
+      const authenticated = await fetch(
+        `${backend.url}/v1/smart-swarm/providers/hermes/snapshot?workspaceId=hermes%3Aglobal`,
+        {
+          headers: { authorization: `Bearer ${operatorToken}` },
+        },
+      );
+      expect(authenticated.status).toBe(200);
+      const authenticatedText = await authenticated.text();
+      expect(authenticatedText).toContain(marker);
+      expect(authenticatedText).not.toContain(secretMarker);
+
+      vite = await createViteServer({
+        configFile: join(webRoot, 'vite.config.ts'),
+        root: webRoot,
+        logLevel: 'error',
+        server: { host: '127.0.0.1', port: 0, strictPort: false },
+      });
+      await vite.listen();
+      const dashboardUrl = vite.resolvedUrls?.local[0];
+      if (!dashboardUrl) throw new Error('Vite did not publish a local dashboard URL');
+      const dashboardPort = Number(new URL(dashboardUrl).port);
+
+      browser = await chromium.launch({ headless: true });
+      context = await browser.newContext();
+      const page = await context.newPage();
+      const browserErrors: string[] = [];
+      const resourceFailures: string[] = [];
+      let ticketRequests = 0;
+      page.on('request', (request) => {
+        if (request.url().endsWith('/events/ticket')) ticketRequests += 1;
+      });
+      page.on('console', (message) => {
+        if (message.type() === 'error' && !message.text().startsWith('Failed to load resource:')) {
+          browserErrors.push(message.text());
+        }
+      });
+      page.on('pageerror', (error) => browserErrors.push(error.message));
+      page.on('response', (response) => {
+        if (response.status() >= 400) resourceFailures.push(`${response.status()} ${response.url()}`);
+      });
+      page.on('requestfailed', (request) => {
+        resourceFailures.push(`${request.failure()?.errorText ?? 'request failed'} ${request.url()}`);
+      });
+
+      await page.goto(`${dashboardUrl}#/smart-swarm`);
+      await expectBrowser(page.getByRole('heading', { name: 'smart-swarm' })).toBeVisible();
+      await page.getByLabel('Runtime provider').selectOption('hermes');
+      await expectBrowser(page.getByLabel('Runtime provider')).toHaveValue('hermes');
+      await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 15_000 });
+      await expectBrowser(page.getByText(new RegExp(`${marker} Worker`))).toBeVisible();
+      await expectBrowser(page.locator('body')).not.toContainText(secretMarker);
+      await expectBrowser(page.getByText(`Depends on ${marker} PM`, { exact: true })).toBeVisible();
+      await expectBrowser(page.getByText(new RegExp(`${marker} operator input required`))).toBeVisible();
+      await expectBrowser(page.getByRole('region', { name: 'Provider capabilities' })).toContainText('unsupported');
+      await expectBrowser(page.getByText('One or more Hermes databases are unavailable or schema-incompatible')).toBeVisible();
+      await expectBrowser(page.getByText(/Approvals unsupported:.*no canonical approval-request source/)).toBeVisible();
+      await expectBrowser(page.getByTitle('The supported Hermes Kanban schema has no canonical log-record source')).toBeVisible();
+
+      await page.getByRole('button', { name: new RegExp(`Inspect ${marker} Worker`) }).click();
+      await expectBrowser(page.getByRole('dialog', { name: new RegExp(`${marker} Worker.*details`) })).toBeVisible();
+      await expectBrowser(page.getByRole('dialog').getByRole('definition').filter({ hasText: 'blocked' })).toBeVisible();
+      await page.getByRole('button', { name: 'Close' }).click();
+
+      const streamedMarker = `${marker} streamed event`;
+      await runHermes(hermesHome, [
+        'comment', worker.id, streamedMarker, '--author', 'e2e-worker',
+      ]);
+      await expectBrowser(page.getByText(new RegExp(streamedMarker))).toBeVisible({ timeout: 15_000 });
+
+      const ticketRequestsBeforeRecovery = ticketRequests;
+      await vite.close();
+      vite = undefined;
+      await expectBrowser(page.getByText('Connection lost · reconnecting')).toBeVisible({ timeout: 10_000 });
+      vite = await createViteServer({
+        configFile: join(webRoot, 'vite.config.ts'),
+        root: webRoot,
+        logLevel: 'error',
+        server: { host: '127.0.0.1', port: dashboardPort, strictPort: true },
+      });
+      await vite.listen();
+      await expect.poll(() => ticketRequests, { timeout: 20_000 }).toBeGreaterThan(ticketRequestsBeforeRecovery);
+      await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 20_000 });
+
+      await page.getByRole('button', { name: new RegExp(`Inspect ${marker} Worker`) }).click();
+      await page.getByRole('button', { name: 'Resolve blocker' }).click();
+      await expectBrowser(page.getByText('Blocker resolved; live state refreshed.')).toBeVisible({ timeout: 15_000 });
+      await expect.poll(async () => (await readTask(hermesHome, worker.id)).status).toBe('ready');
+
+      await expectBrowser(page.getByRole('button', { name: 'Promote task' })).toBeEnabled();
+      await page.getByRole('button', { name: 'Promote task' }).click();
+      await expectBrowser(page.getByText('rejected: Runtime action was not approved by the governor')).toBeVisible();
+      expect((await readTask(hermesHome, worker.id)).status).toBe('ready');
+
+      const approvalResult = await page.evaluate(async ({ workerId }) => {
+        const response = await fetch('/v1/smart-swarm/providers/hermes/actions', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            correlationId: crypto.randomUUID(),
+            idempotencyKey: `approval.resolve:${crypto.randomUUID()}`,
+            action: {
+              type: 'approval.resolve',
+              workspaceId: 'hermes:global',
+              approvalId: `approval:${workerId}`,
+              decision: 'reject',
+              reason: 'Hermes approval decisions are intentionally unsupported',
+            },
+          }),
+        });
+        return await response.json() as { data: { status: string; reason?: string } };
+      }, { workerId: worker.id });
+      expect(approvalResult.data).toEqual(expect.objectContaining({
+        status: 'unsupported',
+        reason: expect.stringContaining('canonical approval'),
+      }));
+
+      await page.getByRole('button', { name: 'Close' }).click();
+      await page.getByLabel('Workspace').selectOption({ label: 'empty-e2e' });
+      await expectBrowser(page.getByText('No runtime work in empty-e2e')).toBeVisible({ timeout: 10_000 });
+      expect(browserErrors).toEqual([]);
+      const unexpectedResourceFailures = resourceFailures.filter((failure) => {
+        if (failure.includes('/v1/network/')) return false;
+        if (failure.includes('/events/') && (
+          failure.includes('ERR_ABORTED') || failure.includes('ERR_INCOMPLETE_CHUNKED_ENCODING')
+        )) return false;
+        return true;
+      });
+      expect(unexpectedResourceFailures).toEqual([]);
+
+      const bundle = await productionBundleText();
+      expect(bundle).not.toContain(`${marker} Worker`);
+      expect(bundle).not.toContain('PM Ada');
+      expect(bundle).not.toContain('task-live');
+    } catch (error) {
+      caught = error;
+    } finally {
+      await context?.close().catch(() => undefined);
+      await browser?.close().catch(() => undefined);
+      await vite?.close().catch(() => undefined);
+      await backend?.close().catch(() => undefined);
+      await rm(sessionDir, { recursive: true, force: true });
+      await rm(hermesHome, { recursive: true, force: true });
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (key === 'ambientHermes') {
+          for (const envKey of ambientHermesEnvKeys) {
+            const original = previousEnv.ambientHermes[envKey];
+            if (original === undefined) delete process.env[envKey];
+            else process.env[envKey] = original;
+          }
+          continue;
+        }
+        const envKey = {
+          hermesHome: 'HERMES_HOME',
+          kanbanDb: 'HERMES_KANBAN_DB',
+          operatorToken: 'FRANKENBEAST_BEAST_OPERATOR_TOKEN',
+          proxyTarget: 'VITE_API_PROXY_TARGET',
+        }[key]!;
+        const scalarValue = value as string | undefined;
+        if (scalarValue === undefined) delete process.env[envKey];
+        else process.env[envKey] = scalarValue;
+      }
+    }
+
+    expect(existsSync(hermesHome)).toBe(false);
+    expect(existsSync(sessionDir)).toBe(false);
+    if (caught) throw caught;
+  }, 120_000);
+});

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -239,14 +239,15 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 20_000 });
 
       await page.getByRole('button', { name: new RegExp(`Inspect ${marker} Worker`) }).click();
-      await page.getByRole('button', { name: 'Resolve blocker' }).click();
-      await expectBrowser(page.getByText('Blocker resolved; refreshing live state.')).toBeVisible({ timeout: 15_000 });
-      await expect.poll(async () => (await readTask(hermesHome, worker.id)).status).toBe('ready');
-
       await expectBrowser(page.getByRole('button', { name: 'Promote task' })).toBeEnabled();
       await page.getByRole('button', { name: 'Promote task' }).click();
       await expectBrowser(page.getByText('rejected: Runtime action was not approved by the governor')).toBeVisible();
-      expect((await readTask(hermesHome, worker.id)).status).toBe('ready');
+      expect((await readTask(hermesHome, worker.id)).status).toBe('blocked');
+
+      await page.getByRole('button', { name: 'Resolve blocker' }).click();
+      await expectBrowser(page.getByText('Blocker resolved; refreshing live state.')).toBeVisible({ timeout: 15_000 });
+      await expect.poll(async () => (await readTask(hermesHome, worker.id)).status).toBe('ready');
+      await expectBrowser(page.getByRole('button', { name: 'Promote task' })).toBeDisabled();
 
       const approvalResult = await page.evaluate(async ({ workerId }) => {
         const response = await fetch('/v1/smart-swarm/providers/hermes/actions', {

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -84,9 +84,16 @@ async function productionBundleText(): Promise<string> {
   return (await Promise.all(files.map((file) => readFile(join(assetsDir, file), 'utf8')))).join('\n');
 }
 
-function isExpectedResourceFailure(failure: string): boolean {
+type ExpectedSseInterruption = 'initial-workspace-selection' | 'forced-outage' | 'workspace-change';
+
+function isSmartSwarmSseRequest(url: string): boolean {
+  return url.includes('/v1/smart-swarm/providers/hermes/events/') && !url.endsWith('/events/ticket');
+}
+
+function isExpectedResourceFailure(failure: string, expectedSseInterruption: ExpectedSseInterruption | null = null): boolean {
   if (failure.startsWith('404 ') && failure.includes('/v1/network/')) return true;
-  return failure.includes('/events/') && (
+  return expectedSseInterruption !== null
+    && failure.includes('/v1/smart-swarm/providers/hermes/events/') && (
     failure.includes('ERR_ABORTED') || failure.includes('ERR_INCOMPLETE_CHUNKED_ENCODING')
   );
 }
@@ -96,6 +103,13 @@ describe('smart-swarm browser resource failure classification', () => {
     expect(isExpectedResourceFailure('404 http://127.0.0.1/v1/network/status')).toBe(true);
     expect(isExpectedResourceFailure('500 http://127.0.0.1/v1/network/status')).toBe(false);
     expect(isExpectedResourceFailure('net::ERR_FAILED http://127.0.0.1/v1/network/status')).toBe(false);
+  });
+
+  it('exempts only specifically identified smart-swarm SSE interruptions', () => {
+    const failure = 'net::ERR_ABORTED http://127.0.0.1/v1/smart-swarm/providers/hermes/events/stream';
+    expect(isExpectedResourceFailure(failure, 'forced-outage')).toBe(true);
+    expect(isExpectedResourceFailure(failure)).toBe(false);
+    expect(isExpectedResourceFailure('net::ERR_ABORTED http://127.0.0.1/v1/brain-vitals/events/stream', 'forced-outage')).toBe(false);
   });
 });
 
@@ -209,10 +223,22 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       context = await browser.newContext();
       const page = await context.newPage();
       const browserErrors: string[] = [];
-      const resourceFailures: string[] = [];
+      const resourceFailures: Array<{
+        failure: string;
+        requestUrl: string;
+      }> = [];
+      const expectedSseInterruptions = new Map<string, ExpectedSseInterruption>();
+      let latestSseRequestUrl: string | null = null;
+      let expectedSseReplacementReason: ExpectedSseInterruption | null = 'initial-workspace-selection';
       let ticketRequests = 0;
       page.on('request', (request) => {
         if (request.url().endsWith('/events/ticket')) ticketRequests += 1;
+        if (isSmartSwarmSseRequest(request.url())) {
+          if (latestSseRequestUrl && expectedSseReplacementReason) {
+            expectedSseInterruptions.set(latestSseRequestUrl, expectedSseReplacementReason);
+          }
+          latestSseRequestUrl = request.url();
+        }
       });
       page.on('console', (message) => {
         if (message.type() === 'error' && !message.text().startsWith('Failed to load resource:')) {
@@ -221,10 +247,18 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       });
       page.on('pageerror', (error) => browserErrors.push(error.message));
       page.on('response', (response) => {
-        if (response.status() >= 400) resourceFailures.push(`${response.status()} ${response.url()}`);
+        if (response.status() >= 400) {
+          resourceFailures.push({
+            failure: `${response.status()} ${response.url()}`,
+            requestUrl: response.url(),
+          });
+        }
       });
       page.on('requestfailed', (request) => {
-        resourceFailures.push(`${request.failure()?.errorText ?? 'request failed'} ${request.url()}`);
+        resourceFailures.push({
+          failure: `${request.failure()?.errorText ?? 'request failed'} ${request.url()}`,
+          requestUrl: request.url(),
+        });
       });
 
       await page.goto(`${dashboardUrl}#/smart-swarm`);
@@ -232,6 +266,7 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       await page.getByLabel('Runtime provider').selectOption('hermes');
       await expectBrowser(page.getByLabel('Runtime provider')).toHaveValue('hermes');
       await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 15_000 });
+      expectedSseReplacementReason = null;
       await expectBrowser(page.getByText(new RegExp(`${marker} Worker`))).toBeVisible();
       await expectBrowser(page.locator('body')).not.toContainText(secretMarker);
       await expectBrowser(page.getByText(`Depends on ${marker} PM`, { exact: true })).toBeVisible();
@@ -253,6 +288,8 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       await expectBrowser(page.getByText(new RegExp(streamedMarker))).toBeVisible({ timeout: 15_000 });
 
       const ticketRequestsBeforeRecovery = ticketRequests;
+      if (latestSseRequestUrl) expectedSseInterruptions.set(latestSseRequestUrl, 'forced-outage');
+      expectedSseReplacementReason = 'forced-outage';
       await vite.close();
       vite = undefined;
       await expectBrowser(page.getByText('Connection lost · reconnecting')).toBeVisible({ timeout: 10_000 });
@@ -265,6 +302,7 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       await vite.listen();
       await expect.poll(() => ticketRequests, { timeout: 20_000 }).toBeGreaterThan(ticketRequestsBeforeRecovery);
       await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 20_000 });
+      expectedSseReplacementReason = null;
 
       await page.getByRole('button', { name: new RegExp(`Inspect ${marker} Worker`) }).click();
       await expectBrowser(page.getByRole('button', { name: 'Promote task' })).toBeEnabled();
@@ -302,10 +340,15 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       }));
 
       await page.getByRole('button', { name: 'Close' }).click();
+      if (latestSseRequestUrl) expectedSseInterruptions.set(latestSseRequestUrl, 'workspace-change');
+      expectedSseReplacementReason = 'workspace-change';
       await page.getByLabel('Workspace').selectOption({ label: 'empty-e2e' });
       await expectBrowser(page.getByText('No runtime work in empty-e2e')).toBeVisible({ timeout: 10_000 });
+      expectedSseReplacementReason = null;
       expect(browserErrors).toEqual([]);
-      const unexpectedResourceFailures = resourceFailures.filter((failure) => !isExpectedResourceFailure(failure));
+      const unexpectedResourceFailures = resourceFailures.filter(({ failure, requestUrl }) => (
+        !isExpectedResourceFailure(failure, expectedSseInterruptions.get(requestUrl) ?? null)
+      ));
       expect(unexpectedResourceFailures).toEqual([]);
 
       const bundle = await productionBundleText();

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -9,6 +9,7 @@ import { chromium, expect as expectBrowser, type Browser, type BrowserContext } 
 import { createServer as createViteServer, type ViteDevServer } from 'vite';
 import { describe, expect, it } from 'vitest';
 import { startChatServer, type ChatServerHandle } from '../../src/http/chat-server.js';
+import { createDefaultRuntimeAdapterRegistry } from '../../src/runtime/index.js';
 
 const execFileAsync = promisify(execFile);
 const enabled = process.env['LIVE_SMART_SWARM_E2E'] === '1';
@@ -150,6 +151,16 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
         llm: { complete: async () => 'unused in smart-swarm E2E' },
         projectName: 'smart-swarm-e2e',
         operatorToken,
+        runtimeRegistry: createDefaultRuntimeAdapterRegistry({
+          command: hermesCommand,
+          hermesHome,
+          kanbanDbPath: join(hermesHome, 'kanban.db'),
+          env: {
+            ...process.env,
+            HERMES_HOME: hermesHome,
+            HERMES_KANBAN_DB: join(hermesHome, 'kanban.db'),
+          },
+        }),
       });
       process.env['VITE_API_PROXY_TARGET'] = backend.url;
 

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -96,6 +96,8 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       kanbanDb: process.env['HERMES_KANBAN_DB'],
       operatorToken: process.env['FRANKENBEAST_BEAST_OPERATOR_TOKEN'],
       proxyTarget: process.env['VITE_API_PROXY_TARGET'],
+      configFile: process.env['FRANKENBEAST_CONFIG_FILE'],
+      configPath: process.env['FRANKENBEAST_CONFIG_PATH'],
       ambientHermes: Object.fromEntries(ambientHermesEnvKeys.map((key) => [key, process.env[key]])),
     };
     let backend: ChatServerHandle | undefined;
@@ -138,6 +140,8 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       process.env['HERMES_HOME'] = hermesHome;
       process.env['HERMES_KANBAN_DB'] = join(hermesHome, 'kanban.db');
       process.env['FRANKENBEAST_BEAST_OPERATOR_TOKEN'] = operatorToken;
+      process.env['FRANKENBEAST_CONFIG_FILE'] = join(hermesHome, 'missing-frankenbeast-config.json');
+      process.env['FRANKENBEAST_CONFIG_PATH'] = join(hermesHome, 'missing-frankenbeast-config.json');
 
       backend = await startChatServer({
         host: '127.0.0.1',
@@ -236,7 +240,7 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
 
       await page.getByRole('button', { name: new RegExp(`Inspect ${marker} Worker`) }).click();
       await page.getByRole('button', { name: 'Resolve blocker' }).click();
-      await expectBrowser(page.getByText('Blocker resolved; live state refreshed.')).toBeVisible({ timeout: 15_000 });
+      await expectBrowser(page.getByText('Blocker resolved; refreshing live state.')).toBeVisible({ timeout: 15_000 });
       await expect.poll(async () => (await readTask(hermesHome, worker.id)).status).toBe('ready');
 
       await expectBrowser(page.getByRole('button', { name: 'Promote task' })).toBeEnabled();
@@ -308,6 +312,8 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
           kanbanDb: 'HERMES_KANBAN_DB',
           operatorToken: 'FRANKENBEAST_BEAST_OPERATOR_TOKEN',
           proxyTarget: 'VITE_API_PROXY_TARGET',
+          configFile: 'FRANKENBEAST_CONFIG_FILE',
+          configPath: 'FRANKENBEAST_CONFIG_PATH',
         }[key]!;
         const scalarValue = value as string | undefined;
         if (scalarValue === undefined) delete process.env[envKey];

--- a/packages/franken-web/src/lib/smart-swarm-api.test.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.test.ts
@@ -391,4 +391,44 @@ describe('SmartSwarmApiClient', () => {
     unsubscribe();
     vi.useRealTimers();
   });
+
+  it('submits provider-neutral runtime actions through the authenticated same-origin API', async () => {
+    const result = {
+      status: 'applied' as const,
+      providerId: 'hermes',
+      correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+      audit: {
+        requestedBy: 'authenticated-operator' as const,
+        actionType: 'blocker.resolve' as const,
+        targetId: 'hermes:global:t_worker',
+        outcome: 'applied' as const,
+        previousState: 'blocked',
+        currentState: 'ready',
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ data: result }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const request = {
+      correlationId: result.correlationId,
+      idempotencyKey: 'blocker.resolve:t_worker:one',
+      action: {
+        type: 'blocker.resolve' as const,
+        workspaceId: 'hermes:global',
+        taskId: 'hermes:global:t_worker',
+        reason: 'Operator resolved the blocker',
+      },
+    };
+
+    await expect(client.executeAction('hermes', request)).resolves.toEqual(result);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/actions`,
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(request),
+      },
+    );
+  });
 });

--- a/packages/franken-web/src/lib/smart-swarm-api.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.ts
@@ -133,6 +133,34 @@ export interface RuntimeEventPage {
   nextCursor: string | null;
 }
 
+export type RuntimeAction =
+  | { type: 'approval.resolve'; workspaceId: string; approvalId: string; decision: 'approve' | 'reject'; reason?: string }
+  | { type: 'blocker.add'; workspaceId: string; taskId: string; category: 'dependency' | 'needs-input' | 'capability' | 'transient'; reason: string }
+  | { type: 'blocker.resolve'; workspaceId: string; taskId: string; reason?: string }
+  | { type: 'task.pause' | 'task.resume' | 'task.cancel'; workspaceId: string; taskId: string; reason?: string }
+  | { type: 'policy.apply'; workspaceId: string; taskId: string; policy: 'promote-task'; reason: string };
+
+export interface RuntimeActionRequest {
+  correlationId: string;
+  causationId?: string;
+  idempotencyKey: string;
+  action: RuntimeAction;
+}
+
+export interface RuntimeActionAudit {
+  requestedBy: 'authenticated-operator';
+  actionType: RuntimeAction['type'];
+  targetId: string;
+  outcome: 'applied' | 'unsupported' | 'rejected' | 'failed';
+  previousState?: string;
+  currentState?: string;
+}
+
+export type RuntimeActionResult =
+  | { status: 'applied'; providerId: string; correlationId: string; replayed?: boolean; audit: RuntimeActionAudit }
+  | { status: 'unsupported' | 'rejected'; providerId: string; correlationId: string; reason: string; audit: RuntimeActionAudit }
+  | { status: 'failed'; providerId: string; correlationId: string; reason: string; audit: RuntimeActionAudit };
+
 export type RuntimeConnectionState = 'connecting' | 'connected' | 'reconnecting' | 'unavailable';
 
 export interface RuntimeSubscriptionHandlers {
@@ -171,6 +199,24 @@ export class SmartSwarmApiClient {
     if (options.activityLimit !== undefined) search.set('activityLimit', String(options.activityLimit));
     const query = search.size > 0 ? `?${search.toString()}` : '';
     return this.request(`/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/snapshot${query}`);
+  }
+
+  async executeAction(providerId: string, request: RuntimeActionRequest): Promise<RuntimeActionResult> {
+    const response = await fetch(
+      `${this.baseUrl}/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/actions`,
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(request),
+      },
+    );
+    if (!response.ok) {
+      const message = await extractResponseErrorMessage(response);
+      throw new SmartSwarmApiError(message ?? `HTTP ${response.status}`, response.status);
+    }
+    const body = await response.json() as { data: RuntimeActionResult };
+    return body.data;
   }
 
   async subscribe(

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -229,7 +229,7 @@ describe('SmartSwarmPage', () => {
         ...provider,
         capabilities: {
           ...provider.capabilities,
-          pause: { status: 'supported' },
+          cancellation: { status: 'supported' },
         },
       }]),
       subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, nextHandlers) => {
@@ -261,7 +261,7 @@ describe('SmartSwarmPage', () => {
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
     await act(async () => finishAction?.());
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Pause task' })).toHaveProperty('disabled', false));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel task' })).toHaveProperty('disabled', false));
   });
 
   it('does not leak an action completion into another task detail dialog', async () => {
@@ -585,6 +585,40 @@ describe('SmartSwarmPage', () => {
     }));
   });
 
+  it('does not expose pause when normalized state cannot keep the task resumable', async () => {
+    const executeAction = vi.fn();
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot: vi.fn().mockResolvedValue({
+        ...snapshot,
+        tasks: {
+          status: 'available',
+          data: snapshot.tasks.status === 'available'
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'running' as const } : task)
+            : [],
+        },
+      }),
+      listProviders: vi.fn().mockResolvedValue([{
+        ...provider,
+        capabilities: {
+          ...provider.capabilities,
+          pause: { status: 'supported' },
+          resume: { status: 'supported' },
+        },
+      }]),
+    })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+
+    const pause = screen.getByRole('button', { name: 'Pause task' });
+    expect(pause).toHaveProperty('disabled', true);
+    expect(pause.getAttribute('title')).toBe(
+      'Pause is disabled because normalized task state does not distinguish paused from queued work.',
+    );
+    fireEvent.click(pause);
+    expect(executeAction).not.toHaveBeenCalled();
+  });
+
   it('reports a typed failed action as failed rather than unsupported', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'failed',
@@ -641,6 +675,7 @@ describe('SmartSwarmPage', () => {
         capabilities: {
           ...provider.capabilities,
           pause: { status: 'supported' },
+          cancellation: { status: 'supported' },
           policyActions: { status: 'supported' },
         },
       }]),
@@ -650,7 +685,7 @@ describe('SmartSwarmPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Promote task' }));
 
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
-    expect(screen.getByRole('button', { name: 'Pause task' })).toHaveProperty('disabled', false);
+    expect(screen.getByRole('button', { name: 'Cancel task' })).toHaveProperty('disabled', false);
   });
 
   it.each([

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -149,6 +149,35 @@ describe('SmartSwarmPage', () => {
     await waitFor(() => expect(document.activeElement).toBe(inspect));
   });
 
+  it('keeps focus trapped when a pending action disables the focused control', async () => {
+    let finishAction: (() => void) | undefined;
+    const executeAction = vi.fn().mockImplementation(() => new Promise((resolve) => {
+      finishAction = () => resolve({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    }));
+    render(<SmartSwarmPage client={createClient({ executeAction })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    const resolveBlocker = screen.getByRole('button', { name: 'Resolve blocker' });
+    resolveBlocker.focus();
+
+    fireEvent.click(resolveBlocker);
+    expect(resolveBlocker).toHaveProperty('disabled', true);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab' });
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close' }));
+    await act(async () => finishAction?.());
+  });
+
   it('resolves a supported blocker through the runtime API and refreshes the live postcondition', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'applied',
@@ -184,6 +213,39 @@ describe('SmartSwarmPage', () => {
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
   });
 
+  it('reuses an action idempotency key after an uncertain response and rotates it after a definitive result', async () => {
+    const executeAction = vi.fn()
+      .mockRejectedValueOnce(new TypeError('network response lost'))
+      .mockResolvedValue({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    render(<SmartSwarmPage client={createClient({ executeAction })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    const resolveBlocker = screen.getByRole('button', { name: 'Resolve blocker' });
+
+    fireEvent.click(resolveBlocker);
+    await screen.findByText('network response lost');
+    fireEvent.click(resolveBlocker);
+    await screen.findByText('Blocker resolved; refreshing live state.');
+
+    const firstKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
+    const retryKey = executeAction.mock.calls[1]?.[1].idempotencyKey;
+    expect(retryKey).toBe(firstKey);
+
+    fireEvent.click(resolveBlocker);
+    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(3));
+    expect(executeAction.mock.calls[2]?.[1].idempotencyKey).not.toBe(retryKey);
+  });
+
   it('submits a governed promotion and reports a typed rejection without claiming state changed', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'rejected',
@@ -204,7 +266,7 @@ describe('SmartSwarmPage', () => {
         tasks: {
           status: 'available',
           data: snapshot.tasks.status === 'available'
-            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'ready' as const } : task)
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'blocked' as const } : task)
             : [],
         },
         blockers: { status: 'available', data: [] },
@@ -224,7 +286,7 @@ describe('SmartSwarmPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
 
     const pause = screen.getByRole('button', { name: 'Pause task' });
-    expect(pause).toHaveProperty('disabled', false);
+    expect(pause).toHaveProperty('disabled', true);
     expect(screen.getByRole('button', { name: 'Resume task' })).toHaveProperty('disabled', true);
     const cancel = screen.getByRole('button', { name: 'Cancel task' });
     expect(cancel).toHaveProperty('disabled', false);
@@ -244,6 +306,7 @@ describe('SmartSwarmPage', () => {
 
   it.each([
     ['queued', 'Resume task'],
+    ['ready', 'Promote task'],
     ['archived', 'Promote task'],
   ] as const)('keeps %s tasks out of unsafe %s actions', async (state, buttonName) => {
     render(<SmartSwarmPage client={createClient({

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -178,6 +178,32 @@ describe('SmartSwarmPage', () => {
     await act(async () => finishAction?.());
   });
 
+  it('keeps task actions locked when an in-flight request dialog is reopened', async () => {
+    let finishAction: (() => void) | undefined;
+    const executeAction = vi.fn().mockImplementation(() => new Promise((resolve) => {
+      finishAction = () => resolve({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    }));
+    render(<SmartSwarmPage client={createClient({ executeAction })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+
+    expect(screen.getByRole('button', { name: 'Resolve blocker' })).toHaveProperty('disabled', true);
+    await act(async () => finishAction?.());
+  });
+
   it('resolves a supported blocker through the runtime API and refreshes the live postcondition', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'applied',
@@ -248,6 +274,60 @@ describe('SmartSwarmPage', () => {
     const retryKey = executeAction.mock.calls[1]?.[1].idempotencyKey;
     expect(retryKey).toBe(firstKey);
   });
+
+  it('retains an uncertain action key across unrelated task state changes', async () => {
+    let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
+    let currentSnapshot = snapshot;
+    const fetchSnapshot = vi.fn().mockImplementation(async () => currentSnapshot);
+    const executeAction = vi.fn()
+      .mockRejectedValueOnce(new TypeError('network response lost'))
+      .mockResolvedValue({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot,
+      subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, nextHandlers) => {
+        handlers = nextHandlers;
+        return vi.fn();
+      }),
+    })} />);
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await screen.findByText('network response lost');
+    const uncertainKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    const baseEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!baseEvent || snapshot.tasks.status !== 'available') throw new Error('Expected runtime fixtures');
+    currentSnapshot = {
+      ...snapshot,
+      tasks: {
+        status: 'available',
+        data: snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'running' as const } : task),
+      },
+    };
+    act(() => handlers.event({ ...baseEvent, id: 'unrelated-state', cursor: 'unrelated-state' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3), { timeout: 1_000 });
+
+    currentSnapshot = snapshot;
+    act(() => handlers.event({ ...baseEvent, id: 'blocked-again', cursor: 'blocked-again' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(4), { timeout: 6_000 });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(2));
+
+    expect(executeAction.mock.calls[1]?.[1].idempotencyKey).toBe(uncertainKey);
+  }, 10_000);
 
   it('retires an uncertain action key after refreshed state confirms the postcondition', async () => {
     let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
@@ -371,6 +451,28 @@ describe('SmartSwarmPage', () => {
         reason: 'Promoted from the authenticated smart-swarm dashboard',
       },
     }));
+  });
+
+  it('reports a typed failed action as failed rather than unsupported', async () => {
+    const executeAction = vi.fn().mockResolvedValue({
+      status: 'failed',
+      providerId: 'hermes',
+      correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+      reason: 'Selected Hermes workspace is unavailable',
+      audit: {
+        requestedBy: 'authenticated-operator',
+        actionType: 'blocker.resolve',
+        targetId: 'task-live',
+        outcome: 'failed',
+      },
+    });
+    render(<SmartSwarmPage client={createClient({ executeAction })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+
+    expect(await screen.findByText('failed: Selected Hermes workspace is unavailable')).toBeDefined();
+    expect(screen.queryByText(/unsupported: Selected Hermes workspace/)).toBeNull();
   });
 
   it.each([

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -302,6 +302,51 @@ describe('SmartSwarmPage', () => {
     expect(retryKey).toBe(firstKey);
   });
 
+  it('retains an uncertain blocker key while the task remains blocked without blocker evidence', async () => {
+    let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
+    const blockerlessSnapshot = {
+      ...snapshot,
+      blockers: { status: 'available' as const, data: [] },
+    };
+    const fetchSnapshot = vi.fn().mockResolvedValue(blockerlessSnapshot);
+    const executeAction = vi.fn()
+      .mockRejectedValueOnce(new TypeError('network response lost'))
+      .mockResolvedValue({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot,
+      subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, nextHandlers) => {
+        handlers = nextHandlers;
+        return vi.fn();
+      }),
+    })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await screen.findByText('network response lost');
+    const firstKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    const baseEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!baseEvent) throw new Error('Expected an event fixture');
+    act(() => handlers.event({ ...baseEvent, id: 'still-blocked', cursor: 'still-blocked' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3), { timeout: 1_000 });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(2));
+
+    expect(executeAction.mock.calls[1]?.[1].idempotencyKey).toBe(firstKey);
+  });
+
   it('retains an uncertain action key across unrelated task state changes', async () => {
     let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
     let currentSnapshot = snapshot;
@@ -554,6 +599,7 @@ describe('SmartSwarmPage', () => {
     ['running', 'Promote task'],
     ['unknown', 'Promote task'],
     ['archived', 'Promote task'],
+    ['unknown', 'Cancel task'],
     ['archived', 'Cancel task'],
   ] as const)('keeps %s tasks out of unsafe %s actions', async (state, buttonName) => {
     render(<SmartSwarmPage client={createClient({

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -234,14 +234,17 @@ describe('SmartSwarmPage', () => {
 
     fireEvent.click(resolveBlocker);
     await screen.findByText('network response lost');
-    fireEvent.click(resolveBlocker);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    const retriedResolveBlocker = screen.getByRole('button', { name: 'Resolve blocker' });
+    fireEvent.click(retriedResolveBlocker);
     await screen.findByText('Blocker resolved; refreshing live state.');
 
     const firstKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
     const retryKey = executeAction.mock.calls[1]?.[1].idempotencyKey;
     expect(retryKey).toBe(firstKey);
 
-    fireEvent.click(resolveBlocker);
+    fireEvent.click(retriedResolveBlocker);
     await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(3));
     expect(executeAction.mock.calls[2]?.[1].idempotencyKey).not.toBe(retryKey);
   });
@@ -308,6 +311,7 @@ describe('SmartSwarmPage', () => {
     ['queued', 'Resume task'],
     ['ready', 'Promote task'],
     ['archived', 'Promote task'],
+    ['archived', 'Cancel task'],
   ] as const)('keeps %s tasks out of unsafe %s actions', async (state, buttonName) => {
     render(<SmartSwarmPage client={createClient({
       fetchSnapshot: vi.fn().mockResolvedValue({
@@ -323,6 +327,7 @@ describe('SmartSwarmPage', () => {
         ...provider,
         capabilities: {
           ...provider.capabilities,
+          cancellation: { status: 'supported' },
           resume: { status: 'supported' },
           policyActions: { status: 'supported' },
         },

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -204,6 +204,66 @@ describe('SmartSwarmPage', () => {
     await act(async () => finishAction?.());
   });
 
+  it('unlocks task actions when live state confirms the postcondition before the request resolves', async () => {
+    let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
+    let currentSnapshot = snapshot;
+    let finishAction: (() => void) | undefined;
+    const executeAction = vi.fn().mockImplementation(() => new Promise((resolve) => {
+      finishAction = () => resolve({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    }));
+    const fetchSnapshot = vi.fn().mockImplementation(async () => currentSnapshot);
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot,
+      listProviders: vi.fn().mockResolvedValue([{
+        ...provider,
+        capabilities: {
+          ...provider.capabilities,
+          pause: { status: 'supported' },
+        },
+      }]),
+      subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, nextHandlers) => {
+        handlers = nextHandlers;
+        return vi.fn();
+      }),
+    })} />);
+    await screen.findByText('Live dashboard');
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    expect(executeAction).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Resolve blocker' })).toHaveProperty('disabled', true);
+
+    currentSnapshot = {
+      ...snapshot,
+      tasks: {
+        status: 'available',
+        data: snapshot.tasks.status === 'available'
+          ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'ready' as const } : task)
+          : [],
+      },
+      blockers: { status: 'available', data: [] },
+    };
+    const baseEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!baseEvent) throw new Error('Expected an event fixture');
+    act(() => handlers.event({ ...baseEvent, id: 'early-confirmation', cursor: 'early-confirmation' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3), { timeout: 1_000 });
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    await act(async () => finishAction?.());
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Pause task' })).toHaveProperty('disabled', false));
+  });
+
   it('does not leak an action completion into another task detail dialog', async () => {
     let finishAction: (() => void) | undefined;
     const executeAction = vi.fn().mockImplementation(() => new Promise((resolve) => {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -210,10 +210,14 @@ describe('SmartSwarmPage', () => {
         reason: 'Resolved from the authenticated smart-swarm dashboard',
       },
     }));
+    expect(screen.getByRole('button', { name: 'Resolve blocker' })).toHaveProperty('disabled', true);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    expect(screen.getByRole('button', { name: 'Resolve blocker' })).toHaveProperty('disabled', true);
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
   });
 
-  it('reuses an action idempotency key after an uncertain response and rotates it after a definitive result', async () => {
+  it('reuses an action idempotency key after an uncertain response', async () => {
     const executeAction = vi.fn()
       .mockRejectedValueOnce(new TypeError('network response lost'))
       .mockResolvedValue({
@@ -243,10 +247,6 @@ describe('SmartSwarmPage', () => {
     const firstKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
     const retryKey = executeAction.mock.calls[1]?.[1].idempotencyKey;
     expect(retryKey).toBe(firstKey);
-
-    fireEvent.click(retriedResolveBlocker);
-    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(3));
-    expect(executeAction.mock.calls[2]?.[1].idempotencyKey).not.toBe(retryKey);
   });
 
   it('retires an uncertain action key after refreshed state confirms the postcondition', async () => {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -170,7 +170,7 @@ describe('SmartSwarmPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
 
-    await screen.findByText('Blocker resolved; live state refreshed.');
+    await screen.findByText('Blocker resolved; refreshing live state.');
     expect(executeAction).toHaveBeenCalledWith('hermes', expect.objectContaining({
       correlationId: expect.any(String),
       idempotencyKey: expect.any(String),
@@ -240,6 +240,35 @@ describe('SmartSwarmPage', () => {
         reason: 'Promoted from the authenticated smart-swarm dashboard',
       },
     }));
+  });
+
+  it.each([
+    ['queued', 'Resume task'],
+    ['archived', 'Promote task'],
+  ] as const)('keeps %s tasks out of unsafe %s actions', async (state, buttonName) => {
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue({
+        ...snapshot,
+        tasks: {
+          status: 'available' as const,
+          data: snapshot.tasks.status === 'available'
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state } : task)
+            : [],
+        },
+      }),
+      listProviders: vi.fn().mockResolvedValue([{
+        ...provider,
+        capabilities: {
+          ...provider.capabilities,
+          resume: { status: 'supported' },
+          policyActions: { status: 'supported' },
+        },
+      }]),
+    })} />);
+
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    expect(screen.getByRole('button', { name: buttonName })).toHaveProperty('disabled', true);
   });
 
   it('names the selected provider in a truthful empty state', async () => {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -551,6 +551,8 @@ describe('SmartSwarmPage', () => {
   it.each([
     ['queued', 'Resume task'],
     ['ready', 'Promote task'],
+    ['running', 'Promote task'],
+    ['unknown', 'Promote task'],
     ['archived', 'Promote task'],
     ['archived', 'Cancel task'],
   ] as const)('keeps %s tasks out of unsafe %s actions', async (state, buttonName) => {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -249,6 +249,72 @@ describe('SmartSwarmPage', () => {
     expect(executeAction.mock.calls[2]?.[1].idempotencyKey).not.toBe(retryKey);
   });
 
+  it('retires an uncertain action key after refreshed state confirms the postcondition', async () => {
+    let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
+    let currentSnapshot = snapshot;
+    const fetchSnapshot = vi.fn().mockImplementation(async () => currentSnapshot);
+    const executeAction = vi.fn()
+      .mockRejectedValueOnce(new TypeError('network response lost'))
+      .mockResolvedValue({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot,
+      subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, nextHandlers) => {
+        handlers = nextHandlers;
+        return vi.fn();
+      }),
+    })} />);
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await screen.findByText('network response lost');
+    const uncertainKey = executeAction.mock.calls[0]?.[1].idempotencyKey;
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    currentSnapshot = {
+      ...snapshot,
+      tasks: {
+        status: 'available',
+        data: snapshot.tasks.status === 'available'
+          ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'ready' as const } : task)
+          : [],
+      },
+      blockers: { status: 'available', data: [] },
+    };
+    const baseEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!baseEvent) throw new Error('Expected an event fixture');
+    act(() => handlers.event({ ...baseEvent, id: 'confirmed-action', cursor: 'confirmed-action' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3), { timeout: 1_000 });
+
+    currentSnapshot = {
+      ...snapshot,
+      blockers: {
+        status: 'available',
+        data: [{
+          id: 'blocker-2', workspaceId: 'board-main', taskId: 'task-live', category: 'dependency',
+          summary: 'Waiting for a new contract', createdAt: '2026-07-26T18:05:00.000Z',
+        }],
+      },
+    };
+    act(() => handlers.event({ ...baseEvent, id: 'new-blocker', cursor: 'new-blocker' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(4), { timeout: 6_000 });
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(2));
+
+    expect(executeAction.mock.calls[1]?.[1].idempotencyKey).not.toBe(uncertainKey);
+  }, 10_000);
+
   it('submits a governed promotion and reports a typed rejection without claiming state changed', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'rejected',

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -204,6 +204,33 @@ describe('SmartSwarmPage', () => {
     await act(async () => finishAction?.());
   });
 
+  it('does not leak an action completion into another task detail dialog', async () => {
+    let finishAction: (() => void) | undefined;
+    const executeAction = vi.fn().mockImplementation(() => new Promise((resolve) => {
+      finishAction = () => resolve({
+        status: 'rejected',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        reason: 'First task action rejected',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'rejected',
+        },
+      });
+    }));
+    render(<SmartSwarmPage client={createClient({ executeAction })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Contract root' }));
+
+    expect(screen.getByRole('dialog', { name: 'Contract root details' })).toBeDefined();
+    await act(async () => finishAction?.());
+    expect(screen.queryByText('rejected: First task action rejected')).toBeNull();
+  });
+
   it('resolves a supported blocker through the runtime API and refreshes the live postcondition', async () => {
     const executeAction = vi.fn().mockResolvedValue({
       status: 'applied',
@@ -473,6 +500,52 @@ describe('SmartSwarmPage', () => {
 
     expect(await screen.findByText('failed: Selected Hermes workspace is unavailable')).toBeDefined();
     expect(screen.queryByText(/unsupported: Selected Hermes workspace/)).toBeNull();
+  });
+
+  it('unlocks a promoted task when refreshed state is already running', async () => {
+    let currentSnapshot = snapshot;
+    const fetchSnapshot = vi.fn().mockImplementation(async () => currentSnapshot);
+    const executeAction = vi.fn().mockImplementation(async () => {
+      currentSnapshot = {
+        ...snapshot,
+        tasks: {
+          status: 'available',
+          data: snapshot.tasks.status === 'available'
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'running' as const } : task)
+            : [],
+        },
+        blockers: { status: 'available', data: [] },
+      };
+      return {
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'policy.apply',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      };
+    });
+    render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot,
+      listProviders: vi.fn().mockResolvedValue([{
+        ...provider,
+        capabilities: {
+          ...provider.capabilities,
+          pause: { status: 'supported' },
+          policyActions: { status: 'supported' },
+        },
+      }]),
+    })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Promote task' }));
+
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
+    expect(screen.getByRole('button', { name: 'Pause task' })).toHaveProperty('disabled', false);
   });
 
   it.each([

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -82,6 +82,19 @@ function createClient(overrides: Partial<SmartSwarmApiClient> = {}): SmartSwarmA
   return {
     listProviders: vi.fn().mockResolvedValue([provider]),
     fetchSnapshot: vi.fn().mockResolvedValue(snapshot),
+    executeAction: vi.fn().mockResolvedValue({
+      status: 'applied',
+      providerId: 'hermes',
+      correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+      audit: {
+        requestedBy: 'authenticated-operator',
+        actionType: 'blocker.resolve',
+        targetId: 'task-live',
+        outcome: 'applied',
+        previousState: 'blocked',
+        currentState: 'ready',
+      },
+    }),
     subscribe: vi.fn().mockImplementation(async (_providerId, _workspaceId, handlers) => {
       handlers.connection?.('connected');
       return vi.fn();
@@ -127,7 +140,8 @@ describe('SmartSwarmPage', () => {
 
     const close = screen.getByRole('button', { name: 'Close' });
     await waitFor(() => expect(document.activeElement).toBe(close));
-    inspect.focus();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Resolve blocker' }));
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab' });
     expect(document.activeElement).toBe(close);
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
@@ -135,8 +149,66 @@ describe('SmartSwarmPage', () => {
     await waitFor(() => expect(document.activeElement).toBe(inspect));
   });
 
-  it('keeps advertised lifecycle controls disabled until mutations are wired', async () => {
+  it('resolves a supported blocker through the runtime API and refreshes the live postcondition', async () => {
+    const executeAction = vi.fn().mockResolvedValue({
+      status: 'applied',
+      providerId: 'hermes',
+      correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+      audit: {
+        requestedBy: 'authenticated-operator',
+        actionType: 'blocker.resolve',
+        targetId: 'task-live',
+        outcome: 'applied',
+        previousState: 'blocked',
+        currentState: 'ready',
+      },
+    });
+    const fetchSnapshot = vi.fn().mockResolvedValue(snapshot);
+    render(<SmartSwarmPage client={createClient({ executeAction, fetchSnapshot })} />);
+    await screen.findByText('Live dashboard');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+
+    await screen.findByText('Blocker resolved; live state refreshed.');
+    expect(executeAction).toHaveBeenCalledWith('hermes', expect.objectContaining({
+      correlationId: expect.any(String),
+      idempotencyKey: expect.any(String),
+      action: {
+        type: 'blocker.resolve',
+        workspaceId: 'board-main',
+        taskId: 'task-live',
+        reason: 'Resolved from the authenticated smart-swarm dashboard',
+      },
+    }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
+  });
+
+  it('submits a governed promotion and reports a typed rejection without claiming state changed', async () => {
+    const executeAction = vi.fn().mockResolvedValue({
+      status: 'rejected',
+      providerId: 'hermes',
+      correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+      reason: 'Runtime action was not approved by the governor',
+      audit: {
+        requestedBy: 'authenticated-operator',
+        actionType: 'policy.apply',
+        targetId: 'task-live',
+        outcome: 'rejected',
+      },
+    });
     render(<SmartSwarmPage client={createClient({
+      executeAction,
+      fetchSnapshot: vi.fn().mockResolvedValue({
+        ...snapshot,
+        tasks: {
+          status: 'available',
+          data: snapshot.tasks.status === 'available'
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live' ? { ...task, state: 'ready' as const } : task)
+            : [],
+        },
+        blockers: { status: 'available', data: [] },
+      }),
       listProviders: vi.fn().mockResolvedValue([{
         ...provider,
         capabilities: {
@@ -144,16 +216,30 @@ describe('SmartSwarmPage', () => {
           pause: { status: 'supported' },
           resume: { status: 'supported' },
           cancellation: { status: 'supported' },
+          policyActions: { status: 'supported' },
         },
       }]),
     })} />);
     await screen.findByText('Live dashboard');
     fireEvent.click(screen.getByRole('button', { name: 'Inspect Live dashboard' }));
 
-    expect(screen.getByRole('button', { name: 'Pause task' })).toHaveProperty('disabled', true);
+    const pause = screen.getByRole('button', { name: 'Pause task' });
+    expect(pause).toHaveProperty('disabled', false);
     expect(screen.getByRole('button', { name: 'Resume task' })).toHaveProperty('disabled', true);
-    expect(screen.getByRole('button', { name: 'Cancel task' })).toHaveProperty('disabled', true);
-    expect(screen.getAllByText('This control is not wired to a runtime mutation yet.')).toHaveLength(3);
+    const cancel = screen.getByRole('button', { name: 'Cancel task' });
+    expect(cancel).toHaveProperty('disabled', false);
+    fireEvent.click(screen.getByRole('button', { name: 'Promote task' }));
+
+    expect(await screen.findByText('rejected: Runtime action was not approved by the governor')).toBeDefined();
+    expect(executeAction).toHaveBeenCalledWith('hermes', expect.objectContaining({
+      action: {
+        type: 'policy.apply',
+        workspaceId: 'board-main',
+        taskId: 'task-live',
+        policy: 'promote-task',
+        reason: 'Promoted from the authenticated smart-swarm dashboard',
+      },
+    }));
   });
 
   it('names the selected provider in a truthful empty state', async () => {

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -23,7 +23,8 @@ interface PendingActionIntent {
   idempotencyKey: string;
   providerId: string;
   taskId: string;
-  initialTaskState: RuntimeTask['state'];
+  action: RuntimeAction['type'];
+  inFlight: boolean;
   awaitingConfirmation: boolean;
 }
 
@@ -43,6 +44,27 @@ function errorMessage(error: unknown): string {
 
 function capabilityReason(capability: RuntimeCapability): string | null {
   return capability.status === 'unsupported' ? capability.reason : null;
+}
+
+function actionPostconditionConfirmed(
+  intent: PendingActionIntent,
+  task: RuntimeTask,
+  blockers: Array<{ taskId: string }> | null,
+): boolean {
+  switch (intent.action) {
+    case 'blocker.resolve':
+      return blockers !== null && !blockers.some((blocker) => blocker.taskId === intent.taskId);
+    case 'task.cancel':
+      return task.state === 'cancelled';
+    case 'policy.apply':
+      return task.state === 'ready';
+    case 'task.pause':
+      return task.state === 'queued';
+    case 'task.resume':
+      return task.state === 'ready' || task.state === 'running';
+    default:
+      return false;
+  }
 }
 
 function taskActivityRank(state: RuntimeTask['state']): number {
@@ -223,6 +245,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
     ? [...(available(snapshot.blockers) ?? [])]
       .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt) || left.id.localeCompare(right.id))
     : [];
+  const confirmedBlockers = snapshot?.blockers.status === 'available' ? blockers : null;
   const approvals = snapshot
     ? [...(available(snapshot.approvals) ?? [])]
       .sort((left, right) => {
@@ -233,16 +256,24 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
       })
     : [];
   const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? null;
+  const selectedTaskActionPending = selectedTask
+    ? [...actionIdempotencyKeys.current.values()].some((intent) => (
+        intent.providerId === providerId
+        && intent.taskId === selectedTask.id
+        && (intent.inFlight || intent.awaitingConfirmation)
+        && !actionPostconditionConfirmed(intent, selectedTask, confirmedBlockers)
+      ))
+    : false;
 
   useEffect(() => {
     for (const [key, intent] of actionIdempotencyKeys.current) {
       if (intent.providerId !== providerId) continue;
       const currentTask = tasks.find((task) => task.id === intent.taskId);
-      if (currentTask && currentTask.state !== intent.initialTaskState) {
+      if (currentTask && actionPostconditionConfirmed(intent, currentTask, confirmedBlockers)) {
         actionIdempotencyKeys.current.delete(key);
       }
     }
-  }, [providerId, tasks]);
+  }, [confirmedBlockers, providerId, tasks]);
 
   const taskNames = useMemo(() => new Map(tasks.map((task) => [task.id, task.title])), [tasks]);
   const newestUnfinishedRunByTask = useMemo(() => {
@@ -656,6 +687,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
       {selectedTask && provider ? (
         <TaskDetail
           actionIdempotencyKeys={actionIdempotencyKeys.current}
+          actionPendingFromStore={selectedTaskActionPending}
           client={client}
           onActionApplied={() => setRefreshNonce((current) => current + 1)}
           onClose={() => setSelectedTaskId(null)}
@@ -672,26 +704,23 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   );
 }
 
-function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempotencyKeys, onActionApplied, onClose }: {
+function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempotencyKeys, actionPendingFromStore, onActionApplied, onClose }: {
   task: RuntimeTask;
   provider: RuntimeProvider;
   runs: RuntimeSnapshot['runs'] extends RuntimeSection<infer T> ? T : never;
   client: SmartSwarmApiClient;
   returnFocus: HTMLButtonElement | null;
   actionIdempotencyKeys: Map<string, PendingActionIntent>;
+  actionPendingFromStore: boolean;
   onActionApplied(): void;
   onClose(): void;
 }) {
   const closeButton = useRef<HTMLButtonElement | null>(null);
-  const previousTaskState = useRef(task.state);
-  const actionIntentPrefix = `${provider.id}:${task.id}:`;
-  const [actionPending, setActionPending] = useState(() => [...actionIdempotencyKeys.entries()]
-    .some(([key, intent]) => key.startsWith(actionIntentPrefix) && intent.awaitingConfirmation));
+  const [actionPending, setActionPending] = useState(actionPendingFromStore);
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   useEffect(() => {
-    if (previousTaskState.current !== task.state) setActionPending(false);
-    previousTaskState.current = task.state;
-  }, [task.state]);
+    setActionPending(actionPendingFromStore);
+  }, [actionPendingFromStore]);
   useEffect(() => {
     closeButton.current?.focus();
     return () => {
@@ -734,13 +763,16 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
       const actionIntentKey = `${provider.id}:${task.id}:${action}`;
       const pendingIntent = actionIdempotencyKeys.get(actionIntentKey);
       const idempotencyKey = pendingIntent?.idempotencyKey ?? `${action}:${crypto.randomUUID()}`;
-      actionIdempotencyKeys.set(actionIntentKey, pendingIntent ?? {
+      const actionIntent = pendingIntent ?? {
         idempotencyKey,
         providerId: provider.id,
         taskId: task.id,
-        initialTaskState: task.state,
+        action,
+        inFlight: true,
         awaitingConfirmation: false,
-      });
+      };
+      actionIntent.inFlight = true;
+      actionIdempotencyKeys.set(actionIntentKey, actionIntent);
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
         idempotencyKey,
@@ -755,6 +787,9 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
       } else if (result.status === 'rejected') {
         actionIdempotencyKeys.delete(actionIntentKey);
         setActionStatus(`rejected: ${result.reason}`);
+      } else if (result.status === 'failed') {
+        actionIdempotencyKeys.delete(actionIntentKey);
+        setActionStatus(`failed: ${result.reason}`);
       } else {
         actionIdempotencyKeys.delete(actionIntentKey);
         setActionStatus(`unsupported: ${result.reason}`);
@@ -762,6 +797,8 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
     } catch (error) {
       setActionStatus(errorMessage(error));
     } finally {
+      const pendingIntent = actionIdempotencyKeys.get(`${provider.id}:${task.id}:${action}`);
+      if (pendingIntent) pendingIntent.inFlight = false;
       if (!awaitingConfirmation) setActionPending(false);
     }
   }

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -783,8 +783,10 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
       });
       if (result.status === 'applied') {
         const appliedIntent = actionIdempotencyKeys.get(actionIntentKey);
-        if (appliedIntent) appliedIntent.awaitingConfirmation = true;
-        awaitingConfirmation = true;
+        if (appliedIntent) {
+          appliedIntent.awaitingConfirmation = true;
+          awaitingConfirmation = true;
+        }
         setActionStatus(successMessage);
         onActionApplied();
       } else if (result.status === 'rejected') {

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -731,6 +731,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
     };
   }, [returnFocus]);
   const pauseReason = capabilityReason(provider.capabilities.pause);
+  const pauseStateReason = 'Pause is disabled because normalized task state does not distinguish paused from queued work.';
   const resumeReason = capabilityReason(provider.capabilities.resume);
   const resumeStateReason = 'Resume is disabled because normalized task state does not distinguish paused from queued work.';
   const cancelReason = capabilityReason(provider.capabilities.cancellation);
@@ -867,7 +868,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
           </>
         ) : null}
         <button
-          disabled={actionPending || pauseReason !== null || (task.state !== 'ready' && task.state !== 'running')}
+          disabled
           onClick={() => {
             void executeTaskAction(
               'task.pause',
@@ -875,7 +876,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
               'Task paused; refreshing live state.',
             );
           }}
-          title={pauseReason ?? undefined}
+          title={pauseReason ?? pauseStateReason}
           type="button"
         >Pause task</button>
         {pauseReason ? <p>{pauseReason}</p> : null}

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -57,7 +57,7 @@ function actionPostconditionConfirmed(
     case 'task.cancel':
       return task.state === 'cancelled';
     case 'policy.apply':
-      return task.state === 'ready';
+      return task.state === 'ready' || task.state === 'running';
     case 'task.pause':
       return task.state === 'queued';
     case 'task.resume':
@@ -689,6 +689,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           actionIdempotencyKeys={actionIdempotencyKeys.current}
           actionPendingFromStore={selectedTaskActionPending}
           client={client}
+          key={`${provider.id}:${selectedTask.id}`}
           onActionApplied={() => setRefreshNonce((current) => current + 1)}
           onClose={() => setSelectedTaskId(null)}
           provider={provider}

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -53,7 +53,9 @@ function actionPostconditionConfirmed(
 ): boolean {
   switch (intent.action) {
     case 'blocker.resolve':
-      return blockers !== null && !blockers.some((blocker) => blocker.taskId === intent.taskId);
+      return task.state !== 'blocked'
+        && blockers !== null
+        && !blockers.some((blocker) => blocker.taskId === intent.taskId);
     case 'task.cancel':
       return task.state === 'cancelled';
     case 'policy.apply':
@@ -889,7 +891,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
         >Resume task</button>
         {resumeReason ? <p>{resumeReason}</p> : null}
         <button
-          disabled={actionPending || cancelReason !== null || task.state === 'succeeded' || task.state === 'failed' || task.state === 'cancelled' || task.state === 'archived'}
+          disabled={actionPending || cancelReason !== null || !['queued', 'ready', 'running', 'blocked'].includes(task.state)}
           onClick={() => {
             void executeTaskAction(
               'task.cancel',

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -672,9 +672,13 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
   }, [returnFocus]);
   const pauseReason = capabilityReason(provider.capabilities.pause);
   const resumeReason = capabilityReason(provider.capabilities.resume);
+  const resumeStateReason = 'Resume is disabled because normalized task state does not distinguish paused from queued work.';
   const cancelReason = capabilityReason(provider.capabilities.cancellation);
   const policyReason = capabilityReason(provider.capabilities.policyActions);
   const blockerReason = capabilityReason(provider.capabilities.blockers);
+  const policyStateReason = ['succeeded', 'failed', 'cancelled', 'archived'].includes(task.state)
+    ? 'Terminal and archived tasks cannot be promoted.'
+    : null;
 
   async function executeTaskAction(
     action: 'blocker.resolve' | 'task.pause' | 'task.resume' | 'task.cancel' | 'policy.apply',
@@ -762,7 +766,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
                 void executeTaskAction(
                   'blocker.resolve',
                   'Resolved from the authenticated smart-swarm dashboard',
-                  'Blocker resolved; live state refreshed.',
+                  'Blocker resolved; refreshing live state.',
                 );
               }}
               title={blockerReason ?? undefined}
@@ -777,7 +781,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
             void executeTaskAction(
               'task.pause',
               'Paused from the authenticated smart-swarm dashboard',
-              'Task paused; live state refreshed.',
+              'Task paused; refreshing live state.',
             );
           }}
           title={pauseReason ?? undefined}
@@ -785,15 +789,15 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
         >Pause task</button>
         {pauseReason ? <p>{pauseReason}</p> : null}
         <button
-          disabled={actionPending || resumeReason !== null || task.state !== 'queued'}
+          disabled
           onClick={() => {
             void executeTaskAction(
               'task.resume',
               'Resumed from the authenticated smart-swarm dashboard',
-              'Task resumed; live state refreshed.',
+              'Task resumed; refreshing live state.',
             );
           }}
-          title={resumeReason ?? undefined}
+          title={resumeReason ?? resumeStateReason}
           type="button"
         >Resume task</button>
         {resumeReason ? <p>{resumeReason}</p> : null}
@@ -803,7 +807,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
             void executeTaskAction(
               'task.cancel',
               'Cancelled from the authenticated smart-swarm dashboard',
-              'Task cancelled; live state refreshed.',
+              'Task cancelled; refreshing live state.',
             );
           }}
           title={cancelReason ?? undefined}
@@ -811,15 +815,15 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
         >Cancel task</button>
         {cancelReason ? <p>{cancelReason}</p> : null}
         <button
-          disabled={actionPending || policyReason !== null || task.state === 'succeeded' || task.state === 'cancelled'}
+          disabled={actionPending || policyReason !== null || policyStateReason !== null}
           onClick={() => {
             void executeTaskAction(
               'policy.apply',
               'Promoted from the authenticated smart-swarm dashboard',
-              'Task promoted; live state refreshed.',
+              'Task promoted; refreshing live state.',
             );
           }}
-          title={policyReason ?? undefined}
+          title={policyReason ?? policyStateReason ?? undefined}
           type="button"
         >Promote task</button>
         {policyReason ? <p>{policyReason}</p> : null}

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -734,8 +734,8 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
   const cancelReason = capabilityReason(provider.capabilities.cancellation);
   const policyReason = capabilityReason(provider.capabilities.policyActions);
   const blockerReason = capabilityReason(provider.capabilities.blockers);
-  const policyStateReason = ['ready', 'succeeded', 'failed', 'cancelled', 'archived'].includes(task.state)
-    ? 'Ready, terminal, and archived tasks cannot be promoted.'
+  const policyStateReason = !['blocked', 'queued'].includes(task.state)
+    ? 'Only blocked and queued tasks can be promoted.'
     : null;
 
   async function executeTaskAction(

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   SmartSwarmApiError,
   type RuntimeAgent,
+  type RuntimeAction,
   type RuntimeCapability,
   type RuntimeConnectionState,
   type RuntimeEvent,
@@ -635,6 +636,8 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
 
       {selectedTask && provider ? (
         <TaskDetail
+          client={client}
+          onActionApplied={() => setRefreshNonce((current) => current + 1)}
           onClose={() => setSelectedTaskId(null)}
           provider={provider}
           returnFocus={taskDetailTrigger.current}
@@ -649,24 +652,69 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   );
 }
 
-function TaskDetail({ task, provider, runs, returnFocus, onClose }: {
+function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied, onClose }: {
   task: RuntimeTask;
   provider: RuntimeProvider;
   runs: RuntimeSnapshot['runs'] extends RuntimeSection<infer T> ? T : never;
+  client: SmartSwarmApiClient;
   returnFocus: HTMLButtonElement | null;
+  onActionApplied(): void;
   onClose(): void;
 }) {
   const closeButton = useRef<HTMLButtonElement | null>(null);
+  const [actionPending, setActionPending] = useState(false);
+  const [actionStatus, setActionStatus] = useState<string | null>(null);
   useEffect(() => {
     closeButton.current?.focus();
     return () => {
       if (returnFocus?.isConnected) returnFocus.focus();
     };
   }, [returnFocus]);
-  const unwiredReason = 'This control is not wired to a runtime mutation yet.';
-  const pauseReason = capabilityReason(provider.capabilities.pause) ?? unwiredReason;
-  const resumeReason = capabilityReason(provider.capabilities.resume) ?? unwiredReason;
-  const cancelReason = capabilityReason(provider.capabilities.cancellation) ?? unwiredReason;
+  const pauseReason = capabilityReason(provider.capabilities.pause);
+  const resumeReason = capabilityReason(provider.capabilities.resume);
+  const cancelReason = capabilityReason(provider.capabilities.cancellation);
+  const policyReason = capabilityReason(provider.capabilities.policyActions);
+  const blockerReason = capabilityReason(provider.capabilities.blockers);
+
+  async function executeTaskAction(
+    action: 'blocker.resolve' | 'task.pause' | 'task.resume' | 'task.cancel' | 'policy.apply',
+    reason: string,
+    successMessage: string,
+  ): Promise<void> {
+    setActionPending(true);
+    setActionStatus(null);
+    try {
+      const runtimeAction: RuntimeAction = action === 'policy.apply'
+        ? {
+            type: action,
+            workspaceId: task.workspaceId,
+            taskId: task.id,
+            policy: 'promote-task',
+            reason,
+          }
+        : {
+            type: action,
+            workspaceId: task.workspaceId,
+            taskId: task.id,
+            reason,
+          };
+      const result = await client.executeAction(provider.id, {
+        correlationId: crypto.randomUUID(),
+        idempotencyKey: `${action}:${crypto.randomUUID()}`,
+        action: runtimeAction,
+      });
+      if (result.status === 'applied') {
+        setActionStatus(successMessage);
+        onActionApplied();
+      } else {
+        setActionStatus(`${result.status}: ${result.reason}`);
+      }
+    } catch (error) {
+      setActionStatus(errorMessage(error));
+    } finally {
+      setActionPending(false);
+    }
+  }
   return (
     <section
       aria-label={`${task.title} details`}
@@ -677,8 +725,16 @@ function TaskDetail({ task, provider, runs, returnFocus, onClose }: {
           event.preventDefault();
           onClose();
         } else if (event.key === 'Tab') {
-          event.preventDefault();
-          closeButton.current?.focus();
+          const focusable = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
+          const first = focusable[0];
+          const last = focusable.at(-1);
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last?.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first?.focus();
+          }
         }
       }}
       role="dialog"
@@ -698,12 +754,76 @@ function TaskDetail({ task, provider, runs, returnFocus, onClose }: {
       </section>
       <section className="smart-swarm-actions" aria-label="Task lifecycle controls">
         <h4>Capability-driven controls</h4>
-        <button disabled title={pauseReason} type="button">Pause task</button>
+        {task.state === 'blocked' ? (
+          <>
+            <button
+              disabled={actionPending || blockerReason !== null}
+              onClick={() => {
+                void executeTaskAction(
+                  'blocker.resolve',
+                  'Resolved from the authenticated smart-swarm dashboard',
+                  'Blocker resolved; live state refreshed.',
+                );
+              }}
+              title={blockerReason ?? undefined}
+              type="button"
+            >Resolve blocker</button>
+            {blockerReason ? <p>{blockerReason}</p> : null}
+          </>
+        ) : null}
+        <button
+          disabled={actionPending || pauseReason !== null || (task.state !== 'ready' && task.state !== 'running')}
+          onClick={() => {
+            void executeTaskAction(
+              'task.pause',
+              'Paused from the authenticated smart-swarm dashboard',
+              'Task paused; live state refreshed.',
+            );
+          }}
+          title={pauseReason ?? undefined}
+          type="button"
+        >Pause task</button>
         {pauseReason ? <p>{pauseReason}</p> : null}
-        <button disabled title={resumeReason} type="button">Resume task</button>
+        <button
+          disabled={actionPending || resumeReason !== null || task.state !== 'queued'}
+          onClick={() => {
+            void executeTaskAction(
+              'task.resume',
+              'Resumed from the authenticated smart-swarm dashboard',
+              'Task resumed; live state refreshed.',
+            );
+          }}
+          title={resumeReason ?? undefined}
+          type="button"
+        >Resume task</button>
         {resumeReason ? <p>{resumeReason}</p> : null}
-        <button disabled title={cancelReason} type="button">Cancel task</button>
+        <button
+          disabled={actionPending || cancelReason !== null || task.state === 'succeeded' || task.state === 'failed' || task.state === 'cancelled'}
+          onClick={() => {
+            void executeTaskAction(
+              'task.cancel',
+              'Cancelled from the authenticated smart-swarm dashboard',
+              'Task cancelled; live state refreshed.',
+            );
+          }}
+          title={cancelReason ?? undefined}
+          type="button"
+        >Cancel task</button>
         {cancelReason ? <p>{cancelReason}</p> : null}
+        <button
+          disabled={actionPending || policyReason !== null || task.state === 'succeeded' || task.state === 'cancelled'}
+          onClick={() => {
+            void executeTaskAction(
+              'policy.apply',
+              'Promoted from the authenticated smart-swarm dashboard',
+              'Task promoted; live state refreshed.',
+            );
+          }}
+          title={policyReason ?? undefined}
+          type="button"
+        >Promote task</button>
+        {policyReason ? <p>{policyReason}</p> : null}
+        {actionStatus ? <p role="status">{actionStatus}</p> : null}
       </section>
     </section>
   );

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -19,6 +19,13 @@ interface SmartSwarmPageProps {
   client: SmartSwarmApiClient;
 }
 
+interface PendingActionIntent {
+  idempotencyKey: string;
+  providerId: string;
+  taskId: string;
+  initialTaskState: RuntimeTask['state'];
+}
+
 const MAX_VISIBLE_TASKS = 200;
 const MAX_VISIBLE_EVIDENCE = 100;
 const STREAM_REFRESH_DEBOUNCE_MS = 250;
@@ -195,7 +202,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const currentWorkspaceId = useRef(workspaceId);
   currentWorkspaceId.current = workspaceId;
   const taskDetailTrigger = useRef<HTMLButtonElement | null>(null);
-  const actionIdempotencyKeys = useRef(new Map<string, string>());
+  const actionIdempotencyKeys = useRef(new Map<string, PendingActionIntent>());
 
   const provider = providers.find((candidate) => candidate.id === providerId);
   const error = snapshotError ?? providerError ?? workspaceCatalogError ?? streamError;
@@ -225,6 +232,16 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
       })
     : [];
   const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? null;
+
+  useEffect(() => {
+    for (const [key, intent] of actionIdempotencyKeys.current) {
+      if (intent.providerId !== providerId) continue;
+      const currentTask = tasks.find((task) => task.id === intent.taskId);
+      if (currentTask && currentTask.state !== intent.initialTaskState) {
+        actionIdempotencyKeys.current.delete(key);
+      }
+    }
+  }, [providerId, tasks]);
 
   const taskNames = useMemo(() => new Map(tasks.map((task) => [task.id, task.title])), [tasks]);
   const newestUnfinishedRunByTask = useMemo(() => {
@@ -660,7 +677,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
   runs: RuntimeSnapshot['runs'] extends RuntimeSection<infer T> ? T : never;
   client: SmartSwarmApiClient;
   returnFocus: HTMLButtonElement | null;
-  actionIdempotencyKeys: Map<string, string>;
+  actionIdempotencyKeys: Map<string, PendingActionIntent>;
   onActionApplied(): void;
   onClose(): void;
 }) {
@@ -706,9 +723,14 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
             reason,
           };
       const actionIntentKey = `${provider.id}:${task.id}:${action}`;
-      const idempotencyKey = actionIdempotencyKeys.get(actionIntentKey)
-        ?? `${action}:${crypto.randomUUID()}`;
-      actionIdempotencyKeys.set(actionIntentKey, idempotencyKey);
+      const pendingIntent = actionIdempotencyKeys.get(actionIntentKey);
+      const idempotencyKey = pendingIntent?.idempotencyKey ?? `${action}:${crypto.randomUUID()}`;
+      actionIdempotencyKeys.set(actionIntentKey, pendingIntent ?? {
+        idempotencyKey,
+        providerId: provider.id,
+        taskId: task.id,
+        initialTaskState: task.state,
+      });
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
         idempotencyKey,

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -24,6 +24,7 @@ interface PendingActionIntent {
   providerId: string;
   taskId: string;
   initialTaskState: RuntimeTask['state'];
+  awaitingConfirmation: boolean;
 }
 
 const MAX_VISIBLE_TASKS = 200;
@@ -682,8 +683,15 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
   onClose(): void;
 }) {
   const closeButton = useRef<HTMLButtonElement | null>(null);
-  const [actionPending, setActionPending] = useState(false);
+  const previousTaskState = useRef(task.state);
+  const actionIntentPrefix = `${provider.id}:${task.id}:`;
+  const [actionPending, setActionPending] = useState(() => [...actionIdempotencyKeys.entries()]
+    .some(([key, intent]) => key.startsWith(actionIntentPrefix) && intent.awaitingConfirmation));
   const [actionStatus, setActionStatus] = useState<string | null>(null);
+  useEffect(() => {
+    if (previousTaskState.current !== task.state) setActionPending(false);
+    previousTaskState.current = task.state;
+  }, [task.state]);
   useEffect(() => {
     closeButton.current?.focus();
     return () => {
@@ -707,6 +715,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
   ): Promise<void> {
     setActionPending(true);
     setActionStatus(null);
+    let awaitingConfirmation = false;
     try {
       const runtimeAction: RuntimeAction = action === 'policy.apply'
         ? {
@@ -730,23 +739,30 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
         providerId: provider.id,
         taskId: task.id,
         initialTaskState: task.state,
+        awaitingConfirmation: false,
       });
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
         idempotencyKey,
         action: runtimeAction,
       });
-      actionIdempotencyKeys.delete(actionIntentKey);
       if (result.status === 'applied') {
+        const appliedIntent = actionIdempotencyKeys.get(actionIntentKey);
+        if (appliedIntent) appliedIntent.awaitingConfirmation = true;
+        awaitingConfirmation = true;
         setActionStatus(successMessage);
         onActionApplied();
+      } else if (result.status === 'rejected') {
+        actionIdempotencyKeys.delete(actionIntentKey);
+        setActionStatus(`rejected: ${result.reason}`);
       } else {
-        setActionStatus(`${result.status}: ${result.reason}`);
+        actionIdempotencyKeys.delete(actionIntentKey);
+        setActionStatus(`unsupported: ${result.reason}`);
       }
     } catch (error) {
       setActionStatus(errorMessage(error));
     } finally {
-      setActionPending(false);
+      if (!awaitingConfirmation) setActionPending(false);
     }
   }
   return (

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -662,6 +662,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
   onClose(): void;
 }) {
   const closeButton = useRef<HTMLButtonElement | null>(null);
+  const actionIdempotencyKeys = useRef(new Map<string, string>());
   const [actionPending, setActionPending] = useState(false);
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   useEffect(() => {
@@ -676,8 +677,8 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
   const cancelReason = capabilityReason(provider.capabilities.cancellation);
   const policyReason = capabilityReason(provider.capabilities.policyActions);
   const blockerReason = capabilityReason(provider.capabilities.blockers);
-  const policyStateReason = ['succeeded', 'failed', 'cancelled', 'archived'].includes(task.state)
-    ? 'Terminal and archived tasks cannot be promoted.'
+  const policyStateReason = ['ready', 'succeeded', 'failed', 'cancelled', 'archived'].includes(task.state)
+    ? 'Ready, terminal, and archived tasks cannot be promoted.'
     : null;
 
   async function executeTaskAction(
@@ -702,11 +703,15 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
             taskId: task.id,
             reason,
           };
+      const idempotencyKey = actionIdempotencyKeys.current.get(action)
+        ?? `${action}:${crypto.randomUUID()}`;
+      actionIdempotencyKeys.current.set(action, idempotencyKey);
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
-        idempotencyKey: `${action}:${crypto.randomUUID()}`,
+        idempotencyKey,
         action: runtimeAction,
       });
+      actionIdempotencyKeys.current.delete(action);
       if (result.status === 'applied') {
         setActionStatus(successMessage);
         onActionApplied();
@@ -732,7 +737,10 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
           const focusable = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
           const first = focusable[0];
           const last = focusable.at(-1);
-          if (event.shiftKey && document.activeElement === first) {
+          if (!focusable.some((element) => element === document.activeElement)) {
+            event.preventDefault();
+            (event.shiftKey ? last : first)?.focus();
+          } else if (event.shiftKey && document.activeElement === first) {
             event.preventDefault();
             last?.focus();
           } else if (!event.shiftKey && document.activeElement === last) {

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -195,6 +195,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const currentWorkspaceId = useRef(workspaceId);
   currentWorkspaceId.current = workspaceId;
   const taskDetailTrigger = useRef<HTMLButtonElement | null>(null);
+  const actionIdempotencyKeys = useRef(new Map<string, string>());
 
   const provider = providers.find((candidate) => candidate.id === providerId);
   const error = snapshotError ?? providerError ?? workspaceCatalogError ?? streamError;
@@ -636,6 +637,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
 
       {selectedTask && provider ? (
         <TaskDetail
+          actionIdempotencyKeys={actionIdempotencyKeys.current}
           client={client}
           onActionApplied={() => setRefreshNonce((current) => current + 1)}
           onClose={() => setSelectedTaskId(null)}
@@ -652,17 +654,17 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   );
 }
 
-function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied, onClose }: {
+function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempotencyKeys, onActionApplied, onClose }: {
   task: RuntimeTask;
   provider: RuntimeProvider;
   runs: RuntimeSnapshot['runs'] extends RuntimeSection<infer T> ? T : never;
   client: SmartSwarmApiClient;
   returnFocus: HTMLButtonElement | null;
+  actionIdempotencyKeys: Map<string, string>;
   onActionApplied(): void;
   onClose(): void;
 }) {
   const closeButton = useRef<HTMLButtonElement | null>(null);
-  const actionIdempotencyKeys = useRef(new Map<string, string>());
   const [actionPending, setActionPending] = useState(false);
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   useEffect(() => {
@@ -703,15 +705,16 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
             taskId: task.id,
             reason,
           };
-      const idempotencyKey = actionIdempotencyKeys.current.get(action)
+      const actionIntentKey = `${provider.id}:${task.id}:${action}`;
+      const idempotencyKey = actionIdempotencyKeys.get(actionIntentKey)
         ?? `${action}:${crypto.randomUUID()}`;
-      actionIdempotencyKeys.current.set(action, idempotencyKey);
+      actionIdempotencyKeys.set(actionIntentKey, idempotencyKey);
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
         idempotencyKey,
         action: runtimeAction,
       });
-      actionIdempotencyKeys.current.delete(action);
+      actionIdempotencyKeys.delete(actionIntentKey);
       if (result.status === 'applied') {
         setActionStatus(successMessage);
         onActionApplied();
@@ -810,7 +813,7 @@ function TaskDetail({ task, provider, runs, client, returnFocus, onActionApplied
         >Resume task</button>
         {resumeReason ? <p>{resumeReason}</p> : null}
         <button
-          disabled={actionPending || cancelReason !== null || task.state === 'succeeded' || task.state === 'failed' || task.state === 'cancelled'}
+          disabled={actionPending || cancelReason !== null || task.state === 'succeeded' || task.state === 'failed' || task.state === 'cancelled' || task.state === 'archived'}
           onClick={() => {
             void executeTaskAction(
               'task.cancel',

--- a/scripts/major-outdated-baseline.json
+++ b/scripts/major-outdated-baseline.json
@@ -223,11 +223,31 @@
     "name": "jsdom",
     "dependent": "@franken/web",
     "location": "node_modules/jsdom",
-    "currentMajor": 25,
-    "latestMajor": 29,
-    "current": "25.0.1",
-    "latest": "29.1.1",
-    "reason": "Existing direct major-version gap present when the CI guard was introduced for issue #1414."
+    "currentMajor": 29,
+    "latestMajor": 30,
+    "current": "29.1.1",
+    "latest": "30.0.0",
+    "reason": "Upstream released JSDOM 30 after PR #3869 was verified; retain JSDOM 29 until the major upgrade receives dedicated browser-test compatibility validation."
+  },
+  {
+    "name": "jsdom",
+    "dependent": "frankenbeast",
+    "location": "node_modules/jsdom",
+    "currentMajor": 29,
+    "latestMajor": 30,
+    "current": "29.1.1",
+    "latest": "30.0.0",
+    "reason": "Upstream released JSDOM 30 after PR #3869 was verified; retain JSDOM 29 until the major upgrade receives dedicated browser-test compatibility validation."
+  },
+  {
+    "name": "openai",
+    "dependent": "@franken/orchestrator",
+    "location": "node_modules/openai",
+    "currentMajor": 6,
+    "latestMajor": 7,
+    "current": "6.48.0",
+    "latest": "7.0.0",
+    "reason": "Upstream released OpenAI 7 after PR #3869 was verified; retain OpenAI 6 until the major upgrade receives dedicated compatibility validation."
   },
   {
     "name": "react",

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -20,5 +20,6 @@
 - [x] Remediate third-round Codex findings with RED→GREEN tests for remount-safe uncertain-action idempotency and archived-task cancellation guards.
 - [x] Remediate fourth-round Codex findings with snapshot-confirmed intent retirement, explicit Hermes command registry wiring, and isolated manual backend state.
 - [x] Remediate fifth-round Codex findings by retaining applied-action locks through snapshot confirmation, removing the Vite-prefixed secret alias, and isolating the E2E registry to Hermes.
+- [x] Remediate sixth-round Codex findings with typed failed outcomes, remount-safe in-flight locks, and action-specific uncertain-key postconditions.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -26,5 +26,10 @@
 - [x] Remediate ninth-round Codex findings with blocked-state confirmation and fail-closed cancellation eligibility.
 - [x] Restore the repository dependency-freshness gate after OpenAI 7 and JSDOM 30 registry drift with exact dependent/location-scoped baselines and RED→GREEN checked-baseline regressions; no opportunistic major upgrade.
 - [x] Re-run the live dependency guard, 24/24 guard tests, serial orchestrator suite (4,887/4,887), root lint/typecheck/build, and `git diff --check`. The first concurrent full-suite run exposed eight load-sensitive orchestrator failures; all passed unchanged in the isolated serial rerun. The first pushed guard regression exposed a CI-only checkout-name mismatch, corrected by using the canonical root package identity `frankenbeast`.
-- [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
+- [x] Reproduce the tenth-round early-confirmation and over-broad SSE exemption findings with focused RED tests.
+- [x] Verify the preserved minimal remediations with 64/64 focused web tests and 2/2 active E2E-classifier tests.
+- [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root test runner's sole unhandled Codex app-server rejection passed unchanged in the serial rerun.
+- [ ] Commit and push the tenth-round remediation with the required identity.
+- [ ] Reply to and resolve both current-head Codex threads.
+- [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -21,5 +21,6 @@
 - [x] Remediate fourth-round Codex findings with snapshot-confirmed intent retirement, explicit Hermes command registry wiring, and isolated manual backend state.
 - [x] Remediate fifth-round Codex findings by retaining applied-action locks through snapshot confirmation, removing the Vite-prefixed secret alias, and isolating the E2E registry to Hermes.
 - [x] Remediate sixth-round Codex findings with typed failed outcomes, remount-safe in-flight locks, and action-specific uncertain-key postconditions.
+- [x] Remediate seventh-round Codex findings with running promotion confirmation, task-keyed dialog state, and strict network-404 failure exemption.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -22,5 +22,6 @@
 - [x] Remediate fifth-round Codex findings by retaining applied-action locks through snapshot confirmation, removing the Vite-prefixed secret alias, and isolating the E2E registry to Hermes.
 - [x] Remediate sixth-round Codex findings with typed failed outcomes, remount-safe in-flight locks, and action-specific uncertain-key postconditions.
 - [x] Remediate seventh-round Codex findings with running promotion confirmation, task-keyed dialog state, and strict network-404 failure exemption.
+- [x] Remediate eighth-round Codex finding by allowlisting only blocked and queued tasks for promotion.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -31,5 +31,7 @@
 - [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root runner's seven load-sensitive orchestrator failures and one unhandled rejection all passed unchanged in the serial rerun.
 - [x] Commit and push the tenth-round remediation as `44b5a3839` with the required identity.
 - [x] Reply to and resolve both current-head Codex threads; fully paginated GraphQL audit reports zero unresolved Codex-authored threads.
-- [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge. Blocked because the PR already has 13 exact `@codex review` triggers, exceeding the approved tier-12 cap; a 14th trigger requires explicit tier-24 escalation.
+- [x] Escalate to approved tier 24 and collect the current-head paused-task resumability finding from trigger `5098759747`.
+- [x] Remediate the tier-24 finding by disabling pause while normalized state cannot distinguish paused from queued work; focused RED→GREEN passed, all 65 page tests and all 844 web tests passed, root lint/typecheck/build passed, and the one remaining load-sensitive serial orchestrator timeout passed in isolation.
+- [ ] Commit/push the remediation, resolve the finding, and run one fresh bounded tier-24 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -28,8 +28,8 @@
 - [x] Re-run the live dependency guard, 24/24 guard tests, serial orchestrator suite (4,887/4,887), root lint/typecheck/build, and `git diff --check`. The first concurrent full-suite run exposed eight load-sensitive orchestrator failures; all passed unchanged in the isolated serial rerun. The first pushed guard regression exposed a CI-only checkout-name mismatch, corrected by using the canonical root package identity `frankenbeast`.
 - [x] Reproduce the tenth-round early-confirmation and over-broad SSE exemption findings with focused RED tests.
 - [x] Verify the preserved minimal remediations with 64/64 focused web tests and 2/2 active E2E-classifier tests.
-- [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root test runner's sole unhandled Codex app-server rejection passed unchanged in the serial rerun.
-- [x] Commit and push the tenth-round remediation with the required identity (`44b5a3839`).
+- [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root runner's seven load-sensitive orchestrator failures and one unhandled rejection all passed unchanged in the serial rerun.
+- [x] Commit and push the tenth-round remediation as `44b5a3839` with the required identity.
 - [ ] Reply to and resolve both current-head Codex threads.
 - [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -15,5 +15,6 @@
 - [x] Run focused tests, full relevant tests, lint, typecheck, build, and `git diff --check`.
 - [x] Self-review the complete diff and final clean workspace status.
 - [x] Commit with David Mendez identity, push, and open one issue-scoped PR (#3869).
+- [x] Remediate first-round Codex findings with RED→GREEN tests, isolated Vite credentials, truthful refresh-pending copy, and terminal-state action guards.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -1,0 +1,19 @@
+# Smart-swarm live Hermes E2E (#3815) progress
+
+- [x] Verify #3812, #3813, and #3814 are available together on exact `origin/main`.
+- [x] Create and verify isolated worktree/branch from exact base.
+- [x] Read issue acceptance criteria and trace runtime HTTP/SSE, Hermes adapter, dashboard, and existing tests.
+- [x] Add a browser-facing runtime action client test and observe the intended RED failure.
+- [x] Implement the minimal provider-neutral browser action client and observe GREEN.
+- [x] Add dashboard mutation controls with RED→GREEN tests for supported, governed-rejected, and unsupported actions.
+- [x] Add a real isolated-Hermes E2E harness that creates PM/worker/dependency/blocker/event evidence through the Hermes CLI.
+- [x] Exercise authenticated HTTP, ticketed SSE, live event arrival, blocker resolution with queried postcondition, governed rejection, unsupported approval decision, and reconnection.
+- [x] Exercise browser provider/workspace selection, topology, task detail, live evidence, and mutation controls without mocked HTTP.
+- [x] Prove the production bundle has no fixture/demo runtime fallback.
+- [x] Verify temporary processes, workspaces, databases, credentials, and browser state are cleaned up.
+- [x] Add a discoverable root npm script and exact operator documentation.
+- [x] Run focused tests, full relevant tests, lint, typecheck, build, and `git diff --check`.
+- [x] Self-review the complete diff and final clean workspace status.
+- [x] Commit with David Mendez identity, push, and open one issue-scoped PR (#3869).
+- [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
+- [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -16,5 +16,6 @@
 - [x] Self-review the complete diff and final clean workspace status.
 - [x] Commit with David Mendez identity, push, and open one issue-scoped PR (#3869).
 - [x] Remediate first-round Codex findings with RED→GREEN tests, isolated Vite credentials, truthful refresh-pending copy, and terminal-state action guards.
+- [x] Remediate second-round Codex findings with RED→GREEN tests for uncertain-action idempotency, pending-action focus trapping, and ready-task promotion guards.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -24,5 +24,7 @@
 - [x] Remediate seventh-round Codex findings with running promotion confirmation, task-keyed dialog state, and strict network-404 failure exemption.
 - [x] Remediate eighth-round Codex finding by allowlisting only blocked and queued tasks for promotion.
 - [x] Remediate ninth-round Codex findings with blocked-state confirmation and fail-closed cancellation eligibility.
+- [x] Restore the repository dependency-freshness gate after OpenAI 7 and JSDOM 30 registry drift with exact dependent/location-scoped baselines and RED→GREEN checked-baseline regressions; no opportunistic major upgrade.
+- [x] Re-run the live dependency guard, 24/24 guard tests, serial orchestrator suite (4,887/4,887), root lint/typecheck/build, and `git diff --check`. The first concurrent full-suite run exposed eight load-sensitive orchestrator failures; all passed unchanged in the isolated serial rerun.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -25,6 +25,6 @@
 - [x] Remediate eighth-round Codex finding by allowlisting only blocked and queued tasks for promotion.
 - [x] Remediate ninth-round Codex findings with blocked-state confirmation and fail-closed cancellation eligibility.
 - [x] Restore the repository dependency-freshness gate after OpenAI 7 and JSDOM 30 registry drift with exact dependent/location-scoped baselines and RED→GREEN checked-baseline regressions; no opportunistic major upgrade.
-- [x] Re-run the live dependency guard, 24/24 guard tests, serial orchestrator suite (4,887/4,887), root lint/typecheck/build, and `git diff --check`. The first concurrent full-suite run exposed eight load-sensitive orchestrator failures; all passed unchanged in the isolated serial rerun.
+- [x] Re-run the live dependency guard, 24/24 guard tests, serial orchestrator suite (4,887/4,887), root lint/typecheck/build, and `git diff --check`. The first concurrent full-suite run exposed eight load-sensitive orchestrator failures; all passed unchanged in the isolated serial rerun. The first pushed guard regression exposed a CI-only checkout-name mismatch, corrected by using the canonical root package identity `frankenbeast`.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -29,7 +29,7 @@
 - [x] Reproduce the tenth-round early-confirmation and over-broad SSE exemption findings with focused RED tests.
 - [x] Verify the preserved minimal remediations with 64/64 focused web tests and 2/2 active E2E-classifier tests.
 - [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root test runner's sole unhandled Codex app-server rejection passed unchanged in the serial rerun.
-- [ ] Commit and push the tenth-round remediation with the required identity.
+- [x] Commit and push the tenth-round remediation with the required identity (`44b5a3839`).
 - [ ] Reply to and resolve both current-head Codex threads.
 - [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -17,5 +17,6 @@
 - [x] Commit with David Mendez identity, push, and open one issue-scoped PR (#3869).
 - [x] Remediate first-round Codex findings with RED→GREEN tests, isolated Vite credentials, truthful refresh-pending copy, and terminal-state action guards.
 - [x] Remediate second-round Codex findings with RED→GREEN tests for uncertain-action idempotency, pending-action focus trapping, and ready-task promotion guards.
+- [x] Remediate third-round Codex findings with RED→GREEN tests for remount-safe uncertain-action idempotency and archived-task cancellation guards.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -23,5 +23,6 @@
 - [x] Remediate sixth-round Codex findings with typed failed outcomes, remount-safe in-flight locks, and action-specific uncertain-key postconditions.
 - [x] Remediate seventh-round Codex findings with running promotion confirmation, task-keyed dialog state, and strict network-404 failure exemption.
 - [x] Remediate eighth-round Codex finding by allowlisting only blocked and queued tasks for promotion.
+- [x] Remediate ninth-round Codex findings with blocked-state confirmation and fail-closed cancellation eligibility.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -19,5 +19,6 @@
 - [x] Remediate second-round Codex findings with RED→GREEN tests for uncertain-action idempotency, pending-action focus trapping, and ready-task promotion guards.
 - [x] Remediate third-round Codex findings with RED→GREEN tests for remount-safe uncertain-action idempotency and archived-task cancellation guards.
 - [x] Remediate fourth-round Codex findings with snapshot-confirmed intent retirement, explicit Hermes command registry wiring, and isolated manual backend state.
+- [x] Remediate fifth-round Codex findings by retaining applied-action locks through snapshot confirmation, removing the Vite-prefixed secret alias, and isolating the E2E registry to Hermes.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -18,5 +18,6 @@
 - [x] Remediate first-round Codex findings with RED→GREEN tests, isolated Vite credentials, truthful refresh-pending copy, and terminal-state action guards.
 - [x] Remediate second-round Codex findings with RED→GREEN tests for uncertain-action idempotency, pending-action focus trapping, and ready-task promotion guards.
 - [x] Remediate third-round Codex findings with RED→GREEN tests for remount-safe uncertain-action idempotency and archived-task cancellation guards.
+- [x] Remediate fourth-round Codex findings with snapshot-confirmed intent retirement, explicit Hermes command registry wiring, and isolated manual backend state.
 - [ ] Run real `@codex review` to exact-head clean, green CI, and zero unresolved Codex threads; do not merge.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
+++ b/tasks/smart-swarm-live-hermes-e2e-3815-progress.md
@@ -30,6 +30,6 @@
 - [x] Verify the preserved minimal remediations with 64/64 focused web tests and 2/2 active E2E-classifier tests.
 - [x] Run the full required local test, lint, typecheck, build, and diff-check gates. Live Hermes E2E passed 3/3; serial orchestrator passed 4,887/4,887; root lint, typecheck, build, and `git diff --check` passed. The concurrent root runner's seven load-sensitive orchestrator failures and one unhandled rejection all passed unchanged in the serial rerun.
 - [x] Commit and push the tenth-round remediation as `44b5a3839` with the required identity.
-- [ ] Reply to and resolve both current-head Codex threads.
-- [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge.
+- [x] Reply to and resolve both current-head Codex threads; fully paginated GraphQL audit reports zero unresolved Codex-authored threads.
+- [ ] Run one bounded tier-12 `@codex review` to exact-head clean, four green CI checks, and fully paginated zero unresolved Codex threads; do not merge. Blocked because the PR already has 13 exact `@codex review` triggers, exceeding the approved tier-12 cap; a 14th trigger requires explicit tier-24 escalation.
 - [ ] Record machine-readable root-blackboard and card handoff.

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -275,7 +275,7 @@ describe("dependency CI guards for issue #1414", () => {
           wanted: "29.1.1",
           latest: "30.0.0",
           location: "node_modules/jsdom",
-          dependent: "frankenbeast-smart-swarm-3815",
+          dependent: "frankenbeast",
         },
       ],
     });

--- a/tests/unit/dependency-ci-guards.test.ts
+++ b/tests/unit/dependency-ci-guards.test.ts
@@ -81,6 +81,17 @@ function runOutdatedGuard(report: unknown, baseline: unknown = []) {
   );
 }
 
+function runOutdatedGuardWithRepoBaseline(report: unknown) {
+  return spawnSync(
+    process.execPath,
+    [OUTDATED_SCRIPT, "--input", writeJson(report)],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+}
+
 function runDependabotSupplyChainGuard(config: string) {
   return spawnSync(
     process.execPath,
@@ -232,6 +243,45 @@ describe("dependency CI guards for issue #1414", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("baseline-approved major gap");
+  });
+
+  it("keeps the OpenAI 7 registry drift in the checked-in baseline", () => {
+    const result = runOutdatedGuardWithRepoBaseline({
+      openai: {
+        current: "6.48.0",
+        wanted: "6.49.0",
+        latest: "7.0.0",
+        location: "node_modules/openai",
+        dependent: "franken-orchestrator",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("baseline-approved major gap");
+  });
+
+  it("keeps the JSDOM 30 registry drift in both checked-in workspace baselines", () => {
+    const result = runOutdatedGuardWithRepoBaseline({
+      jsdom: [
+        {
+          current: "29.1.1",
+          wanted: "29.1.1",
+          latest: "30.0.0",
+          location: "node_modules/jsdom",
+          dependent: "franken-web",
+        },
+        {
+          current: "29.1.1",
+          wanted: "29.1.1",
+          latest: "30.0.0",
+          location: "node_modules/jsdom",
+          dependent: "frankenbeast-smart-swarm-3815",
+        },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("2 baseline-approved major gaps");
   });
 
   it("does not let one baseline entry approve another workspace location", () => {


### PR DESCRIPTION
## Summary
- add a discoverable Playwright gate that creates isolated real Hermes Kanban state and drives the authenticated smart-swarm backend, proxy, SSE stream, and browser UI
- wire provider-neutral dashboard actions for blocker resolution, lifecycle controls, and governed task promotion with typed applied/rejected/unsupported results
- verify live topology/event evidence, reconnection, empty/degraded paths, redaction, production bundle fixture exclusion, postconditions, and cleanup
- add exact automated and manual operator runbook commands

## Test plan
- [x] `npm run test:e2e:smart-swarm:hermes`
- [x] `npm --workspace @franken/web test -- --run src/lib/smart-swarm-api.test.ts src/pages/smart-swarm-page.test.tsx` (59 passed)
- [x] `npm --workspace @franken/orchestrator test -- --fileParallelism=false` (4,910 passed, 8 skipped)
- [x] `npm run lint` (0 errors; pre-existing warnings)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check`

## Notes
- The default parallel `npm run test` completed all assertions but Vitest reported the pre-existing Codex app-server child-process unhandled error; the full orchestrator suite passes with file parallelism disabled.
- No merge performed.

Closes #3815