### PR TITLE
feat(web): make Smart Swarm canonical operations surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -456,7 +456,7 @@ The shipped HTTP server is integrated in `@franken/orchestrator`:
 |---------|----------|-------|
 | Chat server | `packages/franken-orchestrator/src/http/chat-server.ts` | Default port `3737`; WebSocket path `/v1/chat/ws`; loopback dev mode can run without an operator token. |
 | Route mounting | `packages/franken-orchestrator/src/http/chat-app.ts` | Always mounts chat (+ WebSocket) and analytics; mounts Beast agents/SSE, network, and skills/dashboard routes when their deps are supplied. When comms channels are enabled, the `chat-server` CLI resolves comms config, auto-wires a `ChatRuntimeCommsAdapter`, and mounts `/comms/health`, `/v1/comms/*`, and enabled `/webhooks/*` routes in-process. Security (`/api/security`) mounts when `securityConfig` is passed. |
-| Dashboard UI | `packages/franken-web` | Talks to the orchestrator HTTP server, usually through `npm --workspace @franken/web run dev:chat`. The overview keeps the read-only faculty Brain panel separate from the operational Brain Vitals panel. Brain Vitals discovers real definitions/runs through `/v1/beasts/runs`, reads snapshot/history/per-run telemetry through `/v1/brain-vitals/*`, and receives live snapshots/activity through the one-shot cookie-ticket SSE route. |
+| Dashboard UI | `packages/franken-web` | Talks to the orchestrator HTTP server, usually through `npm --workspace @franken/web run dev:chat`. Smart Swarm is the canonical live operations surface and consumes provider-neutral runtime adapters. The overview retains only the separate read-only faculty Brain inspector; the retired `#/brain-vitals` hash redirects to `#/smart-swarm` and no production component queries the legacy Beast-run acceptance store. |
 
 The old standalone Firewall/Critique/Governor HTTP-service table describes historical/target microservice boundaries, not the current local runtime surface.
 
@@ -1060,6 +1060,15 @@ registry ownership decision.
 
 #### Brain Vitals telemetry reads
 
+These routes are a legacy diagnostic/compatibility API, not a production web
+operations surface. Smart Swarm replaces the former Brain Vitals panel and
+Pulse Map in `franken-web`; the legacy hash redirects to `#/smart-swarm`, and
+the overview does not discover Beast runs for vitals. This prevents stale
+acceptance-only `design-interview` data from appearing as current operations.
+Provider-neutral Smart Swarm adapters are authoritative for live topology,
+capabilities, availability, and provenance. Unsupported normalized sections are
+reported explicitly and are never converted to zero-valued metrics.
+
 The Beast daemon owns `/v1/brain-vitals/*`; `chat-server` mounts the same routes
 with local Beast services or proxies them to an attached daemon. Every REST
 request requires the Beast operator token. EventSource connections use the
@@ -1077,14 +1086,14 @@ The stream sends a fresh snapshot every second and separate typed `activity`
 events for cache hits/misses, compaction completion, lifecycle churn,
 resource-threshold crossings, and budget-threshold crossings.
 
-`franken-web` uses those discrete events as the sole pulse-rate input for the
-Brain Vitals panel's primary Live Brain Pulse Map. Its five current nodes map
+The retired `franken-web` Brain Vitals implementation used those discrete events
+as the sole pulse-rate input for the Live Brain Pulse Map. Its five nodes mapped
 directly to the `cache`, `compaction`, `churn`, `resource`, and `cost` event
 dimensions; a rolling one-minute client window controls pulse speed, each
 dimension's normalized health signal controls node state, and the aggregate
 health score controls the center ring. Selecting a node exposes the contributing
 events and their real run ids before the existing per-run telemetry drill-down.
