### PR TITLE
feat(web): drive brain pulse from runtime events

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1099,6 +1099,18 @@ faculty state, but no compatible live faculty activity-event stream yet. Adding
 those nodes is therefore an additive cross-epic follow-up, not a synthetic
 mapping in the Brain Vitals UI.
 
+The canonical Brain Pulse lives on the smart-swarm route and consumes only the
+normalized `/v1/smart-swarm/providers/:providerId/events/:connectionId` stream.
+Every pulse preserves provider context plus the event's workspace, task/run
+entity ids, kind, source timestamp, summary, and stable cursor provenance. The
+browser rejects structurally malformed frames, reconnects from the last accepted
+event/checkpoint cursor, deduplicates replayed event ids per provider, and prunes
+the visible pulse window by source timestamp after one minute. `no activity`,
+`disconnected`, `degraded`, and `unsupported` are separate semantic states;
+reduced-motion clients retain all evidence without the pulse animation. Opening
+a pulse with a task id uses the existing normalized task detail and bounded run
+evidence rather than a staging or Beast-run surrogate.
+
 | Route | Purpose and bounds |
 |-------|--------------------|
 | `GET /v1/brain-vitals/:brainId` | Current one-hour health and telemetry snapshot; health score is persisted for history |

--- a/packages/franken-orchestrator/src/runtime/codex/codex-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/codex/codex-runtime-adapter.ts
@@ -54,6 +54,10 @@ const MAX_THREAD_PAGE_SIZE = 50;
 const MAX_THREAD_PAGES = 100;
 const MAX_CURSOR_JSON_BYTES = 64 * 1024;
 const MAX_EVENT_CURSOR_BYTES = 4_096;
+const MAX_NORMALIZED_METADATA_STRING_LENGTH = 4_096;
+// Reserves the remaining RuntimeEvent id budget for timestamp, status, and the
+// largest valid safe-integer transition suffix.
+const MAX_THREAD_ID_LENGTH = 956;
 const THREAD_STATUS_TYPES = new Set(['active', 'idle', 'notLoaded', 'systemError']);
 const THREAD_SOURCE_KINDS = [
   'cli', 'vscode', 'exec', 'appServer', 'subAgent',
@@ -94,20 +98,24 @@ function timestamp(value: number): string | null {
   return Number.isNaN(date.valueOf()) ? null : date.toISOString();
 }
 
+function isBoundedString(value: unknown, maximum: number, allowEmpty = true): value is string {
+  return typeof value === 'string' && (allowEmpty || value.length > 0) && value.length <= maximum;
+}
+
 function parseThread(value: unknown): CodexThread | null {
   if (!value || typeof value !== 'object') return null;
   const thread = value as Record<string, unknown>;
   if (
-    typeof thread['id'] !== 'string'
-    || typeof thread['sessionId'] !== 'string'
-    || typeof thread['cliVersion'] !== 'string'
+    !isBoundedString(thread['id'], MAX_THREAD_ID_LENGTH, false)
+    || !isBoundedString(thread['sessionId'], MAX_NORMALIZED_METADATA_STRING_LENGTH)
+    || !isBoundedString(thread['cliVersion'], MAX_NORMALIZED_METADATA_STRING_LENGTH)
     || typeof thread['createdAt'] !== 'number'
     || typeof thread['updatedAt'] !== 'number'
     || !timestamp(thread['createdAt'])
     || !timestamp(thread['updatedAt'])
     || typeof thread['cwd'] !== 'string'
     || typeof thread['ephemeral'] !== 'boolean'
-    || typeof thread['modelProvider'] !== 'string'
+    || !isBoundedString(thread['modelProvider'], MAX_NORMALIZED_METADATA_STRING_LENGTH)
     || !thread['status']
     || typeof thread['status'] !== 'object'
     || typeof (thread['status'] as Record<string, unknown>)['type'] !== 'string'

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -1279,7 +1279,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         priority: typeof task['priority'] === 'number' && Number.isSafeInteger(task['priority']) ? task['priority'] : null,
         createdAt: requiredTimestamp(task['created_at']),
         updatedAt,
-        metadata: { runtimeStatus: String(task['status']) },
+        metadata: { runtimeStatus: boundedText(String(task['status'])) },
       };
     });
     const sessionByRunId = new Map<string, string>();
@@ -1329,8 +1329,8 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         lastActiveAt: latestTimestamp(run['last_heartbeat_at'], run['ended_at'], run['started_at']),
         summary: typeof run['summary'] === 'string' ? boundedText(run['summary']) : null,
         metadata: {
-          runtimeStatus: String(run['status']),
-          ...(typeof run['outcome'] === 'string' ? { outcome: run['outcome'] } : {}),
+          runtimeStatus: boundedText(String(run['status'])),
+          ...(typeof run['outcome'] === 'string' ? { outcome: boundedText(run['outcome']) } : {}),
         },
       };
     });

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -148,6 +148,11 @@ function taskId(workspaceId: string, id: unknown): string {
   return prefixed(workspaceId, String(id));
 }
 
+function hasBoundedTaskId(workspaceId: string, value: unknown): boolean {
+  return value !== null && value !== undefined
+    && taskId(workspaceId, value).length <= RUNTIME_EVENT_ID_MAX_LENGTH;
+}
+
 function agentId(workspaceId: string, id: string): string {
   return prefixed(workspaceId, id);
 }
@@ -1197,11 +1202,35 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     try {
       return db.transaction(() => {
         const commentTable = this.commentTable(db);
-        const eventRows = this.readActivityRows(db, 'task_events', 'event', source.workspaceId, after, limit);
+        const eventRows = this.readActivityRows(
+          db,
+          'task_events',
+          'event',
+          source.workspaceId,
+          after,
+          limit,
+          (row) => row['task_id'] === null || hasBoundedTaskId(source.workspaceId, row['task_id']),
+        );
         const commentRows = commentTable === 'comments'
-          ? this.readActivityRows(db, 'comments', 'comment', source.workspaceId, after, limit)
+          ? this.readActivityRows(
+              db,
+              'comments',
+              'comment',
+              source.workspaceId,
+              after,
+              limit,
+              (row) => hasBoundedTaskId(source.workspaceId, row['task_id']),
+            )
           : commentTable === 'task_comments'
-            ? this.readActivityRows(db, 'task_comments', 'comment', source.workspaceId, after, limit)
+            ? this.readActivityRows(
+                db,
+                'task_comments',
+                'comment',
+                source.workspaceId,
+                after,
+                limit,
+                (row) => hasBoundedTaskId(source.workspaceId, row['task_id']),
+              )
             : [];
         return this.normalizeRows(source, [], [], [], eventRows, commentRows, limit * 2).events;
       }).deferred();
@@ -1217,9 +1246,24 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     workspaceId: string,
     after: CursorValue | undefined,
     limit: number,
+    acceptRow?: ((row: RuntimeRow) => boolean) | undefined,
   ): RuntimeRow[] {
+    const acceptedRows = (readBatch: (offset: number) => RuntimeRow[]): RuntimeRow[] => {
+      if (!acceptRow) return readBatch(0);
+      const accepted: RuntimeRow[] = [];
+      let offset = 0;
+      while (accepted.length < limit) {
+        const batch = readBatch(offset);
+        if (batch.length === 0) break;
+        accepted.push(...batch.filter(acceptRow));
+        offset += batch.length;
+        if (batch.length < limit) break;
+      }
+      return accepted.slice(0, limit);
+    };
     if (!after) {
-      return db.prepare(`SELECT * FROM ${table} ORDER BY created_at DESC, id DESC LIMIT ?`).all(limit) as RuntimeRow[];
+      const statement = db.prepare(`SELECT * FROM ${table} ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`);
+      return acceptedRows((offset) => statement.all(limit, offset) as RuntimeRow[]);
     }
 
     const sample = db.prepare(`SELECT created_at FROM ${table} WHERE created_at IS NOT NULL LIMIT 1`).get() as RuntimeRow | undefined;
@@ -1231,20 +1275,24 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     const sourceOrder = activitySource.localeCompare(after.source);
 
     if (workspaceOrder === 0 && sourceOrder === 0) {
-      return db.prepare(`
+      const statement = db.prepare(`
         SELECT * FROM ${table}
         WHERE created_at > ? OR (created_at = ? AND id > ?)
         ORDER BY created_at, id
-        LIMIT ?
-      `).all(threshold, threshold, after.sourceId, limit) as RuntimeRow[];
+        LIMIT ? OFFSET ?
+      `);
+      return acceptedRows((offset) => statement.all(
+        threshold, threshold, after.sourceId, limit, offset,
+      ) as RuntimeRow[]);
     }
     const includeSameTimestamp = workspaceOrder > 0 || (workspaceOrder === 0 && sourceOrder > 0);
-    return db.prepare(`
+    const statement = db.prepare(`
       SELECT * FROM ${table}
       WHERE created_at ${includeSameTimestamp ? '>=' : '>'} ?
       ORDER BY created_at, id
-      LIMIT ?
-    `).all(threshold, limit) as RuntimeRow[];
+      LIMIT ? OFFSET ?
+    `);
+    return acceptedRows((offset) => statement.all(threshold, limit, offset) as RuntimeRow[]);
   }
 
   private normalizeRows(
@@ -1257,20 +1305,17 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     activityLimit: number,
     blockerEventRows: RuntimeRow[] = eventRows,
   ) {
-    const hasBoundedTaskId = (value: unknown): boolean => (
-      value !== null && value !== undefined
-      && taskId(source.workspaceId, value).length <= RUNTIME_EVENT_ID_MAX_LENGTH
-    );
-    taskRows = taskRows.filter((task) => hasBoundedTaskId(task['id']));
+    taskRows = taskRows.filter((task) => hasBoundedTaskId(source.workspaceId, task['id']));
     linkRows = linkRows.filter((link) => (
-      hasBoundedTaskId(link['parent_id']) && hasBoundedTaskId(link['child_id'])
+      hasBoundedTaskId(source.workspaceId, link['parent_id'])
+      && hasBoundedTaskId(source.workspaceId, link['child_id'])
     ));
-    runRows = runRows.filter((run) => hasBoundedTaskId(run['task_id']));
+    runRows = runRows.filter((run) => hasBoundedTaskId(source.workspaceId, run['task_id']));
     eventRows = eventRows.filter((event) => (
-      event['task_id'] === null || hasBoundedTaskId(event['task_id'])
+      event['task_id'] === null || hasBoundedTaskId(source.workspaceId, event['task_id'])
     ));
-    commentRows = commentRows.filter((comment) => hasBoundedTaskId(comment['task_id']));
-    blockerEventRows = blockerEventRows.filter((event) => hasBoundedTaskId(event['task_id']));
+    commentRows = commentRows.filter((comment) => hasBoundedTaskId(source.workspaceId, comment['task_id']));
+    blockerEventRows = blockerEventRows.filter((event) => hasBoundedTaskId(source.workspaceId, event['task_id']));
     const dependencies = new Map<string, string[]>();
     for (const link of linkRows) {
       const child = String(link['child_id']);

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -153,6 +153,12 @@ function hasBoundedTaskId(workspaceId: string, value: unknown): boolean {
     && taskId(workspaceId, value).length <= RUNTIME_EVENT_ID_MAX_LENGTH;
 }
 
+function boundedEventRunId(workspaceId: string, value: unknown): string | null {
+  if (value == null) return null;
+  const normalized = `${workspaceId}:run:${String(value)}`;
+  return normalized.length <= RUNTIME_EVENT_ID_MAX_LENGTH ? normalized : null;
+}
+
 function agentId(workspaceId: string, id: string): string {
   return prefixed(workspaceId, id);
 }
@@ -1168,7 +1174,15 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           )
           ORDER BY run.started_at, run.id
         `).all(activityLimit) as RuntimeRow[];
-        const eventRows = db.prepare('SELECT * FROM task_events ORDER BY created_at DESC, id DESC LIMIT ?').all(activityLimit) as RuntimeRow[];
+        const eventRows = this.readActivityRows(
+          db,
+          'task_events',
+          'event',
+          source.workspaceId,
+          undefined,
+          activityLimit,
+          (row) => row['task_id'] === null || hasBoundedTaskId(source.workspaceId, row['task_id']),
+        );
         const blockerEventRows = db.prepare(`
           SELECT event.*
           FROM task_events event
@@ -1183,11 +1197,17 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
               LIMIT 1
             )
         `).all() as RuntimeRow[];
-        const commentRows = commentTable === 'comments'
-          ? db.prepare('SELECT id, task_id, NULL AS author, body, created_at FROM comments ORDER BY created_at DESC, id DESC LIMIT ?').all(activityLimit) as RuntimeRow[]
-          : commentTable === 'task_comments'
-            ? db.prepare('SELECT id, task_id, author, body, created_at FROM task_comments ORDER BY created_at DESC, id DESC LIMIT ?').all(activityLimit) as RuntimeRow[]
-            : [];
+        const commentRows = commentTable
+          ? this.readActivityRows(
+              db,
+              commentTable,
+              'comment',
+              source.workspaceId,
+              undefined,
+              activityLimit,
+              (row) => hasBoundedTaskId(source.workspaceId, row['task_id']),
+            )
+          : [];
         return this.normalizeRows(
           source, taskRows, linkRows, runRows, eventRows, commentRows, activityLimit, blockerEventRows,
         );
@@ -1452,7 +1472,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         cursor,
         workspaceId: source.workspaceId,
         taskId: event['task_id'] === null ? null : taskId(source.workspaceId, event['task_id']),
-        runId: event['run_id'] == null ? null : `${source.workspaceId}:run:${String(event['run_id'])}`,
+        runId: boundedEventRunId(source.workspaceId, event['run_id']),
         type: event['kind'] === 'blocked' ? 'blocker' : 'lifecycle',
         occurredAt,
         summary: `${boundedText(event['kind']) || 'unknown'} task event`,

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -664,7 +664,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     throwIfAborted(request.signal);
     const inspected = selectedSources.filter((source) => source.status === 'compatible');
     const entries: Array<{ event: RuntimeEvent; cursor: CursorValue }> = [];
-    const sourceLatest = new Map<string, CursorValue>();
+    const sourceCheckpoints = new Map<string, CursorValue>();
     let successfulReads = 0;
     for (const source of inspected) {
       throwIfAborted(request.signal);
@@ -677,10 +677,9 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           const decoded = parseCursor(event.cursor);
           if (decoded) entries.push({ event, cursor: decoded });
         }
-        const latest = events.at(-1);
-        const latestCursor = latest ? parseCursor(latest.cursor) : undefined;
-        if (latestCursor) sourceLatest.set(source.workspaceId, latestCursor);
-        else if (activity.checkpoint) sourceLatest.set(source.workspaceId, activity.checkpoint);
+        if (events.length === 0 && activity.checkpoint) {
+          sourceCheckpoints.set(source.workspaceId, activity.checkpoint);
+        }
       } catch {
         // Preserve healthy workspace activity across transient or corrupt sibling sources.
       }
@@ -722,19 +721,12 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         });
       }
     }
-    if (request.cursor) {
-      const pageWorkspaces = new Set(page.map((entry) => entry.cursor.workspaceId));
-      for (const [workspaceId, latest] of sourceLatest) {
-        if (pageWorkspaces.has(workspaceId)) continue;
-        const current = positions.get(workspaceId);
-        if (!current || eventOrder(latest, current) > 0) positions.set(workspaceId, latest);
-      }
+    for (const [workspaceId, checkpoint] of sourceCheckpoints) {
+      const current = positions.get(workspaceId);
+      if (!current || eventOrder(checkpoint, current) > 0) positions.set(workspaceId, checkpoint);
     }
     if (!request.cursor) {
       const pageWorkspaces = new Set(page.map((entry) => entry.cursor.workspaceId));
-      for (const [workspaceId, latest] of sourceLatest) {
-        if (!pageWorkspaces.has(workspaceId)) positions.set(workspaceId, latest);
-      }
       for (const workspaceId of pageWorkspaces) {
         const firstPageEntry = page.find((entry) => entry.cursor.workspaceId === workspaceId);
         const predecessor = firstPageEntry
@@ -752,7 +744,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     });
     return RuntimeEventPageSchema.parse({
       events,
-      nextCursor: events.at(-1)?.cursor ?? (request.cursor ? cursorForPositions(positions) : null),
+      nextCursor: events.at(-1)?.cursor ?? (positions.size > 0 ? cursorForPositions(positions) : null),
     });
   }
 
@@ -1280,7 +1272,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           .filter((activity) => activity.truncated && activity.checkpoint)
           .map((activity) => activity.checkpoint as CursorValue)
           .sort(eventOrder);
-        const safeThrough = truncatedCheckpoints.at(0);
+        const safeThrough = after ? truncatedCheckpoints.at(0) : undefined;
         const normalizedEvents = this.normalizeRows(
           source, [], [], [], eventActivity.rows, commentActivity.rows, limit * 2,
         ).events;
@@ -1316,12 +1308,14 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
       if (!acceptRow) return { rows: readBatch(0, limit) };
       const accepted: RuntimeRow[] = [];
       let offset = 0;
+      let firstInspected: RuntimeRow | undefined;
       let lastInspected: RuntimeRow | undefined;
       let scanLimitReached = false;
       while (accepted.length < limit && offset < MAX_ACTIVITY_SCAN_ROWS) {
         const batchSize = Math.min(limit, MAX_ACTIVITY_SCAN_ROWS - offset);
         const batch = readBatch(offset, batchSize);
         if (batch.length === 0) break;
+        firstInspected ??= batch.at(0);
         lastInspected = batch.at(-1);
         accepted.push(...batch.filter(acceptRow));
         offset += batch.length;
@@ -1330,12 +1324,12 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
       }
       return {
         rows: accepted.slice(0, limit),
-        ...(lastInspected ? {
+        ...((after ? lastInspected : firstInspected) ? {
           checkpoint: {
-            occurredAt: requiredTimestamp(lastInspected['created_at']),
+            occurredAt: requiredTimestamp((after ? lastInspected : firstInspected)?.['created_at']),
             workspaceId,
             source: activitySource,
-            sourceId: Number(lastInspected['id']),
+            sourceId: Number((after ? lastInspected : firstInspected)?.['id']),
           },
         } : {}),
         ...(scanLimitReached ? { truncated: true } : {}),

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -13,6 +13,7 @@ import {
 } from '../runtime-adapter.js';
 import {
   RuntimeActionResultSchema,
+  RUNTIME_EVENT_ID_MAX_LENGTH,
   RuntimeEventPageSchema,
   RuntimeProviderSchema,
   RuntimeSnapshotSchema,
@@ -1256,6 +1257,20 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     activityLimit: number,
     blockerEventRows: RuntimeRow[] = eventRows,
   ) {
+    const hasBoundedTaskId = (value: unknown): boolean => (
+      value !== null && value !== undefined
+      && taskId(source.workspaceId, value).length <= RUNTIME_EVENT_ID_MAX_LENGTH
+    );
+    taskRows = taskRows.filter((task) => hasBoundedTaskId(task['id']));
+    linkRows = linkRows.filter((link) => (
+      hasBoundedTaskId(link['parent_id']) && hasBoundedTaskId(link['child_id'])
+    ));
+    runRows = runRows.filter((run) => hasBoundedTaskId(run['task_id']));
+    eventRows = eventRows.filter((event) => (
+      event['task_id'] === null || hasBoundedTaskId(event['task_id'])
+    ));
+    commentRows = commentRows.filter((comment) => hasBoundedTaskId(comment['task_id']));
+    blockerEventRows = blockerEventRows.filter((event) => hasBoundedTaskId(event['task_id']));
     const dependencies = new Map<string, string[]>();
     for (const link of linkRows) {
       const child = String(link['child_id']);

--- a/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/hermes/hermes-runtime-adapter.ts
@@ -88,6 +88,12 @@ interface RequestCursorState {
   positions: Map<string, CursorPosition>;
 }
 
+interface ActivityRead {
+  rows: RuntimeRow[];
+  checkpoint?: CursorValue | undefined;
+  truncated?: boolean | undefined;
+}
+
 const REQUIRED_SCHEMA: Record<string, string[]> = {
   tasks: ['id', 'title', 'status', 'created_at', 'workspace_kind'],
   task_runs: ['id', 'task_id', 'status', 'started_at'],
@@ -95,6 +101,7 @@ const REQUIRED_SCHEMA: Record<string, string[]> = {
 };
 const DEFAULT_ACTIVITY_LIMIT = 100;
 const MAX_ACTIVITY_LIMIT = 500;
+const MAX_ACTIVITY_SCAN_ROWS = 2_000;
 const MAX_CURSOR_CHARS = 4 * 1024;
 const MAX_SUMMARY_CHARS = 512;
 const MISSING_WORKSPACE_GRACE_POLLS = 1;
@@ -663,7 +670,8 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
       throwIfAborted(request.signal);
       const after = cursorState.positions.get(source.workspaceId) ?? cursorState.legacy;
       try {
-        const events = this.readEvents(source, after, limit + 1);
+        const activity = this.readEvents(source, after, limit + 1);
+        const events = activity.events;
         successfulReads += 1;
         for (const event of events) {
           const decoded = parseCursor(event.cursor);
@@ -672,6 +680,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         const latest = events.at(-1);
         const latestCursor = latest ? parseCursor(latest.cursor) : undefined;
         if (latestCursor) sourceLatest.set(source.workspaceId, latestCursor);
+        else if (activity.checkpoint) sourceLatest.set(source.workspaceId, activity.checkpoint);
       } catch {
         // Preserve healthy workspace activity across transient or corrupt sibling sources.
       }
@@ -711,6 +720,14 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           ...cursorState.legacy,
           missingPolls: selectedWorkspaceIds.has(cursorState.legacy.workspaceId) ? undefined : 1,
         });
+      }
+    }
+    if (request.cursor) {
+      const pageWorkspaces = new Set(page.map((entry) => entry.cursor.workspaceId));
+      for (const [workspaceId, latest] of sourceLatest) {
+        if (pageWorkspaces.has(workspaceId)) continue;
+        const current = positions.get(workspaceId);
+        if (!current || eventOrder(latest, current) > 0) positions.set(workspaceId, latest);
       }
     }
     if (!request.cursor) {
@@ -1182,7 +1199,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           undefined,
           activityLimit,
           (row) => row['task_id'] === null || hasBoundedTaskId(source.workspaceId, row['task_id']),
-        );
+        ).rows;
         const blockerEventRows = db.prepare(`
           SELECT event.*
           FROM task_events event
@@ -1206,7 +1223,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
               undefined,
               activityLimit,
               (row) => hasBoundedTaskId(source.workspaceId, row['task_id']),
-            )
+            ).rows
           : [];
         return this.normalizeRows(
           source, taskRows, linkRows, runRows, eventRows, commentRows, activityLimit, blockerEventRows,
@@ -1217,12 +1234,16 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     }
   }
 