-Hive Brain's memory/planning/reasoning/action/learning faculty nodes are omitted
+Hive Brain's memory/planning/reasoning/action/learning faculty nodes were omitted
 rather than borrowing vitals data: the read-only `/v1/brain/*` surface has
 faculty state, but no compatible live faculty activity-event stream yet. Adding
 those nodes is therefore an additive cross-epic follow-up, not a synthetic

--- a/docs/runbooks/smart-swarm-hermes-live-e2e.md
+++ b/docs/runbooks/smart-swarm-hermes-live-e2e.md
@@ -25,6 +25,8 @@ The script installs the pinned Playwright Chromium binary if absent, builds the 
 
 - unauthenticated smart-swarm HTTP is rejected and the authenticated Vite proxy succeeds;
 - the browser selects Hermes and renders real CLI-created PM/worker/dependency/blocker/event evidence;
+- the retired `#/brain-vitals` route redirects to Smart Swarm without requesting `/v1/brain-vitals/*`;
+- live metric counts identify their adapter and capture time, while unsupported sections never render as zero;
 - a fresh Hermes comment reaches the dashboard over live SSE;
 - an interrupted dashboard proxy reconnects, obtains a new one-time stream ticket, and returns to connected state;
 - the dashboard resolves a real blocked Hermes task and verifies its CLI-visible postcondition;

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-hermes-live.test.ts
@@ -231,8 +231,10 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
       let latestSseRequestUrl: string | null = null;
       let expectedSseReplacementReason: ExpectedSseInterruption | null = 'initial-workspace-selection';
       let ticketRequests = 0;
+      let legacyBrainVitalsRequests = 0;
       page.on('request', (request) => {
         if (request.url().endsWith('/events/ticket')) ticketRequests += 1;
+        if (request.url().includes('/v1/brain-vitals/')) legacyBrainVitalsRequests += 1;
         if (isSmartSwarmSseRequest(request.url())) {
           if (latestSseRequestUrl && expectedSseReplacementReason) {
             expectedSseInterruptions.set(latestSseRequestUrl, expectedSseReplacementReason);
@@ -261,11 +263,21 @@ describe.runIf(enabled)('live smart-swarm dashboard against isolated Hermes', ()
         });
       });
 
-      await page.goto(`${dashboardUrl}#/smart-swarm`);
-      await expectBrowser(page.getByRole('heading', { name: 'smart-swarm' })).toBeVisible();
+      await page.goto(`${dashboardUrl}#/brain-vitals`);
+      await expectBrowser(page).toHaveURL(/#\/smart-swarm$/u);
+      await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm' })).toBeVisible();
+      expect(legacyBrainVitalsRequests).toBe(0);
       await page.getByLabel('Runtime provider').selectOption('hermes');
       await expectBrowser(page.getByLabel('Runtime provider')).toHaveValue('hermes');
       await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 15_000 });
+      const metricProvenance = page.getByRole('region', { name: 'Live metric provenance' });
+      await expectBrowser(metricProvenance).toContainText('Source: Hermes');
+      await expectBrowser(metricProvenance).toContainText('Captured');
+      await expectBrowser(page.getByTestId('metric-tasks')).toContainText('available');
+      await expectBrowser(page.getByTestId('metric-approvals')).toContainText('unsupported');
+      await expectBrowser(page.getByTestId('metric-approvals')).not.toContainText(/\b0\b/u);
+      await expectBrowser(page.getByTitle(/Tasks available from Hermes/u)).toBeVisible();
+      await expectBrowser(page.getByTitle(/Events available from Hermes/u)).toBeVisible();
       expectedSseReplacementReason = null;
       await expectBrowser(page.getByText(new RegExp(`${marker} Worker`))).toBeVisible();
       await expectBrowser(page.locator('body')).not.toContainText(secretMarker);

--- a/packages/franken-web/README.md
+++ b/packages/franken-web/README.md
@@ -72,24 +72,19 @@ that no unfiltered recent feed exists instead of fabricating one. These requests
 stay behind the same-origin `/v1` proxy and never attach a browser-readable
 operator credential.
 
-The sibling **Brain Vitals** panel is the operational view. It discovers brains
-from real Beast runs, reads aggregate health/history from `/v1/brain-vitals/*`,
-and uses the ticket-authenticated SSE stream to drive its primary **Live Brain
-Pulse Map** plus secondary health, CPU, memory, power, token, cost, cache,
-compaction, and churn charts without a refresh. The fixed, responsive map has
-one node for each live vitals dimension (`cache`, `compaction`, `churn`,
-`resource`, and `cost`). Node pulse rate comes only from typed activity events
-observed in the last minute; no event means an honest idle node. Node color is
-derived from that dimension's health signal, while the center ring reflects the
-aggregate health score. Selecting a node reveals its recent real events and run
-ids, and those run links open the read-only slide-in drill-down backed by
-`/v1/brain-vitals/:brainId/runs/:runId`, including per-run token/cache splits,
-cost, compactions, resource samples, churn classification, and activity events.
-The faculty **Brain** panel answers “what the brain knows”; **Brain Vitals**
-answers “how hard the brain is working.” Memory, planning, reasoning, action,
-and learning nodes are omitted from the map until the Brain routes expose a
-compatible live faculty activity-event feed. The UI renders only the five real
-vitals dimensions and never substitutes vitals or fabricated faculty rates.
+**Smart Swarm** at `#/smart-swarm` is the only live operations surface. It reads
+normalized runtime adapters, presents the adapter-supplied provider label, and
+shows section counts only when the selected adapter marks that section
+available. Each count names its adapter provenance and snapshot capture time;
+unsupported sections render `unsupported` plus the adapter reason instead of a
+misleading zero. The retired `#/brain-vitals` hash redirects to Smart Swarm.
+
+The legacy `/v1/brain-vitals/*` Beast telemetry API remains available for
+bounded diagnostics and compatibility, but `franken-web` does not mount its old
+acceptance panel or query its run-discovery path. Consequently an isolated or
+stale `design-interview` acceptance run cannot populate the production
+dashboard. The read-only faculty **Brain** panel remains separate because it
+answers what a named brain knows; it is not an operational runtime monitor.
 
 If you use a non-default backend port in local development, keep `VITE_API_URL` unset and set `VITE_API_PROXY_TARGET` so the Vite `/v1/chat` proxy keeps chat auth server-side. Beast routes (`/v1/beasts/*`) reuse that same target by default. Set `VITE_BEAST_API_PROXY_TARGET` only when Beast controls run on a different backend, for example a separate local orchestrator or daemon port:
 

--- a/packages/franken-web/src/components/chat-shell/route-model.test.ts
+++ b/packages/franken-web/src/components/chat-shell/route-model.test.ts
@@ -6,9 +6,14 @@ describe('smart-swarm route', () => {
     expect(routeFromHash('#/smart-swarm')).toBe('smart-swarm');
     expect(PRIMARY_NAV_ROUTES).toContainEqual(expect.objectContaining({
       id: 'smart-swarm',
-      label: 'smart-swarm',
+      label: 'Smart Swarm',
       live: true,
     }));
     expect(PRIMARY_NAV_ROUTES.find((route) => route.id === 'smart-swarm')?.summary).not.toMatch(/PM[- ]swarm/i);
+  });
+
+  it('redirects the retired Brain Vitals route to the canonical live surface', () => {
+    expect(routeFromHash('#/brain-vitals')).toBe('smart-swarm');
+    expect(PRIMARY_NAV_ROUTES.some((route) => route.id === ('brain-vitals' as never))).toBe(false);
   });
 });