-  private readEvents(source: DatabaseSource, after: CursorValue | undefined, limit: number): RuntimeEvent[] {
+  private readEvents(
+    source: DatabaseSource,
+    after: CursorValue | undefined,
+    limit: number,
+  ): { events: RuntimeEvent[]; checkpoint?: CursorValue | undefined } {
     const db = this.open(source.path);
     try {
       return db.transaction(() => {
         const commentTable = this.commentTable(db);
-        const eventRows = this.readActivityRows(
+        const eventActivity = this.readActivityRows(
           db,
           'task_events',
           'event',
@@ -1231,7 +1252,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
           limit,
           (row) => row['task_id'] === null || hasBoundedTaskId(source.workspaceId, row['task_id']),
         );
-        const commentRows = commentTable === 'comments'
+        const commentActivity = commentTable === 'comments'
           ? this.readActivityRows(
               db,
               'comments',
@@ -1251,8 +1272,29 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
                 limit,
                 (row) => hasBoundedTaskId(source.workspaceId, row['task_id']),
               )
-            : [];
-        return this.normalizeRows(source, [], [], [], eventRows, commentRows, limit * 2).events;
+            : { rows: [] };
+        const checkpoints = [eventActivity.checkpoint, commentActivity.checkpoint]
+          .filter((checkpoint): checkpoint is CursorValue => checkpoint !== undefined)
+          .sort(eventOrder);
+        const truncatedCheckpoints = [eventActivity, commentActivity]
+          .filter((activity) => activity.truncated && activity.checkpoint)
+          .map((activity) => activity.checkpoint as CursorValue)
+          .sort(eventOrder);
+        const safeThrough = truncatedCheckpoints.at(0);
+        const normalizedEvents = this.normalizeRows(
+          source, [], [], [], eventActivity.rows, commentActivity.rows, limit * 2,
+        ).events;
+        return {
+          events: safeThrough
+            ? normalizedEvents.filter((event) => {
+                const cursor = parseCursor(event.cursor);
+                return cursor !== undefined && eventOrder(cursor, safeThrough) <= 0;
+              })
+            : normalizedEvents,
+          ...(checkpoints.length > 0 ? {
+            checkpoint: safeThrough ?? checkpoints.at(-1),
+          } : {}),
+        };
       }).deferred();
     } finally {
       db.close();
@@ -1267,23 +1309,41 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
     after: CursorValue | undefined,
     limit: number,
     acceptRow?: ((row: RuntimeRow) => boolean) | undefined,
-  ): RuntimeRow[] {
-    const acceptedRows = (readBatch: (offset: number) => RuntimeRow[]): RuntimeRow[] => {
-      if (!acceptRow) return readBatch(0);
+  ): ActivityRead {
+    const acceptedRows = (
+      readBatch: (offset: number, batchSize: number) => RuntimeRow[],
+    ): ActivityRead => {
+      if (!acceptRow) return { rows: readBatch(0, limit) };
       const accepted: RuntimeRow[] = [];
       let offset = 0;
-      while (accepted.length < limit) {
-        const batch = readBatch(offset);
+      let lastInspected: RuntimeRow | undefined;
+      let scanLimitReached = false;
+      while (accepted.length < limit && offset < MAX_ACTIVITY_SCAN_ROWS) {
+        const batchSize = Math.min(limit, MAX_ACTIVITY_SCAN_ROWS - offset);
+        const batch = readBatch(offset, batchSize);
         if (batch.length === 0) break;
+        lastInspected = batch.at(-1);
         accepted.push(...batch.filter(acceptRow));
         offset += batch.length;
-        if (batch.length < limit) break;
+        if (batch.length < batchSize) break;
+        if (offset >= MAX_ACTIVITY_SCAN_ROWS && accepted.length < limit) scanLimitReached = true;
       }
-      return accepted.slice(0, limit);
+      return {
+        rows: accepted.slice(0, limit),
+        ...(lastInspected ? {
+          checkpoint: {
+            occurredAt: requiredTimestamp(lastInspected['created_at']),
+            workspaceId,
+            source: activitySource,
+            sourceId: Number(lastInspected['id']),
+          },
+        } : {}),
+        ...(scanLimitReached ? { truncated: true } : {}),
+      };
     };
     if (!after) {
       const statement = db.prepare(`SELECT * FROM ${table} ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`);
-      return acceptedRows((offset) => statement.all(limit, offset) as RuntimeRow[]);
+      return acceptedRows((offset, batchSize) => statement.all(batchSize, offset) as RuntimeRow[]);
     }
 
     const sample = db.prepare(`SELECT created_at FROM ${table} WHERE created_at IS NOT NULL LIMIT 1`).get() as RuntimeRow | undefined;
@@ -1301,8 +1361,8 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
         ORDER BY created_at, id
         LIMIT ? OFFSET ?
       `);
-      return acceptedRows((offset) => statement.all(
-        threshold, threshold, after.sourceId, limit, offset,
+      return acceptedRows((offset, batchSize) => statement.all(
+        threshold, threshold, after.sourceId, batchSize, offset,
       ) as RuntimeRow[]);
     }
     const includeSameTimestamp = workspaceOrder > 0 || (workspaceOrder === 0 && sourceOrder > 0);
@@ -1312,7 +1372,7 @@ export class HermesRuntimeAdapter implements RuntimeAdapter {
       ORDER BY created_at, id
       LIMIT ? OFFSET ?
     `);
-    return acceptedRows((offset) => statement.all(threshold, limit, offset) as RuntimeRow[]);
+    return acceptedRows((offset, batchSize) => statement.all(threshold, batchSize, offset) as RuntimeRow[]);
   }
 
   private normalizeRows(

--- a/packages/franken-orchestrator/src/runtime/ollama/ollama-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/ollama/ollama-runtime-adapter.ts
@@ -62,6 +62,7 @@ interface EndpointInspection {
 const UNCONFIGURED_REASON = 'Ollama endpoint is not configured; set OLLAMA_HOST or pass an endpoint';
 const UNSUPPORTED_REASON = 'Ollama does not expose a canonical upstream source for this data';
 const MAX_ENDPOINTS = 32;
+const MAX_METADATA_TEXT_LENGTH = 4_096;
 
 class OllamaEndpointError extends Error {}
 
@@ -109,6 +110,16 @@ function hasValidModelEntries(value: unknown): boolean {
 
 function nextModelExpiry(models: readonly OllamaModel[]): string | undefined {
   return models.flatMap((model) => model.expiresAt ? [model.expiresAt] : []).sort()[0];
+}
+
+function boundedModelNames(models: readonly OllamaModel[]): string {
+  const names = models.map((model) => model.name).sort().join(',');
+  if (names.length <= MAX_METADATA_TEXT_LENGTH) return names;
+  let end = MAX_METADATA_TEXT_LENGTH - 1;
+  const previous = names.charCodeAt(end - 1);
+  const next = names.charCodeAt(end);
+  if (previous >= 0xD800 && previous <= 0xDBFF && next >= 0xDC00 && next <= 0xDFFF) end -= 1;
+  return `${names.slice(0, end)}…`;
 }
 
 function endpointUrl(baseUrl: string, path: string): URL {
@@ -287,10 +298,10 @@ export class OllamaRuntimeAdapter implements RuntimeAdapter {
           : {
               ...(inspection.version ? { version: inspection.version } : {}),
               installedModelCount: inspection.installedModels.length,
-              installedModels: inspection.installedModels.map((model) => model.name).sort().join(','),
+              installedModels: boundedModelNames(inspection.installedModels),
               installedModelBytes: inspection.installedModels.reduce((total, model) => total + model.size, 0),
               loadedModelCount: inspection.loadedModels.length,
-              loadedModels: inspection.loadedModels.map((model) => model.name).sort().join(','),
+              loadedModels: boundedModelNames(inspection.loadedModels),
               loadedModelBytes: inspection.loadedModels.reduce((total, model) => total + model.size, 0),
               loadedVramBytes: inspection.loadedModels.reduce((total, model) => total + model.sizeVram, 0),
               ...(nextLoadedModelExpiry ? { nextLoadedModelExpiry } : {}),

--- a/packages/franken-orchestrator/src/runtime/ollama/ollama-runtime-adapter.ts
+++ b/packages/franken-orchestrator/src/runtime/ollama/ollama-runtime-adapter.ts
@@ -112,14 +112,17 @@ function nextModelExpiry(models: readonly OllamaModel[]): string | undefined {
   return models.flatMap((model) => model.expiresAt ? [model.expiresAt] : []).sort()[0];
 }
 
-function boundedModelNames(models: readonly OllamaModel[]): string {
-  const names = models.map((model) => model.name).sort().join(',');
-  if (names.length <= MAX_METADATA_TEXT_LENGTH) return names;
+function boundedMetadataText(value: string): string {
+  if (value.length <= MAX_METADATA_TEXT_LENGTH) return value;
   let end = MAX_METADATA_TEXT_LENGTH - 1;
-  const previous = names.charCodeAt(end - 1);
-  const next = names.charCodeAt(end);
+  const previous = value.charCodeAt(end - 1);
+  const next = value.charCodeAt(end);
   if (previous >= 0xD800 && previous <= 0xDBFF && next >= 0xDC00 && next <= 0xDFFF) end -= 1;
-  return `${names.slice(0, end)}…`;
+  return `${value.slice(0, end)}…`;
+}
+
+function boundedModelNames(models: readonly OllamaModel[]): string {
+  return boundedMetadataText(models.map((model) => model.name).sort().join(','));
 }
 
 function endpointUrl(baseUrl: string, path: string): URL {
@@ -296,7 +299,7 @@ export class OllamaRuntimeAdapter implements RuntimeAdapter {
         metadata: inspection.error
           ? { diagnostic: inspection.error }
           : {
-              ...(inspection.version ? { version: inspection.version } : {}),
+              ...(inspection.version ? { version: boundedMetadataText(inspection.version) } : {}),
               installedModelCount: inspection.installedModels.length,
               installedModels: boundedModelNames(inspection.installedModels),
               installedModelBytes: inspection.installedModels.reduce((total, model) => total + model.size, 0),

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -18,6 +18,8 @@ const IdempotencyKeySchema = z.string().min(1).max(200).regex(/^[A-Za-z0-9._:-]+
 const RuntimeWorkspaceIdSchema = z.string().min(1);
 const RuntimeTaskIdSchema = z.string().min(1);
 const RuntimeApprovalIdSchema = z.string().min(1);
+const RuntimeEventIdSchema = z.string().min(1).max(1_024);
+const RuntimeEventCursorSchema = z.string().min(1).max(4_096);
 const RuntimeActionWorkspaceIdSchema = RuntimeWorkspaceIdSchema;
 const RuntimeActionTaskIdSchema = RuntimeTaskIdSchema;
 const BoundedReasonSchema = z.string().trim().min(1).max(1000);
@@ -192,11 +194,11 @@ export const RuntimeRunSchema = z.object({
 }).strict();
 
 export const RuntimeEventSchema = z.object({
-  id: z.string().min(1),
-  cursor: z.string().min(1),
-  workspaceId: z.string().min(1),
-  taskId: z.string().min(1).nullable(),
-  runId: z.string().min(1).nullable(),
+  id: RuntimeEventIdSchema,
+  cursor: RuntimeEventCursorSchema,
+  workspaceId: RuntimeEventIdSchema,
+  taskId: RuntimeEventIdSchema.nullable(),
+  runId: RuntimeEventIdSchema.nullable(),
   type: z.enum(['lifecycle', 'comment', 'log', 'audit', 'blocker', 'approval', 'unknown']),
   occurredAt: TimestampSchema,
   summary: z.string().max(16_384),

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -19,7 +19,10 @@ const RuntimeWorkspaceIdSchema = z.string().min(1);
 const RuntimeTaskIdSchema = z.string().min(1);
 const RuntimeApprovalIdSchema = z.string().min(1);
 const RuntimeEventIdSchema = z.string().min(1).max(1_024);
-const RuntimeEventCursorSchema = z.string().min(1).max(4_096);
+const RuntimeEventCursorSchema = z.string().min(1).max(4_096).refine(
+  (cursor) => new TextEncoder().encode(cursor).byteLength <= 4_096,
+  'Runtime event cursor exceeds the UTF-8 transport byte limit',
+);
 const RuntimeActionWorkspaceIdSchema = RuntimeWorkspaceIdSchema;
 const RuntimeActionTaskIdSchema = RuntimeTaskIdSchema;
 const BoundedReasonSchema = z.string().trim().min(1).max(1000);

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -1,8 +1,17 @@
 import { z } from 'zod';
 
 const TimestampSchema = z.string().datetime({ offset: true });
-const SafeMetadataValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
-export const RuntimeMetadataSchema = z.record(z.string(), SafeMetadataValueSchema);
+const SafeMetadataValueSchema = z.union([z.string().max(4_096), z.number(), z.boolean(), z.null()]);
+export const RuntimeMetadataSchema = z
+  .record(z.string().min(1).max(256), SafeMetadataValueSchema)
+  .superRefine((metadata, context) => {
+    if (Object.keys(metadata).length > 64) {
+      context.addIssue({ code: 'custom', message: 'Runtime metadata must contain at most 64 entries' });
+    }
+    if (JSON.stringify(metadata).length > 16_384) {
+      context.addIssue({ code: 'custom', message: 'Runtime metadata exceeds the serialized size limit' });
+    }
+  });
 
 const CorrelationIdSchema = z.string().uuid();
 const IdempotencyKeySchema = z.string().min(1).max(200).regex(/^[A-Za-z0-9._:-]+$/u);

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -18,7 +18,8 @@ const IdempotencyKeySchema = z.string().min(1).max(200).regex(/^[A-Za-z0-9._:-]+
 const RuntimeWorkspaceIdSchema = z.string().min(1);
 const RuntimeTaskIdSchema = z.string().min(1);
 const RuntimeApprovalIdSchema = z.string().min(1);
-const RuntimeEventIdSchema = z.string().min(1).max(1_024);
+export const RUNTIME_EVENT_ID_MAX_LENGTH = 1_024;
+const RuntimeEventIdSchema = z.string().min(1).max(RUNTIME_EVENT_ID_MAX_LENGTH);
 const RuntimeEventCursorSchema = z.string().min(1).max(4_096).refine(
   (cursor) => new TextEncoder().encode(cursor).byteLength <= 4_096,
   'Runtime event cursor exceeds the UTF-8 transport byte limit',

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -190,7 +190,7 @@ export const RuntimeEventSchema = z.object({
   runId: z.string().min(1).nullable(),
   type: z.enum(['lifecycle', 'comment', 'log', 'audit', 'blocker', 'approval', 'unknown']),
   occurredAt: TimestampSchema,
-  summary: z.string(),
+  summary: z.string().max(16_384),
   metadata: RuntimeMetadataSchema.optional(),
 }).strict();
 

--- a/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-schemas.ts
@@ -253,7 +253,7 @@ export const RuntimeSnapshotSchema = z.object({
 
 export const RuntimeEventPageSchema = z.object({
   events: z.array(RuntimeEventSchema),
-  nextCursor: z.string().min(1).nullable(),
+  nextCursor: RuntimeEventCursorSchema.nullable(),
 }).strict();
 
 export type RuntimeProvider = z.infer<typeof RuntimeProviderSchema>;

--- a/packages/franken-orchestrator/tests/unit/http/runtime-routes.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/runtime-routes.test.ts
@@ -2180,8 +2180,9 @@ describe('smart-swarm runtime routes', () => {
     await reader.cancel();
   });
 
-  it('accepts large cursors that a runtime adapter can emit', async () => {
+  it('accepts large opaque request cursors when provider prevalidation allows them', async () => {
     const { app, adapter } = createRoutes();
+    vi.mocked(adapter.getEvents).mockResolvedValue({ events: [], nextCursor: null });
     const cursor = 'x'.repeat(70_000);
     const response = await app.request(`/v1/smart-swarm/providers/hermes/events?cursor=${cursor}`, {
       headers: authHeaders(),
@@ -2192,35 +2193,35 @@ describe('smart-swarm runtime routes', () => {
     }));
   });
 
-  it('rejects cursors too large for a replay-safe SSE id before writing', async () => {
+  it('rejects oversized adapter checkpoints before writing an SSE frame', async () => {
     const adapter = runtimeAdapter();
-    vi.mocked(adapter.getEvents).mockResolvedValue(RuntimeEventPageSchema.parse({
+    vi.mocked(adapter.getEvents).mockResolvedValue({
       events: [],
       nextCursor: 'x'.repeat(5_000),
-    }));
+    });
     const stream = { pipe: vi.fn(), onAbort: vi.fn() };
 
     await expect(runRuntimeEventStream(adapter, stream as never, {
       heartbeatIntervalMs: 1_000,
       pollIntervalMs: 1_000,
-    })).rejects.toThrow('transport-safe');
+    })).rejects.toThrow('nextCursor');
     expect(stream.pipe).not.toHaveBeenCalled();
   });
 
-  it('measures replay-safe SSE cursor limits in UTF-8 bytes', async () => {
+  it('measures adapter checkpoint limits in UTF-8 bytes', async () => {
     const adapter = runtimeAdapter();
     vi.mocked(adapter.getEvents)
-      .mockResolvedValueOnce(RuntimeEventPageSchema.parse({
+      .mockResolvedValueOnce({
         events: [],
         nextCursor: '界'.repeat(2_000),
-      }))
+      })
       .mockRejectedValue(new Error('permanent poll failure'));
     const stream = { pipe: vi.fn(), onAbort: vi.fn() };
 
     await expect(runRuntimeEventStream(adapter, stream as never, {
       heartbeatIntervalMs: 1_000,
       pollIntervalMs: 1,
-    })).rejects.toThrow('transport-safe');
+    })).rejects.toThrow('UTF-8 transport byte limit');
     expect(stream.pipe).not.toHaveBeenCalled();
   });
 });

--- a/packages/franken-orchestrator/tests/unit/runtime/codex-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/codex-runtime-adapter.test.ts
@@ -531,6 +531,61 @@ input.on('line', (line) => {
     expect(JSON.stringify(snapshot)).not.toContain('secret-status-value');
   });
 
+  it.each(['sessionId', 'cliVersion', 'modelProvider'] as const)(
+    'degrades safely when thread %s exceeds normalized metadata bounds',
+    async (field) => {
+      const adapter = new CodexRuntimeAdapter({
+        request: async () => ({
+          data: [{
+            id: 'thread-oversized-metadata',
+            sessionId: 'session-1',
+            cliVersion: '0.145.0',
+            createdAt: 1_785_081_400,
+            updatedAt: 1_785_081_660,
+            cwd: '/workspace/project',
+            ephemeral: false,
+            modelProvider: 'openai',
+            status: { type: 'idle' },
+            [field]: 'x'.repeat(4_097),
+          }],
+          nextCursor: null,
+        }),
+      });
+
+      await expect(adapter.describe()).resolves.toEqual(expect.objectContaining({
+        health: expect.objectContaining({ state: 'degraded' }),
+      }));
+      await expect(adapter.getSnapshot()).resolves.toEqual(expect.objectContaining({
+        state: 'degraded',
+        agents: { status: 'available', data: [] },
+      }));
+    },
+  );
+
+  it('degrades safely when a thread id cannot fit normalized event identifiers', async () => {
+    const adapter = new CodexRuntimeAdapter({
+      request: async () => ({
+        data: [{
+          id: 'x'.repeat(957),
+          sessionId: 'session-1',
+          cliVersion: '0.145.0',
+          createdAt: 1_785_081_400,
+          updatedAt: 1_785_081_660,
+          cwd: '/workspace/project',
+          ephemeral: false,
+          modelProvider: 'openai',
+          status: { type: 'idle' },
+        }],
+        nextCursor: null,
+      }),
+    });
+
+    await expect(adapter.getSnapshot()).resolves.toEqual(expect.objectContaining({
+      state: 'degraded',
+      agents: { status: 'available', data: [] },
+    }));
+  });
+
   it('rejects active thread metadata that omits required active flags', async () => {
     const adapter = new CodexRuntimeAdapter({
       request: async () => ({

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -2280,6 +2280,28 @@ if (args.includes('show')) {
     ]));
   });
 
+  it('bounds unconstrained Hermes task and run metadata before shared schema parsing', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'kanban.db');
+    createCurrentKanban(dbPath);
+    const db = new Database(dbPath);
+    db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run('s'.repeat(4_097), 't_parent');
+    db.prepare('UPDATE task_runs SET status = ?, outcome = ? WHERE id = ?')
+      .run('r'.repeat(4_097), 'o'.repeat(4_097), 1);
+    db.close();
+
+    const snapshot = await new HermesRuntimeAdapter({ hermesHome: home }).getSnapshot();
+    if (snapshot.tasks.status !== 'available' || snapshot.runs.status !== 'available') {
+      throw new Error('Expected tasks and runs');
+    }
+
+    const task = snapshot.tasks.data.find((candidate) => candidate.id === 'hermes:global:t_parent')!;
+    const run = snapshot.runs.data.find((candidate) => candidate.id === 'hermes:global:run:1')!;
+    expect(String(task.metadata?.['runtimeStatus']).length).toBeLessThanOrEqual(4_096);
+    expect(String(run.metadata?.['runtimeStatus']).length).toBeLessThanOrEqual(4_096);
+    expect(String(run.metadata?.['outcome']).length).toBeLessThanOrEqual(4_096);
+  });
+
   it('discovers configured databases read-only and normalizes live task topology without leaking storage fields', async () => {
     const home = await createHome();
     await mkdir(join(home, 'kanban', 'boards', 'alpha'), { recursive: true });

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -136,6 +136,29 @@ describe('HermesRuntimeAdapter', () => {
     expect(eventPage.events).toHaveLength(0);
   });
 
+  it('advances past a full page of quarantined Hermes events', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const adapter = new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } });
+    const before = await adapter.getEvents({ limit: 10 });
+    const db = new Database(dbPath);
+    const insert = db.prepare(
+      'INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (?,?,?,?,?,?)',
+    );
+    db.transaction(() => {
+      for (let index = 0; index < 102; index += 1) {
+        insert.run(100 + index, `t_${'x'.repeat(1_100)}`, null, 'progress', null, 1_785_081_700 + index);
+      }
+      insert.run(300, 't_parent', null, 'completed', null, 1_785_081_900);
+    })();
+    db.close();
+
+    const page = await adapter.getEvents({ cursor: before.nextCursor!, limit: 100 });
+
+    expect(page.events.map((event) => event.id)).toEqual(['hermes:global:event:300']);
+  });
+
   it('preserves HERMES_KANBAN_DB when an explicit Hermes home is configured', async () => {
     const home = await createHome();
     const dbPath = join(home, 'configured.db');

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -186,6 +186,68 @@ describe('HermesRuntimeAdapter', () => {
     expect(recoveredPage.events.map((event) => event.id)).toContain('hermes:global:event:4000');
   });
 
+  it('emits a cold-start checkpoint after a bounded quarantined scan', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const db = new Database(dbPath);
+    db.exec('DELETE FROM task_events; DELETE FROM task_comments;');
+    const insert = db.prepare(
+      'INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (?,?,?,?,?,?)',
+    );
+    db.transaction(() => {
+      for (let index = 0; index < 2_000; index += 1) {
+        insert.run(1_000 + index, `t_${'x'.repeat(1_100)}_${index}`, null, 'progress', null, 1_785_081_700 + index);
+      }
+    })();
+    db.close();
+
+    const page = await new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } })
+      .getEvents({ limit: 100 });
+
+    expect(page.events).toEqual([]);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it('preserves valid cold-start events when a descending scan reaches its bound', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const db = new Database(dbPath);
+    db.exec('DELETE FROM task_events; DELETE FROM task_comments;');
+    const insert = db.prepare(
+      'INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (?,?,?,?,?,?)',
+    );
+    insert.run(5_000, 't_parent', null, 'completed', null, 1_785_090_000);
+    db.transaction(() => {
+      for (let index = 0; index < 2_000; index += 1) {
+        insert.run(1_000 + index, `t_${'x'.repeat(1_100)}_${index}`, null, 'progress', null, 1_785_081_700 + index);
+      }
+    })();
+    db.close();
+
+    const page = await new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } })
+      .getEvents({ limit: 100 });
+
+    expect(page.events.map((event) => event.id)).toContain('hermes:global:event:5000');
+  });
+
+  it('does not checkpoint valid events omitted by provider-wide pagination', async () => {
+    const home = await createHome();
+    await mkdir(join(home, 'kanban', 'boards', 'alpha'), { recursive: true });
+    await mkdir(join(home, 'kanban', 'boards', 'beta'), { recursive: true });
+    createCurrentKanban(join(home, 'kanban', 'boards', 'alpha', 'kanban.db'));
+    createCurrentKanban(join(home, 'kanban', 'boards', 'beta', 'kanban.db'));
+    const adapter = new HermesRuntimeAdapter({ hermesHome: home });
+
+    const first = await adapter.getEvents({ limit: 1 });
+    const second = await adapter.getEvents({ cursor: first.nextCursor ?? undefined, limit: 1 });
+
+    expect(new Set([...first.events, ...second.events].map((event) => event.workspaceId))).toEqual(
+      new Set(['hermes:alpha', 'hermes:beta']),
+    );
+  });
+
   it('backfills snapshot activity after quarantining the newest Hermes events', async () => {
     const home = await createHome();
     const dbPath = join(home, 'configured.db');
@@ -1258,7 +1320,7 @@ if (args.includes('show')) {
     expect(recovered.events.map((event) => event.id)).toEqual(['hermes:alpha:event:11']);
   });
 
-  it('seeds initial cursors for healthy workspaces whose older events fall outside the page', async () => {
+  it('replays healthy workspaces whose valid events fall outside the initial page', async () => {
     const home = await createHome();
     await mkdir(join(home, 'kanban', 'boards', 'alpha'), { recursive: true });
     createCurrentKanban(join(home, 'kanban.db'));
@@ -1269,7 +1331,9 @@ if (args.includes('show')) {
     const replay = await adapter.getEvents({ cursor: first.nextCursor!, limit: 10 });
 
     expect(first.events).toHaveLength(1);
-    expect(replay.events).toEqual([]);
+    expect(new Set([...first.events, ...replay.events].map((event) => event.workspaceId))).toEqual(
+      new Set(['hermes:global', 'hermes:alpha']),
+    );
   });
 
   it('preserves legacy cursor workspace ordering until each source advances', async () => {
@@ -1464,7 +1528,7 @@ if (args.includes('show')) {
     }
   });
 
-  it('rejects workspace sets that cannot fit in a bounded replay cursor', async () => {
+  it('keeps provider-wide replay cursors bounded without checkpointing omitted valid workspaces', async () => {
     const home = await createHome();
     for (let index = 0; index < 100; index += 1) {
       const boardName = `workspace-${String(index).padStart(3, '0')}-${'x'.repeat(120)}`;
@@ -1473,8 +1537,10 @@ if (args.includes('show')) {
       createCurrentKanban(join(boardDir, 'kanban.db'));
     }
 
-    await expect(new HermesRuntimeAdapter({ hermesHome: home }).getEvents({ limit: 1 }))
-      .rejects.toThrow('exceeds the supported runtime cursor size');
+    const page = await new HermesRuntimeAdapter({ hermesHome: home }).getEvents({ limit: 1 });
+
+    expect(page.events).toHaveLength(1);
+    expect(page.nextCursor?.length).toBeLessThanOrEqual(4_096);
   });
 
   it('preserves slash commands and API routes in normalized runtime text', async () => {

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -159,6 +159,52 @@ describe('HermesRuntimeAdapter', () => {
     expect(page.events.map((event) => event.id)).toEqual(['hermes:global:event:300']);
   });
 
+  it('backfills snapshot activity after quarantining the newest Hermes events', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const db = new Database(dbPath);
+    const insert = db.prepare(
+      'INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (?,?,?,?,?,?)',
+    );
+    db.transaction(() => {
+      for (let index = 0; index < 102; index += 1) {
+        insert.run(100 + index, `t_${'x'.repeat(1_100)}`, null, 'progress', null, 1_785_081_700 + index);
+      }
+    })();
+    db.close();
+
+    const snapshot = await new HermesRuntimeAdapter({
+      env: { HERMES_KANBAN_DB: dbPath },
+    }).getSnapshot({ activityLimit: 100 });
+
+    expect(snapshot.events.status).toBe('available');
+    if (snapshot.events.status !== 'available') throw new Error('expected available events');
+    expect(snapshot.events.data.map((event) => event.id)).toContain('hermes:global:event:10');
+  });
+
+  it('quarantines oversized Hermes event run identifiers without rejecting activity', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const db = new Database(dbPath);
+    db.prepare('UPDATE task_events SET run_id = ? WHERE id = ?').run(`r_${'x'.repeat(1_100)}`, 10);
+    db.close();
+
+    const adapter = new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } });
+    const snapshot = await adapter.getSnapshot();
+    const eventPage = await adapter.getEvents();
+
+    expect(snapshot.events.status).toBe('available');
+    if (snapshot.events.status !== 'available') throw new Error('expected available events');
+    expect(snapshot.events.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'hermes:global:event:10', runId: null }),
+    ]));
+    expect(eventPage.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'hermes:global:event:10', runId: null }),
+    ]));
+  });
+
   it('preserves HERMES_KANBAN_DB when an explicit Hermes home is configured', async () => {
     const home = await createHome();
     const dbPath = join(home, 'configured.db');

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -108,6 +108,34 @@ describe('HermesRuntimeAdapter', () => {
     }));
   });
 
+  it('quarantines oversized Hermes task identifiers before normalizing topology and events', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const oversizedTaskId = `t_${'x'.repeat(1_100)}`;
+    const db = new Database(dbPath);
+    db.transaction(() => {
+      db.prepare('UPDATE tasks SET id = ? WHERE id = ?').run(oversizedTaskId, 't_child');
+      db.prepare('UPDATE task_links SET child_id = ? WHERE child_id = ?').run(oversizedTaskId, 't_child');
+      db.prepare('UPDATE task_events SET task_id = ? WHERE task_id = ?').run(oversizedTaskId, 't_child');
+      db.prepare('UPDATE task_comments SET task_id = ? WHERE task_id = ?').run(oversizedTaskId, 't_child');
+    })();
+    db.close();
+
+    const adapter = new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } });
+    const snapshot = await adapter.getSnapshot();
+    const eventPage = await adapter.getEvents();
+
+    expect(snapshot.tasks.status).toBe('available');
+    if (snapshot.tasks.status !== 'available') throw new Error('expected available tasks');
+    expect(snapshot.tasks.data).toHaveLength(1);
+    expect(snapshot.tasks.data[0]?.id).toBe('hermes:global:t_parent');
+    expect(snapshot.events.status).toBe('available');
+    if (snapshot.events.status !== 'available') throw new Error('expected available events');
+    expect(snapshot.events.data).toHaveLength(0);
+    expect(eventPage.events).toHaveLength(0);
+  });
+
   it('preserves HERMES_KANBAN_DB when an explicit Hermes home is configured', async () => {
     const home = await createHome();
     const dbPath = join(home, 'configured.db');

--- a/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/hermes-runtime-adapter.test.ts
@@ -159,6 +159,33 @@ describe('HermesRuntimeAdapter', () => {
     expect(page.events.map((event) => event.id)).toEqual(['hermes:global:event:300']);
   });
 
+  it('bounds quarantined replay scans and checkpoints inspected malformed rows', async () => {
+    const home = await createHome();
+    const dbPath = join(home, 'configured.db');
+    createCurrentKanban(dbPath);
+    const adapter = new HermesRuntimeAdapter({ env: { HERMES_KANBAN_DB: dbPath } });
+    const before = await adapter.getEvents({ limit: 100 });
+    if (!before.nextCursor) throw new Error('Expected an initial replay cursor');
+    const db = new Database(dbPath);
+    const insert = db.prepare(
+      'INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (?,?,?,?,?,?)',
+    );
+    db.transaction(() => {
+      for (let index = 0; index < 2_001; index += 1) {
+        insert.run(1_000 + index, `t_${'x'.repeat(1_100)}_${index}`, null, 'progress', null, 1_785_081_700 + index);
+      }
+      insert.run(4_000, 't_parent', null, 'completed', null, 1_785_084_000);
+    })();
+    db.close();
+
+    const quarantinedPage = await adapter.getEvents({ cursor: before.nextCursor, limit: 100 });
+    expect(quarantinedPage.events).toEqual([]);
+    expect(quarantinedPage.nextCursor).not.toBe(before.nextCursor);
+
+    const recoveredPage = await adapter.getEvents({ cursor: quarantinedPage.nextCursor ?? undefined, limit: 100 });
+    expect(recoveredPage.events.map((event) => event.id)).toContain('hermes:global:event:4000');
+  });
+
   it('backfills snapshot activity after quarantining the newest Hermes events', async () => {
     const home = await createHome();
     const dbPath = join(home, 'configured.db');

--- a/packages/franken-orchestrator/tests/unit/runtime/ollama-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/ollama-runtime-adapter.test.ts
@@ -236,6 +236,32 @@ describe('OllamaRuntimeAdapter', () => {
     expect(endpoint.paths).toEqual(['/api/version', '/api/tags', '/api/ps']);
   });
 
+  it('bounds installed and loaded model metadata before parsing a snapshot', async () => {
+    const models = Array.from({ length: 200 }, (_, index) => ({
+      name: `model-${index.toString().padStart(3, '0')}-${'x'.repeat(24)}`,
+      size: index,
+      size_vram: index,
+    }));
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;
+      if (path === '/api/version') return Response.json({ version: '0.11.4' });
+      if (path === '/api/tags') return Response.json({ models });
+      if (path === '/api/ps') return Response.json({ models });
+      return Response.json({ error: 'not found' }, { status: 404 });
+    });
+    const adapter = new OllamaRuntimeAdapter({
+      endpoints: [{ id: 'lab', baseUrl: 'http://127.0.0.1:11434' }],
+      fetchImpl,
+    });
+
+    const snapshot = await adapter.getSnapshot();
+    expect(snapshot.workspaces.status).toBe('available');
+    if (snapshot.workspaces.status !== 'available') throw new Error('expected available workspaces');
+    expect(snapshot.workspaces.data[0]?.metadata?.['installedModels']).toEqual(expect.any(String));
+    expect(String(snapshot.workspaces.data[0]?.metadata?.['installedModels']).length).toBeLessThanOrEqual(4_096);
+    expect(String(snapshot.workspaces.data[0]?.metadata?.['loadedModels']).length).toBeLessThanOrEqual(4_096);
+  });
+
   it('keeps cloud-compatible endpoints available when daemon introspection routes are unsupported', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;

--- a/packages/franken-orchestrator/tests/unit/runtime/ollama-runtime-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/ollama-runtime-adapter.test.ts
@@ -244,7 +244,7 @@ describe('OllamaRuntimeAdapter', () => {
     }));
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;
-      if (path === '/api/version') return Response.json({ version: '0.11.4' });
+      if (path === '/api/version') return Response.json({ version: `v-${'x'.repeat(5_000)}` });
       if (path === '/api/tags') return Response.json({ models });
       if (path === '/api/ps') return Response.json({ models });
       return Response.json({ error: 'not found' }, { status: 404 });
@@ -257,6 +257,7 @@ describe('OllamaRuntimeAdapter', () => {
     const snapshot = await adapter.getSnapshot();
     expect(snapshot.workspaces.status).toBe('available');
     if (snapshot.workspaces.status !== 'available') throw new Error('expected available workspaces');
+    expect(String(snapshot.workspaces.data[0]?.metadata?.['version']).length).toBeLessThanOrEqual(4_096);
     expect(snapshot.workspaces.data[0]?.metadata?.['installedModels']).toEqual(expect.any(String));
     expect(String(snapshot.workspaces.data[0]?.metadata?.['installedModels']).length).toBeLessThanOrEqual(4_096);
     expect(String(snapshot.workspaces.data[0]?.metadata?.['loadedModels']).length).toBeLessThanOrEqual(4_096);

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
@@ -197,6 +197,15 @@ describe('provider-neutral runtime contract', () => {
     expect(RuntimeEventSchema.safeParse({ ...event, summary: `${event.summary}x` }).success).toBe(false);
   });
 
+  it('bounds normalized metadata consistently with browser validation', () => {
+    const metadata = Object.fromEntries(Array.from({ length: 64 }, (_, index) => [`key-${index}`, index]));
+
+    expect(RuntimeMetadataSchema.safeParse(metadata).success).toBe(true);
+    expect(RuntimeMetadataSchema.safeParse({ ...metadata, overflow: true }).success).toBe(false);
+    expect(RuntimeMetadataSchema.safeParse({ key: 'x'.repeat(4_097) }).success).toBe(false);
+    expect(RuntimeMetadataSchema.safeParse({ ['x'.repeat(257)]: true }).success).toBe(false);
+  });
+
   it('requires every capability to declare supported or unsupported state', async () => {
     const value = adapter('one').describe();
     await expect(value).resolves.toMatchObject({ id: 'one' });

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
@@ -6,6 +6,7 @@ import {
   RuntimeApprovalSchema,
   RuntimeBlockerSchema,
   RuntimeCursorError,
+  RuntimeEventSchema,
   RuntimeHealthSchema,
   RuntimeMetadataSchema,
   OllamaRuntimeAdapter,
@@ -178,6 +179,22 @@ describe('provider-neutral runtime contract', () => {
       createdAt: '2026-07-26T12:00:00.000Z',
       updatedAt: null,
     })).toEqual(expect.objectContaining({ id: 't'.repeat(201) }));
+  });
+
+  it('bounds normalized event summaries consistently with browser validation', () => {
+    const event = {
+      id: 'event-1',
+      cursor: 'cursor-1',
+      workspaceId: 'workspace-1',
+      taskId: null,
+      runId: null,
+      type: 'log',
+      occurredAt: '2026-07-26T12:00:00.000Z',
+      summary: 'x'.repeat(16_384),
+    } as const;
+
+    expect(RuntimeEventSchema.safeParse(event).success).toBe(true);
+    expect(RuntimeEventSchema.safeParse({ ...event, summary: `${event.summary}x` }).success).toBe(false);
   });
 
   it('requires every capability to declare supported or unsupported state', async () => {

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
@@ -6,6 +6,7 @@ import {
   RuntimeApprovalSchema,
   RuntimeBlockerSchema,
   RuntimeCursorError,
+  RuntimeEventPageSchema,
   RuntimeEventSchema,
   RuntimeHealthSchema,
   RuntimeMetadataSchema,
@@ -216,6 +217,12 @@ describe('provider-neutral runtime contract', () => {
     expect(RuntimeEventSchema.safeParse({ ...event, runId: `${event.runId}x` }).success).toBe(false);
     expect(RuntimeEventSchema.safeParse({ ...event, cursor: `${event.cursor}x` }).success).toBe(false);
     expect(RuntimeEventSchema.safeParse({ ...event, cursor: '🚀'.repeat(1_025) }).success).toBe(false);
+  });
+
+  it('bounds checkpoint-only event page cursors by UTF-8 transport bytes', () => {
+    expect(RuntimeEventPageSchema.safeParse({ events: [], nextCursor: 'x'.repeat(4_096) }).success).toBe(true);
+    expect(RuntimeEventPageSchema.safeParse({ events: [], nextCursor: 'x'.repeat(4_097) }).success).toBe(false);
+    expect(RuntimeEventPageSchema.safeParse({ events: [], nextCursor: '🚀'.repeat(1_025) }).success).toBe(false);
   });
 
   it('bounds normalized metadata consistently with browser validation', () => {

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
@@ -215,6 +215,7 @@ describe('provider-neutral runtime contract', () => {
     expect(RuntimeEventSchema.safeParse({ ...event, taskId: `${event.taskId}x` }).success).toBe(false);
     expect(RuntimeEventSchema.safeParse({ ...event, runId: `${event.runId}x` }).success).toBe(false);
     expect(RuntimeEventSchema.safeParse({ ...event, cursor: `${event.cursor}x` }).success).toBe(false);
+    expect(RuntimeEventSchema.safeParse({ ...event, cursor: '🚀'.repeat(1_025) }).success).toBe(false);
   });
 
   it('bounds normalized metadata consistently with browser validation', () => {

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-contract.test.ts
@@ -197,6 +197,26 @@ describe('provider-neutral runtime contract', () => {
     expect(RuntimeEventSchema.safeParse({ ...event, summary: `${event.summary}x` }).success).toBe(false);
   });
 
+  it('bounds normalized event identifiers and cursors consistently with browser validation', () => {
+    const event = {
+      id: 'x'.repeat(1_024),
+      cursor: 'x'.repeat(4_096),
+      workspaceId: 'x'.repeat(1_024),
+      taskId: 'x'.repeat(1_024),
+      runId: 'x'.repeat(1_024),
+      type: 'log',
+      occurredAt: '2026-07-26T12:00:00.000Z',
+      summary: 'bounded identifiers',
+    } as const;
+
+    expect(RuntimeEventSchema.safeParse(event).success).toBe(true);
+    expect(RuntimeEventSchema.safeParse({ ...event, id: `${event.id}x` }).success).toBe(false);
+    expect(RuntimeEventSchema.safeParse({ ...event, workspaceId: `${event.workspaceId}x` }).success).toBe(false);
+    expect(RuntimeEventSchema.safeParse({ ...event, taskId: `${event.taskId}x` }).success).toBe(false);
+    expect(RuntimeEventSchema.safeParse({ ...event, runId: `${event.runId}x` }).success).toBe(false);
+    expect(RuntimeEventSchema.safeParse({ ...event, cursor: `${event.cursor}x` }).success).toBe(false);
+  });
+
   it('bounds normalized metadata consistently with browser validation', () => {
     const metadata = Object.fromEntries(Array.from({ length: 64 }, (_, index) => [`key-${index}`, index]));
 

--- a/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-pulse-map.tsx
@@ -99,11 +99,11 @@ export function BrainPulseMap({ snapshot, activities, activityReceipts, onOpenRu
     : [];
 
   return (
-    <section className="brain-pulse-map" role="region" aria-label="Brain pulse map">
+    <section className="brain-pulse-map" role="region" aria-label="Run telemetry activity map">
       <header>
         <div>
-          <h4>Live Brain Pulse Map</h4>
-          <p>Pulse rate reflects real activity events observed in the last minute.</p>
+          <h4>Live run telemetry activity</h4>
+          <p>Rates reflect Beast-run telemetry observed in the last minute, not provider-neutral Brain Pulse events.</p>
         </div>
         <small>{recentActivityCount} recent {recentActivityCount === 1 ? 'event' : 'events'}</small>
       </header>
@@ -145,7 +145,7 @@ export function BrainPulseMap({ snapshot, activities, activityReceipts, onOpenRu
         <section
           className="brain-pulse-map__detail"
           role="region"
-          aria-label={`${LABELS[selectedDimension]} pulse detail`}
+          aria-label={`${LABELS[selectedDimension]} run activity detail`}
         >
           <div>
             <h5>{LABELS[selectedDimension]} activity</h5>

--- a/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
+++ b/packages/franken-web/src/components/brain-vitals/brain-vitals-panel.test.tsx
@@ -155,7 +155,7 @@ describe('BrainVitalsPanel', () => {
     expect(api.fetchBrainVitalsRun).toHaveBeenCalledWith('reviewer', 'run-1');
   });
 
-  it('renders only the five real vitals dimensions and uses their activity for drill-down', async () => {
+  it('labels Beast telemetry as run activity rather than the provider-neutral Brain Pulse', async () => {
     let pushActivity!: (activity: BrainVitalsActivity) => void;
     const api = client({
       subscribeToBrainVitals: vi.fn((_brainId, _onSnapshot, _onError, onActivity) => {
@@ -166,7 +166,8 @@ describe('BrainVitalsPanel', () => {
 
     render(<BrainVitalsPanel client={api} />);
 
-    expect(await screen.findByRole('region', { name: 'Brain pulse map' })).toBeTruthy();
+    expect(await screen.findByRole('region', { name: 'Run telemetry activity map' })).toBeTruthy();
+    expect(screen.queryByRole('region', { name: 'Brain pulse map' })).toBeNull();
     expect(screen.getAllByRole('button', { name: /activity:/ })).toHaveLength(5);
     expect(screen.queryByLabelText('Faculty pulse map availability')).toBeNull();
     expect(screen.queryByText(/Coming soon/)).toBeNull();
@@ -187,7 +188,7 @@ describe('BrainVitalsPanel', () => {
     });
 
     fireEvent.click(compactionNode);
-    expect(screen.getByRole('region', { name: 'Compaction pulse detail' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Compaction run activity detail' })).toBeTruthy();
     expect(screen.getByText('compaction.completed')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Open run run-1 from compaction activity' }));
 

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -1,0 +1,252 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RuntimeEvent,
+  RuntimeProvider,
+  RuntimeSnapshot,
+} from '../../lib/smart-swarm-api';
+import { RuntimeBrainPulse } from './runtime-brain-pulse';
+
+const provider: RuntimeProvider = {
+  id: 'hermes',
+  runtime: 'hermes',
+  displayName: 'Hermes',
+  health: { state: 'connected', checkedAt: '2026-07-28T00:00:00.000Z' },
+  capabilities: {
+    snapshot: { status: 'supported' },
+    streaming: { status: 'supported' },
+    logs: { status: 'supported' },
+    blockers: { status: 'supported' },
+    approvals: { status: 'supported' },
+    pause: { status: 'unsupported', reason: 'Unavailable.' },
+    resume: { status: 'unsupported', reason: 'Unavailable.' },
+    cancellation: { status: 'unsupported', reason: 'Unavailable.' },
+    policyActions: { status: 'unsupported', reason: 'Unavailable.' },
+  },
+};
+
+const snapshot: RuntimeSnapshot = {
+  providerId: 'hermes',
+  state: 'ready',
+  capturedAt: '2026-07-28T00:00:00.000Z',
+  workspaces: { status: 'available', data: [] },
+  agents: { status: 'available', data: [] },
+  tasks: { status: 'available', data: [] },
+  runs: { status: 'available', data: [] },
+  events: { status: 'available', data: [] },
+  blockers: { status: 'available', data: [] },
+  approvals: { status: 'available', data: [] },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('RuntimeBrainPulse', () => {
+  it('prunes pulses when their source timestamp leaves the one-minute window', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-07-28T00:01:00.000Z');
+    vi.setSystemTime(now);
+    const event: RuntimeEvent = {
+      id: 'event-expiring',
+      cursor: 'cursor-expiring',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'comment',
+      occurredAt: new Date(now.getTime() - 59_000).toISOString(),
+      summary: 'Review requested',
+    };
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[event]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+    expect(screen.getByRole('region', { name: 'Runtime brain pulse' }).getAttribute('data-pulse-state')).toBe('active');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByRole('region', { name: 'Runtime brain pulse' }).getAttribute('data-pulse-state')).toBe('idle');
+    expect(screen.queryByText('Review requested')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('No activity');
+  });
+
+  it('deduplicates replayed normalized events by provider and event identity', () => {
+    const event: RuntimeEvent = {
+      id: 'event-1',
+      cursor: 'cursor-1',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'lifecycle',
+      occurredAt: new Date().toISOString(),
+      summary: 'Task started',
+    };
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[event, { ...event }]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const pulse = screen.getByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.textContent).toContain('1 event in the last minute');
+    expect(pulse.getAttribute('data-pulse-state')).toBe('active');
+    expect(pulse.textContent)
+      .toContain('Task started');
+    expect(screen.getAllByRole('button', { name: 'Open source task task-1 for event event-1' })).toHaveLength(1);
+  });
+
+  it('announces no activity only while the supported stream is connected', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('No activity');
+    expect(status.textContent).toContain('Connected');
+  });
+
+  it('announces a disconnected stream without presenting stale activity as live', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="reconnecting"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const status = screen.getByRole('alert');
+    expect(status.textContent).toContain('Disconnected');
+    expect(status.textContent).toContain('Reconnecting');
+    expect(status.textContent).not.toContain('No activity');
+  });
+
+  it('labels retained recent evidence as stale instead of an active pulse while disconnected', () => {
+    const event: RuntimeEvent = {
+      id: 'event-stale',
+      cursor: 'cursor-stale',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'log',
+      occurredAt: new Date().toISOString(),
+      summary: 'Previously received evidence',
+    };
+    render(
+      <RuntimeBrainPulse
+        connection="reconnecting"
+        events={[event]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const pulse = screen.getByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.getAttribute('data-pulse-state')).toBe('stale');
+    expect(pulse.textContent).toContain('1 retained event · not live');
+    expect(pulse.textContent).toContain('Previously received evidence');
+    expect(pulse.textContent).not.toContain('1 event in the last minute');
+  });
+
+  it('announces degraded normalized evidence separately from connection loss', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={{ ...snapshot, state: 'degraded', message: 'One Hermes database is temporarily locked.' }}
+      />,
+    );
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('Degraded');
+    expect(status.textContent).toContain('One Hermes database is temporarily locked.');
+    expect(status.textContent).not.toContain('No activity');
+    expect(status.textContent).not.toContain('Disconnected');
+  });
+
+  it('politely announces arriving event count changes without an alert', () => {
+    const { rerender } = render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+    const event: RuntimeEvent = {
+      id: 'event-announced',
+      cursor: 'cursor-announced',
+      workspaceId: 'board-main',
+      taskId: null,
+      runId: null,
+      type: 'comment',
+      occurredAt: new Date().toISOString(),
+      summary: 'A new review comment arrived',
+    };
+
+    rerender(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[event]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const announcement = document.querySelector('[aria-live="polite"]');
+    expect(announcement?.textContent).toBe('1 event in the last minute');
+    expect(announcement?.getAttribute('aria-live')).toBe('polite');
+    expect(announcement?.getAttribute('aria-atomic')).toBe('true');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('renders unsupported as a semantic state instead of no activity', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="unavailable"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={{
+          ...provider,
+          capabilities: {
+            ...provider.capabilities,
+            streaming: { status: 'unsupported', reason: 'This runtime has no event stream.' },
+          },
+        }}
+        snapshot={{
+          ...snapshot,
+          events: { status: 'unsupported', reason: 'This runtime has no event history.' },
+        }}
+      />,
+    );
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('Unsupported');
+    expect(status.textContent).toContain('This runtime has no event stream.');
+    expect(status.textContent).not.toContain('No activity');
+  });
+});

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -312,6 +312,24 @@ describe('RuntimeBrainPulse', () => {
     expect(alert.textContent).not.toContain('No activity');
   });
 
+  it('prioritizes a known runtime failure while the event transport reconnects', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="reconnecting"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={{ ...snapshot, state: 'schema-incompatible', message: 'Hermes schema version is incompatible.' }}
+      />,
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Unavailable');
+    expect(alert.textContent).toContain('Hermes schema version is incompatible.');
+    expect(alert.textContent).not.toContain('Disconnected');
+    expect(alert.textContent).not.toContain('Reconnecting');
+  });
+
   it('discloses when the displayed event count reaches its retention limit', () => {
     const now = new Date();
     const events = Array.from({ length: 100 }, (_, index): RuntimeEvent => ({

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -110,6 +110,41 @@ describe('RuntimeBrainPulse', () => {
     expect(pulse.textContent).not.toContain('Corrupt future activity');
   });
 
+  it('retains newly received activity for a full minute when the provider clock trails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'));
+    const event: RuntimeEvent = {
+      id: 'event-provider-behind',
+      cursor: 'cursor-provider-behind',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'lifecycle',
+      occurredAt: '2026-07-27T23:59:30.000Z',
+      summary: 'Provider clock trails browser',
+    };
+    const props = {
+      connection: 'connected' as const,
+      onOpenTask: () => undefined,
+      provider,
+      snapshot,
+    };
+    const { rerender } = render(<RuntimeBrainPulse {...props} events={[]} />);
+
+    rerender(<RuntimeBrainPulse {...props} events={[event]} />);
+    expect(screen.getByText('Provider clock trails browser')).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(35_000);
+    });
+    expect(screen.getByText('Provider clock trails browser')).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(screen.queryByText('Provider clock trails browser')).toBeNull();
+  });
+
   it('prunes pulses when their source timestamp leaves the one-minute window', async () => {
     vi.useFakeTimers();
     const now = new Date('2026-07-28T00:01:00.000Z');

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -249,4 +249,24 @@ describe('RuntimeBrainPulse', () => {
     expect(status.textContent).toContain('This runtime has no event stream.');
     expect(status.textContent).not.toContain('No activity');
   });
+
+  it('keeps a supported live stream available when event history is unsupported', () => {
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={{
+          ...snapshot,
+          events: { status: 'unsupported', reason: 'This runtime has no event history.' },
+        }}
+      />,
+    );
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('No activity');
+    expect(status.textContent).not.toContain('Unsupported');
+    expect(status.textContent).not.toContain('event history');
+  });
 });

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -145,6 +145,53 @@ describe('RuntimeBrainPulse', () => {
     expect(screen.queryByText('Provider clock trails browser')).toBeNull();
   });
 
+  it('renders modest negative-skew activity immediately alongside allowed future skew', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'));
+    const props = {
+      connection: 'connected' as const,
+      onOpenTask: () => undefined,
+      provider,
+      snapshot,
+    };
+    const { rerender } = render(<RuntimeBrainPulse {...props} events={[]} />);
+
+    rerender(<RuntimeBrainPulse {...props} events={[
+      {
+        id: 'event-behind-now', cursor: 'cursor-behind-now', workspaceId: 'board-main',
+        taskId: 'task-1', runId: 'run-1', type: 'lifecycle',
+        occurredAt: '2026-07-27T23:59:30.000Z', summary: 'Behind but live',
+      },
+      {
+        id: 'event-ahead-now', cursor: 'cursor-ahead-now', workspaceId: 'board-main',
+        taskId: 'task-1', runId: 'run-1', type: 'lifecycle',
+        occurredAt: '2026-07-28T00:00:55.000Z', summary: 'Ahead but allowed',
+      },
+    ]} />);
+
+    expect(screen.getByText('Behind but live')).toBeTruthy();
+  });
+
+  it('expires allowed future-skew activity one minute after browser receipt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'));
+    render(<RuntimeBrainPulse
+      connection="connected"
+      events={[{
+        id: 'event-ahead-expiry', cursor: 'cursor-ahead-expiry', workspaceId: 'board-main',
+        taskId: 'task-1', runId: 'run-1', type: 'lifecycle',
+        occurredAt: '2026-07-28T00:00:55.000Z', summary: 'Ahead expires',
+      }]}
+      onOpenTask={() => undefined}
+      provider={provider}
+      snapshot={snapshot}
+    />);
+
+    expect(screen.getByText('Ahead expires')).toBeTruthy();
+    await act(async () => { await vi.advanceTimersByTimeAsync(65_000); });
+    expect(screen.queryByText('Ahead expires')).toBeNull();
+  });
+
   it('prunes pulses when their source timestamp leaves the one-minute window', async () => {
     vi.useFakeTimers();
     const now = new Date('2026-07-28T00:01:00.000Z');

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -270,6 +270,48 @@ describe('RuntimeBrainPulse', () => {
     expect(status.textContent).not.toContain('event history');
   });
 
+  it.each([
+    {
+      label: 'snapshot unavailable',
+      expectedReason: 'Snapshot source unavailable.',
+      ignoredReason: 'The runtime provider is healthy.',
+      testProvider: provider,
+      testSnapshot: { ...snapshot, state: 'unavailable' as const, message: 'Snapshot source unavailable.' },
+    },
+    {
+      label: 'provider schema incompatible',
+      expectedReason: 'Provider schema incompatible.',
+      ignoredReason: 'Snapshot data is stale but readable.',
+      testProvider: {
+        ...provider,
+        health: { ...provider.health, state: 'schema-incompatible' as const, message: 'Provider schema incompatible.' },
+      },
+      testSnapshot: { ...snapshot, message: 'Snapshot data is stale but readable.' },
+    },
+  ])('preserves $label while the event transport is connected', ({
+    expectedReason,
+    ignoredReason,
+    testProvider,
+    testSnapshot,
+  }) => {
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[]}
+        onOpenTask={() => undefined}
+        provider={testProvider}
+        snapshot={testSnapshot}
+      />,
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Unavailable');
+    expect(alert.textContent).toContain(expectedReason);
+    expect(alert.textContent).not.toContain(ignoredReason);
+    expect(alert.textContent).not.toContain('Connected');
+    expect(alert.textContent).not.toContain('No activity');
+  });
+
   it('discloses when the displayed event count reaches its retention limit', () => {
     const now = new Date();
     const events = Array.from({ length: 100 }, (_, index): RuntimeEvent => ({

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -269,4 +269,32 @@ describe('RuntimeBrainPulse', () => {
     expect(status.textContent).not.toContain('Unsupported');
     expect(status.textContent).not.toContain('event history');
   });
+
+  it('discloses when the displayed event count reaches its retention limit', () => {
+    const now = new Date();
+    const events = Array.from({ length: 100 }, (_, index): RuntimeEvent => ({
+      id: `event-${index}`,
+      cursor: `cursor-${index}`,
+      workspaceId: 'board-main',
+      taskId: null,
+      runId: null,
+      type: 'log',
+      occurredAt: now.toISOString(),
+      summary: `Event ${index}`,
+    }));
+
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        eventLimit={100}
+        events={events}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    expect(document.querySelector('[aria-live="polite"]')?.textContent)
+      .toBe('Latest 100 retained events from the last minute');
+  });
 });

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -44,6 +44,35 @@ afterEach(() => {
 });
 
 describe('RuntimeBrainPulse', () => {
+  it('keeps fresh runtime events visible when the browser clock is behind', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'));
+    const event: RuntimeEvent = {
+      id: 'event-clock-skew',
+      cursor: 'cursor-clock-skew',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'lifecycle',
+      occurredAt: '2026-07-28T00:00:30.000Z',
+      summary: 'Runtime host is ahead',
+    };
+
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[event]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const pulse = screen.getByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.getAttribute('data-pulse-state')).toBe('active');
+    expect(pulse.textContent).toContain('Runtime host is ahead');
+  });
+
   it('prunes pulses when their source timestamp leaves the one-minute window', async () => {
     vi.useFakeTimers();
     const now = new Date('2026-07-28T00:01:00.000Z');

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.test.tsx
@@ -73,6 +73,43 @@ describe('RuntimeBrainPulse', () => {
     expect(pulse.textContent).toContain('Runtime host is ahead');
   });
 
+  it('does not let an arbitrarily future event hide current runtime activity', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'));
+    const currentEvent: RuntimeEvent = {
+      id: 'event-current',
+      cursor: 'cursor-current',
+      workspaceId: 'board-main',
+      taskId: 'task-1',
+      runId: 'run-1',
+      type: 'lifecycle',
+      occurredAt: '2026-07-28T00:00:00.000Z',
+      summary: 'Current runtime activity',
+    };
+    const futureEvent: RuntimeEvent = {
+      ...currentEvent,
+      id: 'event-future',
+      cursor: 'cursor-future',
+      occurredAt: '2026-07-28T02:00:00.000Z',
+      summary: 'Corrupt future activity',
+    };
+
+    render(
+      <RuntimeBrainPulse
+        connection="connected"
+        events={[currentEvent, futureEvent]}
+        onOpenTask={() => undefined}
+        provider={provider}
+        snapshot={snapshot}
+      />,
+    );
+
+    const pulse = screen.getByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.getAttribute('data-pulse-state')).toBe('active');
+    expect(pulse.textContent).toContain('Current runtime activity');
+    expect(pulse.textContent).not.toContain('Corrupt future activity');
+  });
+
   it('prunes pulses when their source timestamp leaves the one-minute window', async () => {
     vi.useFakeTimers();
     const now = new Date('2026-07-28T00:01:00.000Z');

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -52,12 +52,21 @@ export function RuntimeBrainPulse({
   const unsupportedReason = provider.capabilities.streaming.status === 'unsupported'
     ? provider.capabilities.streaming.reason
     : null;
+  const snapshotUnavailable = snapshot.state === 'unavailable'
+    || snapshot.state === 'schema-incompatible';
+  const providerUnavailable = provider.health.state === 'unavailable'
+    || provider.health.state === 'schema-incompatible';
+  const runtimeUnavailable = snapshotUnavailable || providerUnavailable;
+  const runtimeUnavailableReason = snapshotUnavailable
+    ? snapshot.message ?? 'The normalized runtime snapshot is unavailable.'
+    : provider.health.message ?? 'The normalized runtime provider is unavailable.';
+  const isLiveConnected = connection === 'connected' && !runtimeUnavailable;
   const pulseState = recentEvents.length === 0
     ? 'idle'
-    : connection === 'connected'
+    : isLiveConnected
       ? 'active'
       : 'stale';
-  const eventCountLabel = connection === 'connected'
+  const eventCountLabel = isLiveConnected
     ? eventLimit !== undefined && recentEvents.length >= eventLimit
       ? `Latest ${recentEvents.length} retained events from the last minute`
       : `${recentEvents.length} ${recentEvents.length === 1 ? 'event' : 'events'} in the last minute`
@@ -86,6 +95,10 @@ export function RuntimeBrainPulse({
       ) : connection === 'reconnecting' || connection === 'unavailable' ? (
         <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
           <strong>Disconnected</strong> · {connection === 'reconnecting' ? 'Reconnecting to normalized runtime events.' : 'Live runtime events are unavailable.'}
+        </p>
+      ) : runtimeUnavailable ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
+          <strong>Unavailable</strong> · {runtimeUnavailableReason}
         </p>
       ) : snapshot.state === 'degraded' || provider.health.state === 'degraded' ? (
         <p className="runtime-brain-pulse__state runtime-brain-pulse__state--degraded" role="status">

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -8,6 +8,7 @@ import type {
 
 const PULSE_WINDOW_MS = 60_000;
 const MAX_FUTURE_SKEW_MS = 60_000;
+const MAX_PAST_SKEW_MS = 60_000;
 
 function eventReceiptKey(event: RuntimeEvent): string {
   return `${event.id}\u0000${event.occurredAt}`;
@@ -42,8 +43,15 @@ export function RuntimeBrainPulse({
   useEffect(() => {
     const currentKeys = new Set(events.map(eventReceiptKey));
     const receivedAt = Date.now();
-    for (const key of currentKeys) {
-      if (!knownEventKeys.current.has(key)) receivedAtByEvent.current.set(key, receivedAt);
+    for (const event of events) {
+      const key = eventReceiptKey(event);
+      if (knownEventKeys.current.has(key)) continue;
+      const occurredAt = Date.parse(event.occurredAt);
+      if (
+        Number.isFinite(occurredAt)
+        && occurredAt >= receivedAt - MAX_PAST_SKEW_MS
+        && occurredAt <= receivedAt + MAX_FUTURE_SKEW_MS
+      ) receivedAtByEvent.current.set(key, receivedAt);
     }
     for (const key of receivedAtByEvent.current.keys()) {
       if (!currentKeys.has(key)) receivedAtByEvent.current.delete(key);

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -32,8 +32,16 @@ export function RuntimeBrainPulse({
   onOpenTask,
 }: RuntimeBrainPulseProps) {
   const [now, setNow] = useState(() => Date.now());
+  const [receiptRevision, setReceiptRevision] = useState(0);
   const knownEventKeys = useRef(new Set(events.map(eventReceiptKey)));
-  const receivedAtByEvent = useRef(new Map<string, number>());
+  const receivedAtByEvent = useRef(new Map(events.flatMap((event) => {
+    const occurredAt = Date.parse(event.occurredAt);
+    return Number.isFinite(occurredAt)
+      && occurredAt > now
+      && occurredAt <= now + MAX_FUTURE_SKEW_MS
+      ? [[eventReceiptKey(event), now] as const]
+      : [];
+  })));
 
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 5_000);
@@ -43,6 +51,7 @@ export function RuntimeBrainPulse({
   useEffect(() => {
     const currentKeys = new Set(events.map(eventReceiptKey));
     const receivedAt = Date.now();
+    let receiptAdded = false;
     for (const event of events) {
       const key = eventReceiptKey(event);
       if (knownEventKeys.current.has(key)) continue;
@@ -51,31 +60,27 @@ export function RuntimeBrainPulse({
         Number.isFinite(occurredAt)
         && occurredAt >= receivedAt - MAX_PAST_SKEW_MS
         && occurredAt <= receivedAt + MAX_FUTURE_SKEW_MS
-      ) receivedAtByEvent.current.set(key, receivedAt);
+      ) {
+        receivedAtByEvent.current.set(key, receivedAt);
+        receiptAdded = true;
+      }
     }
     for (const key of receivedAtByEvent.current.keys()) {
       if (!currentKeys.has(key)) receivedAtByEvent.current.delete(key);
     }
     knownEventKeys.current = currentKeys;
+    if (receiptAdded) setReceiptRevision((current) => current + 1);
   }, [events]);
 
   const recentEvents = useMemo(() => {
     const unique = new Map<string, RuntimeEvent>();
-    const pulseNow = events.reduce((latest, event) => {
-      const occurredAt = Date.parse(event.occurredAt);
-      return Number.isFinite(occurredAt) && occurredAt <= now + MAX_FUTURE_SKEW_MS
-        ? Math.max(latest, occurredAt)
-        : latest;
-    }, now);
     for (const event of events) {
       const occurredAt = Date.parse(event.occurredAt);
       const receivedAt = receivedAtByEvent.current.get(eventReceiptKey(event));
+      const freshnessAt = receivedAt ?? occurredAt;
       if (
         !Number.isFinite(occurredAt)
-        || (
-          occurredAt < pulseNow - PULSE_WINDOW_MS
-          && (receivedAt === undefined || receivedAt < now - PULSE_WINDOW_MS)
-        )
+        || freshnessAt < now - PULSE_WINDOW_MS
         || occurredAt > now + MAX_FUTURE_SKEW_MS
       ) continue;
       const current = unique.get(event.id);
@@ -85,7 +90,7 @@ export function RuntimeBrainPulse({
       Date.parse(right.occurredAt) - Date.parse(left.occurredAt)
       || left.id.localeCompare(right.id)
     ));
-  }, [events, now]);
+  }, [events, now, receiptRevision]);
   const unsupportedReason = provider.capabilities.streaming.status === 'unsupported'
     ? provider.capabilities.streaming.reason
     : null;

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -86,11 +86,13 @@ export function RuntimeBrainPulse({
       const current = unique.get(event.id);
       if (!current || occurredAt > Date.parse(current.occurredAt)) unique.set(event.id, event);
     }
-    return [...unique.values()].sort((left, right) => (
-      Date.parse(right.occurredAt) - Date.parse(left.occurredAt)
-      || left.id.localeCompare(right.id)
-    ));
-  }, [events, now, receiptRevision]);
+    return [...unique.values()]
+      .sort((left, right) => (
+        Date.parse(right.occurredAt) - Date.parse(left.occurredAt)
+        || left.id.localeCompare(right.id)
+      ))
+      .slice(0, eventLimit);
+  }, [eventLimit, events, now, receiptRevision]);
   const unsupportedReason = provider.capabilities.streaming.status === 'unsupported'
     ? provider.capabilities.streaming.reason
     : null;

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -92,13 +92,13 @@ export function RuntimeBrainPulse({
         <p className="runtime-brain-pulse__state runtime-brain-pulse__state--unsupported" role="status">
           <strong>Unsupported</strong> · {unsupportedReason}
         </p>
-      ) : connection === 'reconnecting' || connection === 'unavailable' ? (
-        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
-          <strong>Disconnected</strong> · {connection === 'reconnecting' ? 'Reconnecting to normalized runtime events.' : 'Live runtime events are unavailable.'}
-        </p>
       ) : runtimeUnavailable ? (
         <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
           <strong>Unavailable</strong> · {runtimeUnavailableReason}
+        </p>
+      ) : connection === 'reconnecting' || connection === 'unavailable' ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
+          <strong>Disconnected</strong> · {connection === 'reconnecting' ? 'Reconnecting to normalized runtime events.' : 'Live runtime events are unavailable.'}
         </p>
       ) : snapshot.state === 'degraded' || provider.health.state === 'degraded' ? (
         <p className="runtime-brain-pulse__state runtime-brain-pulse__state--degraded" role="status">

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   RuntimeConnectionState,
   RuntimeEvent,
@@ -8,6 +8,10 @@ import type {
 
 const PULSE_WINDOW_MS = 60_000;
 const MAX_FUTURE_SKEW_MS = 60_000;
+
+function eventReceiptKey(event: RuntimeEvent): string {
+  return `${event.id}\u0000${event.occurredAt}`;
+}
 
 interface RuntimeBrainPulseProps {
   provider: RuntimeProvider;
@@ -27,11 +31,25 @@ export function RuntimeBrainPulse({
   onOpenTask,
 }: RuntimeBrainPulseProps) {
   const [now, setNow] = useState(() => Date.now());
+  const knownEventKeys = useRef(new Set(events.map(eventReceiptKey)));
+  const receivedAtByEvent = useRef(new Map<string, number>());
 
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 5_000);
     return () => clearInterval(timer);
   }, []);
+
+  useEffect(() => {
+    const currentKeys = new Set(events.map(eventReceiptKey));
+    const receivedAt = Date.now();
+    for (const key of currentKeys) {
+      if (!knownEventKeys.current.has(key)) receivedAtByEvent.current.set(key, receivedAt);
+    }
+    for (const key of receivedAtByEvent.current.keys()) {
+      if (!currentKeys.has(key)) receivedAtByEvent.current.delete(key);
+    }
+    knownEventKeys.current = currentKeys;
+  }, [events]);
 
   const recentEvents = useMemo(() => {
     const unique = new Map<string, RuntimeEvent>();
@@ -43,9 +61,13 @@ export function RuntimeBrainPulse({
     }, now);
     for (const event of events) {
       const occurredAt = Date.parse(event.occurredAt);
+      const receivedAt = receivedAtByEvent.current.get(eventReceiptKey(event));
       if (
         !Number.isFinite(occurredAt)
-        || occurredAt < pulseNow - PULSE_WINDOW_MS
+        || (
+          occurredAt < pulseNow - PULSE_WINDOW_MS
+          && (receivedAt === undefined || receivedAt < now - PULSE_WINDOW_MS)
+        )
         || occurredAt > now + MAX_FUTURE_SKEW_MS
       ) continue;
       const current = unique.get(event.id);

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../../lib/smart-swarm-api';
 
 const PULSE_WINDOW_MS = 60_000;
+const MAX_FUTURE_SKEW_MS = 60_000;
 
 interface RuntimeBrainPulseProps {
   provider: RuntimeProvider;
@@ -36,13 +37,16 @@ export function RuntimeBrainPulse({
     const unique = new Map<string, RuntimeEvent>();
     const pulseNow = events.reduce((latest, event) => {
       const occurredAt = Date.parse(event.occurredAt);
-      return Number.isFinite(occurredAt) ? Math.max(latest, occurredAt) : latest;
+      return Number.isFinite(occurredAt) && occurredAt <= now + MAX_FUTURE_SKEW_MS
+        ? Math.max(latest, occurredAt)
+        : latest;
     }, now);
     for (const event of events) {
       const occurredAt = Date.parse(event.occurredAt);
       if (
         !Number.isFinite(occurredAt)
         || occurredAt < pulseNow - PULSE_WINDOW_MS
+        || occurredAt > now + MAX_FUTURE_SKEW_MS
       ) continue;
       const current = unique.get(event.id);
       if (!current || occurredAt > Date.parse(current.occurredAt)) unique.set(event.id, event);

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  RuntimeConnectionState,
+  RuntimeEvent,
+  RuntimeProvider,
+  RuntimeSnapshot,
+} from '../../lib/smart-swarm-api';
+
+const PULSE_WINDOW_MS = 60_000;
+
+interface RuntimeBrainPulseProps {
+  provider: RuntimeProvider;
+  snapshot: RuntimeSnapshot;
+  connection: RuntimeConnectionState;
+  events: readonly RuntimeEvent[];
+  onOpenTask(event: RuntimeEvent, trigger: HTMLButtonElement): void;
+}
+
+export function RuntimeBrainPulse({
+  provider,
+  snapshot,
+  connection,
+  events,
+  onOpenTask,
+}: RuntimeBrainPulseProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const recentEvents = useMemo(() => {
+    const unique = new Map<string, RuntimeEvent>();
+    for (const event of events) {
+      const occurredAt = Date.parse(event.occurredAt);
+      if (
+        !Number.isFinite(occurredAt)
+        || occurredAt < now - PULSE_WINDOW_MS
+        || occurredAt > now + 5_000
+      ) continue;
+      const current = unique.get(event.id);
+      if (!current || occurredAt > Date.parse(current.occurredAt)) unique.set(event.id, event);
+    }
+    return [...unique.values()].sort((left, right) => (
+      Date.parse(right.occurredAt) - Date.parse(left.occurredAt)
+      || left.id.localeCompare(right.id)
+    ));
+  }, [events, now]);
+  const unsupportedReason = provider.capabilities.streaming.status === 'unsupported'
+    ? provider.capabilities.streaming.reason
+    : snapshot.events.status === 'unsupported'
+      ? snapshot.events.reason
+      : null;
+  const pulseState = recentEvents.length === 0
+    ? 'idle'
+    : connection === 'connected'
+      ? 'active'
+      : 'stale';
+  const eventCountLabel = connection === 'connected'
+    ? `${recentEvents.length} ${recentEvents.length === 1 ? 'event' : 'events'} in the last minute`
+    : `${recentEvents.length} retained ${recentEvents.length === 1 ? 'event' : 'events'} · not live`;
+
+  return (
+    <section
+      aria-label="Runtime brain pulse"
+      className="runtime-brain-pulse rail-card"
+      data-connection={connection}
+      data-pulse-state={pulseState}
+      data-runtime-state={snapshot.state}
+      role="region"
+    >
+      <header>
+        <div>
+          <p className="eyebrow">Brain Pulse</p>
+          <h3>Normalized runtime activity</h3>
+        </div>
+        <strong aria-atomic="true" aria-live="polite">{eventCountLabel}</strong>
+      </header>
+      {unsupportedReason ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--unsupported" role="status">
+          <strong>Unsupported</strong> · {unsupportedReason}
+        </p>
+      ) : connection === 'reconnecting' || connection === 'unavailable' ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--disconnected" role="alert">
+          <strong>Disconnected</strong> · {connection === 'reconnecting' ? 'Reconnecting to normalized runtime events.' : 'Live runtime events are unavailable.'}
+        </p>
+      ) : snapshot.state === 'degraded' || provider.health.state === 'degraded' ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--degraded" role="status">
+          <strong>Degraded</strong> · {snapshot.message ?? provider.health.message ?? 'Some normalized runtime evidence is temporarily unavailable.'}
+        </p>
+      ) : connection === 'connected' && recentEvents.length === 0 ? (
+        <p className="runtime-brain-pulse__state runtime-brain-pulse__state--idle" role="status">
+          <strong>No activity</strong> · Connected; no normalized runtime events in the last minute.
+        </p>
+      ) : null}
+      <ol>
+        {recentEvents.map((event) => (
+          <li key={`${provider.id}:${event.id}`}>
+            <time dateTime={event.occurredAt}>{new Date(event.occurredAt).toLocaleTimeString()}</time>
+            <strong>{event.type}</strong>
+            <span>{event.summary}</span>
+            <span>{provider.displayName}</span>
+            <span>{event.workspaceId}</span>
+            <span>{event.taskId ?? 'No task'}</span>
+            <span>{event.runId ?? 'No run'}</span>
+            {event.taskId ? (
+              <button
+                aria-label={`Open source task ${event.taskId} for event ${event.id}`}
+                onClick={(clickEvent) => onOpenTask(event, clickEvent.currentTarget)}
+                type="button"
+              >
+                Open source
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -13,6 +13,7 @@ interface RuntimeBrainPulseProps {
   snapshot: RuntimeSnapshot;
   connection: RuntimeConnectionState;
   events: readonly RuntimeEvent[];
+  eventLimit?: number;
   onOpenTask(event: RuntimeEvent, trigger: HTMLButtonElement): void;
 }
 
@@ -21,6 +22,7 @@ export function RuntimeBrainPulse({
   snapshot,
   connection,
   events,
+  eventLimit,
   onOpenTask,
 }: RuntimeBrainPulseProps) {
   const [now, setNow] = useState(() => Date.now());
@@ -56,7 +58,9 @@ export function RuntimeBrainPulse({
       ? 'active'
       : 'stale';
   const eventCountLabel = connection === 'connected'
-    ? `${recentEvents.length} ${recentEvents.length === 1 ? 'event' : 'events'} in the last minute`
+    ? eventLimit !== undefined && recentEvents.length >= eventLimit
+      ? `Latest ${recentEvents.length} retained events from the last minute`
+      : `${recentEvents.length} ${recentEvents.length === 1 ? 'event' : 'events'} in the last minute`
     : `${recentEvents.length} retained ${recentEvents.length === 1 ? 'event' : 'events'} · not live`;
 
   return (

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -34,12 +34,15 @@ export function RuntimeBrainPulse({
 
   const recentEvents = useMemo(() => {
     const unique = new Map<string, RuntimeEvent>();
+    const pulseNow = events.reduce((latest, event) => {
+      const occurredAt = Date.parse(event.occurredAt);
+      return Number.isFinite(occurredAt) ? Math.max(latest, occurredAt) : latest;
+    }, now);
     for (const event of events) {
       const occurredAt = Date.parse(event.occurredAt);
       if (
         !Number.isFinite(occurredAt)
-        || occurredAt < now - PULSE_WINDOW_MS
-        || occurredAt > now + 5_000
+        || occurredAt < pulseNow - PULSE_WINDOW_MS
       ) continue;
       const current = unique.get(event.id);
       if (!current || occurredAt > Date.parse(current.occurredAt)) unique.set(event.id, event);

--- a/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
+++ b/packages/franken-web/src/components/smart-swarm/runtime-brain-pulse.tsx
@@ -49,9 +49,7 @@ export function RuntimeBrainPulse({
   }, [events, now]);
   const unsupportedReason = provider.capabilities.streaming.status === 'unsupported'
     ? provider.capabilities.streaming.reason
-    : snapshot.events.status === 'unsupported'
-      ? snapshot.events.reason
-      : null;
+    : null;
   const pulseState = recentEvents.length === 0
     ? 'idle'
     : connection === 'connected'

--- a/packages/franken-web/src/lib/smart-swarm-api.test.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.test.ts
@@ -85,6 +85,34 @@ describe('SmartSwarmApiClient', () => {
     await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
   });
 
+  it('rejects runtime event cursors that exceed the UTF-8 transport byte limit', async () => {
+    const snapshot = {
+      providerId: 'hermes',
+      state: 'ready',
+      capturedAt: '2026-07-26T18:00:01.000Z',
+      workspaces: { status: 'available', data: [] },
+      agents: { status: 'available', data: [] },
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [] },
+      events: { status: 'available', data: [{
+        id: 'event-1',
+        cursor: '🚀'.repeat(1_025),
+        workspaceId: 'board-main',
+        taskId: null,
+        runId: null,
+        type: 'log',
+        occurredAt: '2026-07-26T18:00:02.000Z',
+        summary: 'Oversized transport cursor',
+      }] },
+      blockers: { status: 'available', data: [] },
+      approvals: { status: 'available', data: [] },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ data: snapshot })));
+    const client = new SmartSwarmApiClient(BASE_URL);
+
+    await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
+  });
+
   it('rejects parseable timestamps that are not normalized ISO datetimes', async () => {
     const snapshot = {
       providerId: 'hermes',
@@ -112,6 +140,37 @@ describe('SmartSwarmApiClient', () => {
 
     await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
   });
+
+  it.each(['2026-02-29T12:00:00Z', '2026-02-31T12:00:00Z'])(
+    'rejects impossible calendar timestamp %s',
+    async (occurredAt) => {
+      const snapshot = {
+        providerId: 'hermes',
+        state: 'ready',
+        capturedAt: '2026-07-26T18:00:01.000Z',
+        workspaces: { status: 'available', data: [] },
+        agents: { status: 'available', data: [] },
+        tasks: { status: 'available', data: [] },
+        runs: { status: 'available', data: [] },
+        events: { status: 'available', data: [{
+          id: 'event-1',
+          cursor: 'cursor-1',
+          workspaceId: 'board-main',
+          taskId: null,
+          runId: null,
+          type: 'log',
+          occurredAt,
+          summary: 'Impossible calendar date',
+        }] },
+        blockers: { status: 'available', data: [] },
+        approvals: { status: 'available', data: [] },
+      };
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ data: snapshot })));
+      const client = new SmartSwarmApiClient(BASE_URL);
+
+      await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
+    },
+  );
 
   it('rejects malformed runtime event section discriminants', async () => {
     const snapshot = {
@@ -392,7 +451,7 @@ describe('SmartSwarmApiClient', () => {
     unsubscribe();
   });
 
-  it('reconnects after a malformed activity event from the last validated cursor', async () => {
+  it('quarantines a malformed activity frame by reconnecting after its SSE cursor', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
     const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
@@ -421,7 +480,7 @@ describe('SmartSwarmApiClient', () => {
 
     expect(EventSourceMock).toHaveBeenNthCalledWith(
       2,
-      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-2?cursor=validated-checkpoint`,
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-2?cursor=poisonous-cursor`,
       { withCredentials: true },
     );
     unsubscribe();

--- a/packages/franken-web/src/lib/smart-swarm-api.test.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.test.ts
@@ -57,6 +57,34 @@ describe('SmartSwarmApiClient', () => {
     );
   });
 
+  it('rejects malformed runtime events in snapshots before they can pulse', async () => {
+    const snapshot = {
+      providerId: 'hermes',
+      state: 'ready',
+      capturedAt: '2026-07-26T18:00:01.000Z',
+      workspaces: { status: 'available', data: [] },
+      agents: { status: 'available', data: [] },
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [] },
+      events: { status: 'available', data: [{
+        id: 'event-1',
+        cursor: 'cursor-1',
+        workspaceId: 'board-main',
+        taskId: null,
+        runId: null,
+        type: 'log',
+        occurredAt: '2026-07-26T18:00:02.000Z',
+        summary: 'x'.repeat(16_385),
+      }] },
+      blockers: { status: 'available', data: [] },
+      approvals: { status: 'available', data: [] },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ data: snapshot })));
+    const client = new SmartSwarmApiClient(BASE_URL);
+
+    await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
+  });
+
   it('reconnects the live stream with the last real event cursor', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -156,6 +184,38 @@ describe('SmartSwarmApiClient', () => {
     unsubscribe();
   });
 
+  it('rejects oversized checkpoint cursor IDs without replaying them', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const listeners: Record<string, (event: MessageEvent) => void> = {};
+      sources.push(listeners);
+      this.close = vi.fn();
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(Response.json({ connectionId: 'stream-1' }))
+      .mockResolvedValueOnce(Response.json({ connectionId: 'stream-2' })));
+    const error = vi.fn();
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event: vi.fn(), error });
+
+    sources[0]!.checkpoint!(new MessageEvent('checkpoint', { lastEventId: 'x'.repeat(4_097) }));
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('checkpoint cursor') }));
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(EventSourceMock).toHaveBeenNthCalledWith(
+      2,
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-2`,
+      { withCredentials: true },
+    );
+    unsubscribe();
+  });
+
   it('reconnects after a malformed activity event', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -187,7 +247,101 @@ describe('SmartSwarmApiClient', () => {
     unsubscribe();
   });
 
-  it('reconnects after a malformed activity event from the malformed frame cursor', async () => {
+  it('rejects structurally malformed runtime events before they can pulse', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const sources: Array<{ close: ReturnType<typeof vi.fn>; listeners: Record<string, (event: MessageEvent) => void> }> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const source = { close: vi.fn(), listeners: {} as Record<string, (event: MessageEvent) => void> };
+      sources.push(source);
+      this.close = source.close;
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        source.listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(Response.json({ connectionId: 'stream-1' }))
+      .mockResolvedValueOnce(Response.json({ connectionId: 'stream-2' })));
+    const event = vi.fn();
+    const error = vi.fn();
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event, error });
+
+    sources[0]!.listeners.activity!(new MessageEvent('activity', {
+      data: JSON.stringify({ id: 'event-1', cursor: 'cursor-1', workspaceId: 'board-main' }),
+      lastEventId: 'cursor-1',
+    }));
+
+    expect(event).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('Malformed runtime event') }));
+    expect(sources[0]!.close).toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(EventSourceMock).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('rejects oversized event fields and nested metadata before they can pulse', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const listeners: Record<string, (event: MessageEvent) => void> = {};
+      sources.push(listeners);
+      this.close = vi.fn();
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ connectionId: 'stream-1' })));
+    const event = vi.fn();
+    const error = vi.fn();
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event, error });
+
+    sources[0]!.activity!(new MessageEvent('activity', { data: JSON.stringify({
+      id: 'event-1',
+      cursor: 'cursor-1',
+      workspaceId: 'board-main',
+      taskId: null,
+      runId: null,
+      type: 'log',
+      occurredAt: '2026-07-26T18:00:02.000Z',
+      summary: 'x'.repeat(16_385),
+      metadata: { nested: { payload: 'must not reach the UI' } },
+    }) }));
+
+    expect(event).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('Malformed runtime event') }));
+    unsubscribe();
+  });
+
+  it('rejects oversized raw activity payloads before parsing them', async () => {
+    const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const listeners: Record<string, (event: MessageEvent) => void> = {};
+      sources.push(listeners);
+      this.close = vi.fn();
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ connectionId: 'stream-1' })));
+    const error = vi.fn();
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event: vi.fn(), error });
+    const parse = vi.spyOn(JSON, 'parse');
+
+    sources[0]!.activity!(new MessageEvent('activity', { data: `${' '.repeat(262_145)}{}` }));
+
+    expect(parse).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('activity payload') }));
+    unsubscribe();
+  });
+
+  it('reconnects after a malformed activity event from the last validated cursor', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
     const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
@@ -206,6 +360,7 @@ describe('SmartSwarmApiClient', () => {
     const client = new SmartSwarmApiClient(BASE_URL);
     const unsubscribe = await client.subscribe('hermes', undefined, { event: vi.fn() });
     sources[0]!.open!(new MessageEvent('open'));
+    sources[0]!.checkpoint!(new MessageEvent('checkpoint', { lastEventId: 'validated-checkpoint' }));
 
     sources[0]!.activity!(new MessageEvent('activity', {
       data: '{bad json',
@@ -215,13 +370,13 @@ describe('SmartSwarmApiClient', () => {
 
     expect(EventSourceMock).toHaveBeenNthCalledWith(
       2,
-      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-2?cursor=poisonous-cursor`,
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-2?cursor=validated-checkpoint`,
       { withCredentials: true },
     );
     unsubscribe();
   });
 
-  it('drops a replay cursor after repeated failures before the stream opens', async () => {
+  it('preserves a replay cursor across generic pre-open failures and drops it only after explicit rejection', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);
     const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
@@ -234,12 +389,30 @@ describe('SmartSwarmApiClient', () => {
       }) as EventSource['addEventListener'];
     });
     vi.stubGlobal('EventSource', EventSourceMock);
-    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(Response.json({ connectionId: `stream-${sources.length + 1}` }))));
+    let cursorValidationAttempts = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/events?')) {
+        cursorValidationAttempts += 1;
+        return Promise.resolve(new Response(JSON.stringify({ error: { message: 'Cursor rejected' } }), {
+          status: cursorValidationAttempts === 3 ? 422 : 503,
+        }));
+      }
+      return Promise.resolve(Response.json({ connectionId: `stream-${sources.length + 1}` }));
+    }));
     const client = new SmartSwarmApiClient(BASE_URL);
     const unsubscribe = await client.subscribe('hermes', 'board-main', { event: vi.fn() });
     sources[0]!.open!(new MessageEvent('open'));
     sources[0]!.activity!(new MessageEvent('activity', {
-      data: JSON.stringify({ id: 'event-1', cursor: 'stale-cursor', workspaceId: 'board-main' }),
+      data: JSON.stringify({
+        id: 'event-1',
+        cursor: 'replay-cursor',
+        workspaceId: 'board-main',
+        taskId: null,
+        runId: null,
+        type: 'lifecycle',
+        occurredAt: '2026-07-26T18:00:02.000Z',
+        summary: 'Task started',
+      }),
     }));
     sources[0]!.error!(new MessageEvent('error'));
     await vi.advanceTimersByTimeAsync(1_000);
@@ -249,10 +422,96 @@ describe('SmartSwarmApiClient', () => {
     await vi.advanceTimersByTimeAsync(4_000);
 
     expect(EventSourceMock).toHaveBeenLastCalledWith(
-      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-4?workspaceId=board-main`,
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-4?workspaceId=board-main&cursor=replay-cursor`,
+      { withCredentials: true },
+    );
+
+    sources[3]!.error!(new MessageEvent('error'));
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(EventSourceMock).toHaveBeenLastCalledWith(
+      `${BASE_URL}/v1/smart-swarm/providers/hermes/events/stream-5?workspaceId=board-main`,
       { withCredentials: true },
     );
     unsubscribe();
+  });
+
+  it('times out cursor validation so a hung request cannot block reconnection', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const listeners: Record<string, (event: MessageEvent) => void> = {};
+      sources.push(listeners);
+      this.close = vi.fn();
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    let validationSignal: AbortSignal | undefined;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/events?')) {
+        validationSignal = init?.signal ?? undefined;
+        return new Promise<Response>(() => undefined);
+      }
+      return Promise.resolve(Response.json({ connectionId: `stream-${sources.length + 1}` }));
+    }));
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event: vi.fn() });
+    sources[0]!.open!(new MessageEvent('open'));
+    sources[0]!.activity!(new MessageEvent('activity', { data: JSON.stringify({
+      id: 'event-1', cursor: 'replay-cursor', workspaceId: 'board-main', taskId: null, runId: null,
+      type: 'log', occurredAt: '2026-07-26T18:00:02.000Z', summary: 'validated',
+    }) }));
+    sources[0]!.error!(new MessageEvent('error'));
+    await vi.advanceTimersByTimeAsync(1_000);
+    sources[1]!.error!(new MessageEvent('error'));
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(validationSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(EventSourceMock).toHaveBeenCalledTimes(3);
+    unsubscribe();
+  });
+
+  it('aborts an in-flight cursor validation when unsubscribed', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const sources: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const EventSourceMock = vi.fn(function (this: EventSource) {
+      const listeners: Record<string, (event: MessageEvent) => void> = {};
+      sources.push(listeners);
+      this.close = vi.fn();
+      this.addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners[type] = listener as (event: MessageEvent) => void;
+      }) as EventSource['addEventListener'];
+    });
+    vi.stubGlobal('EventSource', EventSourceMock);
+    let validationSignal: AbortSignal | undefined;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/events?')) {
+        validationSignal = init?.signal ?? undefined;
+        return new Promise<Response>(() => undefined);
+      }
+      return Promise.resolve(Response.json({ connectionId: `stream-${sources.length + 1}` }));
+    }));
+    const client = new SmartSwarmApiClient(BASE_URL);
+    const unsubscribe = await client.subscribe('hermes', undefined, { event: vi.fn() });
+    sources[0]!.open!(new MessageEvent('open'));
+    sources[0]!.activity!(new MessageEvent('activity', { data: JSON.stringify({
+      id: 'event-1', cursor: 'replay-cursor', workspaceId: 'board-main', taskId: null, runId: null,
+      type: 'log', occurredAt: '2026-07-26T18:00:02.000Z', summary: 'validated',
+    }) }));
+    sources[0]!.error!(new MessageEvent('error'));
+    await vi.advanceTimersByTimeAsync(1_000);
+    sources[1]!.error!(new MessageEvent('error'));
+
+    unsubscribe();
+
+    expect(validationSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(EventSourceMock).toHaveBeenCalledTimes(2);
   });
 
   it('ignores callbacks from an event source superseded by reconnect', async () => {

--- a/packages/franken-web/src/lib/smart-swarm-api.test.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.test.ts
@@ -85,6 +85,57 @@ describe('SmartSwarmApiClient', () => {
     await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
   });
 
+  it('rejects parseable timestamps that are not normalized ISO datetimes', async () => {
+    const snapshot = {
+      providerId: 'hermes',
+      state: 'ready',
+      capturedAt: '2026-07-26T18:00:01.000Z',
+      workspaces: { status: 'available', data: [] },
+      agents: { status: 'available', data: [] },
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [] },
+      events: { status: 'available', data: [{
+        id: 'event-1',
+        cursor: 'cursor-1',
+        workspaceId: 'board-main',
+        taskId: null,
+        runId: null,
+        type: 'log',
+        occurredAt: '07/28/2026',
+        summary: 'Browser-dependent timestamp',
+      }] },
+      blockers: { status: 'available', data: [] },
+      approvals: { status: 'available', data: [] },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ data: snapshot })));
+    const client = new SmartSwarmApiClient(BASE_URL);
+
+    await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event');
+  });
+
+  it('rejects malformed runtime event section discriminants', async () => {
+    const snapshot = {
+      providerId: 'hermes',
+      state: 'ready',
+      capturedAt: '2026-07-26T18:00:01.000Z',
+      workspaces: { status: 'available', data: [] },
+      agents: { status: 'available', data: [] },
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [] },
+      events: { status: 'unsupported' },
+      blockers: { status: 'available', data: [] },
+      approvals: { status: 'available', data: [] },
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json({ data: snapshot }))
+      .mockResolvedValueOnce(Response.json({ data: { ...snapshot, events: { status: 'available', data: [], extra: true } } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new SmartSwarmApiClient(BASE_URL);
+
+    await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event snapshot');
+    await expect(client.fetchSnapshot('hermes')).rejects.toThrow('Malformed runtime event snapshot');
+  });
+
   it('reconnects the live stream with the last real event cursor', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);

--- a/packages/franken-web/src/lib/smart-swarm-api.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.ts
@@ -2,6 +2,7 @@ import { extractResponseErrorMessage } from './http-error';
 
 const STREAM_RECONNECT_BASE_DELAY_MS = 1_000;
 const STREAM_RECONNECT_MAX_DELAY_MS = 30_000;
+const CURSOR_VALIDATION_TIMEOUT_MS = 10_000;
 
 export type RuntimeCapability =
   | { status: 'supported' }
@@ -169,6 +170,63 @@ export interface RuntimeSubscriptionHandlers {
   error?(error: Error): void;
 }
 
+const RUNTIME_EVENT_TYPES = new Set<RuntimeEvent['type']>([
+  'lifecycle', 'comment', 'log', 'audit', 'blocker', 'approval', 'unknown',
+]);
+const RUNTIME_EVENT_KEYS = new Set([
+  'id', 'cursor', 'workspaceId', 'taskId', 'runId', 'type', 'occurredAt', 'summary', 'metadata',
+]);
+const MAX_RUNTIME_EVENT_ID_LENGTH = 1_024;
+const MAX_RUNTIME_EVENT_CURSOR_LENGTH = 4_096;
+const MAX_RUNTIME_EVENT_SUMMARY_LENGTH = 16_384;
+const MAX_RUNTIME_EVENT_METADATA_LENGTH = 16_384;
+const MAX_RUNTIME_EVENT_METADATA_ENTRIES = 64;
+const MAX_RUNTIME_EVENT_METADATA_KEY_LENGTH = 256;
+const MAX_RUNTIME_EVENT_METADATA_STRING_LENGTH = 4_096;
+const MAX_RUNTIME_EVENT_RAW_PAYLOAD_LENGTH = 262_144;
+
+function isBoundedString(value: unknown, maximum: number, allowEmpty = false): value is string {
+  return typeof value === 'string' && (allowEmpty || value.length > 0) && value.length <= maximum;
+}
+
+function isRuntimeEventMetadata(value: unknown): value is RuntimeEvent['metadata'] {
+  if (value === undefined) return true;
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const entries = Object.entries(value);
+  if (entries.length > MAX_RUNTIME_EVENT_METADATA_ENTRIES) return false;
+  if (JSON.stringify(value).length > MAX_RUNTIME_EVENT_METADATA_LENGTH) return false;
+  return entries.every(([key, entry]) => (
+    key.length > 0
+    && key.length <= MAX_RUNTIME_EVENT_METADATA_KEY_LENGTH
+    && (entry === null
+      || typeof entry === 'boolean'
+      || (typeof entry === 'number' && Number.isFinite(entry))
+      || isBoundedString(entry, MAX_RUNTIME_EVENT_METADATA_STRING_LENGTH, true))
+  ));
+}
+
+function parseRuntimeEvent(value: unknown): RuntimeEvent {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Malformed runtime event: expected an object.');
+  }
+  const candidate = value as Partial<RuntimeEvent>;
+  if (
+    Object.keys(value).some((key) => !RUNTIME_EVENT_KEYS.has(key))
+    || !isBoundedString(candidate.id, MAX_RUNTIME_EVENT_ID_LENGTH)
+    || !isBoundedString(candidate.cursor, MAX_RUNTIME_EVENT_CURSOR_LENGTH)
+    || !isBoundedString(candidate.workspaceId, MAX_RUNTIME_EVENT_ID_LENGTH)
+    || (candidate.taskId !== null && !isBoundedString(candidate.taskId, MAX_RUNTIME_EVENT_ID_LENGTH))
+    || (candidate.runId !== null && !isBoundedString(candidate.runId, MAX_RUNTIME_EVENT_ID_LENGTH))
+    || typeof candidate.type !== 'string' || !RUNTIME_EVENT_TYPES.has(candidate.type as RuntimeEvent['type'])
+    || !isBoundedString(candidate.occurredAt, 64) || !Number.isFinite(Date.parse(candidate.occurredAt))
+    || !isBoundedString(candidate.summary, MAX_RUNTIME_EVENT_SUMMARY_LENGTH, true)
+    || !isRuntimeEventMetadata(candidate.metadata)
+  ) {
+    throw new Error('Malformed runtime event: normalized provenance fields are invalid or exceed safe limits.');
+  }
+  return candidate as RuntimeEvent;
+}
+
 export class SmartSwarmApiError extends Error {
   constructor(
     message: string,
@@ -190,7 +248,7 @@ export class SmartSwarmApiClient {
     return this.request('/v1/smart-swarm/providers');
   }
 
-  fetchSnapshot(
+  async fetchSnapshot(
     providerId: string,
     options: { workspaceId?: string; activityLimit?: number } = {},
   ): Promise<RuntimeSnapshot> {
@@ -198,7 +256,18 @@ export class SmartSwarmApiClient {
     if (options.workspaceId) search.set('workspaceId', options.workspaceId);
     if (options.activityLimit !== undefined) search.set('activityLimit', String(options.activityLimit));
     const query = search.size > 0 ? `?${search.toString()}` : '';
-    return this.request(`/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/snapshot${query}`);
+    const snapshot = await this.request<RuntimeSnapshot>(
+      `/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/snapshot${query}`,
+    );
+    if (
+      !snapshot.events
+      || typeof snapshot.events !== 'object'
+      || (snapshot.events.status === 'available' && !Array.isArray(snapshot.events.data))
+    ) {
+      throw new Error('Malformed runtime event snapshot: expected a normalized event section.');
+    }
+    if (snapshot.events.status === 'available') snapshot.events.data.forEach(parseRuntimeEvent);
+    return snapshot;
   }
 
   async executeAction(providerId: string, request: RuntimeActionRequest): Promise<RuntimeActionResult> {
@@ -227,8 +296,9 @@ export class SmartSwarmApiClient {
     const baseUrl = this.baseUrl;
     let source: EventSource | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let cursorValidationController: AbortController | undefined;
+    let cursorValidationTimer: ReturnType<typeof setTimeout> | undefined;
     let reconnectAttempt = 0;
-    let consecutivePreOpenFailures = 0;
     let cursor: string | undefined;
     let closed = false;
 
@@ -282,38 +352,77 @@ export class SmartSwarmApiClient {
       const activeSource = new EventSource(`${baseUrl}${streamPath}${query}`, { withCredentials: true });
       source = activeSource;
       let opened = false;
+      let handlingPreOpenFailure = false;
       activeSource.addEventListener('open', () => {
         if (source !== activeSource || closed) return;
         opened = true;
         reconnectAttempt = 0;
-        consecutivePreOpenFailures = 0;
         handlers.connection?.('connected');
       });
       activeSource.addEventListener('checkpoint', (rawEvent) => {
         if (source !== activeSource || closed) return;
         const lastEventId = (rawEvent as MessageEvent<string>).lastEventId;
-        if (lastEventId) cursor = lastEventId;
+        if (!lastEventId) return;
+        if (!isBoundedString(lastEventId, MAX_RUNTIME_EVENT_CURSOR_LENGTH)) {
+          handlers.error?.(new Error('Malformed checkpoint cursor: value exceeds safe limits.'));
+          scheduleReconnect();
+          return;
+        }
+        cursor = lastEventId;
       });
       activeSource.addEventListener('activity', (rawEvent) => {
         if (source !== activeSource || closed) return;
         try {
-          const event = JSON.parse((rawEvent as MessageEvent<string>).data) as RuntimeEvent;
+          const data = (rawEvent as MessageEvent<unknown>).data;
+          if (typeof data !== 'string' || data.length > MAX_RUNTIME_EVENT_RAW_PAYLOAD_LENGTH) {
+            throw new Error('Malformed activity payload: raw data exceeds safe limits.');
+          }
+          const event = parseRuntimeEvent(JSON.parse(data));
           cursor = event.cursor;
           handlers.event(event);
         } catch (error) {
-          const lastEventId = (rawEvent as MessageEvent<string>).lastEventId;
-          if (lastEventId) cursor = lastEventId;
           handlers.error?.(error instanceof Error ? error : new Error('Unable to parse smart-swarm activity.'));
           scheduleReconnect();
         }
       });
       activeSource.addEventListener('error', () => {
-        if (source !== activeSource || closed) return;
-        if (!opened && cursor) {
-          consecutivePreOpenFailures += 1;
-          if (consecutivePreOpenFailures >= 2) cursor = undefined;
+        if (source !== activeSource || closed || handlingPreOpenFailure) return;
+        if (opened || !cursor) {
+          scheduleReconnect();
+          return;
         }
-        scheduleReconnect();
+        handlingPreOpenFailure = true;
+        activeSource.close();
+        const failedCursor = cursor;
+        const validationSearch = new URLSearchParams({ cursor: failedCursor, limit: '1' });
+        if (workspaceId) validationSearch.set('workspaceId', workspaceId);
+        const validationController = new AbortController();
+        cursorValidationController = validationController;
+        cursorValidationTimer = setTimeout(() => {
+          if (cursorValidationController !== validationController) return;
+          cursorValidationController = undefined;
+          cursorValidationTimer = undefined;
+          validationController.abort();
+          if (source === activeSource && !closed) scheduleReconnect();
+        }, CURSOR_VALIDATION_TIMEOUT_MS);
+        void fetch(
+          `${baseUrl}/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/events?${validationSearch.toString()}`,
+          { method: 'GET', credentials: 'include', signal: validationController.signal },
+        ).then((response) => {
+          if (cursorValidationController !== validationController) return;
+          if (cursorValidationTimer) clearTimeout(cursorValidationTimer);
+          cursorValidationController = undefined;
+          cursorValidationTimer = undefined;
+          if (source !== activeSource || closed) return;
+          if (response.status === 422 && cursor === failedCursor) cursor = undefined;
+          scheduleReconnect();
+        }).catch(() => {
+          if (cursorValidationController !== validationController) return;
+          if (cursorValidationTimer) clearTimeout(cursorValidationTimer);
+          cursorValidationController = undefined;
+          cursorValidationTimer = undefined;
+          if (source === activeSource && !closed) scheduleReconnect();
+        });
       });
     }
 
@@ -327,6 +436,10 @@ export class SmartSwarmApiClient {
     return () => {
       closed = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (cursorValidationTimer) clearTimeout(cursorValidationTimer);
+      cursorValidationController?.abort();
+      cursorValidationController = undefined;
+      cursorValidationTimer = undefined;
       closeSource();
     };
   }

--- a/packages/franken-web/src/lib/smart-swarm-api.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.ts
@@ -190,6 +190,21 @@ function isBoundedString(value: unknown, maximum: number, allowEmpty = false): v
   return typeof value === 'string' && (allowEmpty || value.length > 0) && value.length <= maximum;
 }
 
+function isBoundedUtf8String(value: unknown, maximum: number): value is string {
+  return isBoundedString(value, maximum) && new TextEncoder().encode(value).byteLength <= maximum;
+}
+
+function hasValidCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T/u.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1]!;
+}
+
 function isRuntimeEventMetadata(value: unknown): value is RuntimeEvent['metadata'] {
   if (value === undefined) return true;
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
@@ -214,13 +229,14 @@ function parseRuntimeEvent(value: unknown): RuntimeEvent {
   if (
     Object.keys(value).some((key) => !RUNTIME_EVENT_KEYS.has(key))
     || !isBoundedString(candidate.id, MAX_RUNTIME_EVENT_ID_LENGTH)
-    || !isBoundedString(candidate.cursor, MAX_RUNTIME_EVENT_CURSOR_LENGTH)
+    || !isBoundedUtf8String(candidate.cursor, MAX_RUNTIME_EVENT_CURSOR_LENGTH)
     || !isBoundedString(candidate.workspaceId, MAX_RUNTIME_EVENT_ID_LENGTH)
     || (candidate.taskId !== null && !isBoundedString(candidate.taskId, MAX_RUNTIME_EVENT_ID_LENGTH))
     || (candidate.runId !== null && !isBoundedString(candidate.runId, MAX_RUNTIME_EVENT_ID_LENGTH))
     || typeof candidate.type !== 'string' || !RUNTIME_EVENT_TYPES.has(candidate.type as RuntimeEvent['type'])
     || !isBoundedString(candidate.occurredAt, 64)
     || !NORMALIZED_TIMESTAMP_PATTERN.test(candidate.occurredAt)
+    || !hasValidCalendarDate(candidate.occurredAt)
     || !Number.isFinite(Date.parse(candidate.occurredAt))
     || !isBoundedString(candidate.summary, MAX_RUNTIME_EVENT_SUMMARY_LENGTH, true)
     || !isRuntimeEventMetadata(candidate.metadata)
@@ -376,7 +392,7 @@ export class SmartSwarmApiClient {
         if (source !== activeSource || closed) return;
         const lastEventId = (rawEvent as MessageEvent<string>).lastEventId;
         if (!lastEventId) return;
-        if (!isBoundedString(lastEventId, MAX_RUNTIME_EVENT_CURSOR_LENGTH)) {
+        if (!isBoundedUtf8String(lastEventId, MAX_RUNTIME_EVENT_CURSOR_LENGTH)) {
           handlers.error?.(new Error('Malformed checkpoint cursor: value exceeds safe limits.'));
           scheduleReconnect();
           return;
@@ -395,6 +411,10 @@ export class SmartSwarmApiClient {
           handlers.event(event);
         } catch (error) {
           handlers.error?.(error instanceof Error ? error : new Error('Unable to parse smart-swarm activity.'));
+          const rejectedCursor = (rawEvent as MessageEvent<unknown>).lastEventId;
+          if (rejectedCursor && isBoundedUtf8String(rejectedCursor, MAX_RUNTIME_EVENT_CURSOR_LENGTH)) {
+            cursor = rejectedCursor;
+          }
           scheduleReconnect();
         }
       });

--- a/packages/franken-web/src/lib/smart-swarm-api.ts
+++ b/packages/franken-web/src/lib/smart-swarm-api.ts
@@ -173,6 +173,7 @@ export interface RuntimeSubscriptionHandlers {
 const RUNTIME_EVENT_TYPES = new Set<RuntimeEvent['type']>([
   'lifecycle', 'comment', 'log', 'audit', 'blocker', 'approval', 'unknown',
 ]);
+const NORMALIZED_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u;
 const RUNTIME_EVENT_KEYS = new Set([
   'id', 'cursor', 'workspaceId', 'taskId', 'runId', 'type', 'occurredAt', 'summary', 'metadata',
 ]);
@@ -218,13 +219,29 @@ function parseRuntimeEvent(value: unknown): RuntimeEvent {
     || (candidate.taskId !== null && !isBoundedString(candidate.taskId, MAX_RUNTIME_EVENT_ID_LENGTH))
     || (candidate.runId !== null && !isBoundedString(candidate.runId, MAX_RUNTIME_EVENT_ID_LENGTH))
     || typeof candidate.type !== 'string' || !RUNTIME_EVENT_TYPES.has(candidate.type as RuntimeEvent['type'])
-    || !isBoundedString(candidate.occurredAt, 64) || !Number.isFinite(Date.parse(candidate.occurredAt))
+    || !isBoundedString(candidate.occurredAt, 64)
+    || !NORMALIZED_TIMESTAMP_PATTERN.test(candidate.occurredAt)
+    || !Number.isFinite(Date.parse(candidate.occurredAt))
     || !isBoundedString(candidate.summary, MAX_RUNTIME_EVENT_SUMMARY_LENGTH, true)
     || !isRuntimeEventMetadata(candidate.metadata)
   ) {
     throw new Error('Malformed runtime event: normalized provenance fields are invalid or exceed safe limits.');
   }
   return candidate as RuntimeEvent;
+}
+
+function isRuntimeEventSection(value: unknown): value is RuntimeSnapshot['events'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as { status?: unknown; data?: unknown; reason?: unknown };
+  const keys = Object.keys(value);
+  if (candidate.status === 'available') {
+    return keys.length === 2 && keys.includes('data') && Array.isArray(candidate.data);
+  }
+  return candidate.status === 'unsupported'
+    && keys.length === 2
+    && keys.includes('reason')
+    && typeof candidate.reason === 'string'
+    && candidate.reason.length > 0;
 }
 
 export class SmartSwarmApiError extends Error {
@@ -259,11 +276,7 @@ export class SmartSwarmApiClient {
     const snapshot = await this.request<RuntimeSnapshot>(
       `/v1/smart-swarm/providers/${encodeURIComponent(providerId)}/snapshot${query}`,
     );
-    if (
-      !snapshot.events
-      || typeof snapshot.events !== 'object'
-      || (snapshot.events.status === 'available' && !Array.isArray(snapshot.events.data))
-    ) {
+    if (!isRuntimeEventSection(snapshot.events)) {
       throw new Error('Malformed runtime event snapshot: expected a normalized event section.');
     }
     if (snapshot.events.status === 'available') snapshot.events.data.forEach(parseRuntimeEvent);

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -140,6 +140,34 @@ describe('SmartSwarmPage', () => {
     expect(detail.textContent).toContain('run-1');
   });
 
+  it('does not let impossible future evidence evict current pulse activity', async () => {
+    const sourceEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!sourceEvent) throw new Error('Expected normalized runtime event');
+    const current = {
+      ...sourceEvent,
+      id: 'event-current',
+      occurredAt: new Date().toISOString(),
+      summary: 'Current activity',
+    };
+    const impossibleFuture = Array.from({ length: 100 }, (_, index) => ({
+      ...sourceEvent,
+      id: `event-future-${index}`,
+      occurredAt: new Date(Date.now() + 3_600_000 + index).toISOString(),
+      summary: `Impossible future ${index}`,
+    }));
+    const futureHeavySnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      events: { status: 'available', data: [current, ...impossibleFuture] },
+    };
+
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(futureHeavySnapshot),
+    })} />);
+
+    const pulse = await screen.findByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.textContent).toContain('Current activity');
+  });
+
   it('does not resolve a pulse source task from a different workspace', async () => {
     const occurredAt = new Date().toISOString();
     const crossWorkspaceSnapshot: RuntimeSnapshot = {
@@ -656,33 +684,36 @@ describe('SmartSwarmPage', () => {
     expect(retryKey).toBe(firstKey);
   });
 
-  it('isolates pending actions for the same task id across workspaces', async () => {
+  it('isolates delimiter-colliding pending action identities across workspaces', async () => {
     const workspaceCatalog = [
-      { id: 'board-main', name: 'Main board', kind: 'workspace' as const, state: 'available' as const },
-      { id: 'board-other', name: 'Other board', kind: 'workspace' as const, state: 'available' as const },
+      { id: 'a:b', name: 'Main board', kind: 'workspace' as const, state: 'available' as const },
+      { id: 'a', name: 'Other board', kind: 'workspace' as const, state: 'available' as const },
     ];
-    const snapshotFor = (selectedWorkspace: string): RuntimeSnapshot => ({
-      ...snapshot,
-      workspaces: { status: 'available', data: workspaceCatalog },
-      tasks: {
-        status: 'available',
-        data: snapshot.tasks.status === 'available'
-          ? snapshot.tasks.data.map((task) => task.id === 'task-live'
-            ? { ...task, workspaceId: selectedWorkspace, title: `${selectedWorkspace} live task` }
-            : { ...task, workspaceId: selectedWorkspace })
-          : [],
-      },
-      runs: { status: 'available', data: [] },
-      events: { status: 'available', data: [] },
-      blockers: {
-        status: 'available',
-        data: [{
-          id: `${selectedWorkspace}-blocker`, workspaceId: selectedWorkspace, taskId: 'task-live',
-          category: 'dependency', summary: 'Waiting', createdAt: '2026-07-26T17:50:00.000Z',
-        }],
-      },
-      approvals: { status: 'available', data: [] },
-    });
+    const snapshotFor = (selectedWorkspace: string): RuntimeSnapshot => {
+      const selectedTaskId = selectedWorkspace === 'a:b' ? 'c' : 'b:c';
+      return {
+        ...snapshot,
+        workspaces: { status: 'available', data: workspaceCatalog },
+        tasks: {
+          status: 'available',
+          data: snapshot.tasks.status === 'available'
+            ? snapshot.tasks.data.map((task) => task.id === 'task-live'
+              ? { ...task, id: selectedTaskId, workspaceId: selectedWorkspace, title: `${selectedWorkspace} live task` }
+              : { ...task, workspaceId: selectedWorkspace })
+            : [],
+        },
+        runs: { status: 'available', data: [] },
+        events: { status: 'available', data: [] },
+        blockers: {
+          status: 'available',
+          data: [{
+            id: `${selectedWorkspace}-blocker`, workspaceId: selectedWorkspace, taskId: selectedTaskId,
+            category: 'dependency', summary: 'Waiting', createdAt: '2026-07-26T17:50:00.000Z',
+          }],
+        },
+        approvals: { status: 'available', data: [] },
+      };
+    };
     const executeAction = vi.fn()
       .mockRejectedValueOnce(new TypeError('workspace A response lost'))
       .mockResolvedValue({
@@ -692,25 +723,25 @@ describe('SmartSwarmPage', () => {
         audit: {
           requestedBy: 'authenticated-operator',
           actionType: 'blocker.resolve',
-          targetId: 'task-live',
+          targetId: 'b:c',
           outcome: 'applied',
         },
       });
     const fetchSnapshot = vi.fn().mockImplementation(async (_providerId, options) => (
-      snapshotFor(options?.workspaceId === 'board-other' ? 'board-other' : 'board-main')
+      snapshotFor(options?.workspaceId === 'a' ? 'a' : 'a:b')
     ));
     render(<SmartSwarmPage client={createClient({ executeAction, fetchSnapshot })} />);
-    await screen.findByText('board-main live task');
-    fireEvent.click(screen.getByRole('button', { name: 'Inspect board-main live task' }));
+    await screen.findByText('a:b live task');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect a:b live task' }));
     fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
     await screen.findByText('workspace A response lost');
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Workspace' }), {
-      target: { value: 'board-other' },
+      target: { value: 'a' },
     });
-    await screen.findByText('board-other live task');
-    fireEvent.click(screen.getByRole('button', { name: 'Inspect board-other live task' }));
+    await screen.findByText('a live task');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect a live task' }));
     const otherResolve = screen.getByRole('button', { name: 'Resolve blocker' });
     expect(otherResolve).toHaveProperty('disabled', false);
     fireEvent.click(otherResolve);

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -656,6 +656,70 @@ describe('SmartSwarmPage', () => {
     expect(retryKey).toBe(firstKey);
   });
 
+  it('isolates pending actions for the same task id across workspaces', async () => {
+    const workspaceCatalog = [
+      { id: 'board-main', name: 'Main board', kind: 'workspace' as const, state: 'available' as const },
+      { id: 'board-other', name: 'Other board', kind: 'workspace' as const, state: 'available' as const },
+    ];
+    const snapshotFor = (selectedWorkspace: string): RuntimeSnapshot => ({
+      ...snapshot,
+      workspaces: { status: 'available', data: workspaceCatalog },
+      tasks: {
+        status: 'available',
+        data: snapshot.tasks.status === 'available'
+          ? snapshot.tasks.data.map((task) => task.id === 'task-live'
+            ? { ...task, workspaceId: selectedWorkspace, title: `${selectedWorkspace} live task` }
+            : { ...task, workspaceId: selectedWorkspace })
+          : [],
+      },
+      runs: { status: 'available', data: [] },
+      events: { status: 'available', data: [] },
+      blockers: {
+        status: 'available',
+        data: [{
+          id: `${selectedWorkspace}-blocker`, workspaceId: selectedWorkspace, taskId: 'task-live',
+          category: 'dependency', summary: 'Waiting', createdAt: '2026-07-26T17:50:00.000Z',
+        }],
+      },
+      approvals: { status: 'available', data: [] },
+    });
+    const executeAction = vi.fn()
+      .mockRejectedValueOnce(new TypeError('workspace A response lost'))
+      .mockResolvedValue({
+        status: 'applied',
+        providerId: 'hermes',
+        correlationId: '018f6f2d-c734-7cc9-b1b6-112233445566',
+        audit: {
+          requestedBy: 'authenticated-operator',
+          actionType: 'blocker.resolve',
+          targetId: 'task-live',
+          outcome: 'applied',
+        },
+      });
+    const fetchSnapshot = vi.fn().mockImplementation(async (_providerId, options) => (
+      snapshotFor(options?.workspaceId === 'board-other' ? 'board-other' : 'board-main')
+    ));
+    render(<SmartSwarmPage client={createClient({ executeAction, fetchSnapshot })} />);
+    await screen.findByText('board-main live task');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect board-main live task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve blocker' }));
+    await screen.findByText('workspace A response lost');
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Workspace' }), {
+      target: { value: 'board-other' },
+    });
+    await screen.findByText('board-other live task');
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect board-other live task' }));
+    const otherResolve = screen.getByRole('button', { name: 'Resolve blocker' });
+    expect(otherResolve).toHaveProperty('disabled', false);
+    fireEvent.click(otherResolve);
+    await waitFor(() => expect(executeAction).toHaveBeenCalledTimes(2));
+
+    expect(executeAction.mock.calls[1]?.[1].idempotencyKey)
+      .not.toBe(executeAction.mock.calls[0]?.[1].idempotencyKey);
+  });
+
   it('retains an uncertain blocker key while the task remains blocked without blocker evidence', async () => {
     let handlers!: Parameters<SmartSwarmApiClient['subscribe']>[2];
     const blockerlessSnapshot = {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { SmartSwarmPage } from './smart-swarm-page';
 import { SmartSwarmApiError } from '../lib/smart-swarm-api';
 import type {
+  RuntimeEvent,
   RuntimeProvider,
   RuntimeSnapshot,
   SmartSwarmApiClient,
@@ -238,6 +239,60 @@ describe('SmartSwarmPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open source task task-missing for event event-missing' }));
     detail = await screen.findByRole('dialog', { name: 'Source task task-missing unavailable' });
     expect(detail.textContent).toContain('Referenced run evidence is unavailable');
+  });
+
+  it('upgrades an open pulse source when a later topology refresh includes its task', async () => {
+    const occurredAt = new Date().toISOString();
+    const sourceEvent: RuntimeEvent = {
+      id: 'event-late-task',
+      cursor: 'cursor-late-task',
+      workspaceId: 'board-main',
+      taskId: 'task-late',
+      runId: null,
+      type: 'log',
+      occurredAt,
+      summary: 'Task topology will arrive later',
+    };
+    const withoutTask: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'available', data: [] },
+      events: { status: 'available', data: [sourceEvent] },
+    };
+    const withTask: RuntimeSnapshot = {
+      ...withoutTask,
+      tasks: { status: 'available', data: [{
+        id: 'task-late',
+        workspaceId: 'board-main',
+        title: 'Late topology task',
+        state: 'running',
+        parentIds: [],
+        dependencyIds: [],
+        ownerIds: [],
+        priority: null,
+        createdAt: occurredAt,
+        updatedAt: occurredAt,
+      }] },
+    };
+    const fetchSnapshot = vi.fn()
+      .mockResolvedValueOnce(withoutTask)
+      .mockResolvedValueOnce(withoutTask)
+      .mockResolvedValueOnce(withoutTask)
+      .mockResolvedValue(withTask);
+    render(<SmartSwarmPage client={createClient({ fetchSnapshot })} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open source task task-late for event event-late-task' }));
+    expect(await screen.findByRole('dialog', { name: 'Source task task-late unavailable' })).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh topology' }));
+    await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledTimes(3));
+    expect(screen.getByRole('dialog', { name: 'Source task task-late unavailable' })).toBeDefined();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh topology' }).hasAttribute('disabled')).toBe(false));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh topology' }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Late topology task details' });
+    expect(detail.textContent).toContain('Late topology task');
+    expect(screen.queryByRole('dialog', { name: 'Source task task-late unavailable' })).toBeNull();
   });
 
   it('does not resolve referenced run evidence for a different task', async () => {

--- a/packages/franken-web/src/pages/smart-swarm-page.test.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.test.tsx
@@ -106,6 +106,190 @@ function createClient(overrides: Partial<SmartSwarmApiClient> = {}): SmartSwarmA
 afterEach(cleanup);
 
 describe('SmartSwarmPage', () => {
+  it('pulses from recent normalized runtime events with traceable provider and entity provenance', async () => {
+    const occurredAt = new Date().toISOString();
+    const sourceEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!sourceEvent) throw new Error('Expected normalized runtime event');
+    const liveSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      events: {
+        status: 'available',
+        data: [{
+          ...sourceEvent,
+          occurredAt,
+        }],
+      },
+    };
+
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(liveSnapshot),
+    })} />);
+
+    const pulse = await screen.findByRole('region', { name: 'Runtime brain pulse' });
+    expect(pulse.textContent).toContain('1 event in the last minute');
+    expect(pulse.textContent).toContain('Hermes');
+    expect(pulse.textContent).toContain('board-main');
+    expect(pulse.textContent).toContain('task-live');
+    expect(pulse.textContent).toContain('run-1');
+    expect(pulse.textContent).toContain('log');
+    expect(pulse.querySelector('time')?.getAttribute('datetime')).toBe(occurredAt);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open source task task-live for event event-1' }));
+    const detail = await screen.findByRole('dialog', { name: 'Live dashboard details' });
+    expect(detail.textContent).toContain('run-1');
+  });
+
+  it('does not resolve a pulse source task from a different workspace', async () => {
+    const occurredAt = new Date().toISOString();
+    const crossWorkspaceSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'available', data: [{
+        id: 'task-cross', workspaceId: 'board-other', title: 'Wrong workspace task', state: 'running',
+        parentIds: [], dependencyIds: [], ownerIds: [], priority: null, createdAt: occurredAt, updatedAt: occurredAt,
+      }] },
+      runs: { status: 'available', data: [] },
+      events: { status: 'available', data: [{
+        id: 'event-cross', cursor: 'cursor-cross', workspaceId: 'board-main', taskId: 'task-cross', runId: null,
+        type: 'audit', occurredAt, summary: 'Cross-workspace task reference',
+      }] },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(crossWorkspaceSnapshot),
+    })} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open source task task-cross for event event-cross' }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Source task task-cross unavailable' });
+    expect(detail.textContent).toContain('outside the bounded task snapshot');
+    expect(detail.textContent).not.toContain('Wrong workspace task');
+  });
+
+  it('does not include same-task-id run evidence from another workspace', async () => {
+    const occurredAt = new Date().toISOString();
+    const crossWorkspaceRunSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      runs: { status: 'available', data: [{
+        id: 'run-cross', workspaceId: 'board-other', taskId: 'task-live', agentId: null, sessionId: null,
+        state: 'running', startedAt: occurredAt, finishedAt: null, lastActiveAt: occurredAt, summary: 'Wrong workspace run',
+      }] },
+      events: { status: 'available', data: [{
+        id: 'event-cross-run', cursor: 'cursor-cross-run', workspaceId: 'board-main', taskId: 'task-live', runId: null,
+        type: 'log', occurredAt, summary: 'Task emitted workspace-scoped evidence',
+      }] },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(crossWorkspaceRunSnapshot),
+    })} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open source task task-live for event event-cross-run' }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Live dashboard details' });
+    expect(detail.textContent).not.toContain('run-cross');
+    expect(detail.textContent).not.toContain('Wrong workspace run');
+  });
+
+  it('opens pulse sources outside the task bound with referenced run evidence or an explicit unavailable state', async () => {
+    const occurredAt = new Date().toISOString();
+    const externalRun = {
+      id: 'run-external',
+      workspaceId: 'board-main',
+      taskId: 'task-external',
+      agentId: 'worker-1',
+      sessionId: 'session-external',
+      state: 'running' as const,
+      startedAt: occurredAt,
+      finishedAt: null,
+      lastActiveAt: occurredAt,
+      summary: 'External task run is still observable',
+    };
+    const boundedSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'available', data: snapshot.tasks.status === 'available' ? snapshot.tasks.data : [] },
+      runs: { status: 'available', data: [externalRun] },
+      events: {
+        status: 'available',
+        data: [
+          {
+            id: 'event-external', cursor: 'cursor-external', workspaceId: 'board-main', taskId: 'task-external', runId: 'run-external', type: 'log',
+            occurredAt, summary: 'External task emitted evidence',
+          },
+          {
+            id: 'event-missing', cursor: 'cursor-missing', workspaceId: 'board-main', taskId: 'task-missing', runId: 'run-missing', type: 'audit',
+            occurredAt, summary: 'Missing source emitted evidence',
+          },
+        ],
+      },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(boundedSnapshot),
+    })} />);
+
+    const externalTrigger = await screen.findByRole('button', { name: 'Open source task task-external for event event-external' });
+    fireEvent.click(externalTrigger);
+    let detail = await screen.findByRole('dialog', { name: 'Source task task-external unavailable' });
+    expect(detail.textContent).toContain('outside the bounded task snapshot');
+    expect(detail.textContent).toContain('run-external');
+    expect(detail.textContent).toContain('External task run is still observable');
+    externalTrigger.focus();
+    fireEvent.keyDown(detail, { key: 'Tab' });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open source task task-missing for event event-missing' }));
+    detail = await screen.findByRole('dialog', { name: 'Source task task-missing unavailable' });
+    expect(detail.textContent).toContain('Referenced run evidence is unavailable');
+  });
+
+  it('does not resolve referenced run evidence for a different task', async () => {
+    const occurredAt = new Date().toISOString();
+    const mismatchedRunSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [{
+        id: 'run-collision', workspaceId: 'board-main', taskId: 'task-other', agentId: null, sessionId: null,
+        state: 'running', startedAt: occurredAt, finishedAt: null, lastActiveAt: occurredAt, summary: 'Wrong task run',
+      }] },
+      events: { status: 'available', data: [{
+        id: 'event-collision', cursor: 'cursor-collision', workspaceId: 'board-main', taskId: 'task-source', runId: 'run-collision',
+        type: 'log', occurredAt, summary: 'Task provenance must match',
+      }] },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(mismatchedRunSnapshot),
+    })} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open source task task-source for event event-collision' }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Source task task-source unavailable' });
+    expect(detail.textContent).toContain('Referenced run evidence is unavailable');
+    expect(detail.textContent).not.toContain('Wrong task run');
+  });
+
+  it('does not resolve referenced run evidence from a different workspace', async () => {
+    const occurredAt = new Date().toISOString();
+    const mismatchedRunSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      tasks: { status: 'available', data: [] },
+      runs: { status: 'available', data: [{
+        id: 'run-collision', workspaceId: 'board-other', taskId: 'task-source', agentId: null, sessionId: null,
+        state: 'running', startedAt: occurredAt, finishedAt: null, lastActiveAt: occurredAt, summary: 'Wrong workspace run',
+      }] },
+      events: { status: 'available', data: [{
+        id: 'event-collision', cursor: 'cursor-collision', workspaceId: 'board-main', taskId: 'task-source', runId: 'run-collision',
+        type: 'log', occurredAt, summary: 'Workspace provenance must match',
+      }] },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(mismatchedRunSnapshot),
+    })} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open source task task-source for event event-collision' }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Source task task-source unavailable' });
+    expect(detail.textContent).toContain('Referenced run evidence is unavailable');
+    expect(detail.textContent).not.toContain('Wrong workspace run');
+  });
+
   it('renders normalized provider, workspace, topology, and real evidence', async () => {
     const client = createClient();
     render(<SmartSwarmPage client={client} />);
@@ -181,6 +365,27 @@ describe('SmartSwarmPage', () => {
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
     expect(screen.queryByRole('dialog')).toBeNull();
     await waitFor(() => expect(document.activeElement).toBe(inspect));
+  });
+
+  it('restores focus to the pulse Open source trigger after task drill-down closes', async () => {
+    const sourceEvent = snapshot.events.status === 'available' ? snapshot.events.data[0] : undefined;
+    if (!sourceEvent) throw new Error('Expected normalized runtime event');
+    const liveSnapshot: RuntimeSnapshot = {
+      ...snapshot,
+      events: { status: 'available', data: [{ ...sourceEvent, occurredAt: new Date().toISOString() }] },
+    };
+    render(<SmartSwarmPage client={createClient({
+      fetchSnapshot: vi.fn().mockResolvedValue(liveSnapshot),
+    })} />);
+    const openSource = await screen.findByRole('button', { name: 'Open source task task-live for event event-1' });
+    openSource.focus();
+
+    fireEvent.click(openSource);
+    const close = await screen.findByRole('button', { name: 'Close' });
+    await waitFor(() => expect(document.activeElement).toBe(close));
+    fireEvent.click(close);
+
+    await waitFor(() => expect(document.activeElement).toBe(openSource));
   });
 
   it('keeps focus trapped when a pending action disables the focused control', async () => {

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -690,6 +690,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           {provider ? (
             <RuntimeBrainPulse
               connection={connection}
+              eventLimit={MAX_VISIBLE_EVIDENCE}
               events={filteredEvents}
               onOpenTask={(event, trigger) => {
                 taskDetailTrigger.current = trigger;

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -23,6 +23,7 @@ interface SmartSwarmPageProps {
 interface PendingActionIntent {
   idempotencyKey: string;
   providerId: string;
+  workspaceId: string;
   taskId: string;
   action: RuntimeAction['type'];
   inFlight: boolean;
@@ -34,6 +35,15 @@ const MAX_VISIBLE_EVIDENCE = 100;
 const STREAM_REFRESH_DEBOUNCE_MS = 250;
 const TOPOLOGY_REFRESH_INTERVAL_MS = 5_000;
 const TERMINAL_RUN_STATES = new Set(['succeeded', 'failed', 'cancelled']);
+
+function actionIntentKey(
+  providerId: string,
+  workspaceId: string,
+  taskId: string,
+  action: RuntimeAction['type'],
+): string {
+  return `${providerId}:${workspaceId}:${taskId}:${action}`;
+}
 
 function available<T>(section: RuntimeSection<T>): T | null {
   return section.status === 'available' ? section.data : null;
@@ -50,13 +60,15 @@ function capabilityReason(capability: RuntimeCapability): string | null {
 function actionPostconditionConfirmed(
   intent: PendingActionIntent,
   task: RuntimeTask,
-  blockers: Array<{ taskId: string }> | null,
+  blockers: Array<{ workspaceId: string; taskId: string }> | null,
 ): boolean {
   switch (intent.action) {
     case 'blocker.resolve':
       return task.state !== 'blocked'
         && blockers !== null
-        && !blockers.some((blocker) => blocker.taskId === intent.taskId);
+        && !blockers.some((blocker) => (
+          blocker.workspaceId === intent.workspaceId && blocker.taskId === intent.taskId
+        ));
     case 'task.cancel':
       return task.state === 'cancelled';
     case 'policy.apply':
@@ -359,6 +371,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const selectedTaskActionPending = selectedTask
     ? [...actionIdempotencyKeys.current.values()].some((intent) => (
         intent.providerId === providerId
+        && intent.workspaceId === selectedTask.workspaceId
         && intent.taskId === selectedTask.id
         && (intent.inFlight || intent.awaitingConfirmation)
         && !actionPostconditionConfirmed(intent, selectedTask, confirmedBlockers)
@@ -368,7 +381,9 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   useEffect(() => {
     for (const [key, intent] of actionIdempotencyKeys.current) {
       if (intent.providerId !== providerId) continue;
-      const currentTask = tasks.find((task) => task.id === intent.taskId);
+      const currentTask = tasks.find((task) => (
+        task.workspaceId === intent.workspaceId && task.id === intent.taskId
+      ));
       if (currentTask && actionPostconditionConfirmed(intent, currentTask, confirmedBlockers)) {
         actionIdempotencyKeys.current.delete(key);
       }
@@ -973,26 +988,27 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
             taskId: task.id,
             reason,
           };
-      const actionIntentKey = `${provider.id}:${task.id}:${action}`;
-      const pendingIntent = actionIdempotencyKeys.get(actionIntentKey);
+      const intentKey = actionIntentKey(provider.id, task.workspaceId, task.id, action);
+      const pendingIntent = actionIdempotencyKeys.get(intentKey);
       const idempotencyKey = pendingIntent?.idempotencyKey ?? `${action}:${crypto.randomUUID()}`;
       const actionIntent = pendingIntent ?? {
         idempotencyKey,
         providerId: provider.id,
+        workspaceId: task.workspaceId,
         taskId: task.id,
         action,
         inFlight: true,
         awaitingConfirmation: false,
       };
       actionIntent.inFlight = true;
-      actionIdempotencyKeys.set(actionIntentKey, actionIntent);
+      actionIdempotencyKeys.set(intentKey, actionIntent);
       const result = await client.executeAction(provider.id, {
         correlationId: crypto.randomUUID(),
         idempotencyKey,
         action: runtimeAction,
       });
       if (result.status === 'applied') {
-        const appliedIntent = actionIdempotencyKeys.get(actionIntentKey);
+        const appliedIntent = actionIdempotencyKeys.get(intentKey);
         if (appliedIntent) {
           appliedIntent.awaitingConfirmation = true;
           awaitingConfirmation = true;
@@ -1000,19 +1016,21 @@ function TaskDetail({ task, provider, runs, client, returnFocus, actionIdempoten
         setActionStatus(successMessage);
         onActionApplied();
       } else if (result.status === 'rejected') {
-        actionIdempotencyKeys.delete(actionIntentKey);
+        actionIdempotencyKeys.delete(intentKey);
         setActionStatus(`rejected: ${result.reason}`);
       } else if (result.status === 'failed') {
-        actionIdempotencyKeys.delete(actionIntentKey);
+        actionIdempotencyKeys.delete(intentKey);
         setActionStatus(`failed: ${result.reason}`);
       } else {
-        actionIdempotencyKeys.delete(actionIntentKey);
+        actionIdempotencyKeys.delete(intentKey);
         setActionStatus(`unsupported: ${result.reason}`);
       }
     } catch (error) {
       setActionStatus(errorMessage(error));
     } finally {
-      const pendingIntent = actionIdempotencyKeys.get(`${provider.id}:${task.id}:${action}`);
+      const pendingIntent = actionIdempotencyKeys.get(
+        actionIntentKey(provider.id, task.workspaceId, task.id, action),
+      );
       if (pendingIntent) pendingIntent.inFlight = false;
       if (!awaitingConfirmation) setActionPending(false);
     }

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -336,8 +336,9 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           || left.id.localeCompare(right.id);
       })
     : [];
+  const selectedTaskLookupId = selectedTaskId ?? selectedPulseSource?.taskId ?? null;
   const selectedTask = tasks.find((task) => (
-    task.id === selectedTaskId
+    task.id === selectedTaskLookupId
     && (!selectedPulseSource || task.workspaceId === selectedPulseSource.workspaceId)
   )) ?? null;
   const referencedRun = selectedPulseSource?.runId

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -42,7 +42,7 @@ function actionIntentKey(
   taskId: string,
   action: RuntimeAction['type'],
 ): string {
-  return `${providerId}:${workspaceId}:${taskId}:${action}`;
+  return JSON.stringify([providerId, workspaceId, taskId, action]);
 }
 
 function available<T>(section: RuntimeSection<T>): T | null {
@@ -332,7 +332,6 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
       ...liveEvents,
     ].map((event) => [event.id, event])).values()]
       .sort(compareRuntimeEvidenceRecency)
-      .slice(0, MAX_VISIBLE_EVIDENCE)
     : [];
   const blockers = snapshot
     ? [...(available(snapshot.blockers) ?? [])]
@@ -561,8 +560,8 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const visibleTasks = [...filteredTasks]
     .sort(compareTaskActivity)
     .slice(0, MAX_VISIBLE_TASKS);
-  const filteredEvents = events
-    .filter((event) => !workspaceId || event.workspaceId === workspaceId)
+  const pulseEvents = events.filter((event) => !workspaceId || event.workspaceId === workspaceId);
+  const filteredEvents = [...pulseEvents]
     .sort((left, right) => Date.parse(right.occurredAt) - Date.parse(left.occurredAt))
     .slice(0, 100);
   const filteredBlockers = blockers.filter((blocker) => !workspaceId || blocker.workspaceId === workspaceId);
@@ -707,7 +706,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
             <RuntimeBrainPulse
               connection={connection}
               eventLimit={MAX_VISIBLE_EVIDENCE}
-              events={filteredEvents}
+              events={pulseEvents}
               onOpenTask={(event, trigger) => {
                 taskDetailTrigger.current = trigger;
                 setSelectedPulseSource(event);

--- a/packages/franken-web/src/pages/smart-swarm-page.tsx
+++ b/packages/franken-web/src/pages/smart-swarm-page.tsx
@@ -14,6 +14,7 @@ import {
   type RuntimeWorkspace,
   type SmartSwarmApiClient,
 } from '../lib/smart-swarm-api';
+import { RuntimeBrainPulse } from '../components/smart-swarm/runtime-brain-pulse';
 
 interface SmartSwarmPageProps {
   client: SmartSwarmApiClient;
@@ -285,6 +286,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
   const [snapshot, setSnapshot] = useState<RuntimeSnapshot | null>(null);
   const [liveEvents, setLiveEvents] = useState<RuntimeEvent[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [selectedPulseSource, setSelectedPulseSource] = useState<RuntimeEvent | null>(null);
   const [loading, setLoading] = useState(true);
   const [providerError, setProviderError] = useState<unknown>(null);
   const [snapshotError, setSnapshotError] = useState<unknown>(null);
@@ -334,7 +336,25 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           || left.id.localeCompare(right.id);
       })
     : [];
-  const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? null;
+  const selectedTask = tasks.find((task) => (
+    task.id === selectedTaskId
+    && (!selectedPulseSource || task.workspaceId === selectedPulseSource.workspaceId)
+  )) ?? null;
+  const referencedRun = selectedPulseSource?.runId
+    ? runs.find((run) => (
+      run.id === selectedPulseSource.runId
+      && run.workspaceId === selectedPulseSource.workspaceId
+      && run.taskId === selectedPulseSource.taskId
+    )) ?? null
+    : null;
+  const selectedTaskRuns = selectedTask
+    ? [...new Map([
+        ...(referencedRun ? [referencedRun] : []),
+        ...runs.filter((run) => (
+          run.taskId === selectedTask.id && run.workspaceId === selectedTask.workspaceId
+        )).sort(compareRuntimeRunRecency),
+      ].map((run) => [run.id, run])).values()].slice(0, 20)
+    : [];
   const selectedTaskActionPending = selectedTask
     ? [...actionIdempotencyKeys.current.values()].some((intent) => (
         intent.providerId === providerId
@@ -400,6 +420,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           setLiveEvents([]);
           setWorkspaceCatalog(null);
           setWorkspaceId('');
+          setSelectedPulseSource(null);
           setSelectedTaskId(null);
           setSnapshotError(null);
           setWorkspaceCatalogError(null);
@@ -545,6 +566,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
         const catalogWorkspaces = catalogSnapshot.workspaces.data;
         if (!catalogWorkspaces.some((workspace) => workspace.id === currentWorkspaceId.current)) {
           setSnapshot(null);
+          setSelectedPulseSource(null);
           setSelectedTaskId(null);
           setWorkspaceId(preferredWorkspaceId(catalogWorkspaces));
         }
@@ -591,6 +613,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
                 setLiveEvents([]);
                 setWorkspaceCatalog(null);
                 setWorkspaceId('');
+                setSelectedPulseSource(null);
                 setSelectedTaskId(null);
                 setWorkspaceCatalogError(null);
                 setStreamError(null);
@@ -610,6 +633,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
               onChange={(event) => {
                 setSnapshot(null);
                 setLiveEvents([]);
+                setSelectedPulseSource(null);
                 setSelectedTaskId(null);
                 setLoading(true);
                 setWorkspaceId(event.target.value);
@@ -663,6 +687,19 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
 
       {snapshot ? (
         <>
+          {provider ? (
+            <RuntimeBrainPulse
+              connection={connection}
+              events={filteredEvents}
+              onOpenTask={(event, trigger) => {
+                taskDetailTrigger.current = trigger;
+                setSelectedPulseSource(event);
+                setSelectedTaskId(event.taskId);
+              }}
+              provider={provider}
+              snapshot={snapshot}
+            />
+          ) : null}
           <section className="smart-swarm-capabilities rail-card" aria-label="Provider capabilities">
             <div>
               <p className="eyebrow">Runtime status</p>
@@ -740,6 +777,7 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
                         className="smart-swarm-task"
                         onClick={(event) => {
                           taskDetailTrigger.current = event.currentTarget;
+                          setSelectedPulseSource(null);
                           setSelectedTaskId(task.id);
                         }}
                         type="button"
@@ -804,17 +842,75 @@ export function SmartSwarmPage({ client }: SmartSwarmPageProps) {
           client={client}
           key={`${provider.id}:${selectedTask.id}`}
           onActionApplied={() => setRefreshNonce((current) => current + 1)}
-          onClose={() => setSelectedTaskId(null)}
+          onClose={() => {
+            setSelectedPulseSource(null);
+            setSelectedTaskId(null);
+          }}
           provider={provider}
           returnFocus={taskDetailTrigger.current}
-          runs={runs
-            .filter((run) => run.taskId === selectedTask.id)
-            .sort(compareRuntimeRunRecency)
-            .slice(0, 20)}
+          runs={selectedTaskRuns}
           task={selectedTask}
+        />
+      ) : selectedPulseSource?.taskId ? (
+        <UnavailableSourceDetail
+          event={selectedPulseSource}
+          onClose={() => {
+            setSelectedPulseSource(null);
+            setSelectedTaskId(null);
+          }}
+          referencedRun={referencedRun}
+          returnFocus={taskDetailTrigger.current}
         />
       ) : null}
     </main>
+  );
+}
+
+function UnavailableSourceDetail({ event, referencedRun, returnFocus, onClose }: {
+  event: RuntimeEvent;
+  referencedRun: RuntimeRun | null;
+  returnFocus: HTMLButtonElement | null;
+  onClose(): void;
+}) {
+  const closeButton = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    closeButton.current?.focus();
+    return () => {
+      if (returnFocus?.isConnected) returnFocus.focus();
+    };
+  }, [returnFocus]);
+  return (
+    <section
+      aria-label={`Source task ${event.taskId} unavailable`}
+      aria-modal="true"
+      className="smart-swarm-detail"
+      onKeyDown={(keyEvent) => {
+        if (keyEvent.key === 'Escape') {
+          keyEvent.preventDefault();
+          onClose();
+        } else if (keyEvent.key === 'Tab') {
+          keyEvent.preventDefault();
+          closeButton.current?.focus();
+        }
+      }}
+      role="dialog"
+    >
+      <header>
+        <div><p className="eyebrow">Unavailable source</p><h3>Task {event.taskId}</h3></div>
+        <button className="button button--secondary button--compact" onClick={onClose} ref={closeButton} type="button">Close</button>
+      </header>
+      <p role="status">The referenced task is outside the bounded task snapshot.</p>
+      <dl>
+        <div><dt>Event</dt><dd>{event.id}</dd></div>
+        <div><dt>Workspace</dt><dd>{event.workspaceId}</dd></div>
+      </dl>
+      <section>
+        <h4>Referenced run evidence</h4>
+        {referencedRun ? (
+          <article><strong>{referencedRun.id}</strong><span>{referencedRun.state}</span><p>{referencedRun.summary ?? 'No run summary.'}</p></article>
+        ) : <p>Referenced run evidence is unavailable.</p>}
+      </section>
+    </section>
   );
 }
 

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -2404,6 +2404,11 @@ button {
   font-size: 0.76rem;
 }
 
+.runtime-brain-pulse li span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .runtime-brain-pulse button {
   padding: 0.4rem 0.6rem;
   border: 1px solid var(--control-border);

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -2579,7 +2579,8 @@ button {
 @media (prefers-reduced-motion: reduce) {
   .smart-swarm-connection,
   .smart-swarm-task,
-  .runtime-brain-pulse {
+  .runtime-brain-pulse,
+  .runtime-brain-pulse[data-pulse-state="active"] {
     animation: none;
     transition: none;
   }

--- a/packages/franken-web/src/styles/app.css
+++ b/packages/franken-web/src/styles/app.css
@@ -2344,6 +2344,80 @@ button {
   background: rgba(255, 122, 107, 0.1);
 }
 
+.runtime-brain-pulse {
+  gap: 0.75rem;
+}
+
+.runtime-brain-pulse > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.runtime-brain-pulse h3,
+.runtime-brain-pulse p {
+  margin: 0;
+}
+
+.runtime-brain-pulse[data-pulse-state="active"] {
+  animation: runtime-brain-pulse 1.4s ease-in-out infinite;
+  border-color: var(--accent);
+}
+
+.runtime-brain-pulse__state {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  color: var(--text-muted);
+}
+
+.runtime-brain-pulse__state--disconnected {
+  border-color: rgba(255, 122, 107, 0.42);
+}
+
+.runtime-brain-pulse__state--degraded {
+  border-color: rgba(255, 205, 86, 0.42);
+}
+
+.runtime-brain-pulse ol {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.runtime-brain-pulse li {
+  display: grid;
+  grid-template-columns: auto auto minmax(8rem, 1fr) repeat(4, auto) auto;
+  gap: 0.55rem;
+  align-items: center;
+  padding: 0.65rem;
+  border-left: 3px solid var(--accent);
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.runtime-brain-pulse time,
+.runtime-brain-pulse li span {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
+
+.runtime-brain-pulse button {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--control-border);
+  border-radius: 0.55rem;
+  background: var(--control-bg);
+  color: var(--accent-strong);
+}
+
+@keyframes runtime-brain-pulse {
+  50% {
+    box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+}
+
 .smart-swarm-capabilities {
   grid-template-columns: minmax(12rem, 0.45fr) minmax(0, 1fr);
   align-items: start;
@@ -2504,7 +2578,9 @@ button {
 
 @media (prefers-reduced-motion: reduce) {
   .smart-swarm-connection,
-  .smart-swarm-task {
+  .smart-swarm-task,
+  .runtime-brain-pulse {
+    animation: none;
     transition: none;
   }
 }
@@ -2520,6 +2596,10 @@ button {
 
   .smart-swarm-header,
   .smart-swarm-capabilities {
+    grid-template-columns: 1fr;
+  }
+
+  .runtime-brain-pulse li {
     grid-template-columns: 1fr;
   }
 

--- a/packages/franken-web/tests/styles/app-css.test.ts
+++ b/packages/franken-web/tests/styles/app-css.test.ts
@@ -25,4 +25,8 @@ describe('app.css smart-swarm dashboard', () => {
     expect(appCss).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\.smart-swarm-connection/m);
     expect(appCss).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\.runtime-brain-pulse\[data-pulse-state="active"\][\s\S]*?animation:\s*none;/m);
   });
+
+  it('wraps long normalized pulse evidence without expanding the dashboard', () => {
+    expect(appCss).toMatch(/\.runtime-brain-pulse li span\s*\{[\s\S]*?min-width:\s*0;[\s\S]*?overflow-wrap:\s*anywhere;/m);
+  });
 });

--- a/packages/franken-web/tests/styles/app-css.test.ts
+++ b/packages/franken-web/tests/styles/app-css.test.ts
@@ -23,5 +23,6 @@ describe('app.css smart-swarm dashboard', () => {
     expect(appCss).toMatch(/\.smart-swarm-layout\s*\{[\s\S]*?grid-template-columns:/m);
     expect(appCss).toMatch(/@media\s*\(max-width:\s*1100px\)\s*\{[\s\S]*?\.smart-swarm-layout\s*\{\s*grid-template-columns:\s*1fr;/m);
     expect(appCss).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\.smart-swarm-connection/m);
+    expect(appCss).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\.runtime-brain-pulse\[data-pulse-state="active"\][\s\S]*?animation:\s*none;/m);
   });
 });

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -1,0 +1,12 @@
+# #3856 Live Brain Pulse from Runtime Events — Progress
+
+- [x] Read live issue #3856 and verify isolated worktree is clean at current `origin/main` with required Git identity.
+- [x] Trace the existing Beast-run Brain Pulse implementation and normalized smart-swarm runtime event stream.
+- [x] Define the smallest provider-neutral pulse contract and affected UI/API boundaries.
+- [x] RED: add focused tests for genuine normalized events, provenance, live updates, deduplication, replay/pruning, malformed input, provider unsupported/degraded/disconnected/no-activity states, drill-down, and accessibility/reduced motion.
+- [x] GREEN: implement runtime-backed Brain Pulse without fixture/demo/staging production data.
+- [x] Run focused tests, lint, typecheck, build, and relevant full suites.
+- [x] Independently review the diff and remediate findings.
+- [x] Update architecture docs with source, cursor, validation, state, motion, and drill-down behavior.
+- [ ] Commit as David Mendez, push, open a linked PR, and complete exact-head Codex/CI/thread gates.
+- [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -10,5 +10,6 @@
 - [x] Update architecture docs with source, cursor, validation, state, motion, and drill-down behavior.
 - [x] Commit as David Mendez, push, and open linked PR #3872.
 - [x] Address all three first-round current-head Codex findings with focused RED/GREEN coverage.
+- [x] Address all five follow-up current-head Codex findings with focused RED/GREEN coverage: exact event-section discriminants, normalized timestamps, shared metadata bounds, wrapping for long evidence, and honest retained-event counts.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -8,5 +8,7 @@
 - [x] Run focused tests, lint, typecheck, build, and relevant full suites.
 - [x] Independently review the diff and remediate findings.
 - [x] Update architecture docs with source, cursor, validation, state, motion, and drill-down behavior.
-- [ ] Commit as David Mendez, push, open a linked PR, and complete exact-head Codex/CI/thread gates.
+- [x] Commit as David Mendez, push, and open linked PR #3872.
+- [x] Address all three first-round current-head Codex findings with focused RED/GREEN coverage.
+- [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -12,5 +12,6 @@
 - [x] Address all three first-round current-head Codex findings with focused RED/GREEN coverage.
 - [x] Address all five follow-up current-head Codex findings with focused RED/GREEN coverage: exact event-section discriminants, normalized timestamps, shared metadata bounds, wrapping for long evidence, and honest retained-event counts.
 - [x] Address all four third-round current-head Codex findings plus two independent local review findings: normalized ID/cursor bounds, unavailable-state semantics, retained source-task resolution, Codex metadata limits, transition suffix budget, and source-specific status reasons.
+- [x] Address all five fifth-round current-head Codex findings with focused RED/GREEN coverage: poison-frame quarantine, runtime-failure precedence, UTF-8 cursor bytes, impossible calendar dates, and bounded Hermes status/outcome metadata.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -14,5 +14,6 @@
 - [x] Address all four third-round current-head Codex findings plus two independent local review findings: normalized ID/cursor bounds, unavailable-state semantics, retained source-task resolution, Codex metadata limits, transition suffix budget, and source-specific status reasons.
 - [x] Address all five fifth-round current-head Codex findings with focused RED/GREEN coverage: poison-frame quarantine, runtime-failure precedence, UTF-8 cursor bytes, impossible calendar dates, and bounded Hermes status/outcome metadata.
 - [x] Address the tier-12 follow-up finding with RED/GREEN coverage by bounding Ollama installed/loaded model-name metadata before shared snapshot parsing.
+- [x] Address all three replacement-head Codex findings with RED/GREEN coverage: bounded Ollama version metadata, clock-skew-tolerant pulse freshness, and consistent quarantine of oversized Hermes task IDs.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -17,5 +17,6 @@
 - [x] Address all three replacement-head Codex findings with RED/GREEN coverage: bounded Ollama version metadata, clock-skew-tolerant pulse freshness, and consistent quarantine of oversized Hermes task IDs.
 - [x] Address all three tier-12 follow-up findings with RED/GREEN coverage: replay progress past quarantined Hermes rows, bounded future clock skew, and bounded checkpoint-only cursors.
 - [x] Address the final tier-12 findings round with RED/GREEN coverage: snapshot backfill after quarantine, bounded Hermes event run references, and full-minute retention for newly received negative-skew activity.
+- [x] Address the next current-head findings round with RED/GREEN coverage: bounded malformed-row scans/checkpoint progress, workspace-scoped action identity, immediate receipt-freshness render, and browser-time-bounded future-skew expiry.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -15,5 +15,6 @@
 - [x] Address all five fifth-round current-head Codex findings with focused RED/GREEN coverage: poison-frame quarantine, runtime-failure precedence, UTF-8 cursor bytes, impossible calendar dates, and bounded Hermes status/outcome metadata.
 - [x] Address the tier-12 follow-up finding with RED/GREEN coverage by bounding Ollama installed/loaded model-name metadata before shared snapshot parsing.
 - [x] Address all three replacement-head Codex findings with RED/GREEN coverage: bounded Ollama version metadata, clock-skew-tolerant pulse freshness, and consistent quarantine of oversized Hermes task IDs.
+- [x] Address all three tier-12 follow-up findings with RED/GREEN coverage: replay progress past quarantined Hermes rows, bounded future clock skew, and bounded checkpoint-only cursors.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -16,5 +16,6 @@
 - [x] Address the tier-12 follow-up finding with RED/GREEN coverage by bounding Ollama installed/loaded model-name metadata before shared snapshot parsing.
 - [x] Address all three replacement-head Codex findings with RED/GREEN coverage: bounded Ollama version metadata, clock-skew-tolerant pulse freshness, and consistent quarantine of oversized Hermes task IDs.
 - [x] Address all three tier-12 follow-up findings with RED/GREEN coverage: replay progress past quarantined Hermes rows, bounded future clock skew, and bounded checkpoint-only cursors.
+- [x] Address the final tier-12 findings round with RED/GREEN coverage: snapshot backfill after quarantine, bounded Hermes event run references, and full-minute retention for newly received negative-skew activity.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -13,5 +13,6 @@
 - [x] Address all five follow-up current-head Codex findings with focused RED/GREEN coverage: exact event-section discriminants, normalized timestamps, shared metadata bounds, wrapping for long evidence, and honest retained-event counts.
 - [x] Address all four third-round current-head Codex findings plus two independent local review findings: normalized ID/cursor bounds, unavailable-state semantics, retained source-task resolution, Codex metadata limits, transition suffix budget, and source-specific status reasons.
 - [x] Address all five fifth-round current-head Codex findings with focused RED/GREEN coverage: poison-frame quarantine, runtime-failure precedence, UTF-8 cursor bytes, impossible calendar dates, and bounded Hermes status/outcome metadata.
+- [x] Address the tier-12 follow-up finding with RED/GREEN coverage by bounding Ollama installed/loaded model-name metadata before shared snapshot parsing.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -18,5 +18,6 @@
 - [x] Address all three tier-12 follow-up findings with RED/GREEN coverage: replay progress past quarantined Hermes rows, bounded future clock skew, and bounded checkpoint-only cursors.
 - [x] Address the final tier-12 findings round with RED/GREEN coverage: snapshot backfill after quarantine, bounded Hermes event run references, and full-minute retention for newly received negative-skew activity.
 - [x] Address the next current-head findings round with RED/GREEN coverage: bounded malformed-row scans/checkpoint progress, workspace-scoped action identity, immediate receipt-freshness render, and browser-time-bounded future-skew expiry.
+- [x] Address the follow-up findings with RED/GREEN coverage: cold poison checkpoints, pagination-safe workspace cursors, cold valid-event retention, post-skew evidence capping, and collision-free action tuple keys.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.

--- a/tasks/3856-live-brain-pulse-events-progress.md
+++ b/tasks/3856-live-brain-pulse-events-progress.md
@@ -11,5 +11,6 @@
 - [x] Commit as David Mendez, push, and open linked PR #3872.
 - [x] Address all three first-round current-head Codex findings with focused RED/GREEN coverage.
 - [x] Address all five follow-up current-head Codex findings with focused RED/GREEN coverage: exact event-section discriminants, normalized timestamps, shared metadata bounds, wrapping for long evidence, and honest retained-event counts.
+- [x] Address all four third-round current-head Codex findings plus two independent local review findings: normalized ID/cursor bounds, unavailable-state semantics, retained source-task resolution, Codex metadata limits, transition suffix budget, and source-specific status reasons.
 - [ ] Push remediation and complete fresh exact-head Codex/CI/thread gates.
 - [ ] Guarded squash merge exact reviewed head, verify issue closure/deployment/public authenticated browser evidence, and record terminal Kanban handoff.


### PR DESCRIPTION
## Summary
- drive Brain Pulse from provider-neutral normalized runtime events with provenance, bounded retention, reconnect/replay safety, and semantic runtime states
- validate snapshot and streamed event payloads before rendering, preserve valid cursors, and bound invalid-cursor recovery
- add accessible source drill-down, reduced-motion styling, and distinguish legacy Beast run telemetry from canonical Brain Pulse

## Test plan
- [x] 120 focused web tests pass
- [x] npm run typecheck
- [x] npm run lint (0 errors; existing warnings)
- [x] npm run build
- [x] independent review returned no security or logic findings

Closes #3856