--- a/packages/franken-web/src/components/chat-shell/route-model.ts
+++ b/packages/franken-web/src/components/chat-shell/route-model.ts
@@ -12,7 +12,7 @@ export const ROUTES: DashboardRoute[] = [
   { id: 'dashboard', label: 'Overview', summary: 'Snapshot controls for skills, security, and providers', live: true },
   { id: 'chat', label: 'Chat', summary: 'Live CLI-parity operator console', live: true },
   { id: 'beasts', label: 'Beasts', summary: 'Dispatch, inspect, and control tracked beast runs', live: true },
-  { id: 'smart-swarm', label: 'smart-swarm', summary: 'Live provider-neutral runtime topology and operator evidence', live: true },
+  { id: 'smart-swarm', label: 'Smart Swarm', summary: 'Canonical live provider-neutral operations and runtime evidence', live: true },
   { id: 'network', label: 'Network', summary: 'Service controls and operator config', live: true },
   { id: 'sessions', label: 'Sessions', summary: 'Coming online once session explorer lands', live: false },
   { id: 'analytics', label: 'Analytics', summary: 'Observer, governor, security, and cost telemetry', live: true },
@@ -24,6 +24,7 @@ export const ROUTES: DashboardRoute[] = [
 export const PRIMARY_NAV_ROUTES = ROUTES.filter((route) => route.live);
 
 export function routeFromHash(hash: string): RouteId {
-  const candidate = hash.replace(/^#\/?/, '') as RouteId;
-  return PRIMARY_NAV_ROUTES.some((route) => route.id === candidate) ? candidate : 'chat';
+  const candidate = hash.replace(/^#\/?/, '');
+  if (candidate === 'brain-vitals') return 'smart-swarm';
+  return PRIMARY_NAV_ROUTES.find((route) => route.id === candidate)?.id ?? 'chat';
 }

--- a/packages/franken-web/src/pages/dashboard-page.test.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.test.tsx
@@ -126,6 +126,19 @@ describe('DashboardPage', () => {
     expect(client.fetchBrainState).not.toHaveBeenCalled();
   });
 
+  it('does not mount the retired acceptance-only Brain Vitals data path', async () => {
+    const listBrainVitalsRuns = vi.fn().mockRejectedValue(
+      new Error('The stale design-interview acceptance store must not be queried.'),
+    );
+    const client = mockClient({ listBrainVitalsRuns });
+
+    render(<DashboardPage client={client} />);
+
+    await screen.findByRole('region', { name: 'Brain faculties' });
+    expect(listBrainVitalsRuns).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Brain Vitals/i)).toBeNull();
+  });
+
   it('renders partial dependency outages with remediation and safe work guidance', async () => {
     const client = mockClient();
 

--- a/packages/franken-web/src/pages/dashboard-page.tsx
+++ b/packages/franken-web/src/pages/dashboard-page.tsx
@@ -6,7 +6,6 @@ import { ProviderPanel } from '../components/providers/provider-panel';
 import { AvailabilityPanel } from '../components/availability/availability-panel';
 import { SloPanel } from '../components/availability/slo-panel';
 import { BrainPanel } from '../components/brain/brain-panel';
-import { BrainVitalsPanel } from '../components/brain-vitals/brain-vitals-panel';
 import type { DashboardApiClient, DashboardSecurity, DashboardSnapshot } from '../lib/dashboard-api';
 
 interface DashboardPageProps {
@@ -391,7 +390,6 @@ export function DashboardPage({ client }: DashboardPageProps) {
         )}
         <ProviderPanel providers={providers} />
         <BrainPanel client={client} />
-        <BrainVitalsPanel client={client} />
         <AvailabilityPanel availability={availability ?? undefined} />
         <SloPanel slo={slo} />
       </div>

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -154,6 +154,7 @@ describe('SmartSwarmPage', () => {
     expect(screen.getByTestId('metric-workspaces').textContent).toContain('1');
     expect(screen.getByTestId('metric-workspaces').textContent).toContain('available');
     expect(screen.getByTestId('metric-tasks').textContent).toContain('unsupported');
+    expect(screen.getByTestId('metric-event-history').textContent).toContain('unsupported');
     expect(screen.getByTestId('metric-approvals').textContent).toContain('unsupported');
     expect(screen.getByTestId('metric-approvals').textContent).not.toMatch(/\b0\b/);
     const topology = screen.getByRole('region', { name: 'Runtime topology' });

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -131,6 +131,39 @@ describe('SmartSwarmPage', () => {
     expect(screen.getByText('Pause is not supported by Hermes.')).toBeDefined();
   });
 
+  it('renders capability-aware metric provenance from adapter metadata', async () => {
+    const adapterProvider = {
+      ...provider,
+      displayName: 'Hermes production adapter',
+    };
+    const unsupportedSections: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'unsupported', reason: 'Hermes exposes no canonical task source.' },
+      events: { status: 'unsupported', reason: 'Hermes exposes no canonical event source.' },
+      approvals: { status: 'unsupported', reason: 'Hermes exposes no canonical approval source.' },
+    };
+
+    render(<SmartSwarmPage client={createClient({
+      listProviders: vi.fn().mockResolvedValue([adapterProvider]),
+      fetchSnapshot: vi.fn().mockResolvedValue(unsupportedSections),
+    })} />);
+
+    const metrics = await screen.findByRole('region', { name: 'Live metric provenance' });
+    expect(metrics.textContent).toContain('Hermes production adapter');
+    expect(metrics.textContent).toContain('Captured 7/26/2026');
+    expect(screen.getByTestId('metric-workspaces').textContent).toContain('1');
+    expect(screen.getByTestId('metric-workspaces').textContent).toContain('available');
+    expect(screen.getByTestId('metric-tasks').textContent).toContain('unsupported');
+    expect(screen.getByTestId('metric-approvals').textContent).toContain('unsupported');
+    expect(screen.getByTestId('metric-approvals').textContent).not.toMatch(/\b0\b/);
+    const topology = screen.getByRole('region', { name: 'Runtime topology' });
+    expect(topology.textContent).toContain('Tasks unsupported');
+    expect(topology.textContent).not.toContain('0 tasks');
+    const activity = screen.getByRole('heading', { name: 'Events and logs' }).closest('section');
+    expect(activity?.textContent).toContain('Events unsupported');
+    expect(activity?.textContent).not.toMatch(/Events and logs0/u);
+  });
+
   it('moves focus into task details and restores it to the inspect trigger', async () => {
     render(<SmartSwarmPage client={createClient()} />);
     const inspect = await screen.findByRole('button', { name: 'Inspect Live dashboard' });
@@ -685,7 +718,7 @@ describe('SmartSwarmPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Promote task' }));
 
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
-    expect(screen.getByRole('button', { name: 'Cancel task' })).toHaveProperty('disabled', false);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel task' })).toHaveProperty('disabled', false));
   });
 
   it.each([
@@ -1213,6 +1246,7 @@ describe('SmartSwarmPage', () => {
 
     expect(screen.getByText('Live event without history')).toBeDefined();
     expect(screen.getByText('Historical event queries are unavailable.')).toBeDefined();
+    expect(screen.getByTitle('Events received live from Hermes.').textContent).toContain('1 live event');
   });
 
   it('keeps newest activity first before and after snapshot refreshes', async () => {
@@ -1252,6 +1286,7 @@ describe('SmartSwarmPage', () => {
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(2));
 
     act(() => handlers.event(newestEvent));
+    expect(screen.getByTitle(/Snapshot captured .* includes events received by the live stream/u)).toBeDefined();
     expect(screen.getByText('Newest event').compareDocumentPosition(screen.getByText('Focused tests passed')))
       .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3), { timeout: 1_000 });

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -200,6 +200,83 @@ function UnsupportedSection({ label, section }: { label: string; section: Runtim
   );
 }
 
+function MetricProvenance({
+  label,
+  provider,
+  capturedAt,
+  section,
+}: {
+  label: string;
+  provider: RuntimeProvider | undefined;
+  capturedAt: string;
+  section: RuntimeSection<unknown[]>;
+}) {
+  const source = provider?.displayName ?? 'Unknown runtime adapter';
+  return (
+    <div data-testid={`metric-${label.toLowerCase()}`}>
+      <dt>{label}</dt>
+      <dd>
+        <strong>{section.status === 'available' ? section.data.length : 'unsupported'}</strong>
+        <span>{section.status}</span>
+        <small>Source: {source} · Captured {new Date(capturedAt).toLocaleString()}</small>
+      </dd>
+    </div>
+  );
+}
+
+function MetricCount({
+  availableText,
+  capturedAt,
+  label,
+  provider,
+  section,
+}: {
+  availableText: string;
+  capturedAt: string;
+  label: string;
+  provider: RuntimeProvider | undefined;
+  section: RuntimeSection<unknown[]>;
+}) {
+  if (section.status === 'unsupported') {
+    return <span title={section.reason}>{label} unsupported</span>;
+  }
+  return (
+    <span title={`${label} available from ${provider?.displayName ?? 'runtime adapter'}. Captured ${new Date(capturedAt).toLocaleString()}.`}>
+      {availableText}
+    </span>
+  );
+}
+
+function EventMetricCount({
+  capturedAt,
+  count,
+  liveEventCount,
+  provider,
+  section,
+}: {
+  capturedAt: string;
+  count: number;
+  liveEventCount: number;
+  provider: RuntimeProvider | undefined;
+  section: RuntimeSection<RuntimeEvent[]>;
+}) {
+  const source = provider?.displayName ?? 'runtime adapter';
+  if (section.status === 'unsupported') {
+    if (liveEventCount === 0) return <span title={section.reason}>Events unsupported</span>;
+    return (
+      <span title={`Events received live from ${source}.`}>
+        {count} live {count === 1 ? 'event' : 'events'}
+      </span>
+    );
+  }
+  const streamProvenance = liveEventCount > 0 ? '; includes events received by the live stream' : '';
+  return (
+    <span title={`Events available from ${source}. Snapshot captured ${new Date(capturedAt).toLocaleString()}${streamProvenance}.`}>
+      {count}
+    </span>
+  );
+}
+
 export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const [providers, setProviders] = useState<RuntimeProvider[]>([]);
   const [providerId, setProviderId] = useState('');
@@ -500,8 +577,8 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
       <header className="smart-swarm-header rail-card">
         <div>
           <p className="eyebrow">Provider-neutral runtime</p>
-          <h2>smart-swarm</h2>
-          <p>Live normalized topology and bounded operator evidence.</p>
+          <h2>Smart Swarm</h2>
+          <p>The canonical live operations surface for normalized topology and bounded provider evidence.</p>
         </div>
         <div className="smart-swarm-selectors">
           <label className="field-stack">
@@ -604,13 +681,36 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
             </dl>
           </section>
 
+          <section className="smart-swarm-capabilities rail-card" aria-label="Live metric provenance">
+            <div>
+              <p className="eyebrow">Availability and provenance</p>
+              <h3>Live metrics</h3>
+              <p>Counts are shown only when the selected runtime adapter supplies that section.</p>
+            </div>
+            <dl>
+              <MetricProvenance label="Workspaces" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.workspaces} />
+              <MetricProvenance label="Agents" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.agents} />
+              <MetricProvenance label="Tasks" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.tasks} />
+              <MetricProvenance label="Runs" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.runs} />
+              <MetricProvenance label="Events" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.events} />
+              <MetricProvenance label="Blockers" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.blockers} />
+              <MetricProvenance label="Approvals" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.approvals} />
+            </dl>
+          </section>
+
           <div className="smart-swarm-layout">
             <section className="smart-swarm-topology rail-card" aria-label="Runtime topology">
               <div className="rail-card__header">
                 <div><p className="eyebrow">Topology</p><h3>Tasks and agents</h3></div>
-                <span>{filteredTasks.length > MAX_VISIBLE_TASKS
-                  ? `Showing ${MAX_VISIBLE_TASKS} of ${filteredTasks.length} tasks`
-                  : `${filteredTasks.length} tasks`}</span>
+                <MetricCount
+                  availableText={filteredTasks.length > MAX_VISIBLE_TASKS
+                    ? `Showing ${MAX_VISIBLE_TASKS} of ${filteredTasks.length} tasks`
+                    : `${filteredTasks.length} tasks`}
+                  capturedAt={snapshot.capturedAt}
+                  label="Tasks"
+                  provider={provider}
+                  section={snapshot.tasks}
+                />
               </div>
               <UnsupportedSection label="Agents" section={snapshot.agents} />
               <UnsupportedSection label="Tasks" section={snapshot.tasks} />
@@ -645,7 +745,9 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
                         type="button"
                       >
                         <span><strong>{task.title}</strong><small>{task.state} · priority {task.priority ?? 'unset'}</small></span>
-                        <span>{currentRun ? `Run ${currentRun.id}: ${currentRun.state}` : 'No current run'}</span>
+                        <span>{currentRun
+                          ? `Run ${currentRun.id}: ${currentRun.state}`
+                          : snapshot.runs.status === 'unsupported' ? 'Runs unsupported' : 'No current run'}</span>
                         {parents.map((parent) => <small key={`parent:${parent.id}`}>Parent {parent.label}</small>)}
                         {dependencies.map((dependency) => <small key={`dependency:${dependency.id}`}>Depends on {dependency.label}</small>)}
                       </button>
@@ -657,8 +759,17 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
 
             <aside className="smart-swarm-evidence">
               <section className="rail-card">
-                <div className="rail-card__header"><div><p className="eyebrow">Activity</p><h3>Events and logs</h3></div><span>{filteredEvents.length}</span></div>
-                <UnsupportedSection label="Events" section={snapshot.events} />
+                <div className="rail-card__header">
+                  <div><p className="eyebrow">Activity</p><h3>Events and logs</h3></div>
+                  <EventMetricCount
+                    capturedAt={snapshot.capturedAt}
+                    count={filteredEvents.length}
+                    liveEventCount={liveEvents.length}
+                    provider={provider}
+                    section={snapshot.events}
+                  />
+                </div>
+                <UnsupportedSection label="Event history" section={snapshot.events} />
                 <ol className="smart-swarm-timeline">
                   {filteredEvents.map((event) => (
                     <li key={event.id}><time dateTime={event.occurredAt}>{new Date(event.occurredAt).toLocaleTimeString()}</time><strong>{event.type}</strong><span>{event.summary}</span></li>

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -213,7 +213,7 @@ function MetricProvenance({
 }) {
   const source = provider?.displayName ?? 'Unknown runtime adapter';
   return (
-    <div data-testid={`metric-${label.toLowerCase()}`}>
+    <div data-testid={`metric-${label.toLowerCase().replaceAll(' ', '-')}`}>
       <dt>{label}</dt>
       <dd>
         <strong>{section.status === 'available' ? section.data.length : 'unsupported'}</strong>
@@ -692,7 +692,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
               <MetricProvenance label="Agents" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.agents} />
               <MetricProvenance label="Tasks" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.tasks} />
               <MetricProvenance label="Runs" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.runs} />
-              <MetricProvenance label="Events" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.events} />
+              <MetricProvenance label="Event history" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.events} />
               <MetricProvenance label="Blockers" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.blockers} />
               <MetricProvenance label="Approvals" provider={provider} capturedAt={snapshot.capturedAt} section={snapshot.approvals} />
             </dl>

--- a/tasks/reconcile-brain-vitals-smart-swarm-3855-progress.md
+++ b/tasks/reconcile-brain-vitals-smart-swarm-3855-progress.md
@@ -1,0 +1,28 @@
+# Issue #3855 — Canonical Live Operations Surface Progress
+
+- [x] Read the live issue and treat its acceptance criteria and definition of done as authoritative.
+- [x] Verify the isolated worktree is clean, at exact current `origin/main`, and uses David Mendez <me@davidmendez.dev>.
+- [x] Inspect Smart Swarm and legacy Brain Vitals routes, navigation, data contracts, provider metadata, docs, and tests.
+- [x] Document the canonical product decision: Smart Swarm replaces the acceptance-only legacy Brain Vitals operator surface.
+- [x] RED→GREEN: prove legacy Brain Vitals navigation/route resolves to the canonical Smart Swarm surface.
+- [x] RED→GREEN: prove stale `design-interview`/fixture data cannot populate production paths.
+- [x] RED→GREEN: expose traceable metric provenance and capability/availability metadata without misleading zero values.
+- [x] RED→GREEN: derive provider-specific labels from adapter metadata rather than shared UI branches.
+- [x] Align route names, navigation, docs, empty states, and completion messaging with the canonical product model.
+- [x] Run focused tests, full relevant suites, lint, typecheck, build, and `git diff --check`.
+- [x] Complete independent pre-commit review and remediate blocking findings.
+- [ ] Commit with conventional metadata, push, and open a linked PR.
+- [ ] Complete bounded exact-head GitHub Codex review/remediation, green CI, and zero unresolved threads.
+- [ ] Guarded exact-head routine merge and verify issue closure.
+- [ ] Verify public deployment and browser acceptance against real current Hermes work with no fixture/staging fallback.
+
+## Verification evidence
+
+- RED route test: legacy `#/brain-vitals` initially resolved to `chat`; GREEN resolves to `#/smart-swarm`.
+- RED stale-data test: the dashboard initially invoked the acceptance-only Brain Vitals API; GREEN does not mount or query it.
+- RED provenance test: operational counts initially had no capability/provenance presentation; GREEN labels every count as available or unsupported and attributes it to adapter metadata plus snapshot capture time.
+- `npm test --workspace @franken/web -- --run`: 85 files, 847 tests passed.
+- `LIVE_SMART_SWARM_E2E=1 npx vitest run tests/e2e/smart-swarm-hermes-live.test.ts`: 3 tests passed, including authenticated HTTP/SSE and real Chromium proof against isolated current Hermes state.
+- `npm run lint`, `npm run typecheck`, `npm run build`, and `git diff --check`: passed.
+- Full `@franken/orchestrator` run: 4,887/4,887 tests passed, but Vitest reported one pre-existing unhandled `Codex app-server is unavailable` rejection from `runtime-contract.test.ts`; that file passes 12/12 alone and the initially timing-sensitive files pass 157/157 without cross-suite contention.
+- Final independent review passed with no security concerns or logic errors after remediation of snapshot-plus-live event provenance.


### PR DESCRIPTION
## Summary
- make Smart Swarm the canonical live operations surface and redirect the legacy Brain Vitals hash
- remove the acceptance-only Brain Vitals dashboard data path so stale design-interview records cannot populate production UI
- expose adapter-derived metric provenance and capability-aware unavailable states, including honest snapshot/live-stream event attribution
- extend real Hermes Chromium coverage and document the product decision

## Test plan
- [x] focused web regressions: 110/110
- [x] full web suite: 847/847
- [x] live Hermes + Chromium E2E: 3/3
- [x] lint
- [x] typecheck
- [x] build
- [x] git diff --check
- [x] independent review: no security or logic findings

## Known baseline
The full orchestrator run executes all 4,887 tests successfully but local Vitest exits non-zero on a pre-existing unhandled Codex app-server-unavailable rejection from runtime-contract.test.ts. That file passes 12/12 alone and all initially timing-sensitive files pass separately.

Closes #3855