### PR TITLE
fix(web): authenticate forwarded dashboard origins

### DIFF
--- a/docs/runbooks/smart-swarm-reviewed-main-cutover.md
+++ b/docs/runbooks/smart-swarm-reviewed-main-cutover.md
@@ -1,0 +1,56 @@
+# Smart Swarm reviewed-main dashboard cutover
+
+This runbook replaces the acceptance-only `brain-vitals-stage` deployment with the canonical Smart Swarm operator surface backed by the live Hermes Kanban database.
+
+## Deployment contract
+
+- Deploy only an immutable commit already merged to reviewed `origin/main`.
+- Use a detached deployment checkout and point `$HOME/.local/share/frankenbeast/live-dashboard/current` at that checkout.
+- Build with `npm ci && npm run build` inside the detached checkout.
+- Configure the backend explicitly with:
+  - `HERMES_HOME=$HOME/.hermes`
+  - `HERMES_KANBAN_DB=$HERMES_HOME/kanban.db`
+- Keep backend port `3747` and dashboard/BFF port `5190` bound to `127.0.0.1` only.
+- Expose only the dashboard/BFF through an authenticated HTTPS tunnel.
+- Set `FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_ORIGIN` to the tunnel's exact public HTTPS origin (scheme plus host, with no path).
+- Generate a separate high-entropy proxy token, load it into the dashboard through a systemd encrypted credential as `FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN`, and configure the tunnel traffic policy to remove any client-supplied `X-Frankenbeast-Proxy-Token` before adding the credential value. Never reuse the operator token.
+- Forwarded HTTP/WebSocket origin metadata is rejected unless it matches the explicit origin, arrives through the loopback proxy peer, and carries the matching proxy token. The BFF strips the proxy token before forwarding upstream.
+- Load the operator and proxy tokens through separate systemd encrypted credentials. Never store or print them in a unit, wrapper, repository file, command transcript, or acceptance artifact.
+- Make service wrappers compare the detached checkout's `git rev-parse HEAD` with the configured reviewed SHA and fail closed on a mismatch.
+- Do not seed, copy, or fall back to staging, fixture, demo, `design-interview`, or synthetic acceptance records.
+
+The durable user services are:
+
+- `frankenbeast-smart-swarm-live-backend.service`
+- `frankenbeast-smart-swarm-live-dashboard.service`
+- `frankenbeast-smart-swarm-live-ngrok.service`
+
+The former `frankenbeast-brain-vitals-stage-*` units must remain disabled and inactive after cutover.
+
+## Verification
+
+1. Confirm all three live units are enabled and active.
+2. Confirm the backend and dashboard process working directories resolve through the immutable `current` symlink and that the detached checkout HEAD equals the recorded reviewed SHA.
+3. Confirm ports `3747`, `5190`, and ngrok's local control port are loopback-only.
+4. Confirm an unauthenticated public request returns `401` and authenticated local/public dashboard requests return `200`.
+5. Compare the local and public `index.html` SHA-256 digests.
+6. Query the authenticated local and public Hermes provider/snapshot APIs. Confirm both expose current real task/workspace/activity state and no `design-interview` fallback.
+7. Mint an authenticated runtime SSE ticket and receive a public stream frame.
+8. In a real browser, open `#/brain-vitals`, confirm it canonicalizes to `#/smart-swarm`, select Hermes, observe `Live · connected`, and verify a current live task is visible without console errors or unexpected resource failures.
+9. Restart all three live units, then repeat health, provenance, API, SSE, and browser checks.
+
+Do not publish credentials, raw database contents, authenticated request headers, or unredacted task bodies as evidence.
+
+## Rollback
+
+1. Stop and disable the three `frankenbeast-smart-swarm-live-*` units.
+2. Repoint the `current` symlink to the previous immutable reviewed deployment checkout; never point it at a mutable development worktree.
+3. Update each unit's expected SHA to the rollback commit and run `systemctl --user daemon-reload`.
+4. Enable/start the live backend, dashboard, and ngrok units in dependency order.
+5. Repeat every verification step above against the rollback SHA.
+
+If the replacement cannot pass authenticated local/public health, SSE, browser, and provenance checks, keep the public tunnel stopped rather than serving an unverified or stale artifact.
+
+## Teardown
+
+When the operator explicitly withdraws the public dashboard, disable and stop the three live units. Remove only the dashboard `current` symlink and local tunnel policy/credential material after confirming no other service references them. Detached deployment checkouts can then be removed with `git worktree remove` from the repository that owns them.

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { timingSafeEqual } from 'node:crypto';
 import { createServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { readFile, stat } from 'node:fs/promises';
@@ -12,6 +13,7 @@ const SERVICE_IDENTITY = 'dashboard-web';
 const LOCAL_HTTP_PROTOCOL = 'http:';
 const RESERVED_PREFIXES = ['/api', '/v1', '/webhooks', '/comms'];
 const TRUSTED_REMOTE_ADDRESS_HEADER = 'x-frankenbeast-remote-address';
+const TRUSTED_PROXY_TOKEN_HEADER = 'x-frankenbeast-proxy-token';
 const MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
   '.gif': 'image/gif',
@@ -47,6 +49,8 @@ const HOP_BY_HOP_HEADERS = [
 export interface DashboardStaticResponseOptions {
   apiTarget?: string | undefined;
   operatorToken?: string | undefined;
+  trustedProxyOrigin?: string | undefined;
+  trustedProxyToken?: string | undefined;
   signal?: AbortSignal | undefined;
   buildStatus?: DashboardBuildStatus | undefined;
 }
@@ -94,16 +98,74 @@ function removeHopByHopHeaders(headers: Headers): void {
   }
 }
 
-function isSameOriginProxyRequest(request: Request): boolean {
+function firstForwardedValue(value: string | null | undefined): string | undefined {
+  return value?.split(',')[0]?.trim() || undefined;
+}
+
+function parseTrustedProxyOrigin(value: string | undefined): URL | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    if (!['http:', 'https:'].includes(parsed.protocol)
+      || parsed.username
+      || parsed.password
+      || parsed.pathname !== '/'
+      || parsed.search
+      || parsed.hash) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isLoopbackAddress(value: string | null): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase().replace(/^\[|\]$/gu, '');
+  if (normalized === 'localhost' || normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') return true;
+  const ipv4 = normalized.replace(/^::ffff:/u, '');
+  return /^127(?:\.\d{1,3}){3}$/u.test(ipv4)
+    && ipv4.split('.').every((part) => Number(part) >= 0 && Number(part) <= 255);
+}
+
+function secretsMatch(actual: string | null, expected: string | undefined): boolean {
+  if (!actual || !expected) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function trustedForwardedOrigin(
+  request: Request,
+  configuredOrigin: string | undefined,
+  configuredToken: string | undefined,
+): URL | undefined {
+  const forwardedHost = firstForwardedValue(request.headers.get('x-forwarded-host'));
+  const forwardedProto = firstForwardedValue(request.headers.get('x-forwarded-proto'));
+  if (!forwardedHost && !forwardedProto) return undefined;
+  const trustedOrigin = parseTrustedProxyOrigin(configuredOrigin);
+  if (!trustedOrigin
+    || !isLoopbackAddress(request.headers.get(TRUSTED_REMOTE_ADDRESS_HEADER))
+    || !secretsMatch(request.headers.get(TRUSTED_PROXY_TOKEN_HEADER), configuredToken)
+    || forwardedHost !== trustedOrigin.host
+    || `${forwardedProto}:` !== trustedOrigin.protocol) return undefined;
+  return trustedOrigin;
+}
+
+function isSameOriginProxyRequest(
+  request: Request,
+  trustedProxyOrigin?: string,
+  trustedProxyToken?: string,
+): boolean {
   const fetchSite = request.headers.get('sec-fetch-site');
   if (fetchSite && !['none', 'same-origin'].includes(fetchSite)) {
     return false;
   }
 
+  const hasForwardedOrigin = request.headers.has('x-forwarded-host') || request.headers.has('x-forwarded-proto');
+  const forwardedOrigin = trustedForwardedOrigin(request, trustedProxyOrigin, trustedProxyToken);
+  if (hasForwardedOrigin && !forwardedOrigin) return false;
+
   const origin = request.headers.get('origin');
-  if (!origin && !fetchSite) {
-    return false;
-  }
   if (!origin) {
     return fetchSite === 'same-origin';
   }
@@ -111,7 +173,9 @@ function isSameOriginProxyRequest(request: Request): boolean {
   try {
     const originUrl = new URL(origin);
     const requestUrl = new URL(request.url);
-    return originUrl.protocol === requestUrl.protocol && originUrl.host === requestUrl.host;
+    const effectiveProtocol = forwardedOrigin?.protocol ?? requestUrl.protocol;
+    const effectiveHost = forwardedOrigin?.host ?? requestUrl.host;
+    return originUrl.protocol === effectiveProtocol && originUrl.host === effectiveHost;
   } catch {
     return false;
   }
@@ -126,7 +190,9 @@ async function createProxyResponse(
   if (!apiTarget || !isReservedBackendPath(sourceUrl.pathname)) {
     return undefined;
   }
-  if (options.operatorToken && !isPublicWebhookPath(sourceUrl.pathname) && !isSameOriginProxyRequest(request)) {
+  if (options.operatorToken
+    && !isPublicWebhookPath(sourceUrl.pathname)
+    && !isSameOriginProxyRequest(request, options.trustedProxyOrigin, options.trustedProxyToken)) {
     return response('Forbidden', { status: 403, headers: { 'content-type': 'text/plain; charset=utf-8' } });
   }
 
@@ -134,8 +200,10 @@ async function createProxyResponse(
   const headers = new Headers(request.headers);
   removeHopByHopHeaders(headers);
   const hadUpstreamProxyMetadata = headers.has('x-forwarded-host') || headers.has('x-forwarded-proto');
+  const forwardedOrigin = trustedForwardedOrigin(request, options.trustedProxyOrigin, options.trustedProxyToken);
   const trustedRemoteAddress = headers.get(TRUSTED_REMOTE_ADDRESS_HEADER);
   headers.delete(TRUSTED_REMOTE_ADDRESS_HEADER);
+  headers.delete(TRUSTED_PROXY_TOKEN_HEADER);
   if (trustedRemoteAddress
     && (headers.has('x-forwarded-for') || headers.has('x-real-ip') || !hadUpstreamProxyMetadata)) {
     const forwardedFor = headers.get('x-forwarded-for');
@@ -143,8 +211,8 @@ async function createProxyResponse(
       ? `${forwardedFor}, ${trustedRemoteAddress}`
       : trustedRemoteAddress);
   }
-  headers.set('x-forwarded-host', sourceUrl.host);
-  headers.set('x-forwarded-proto', sourceUrl.protocol.replace(/:$/, ''));
+  headers.set('x-forwarded-host', forwardedOrigin?.host ?? sourceUrl.host);
+  headers.set('x-forwarded-proto', forwardedOrigin?.protocol.replace(/:$/, '') ?? sourceUrl.protocol.replace(/:$/, ''));
   if (options.operatorToken) {
     headers.set('authorization', `Bearer ${options.operatorToken}`);
   }
@@ -371,25 +439,42 @@ function attachBackendUpgradeProxy(server: HttpServer, options: DashboardStaticS
   server.on('upgrade', (req, socket, head) => {
     const apiTarget = normalizeBaseUrl(options.apiTarget);
     const host = req.headers.host ?? `${options.host}:${options.port}`;
-    const requestUrl = new URL(req.url ?? '/', requestBaseUrlFromIncoming(req.headers, host));
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(req.url ?? '/', requestBaseUrlFromIncoming(req.headers, host));
+    } catch {
+      sendUpgradeFailure(socket, 400, 'Bad Request');
+      return;
+    }
     if (!apiTarget || !isReservedBackendPath(requestUrl.pathname)) {
       sendUpgradeFailure(socket, 404, 'Not Found');
       return;
     }
 
-    const sameOriginProbe = new Request(requestUrl, { headers: headersFromIncoming(req.headers), method: 'GET' });
-    if (options.operatorToken && !isSameOriginProxyRequest(sameOriginProbe)) {
+    const incomingHeaders = headersFromIncoming(req.headers);
+    if (req.socket.remoteAddress) {
+      incomingHeaders.set(TRUSTED_REMOTE_ADDRESS_HEADER, req.socket.remoteAddress);
+    }
+    const sameOriginProbe = new Request(requestUrl, { headers: incomingHeaders, method: 'GET' });
+    if (options.operatorToken
+      && !isSameOriginProxyRequest(sameOriginProbe, options.trustedProxyOrigin, options.trustedProxyToken)) {
       sendUpgradeFailure(socket, 403, 'Forbidden');
       return;
     }
+    const forwardedOrigin = trustedForwardedOrigin(
+      sameOriginProbe,
+      options.trustedProxyOrigin,
+      options.trustedProxyToken,
+    );
 
     const targetUrl = resolveProxyTargetUrl(apiTarget, requestUrl);
-    const headers = {
+    const headers: IncomingHttpHeaders = {
       ...req.headers,
       host: targetUrl.host,
-      'x-forwarded-host': requestUrl.host,
-      'x-forwarded-proto': requestUrl.protocol.replace(/:$/, ''),
+      'x-forwarded-host': forwardedOrigin?.host ?? requestUrl.host,
+      'x-forwarded-proto': forwardedOrigin?.protocol.replace(/:$/, '') ?? requestUrl.protocol.replace(/:$/, ''),
     };
+    delete headers[TRUSTED_PROXY_TOKEN_HEADER];
     if (options.operatorToken) {
       headers.authorization = `Bearer ${options.operatorToken}`;
     }
@@ -559,6 +644,16 @@ export async function parseCliArgs(argv: string[]): Promise<DashboardStaticServe
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid --port value: ${rawPort ?? ''}`);
   }
+  const rawTrustedProxyOrigin = readValue('--trusted-proxy-origin')
+    ?? process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_ORIGIN;
+  const trustedProxyOrigin = parseTrustedProxyOrigin(rawTrustedProxyOrigin)?.origin;
+  if (rawTrustedProxyOrigin && !trustedProxyOrigin) {
+    throw new Error(`Invalid --trusted-proxy-origin value: ${rawTrustedProxyOrigin}`);
+  }
+  const trustedProxyToken = process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN?.trim() || undefined;
+  if (Boolean(trustedProxyOrigin) !== Boolean(trustedProxyToken)) {
+    throw new Error('Trusted proxy origin and token must be configured together');
+  }
   const buildArgStart = argv.indexOf('--build-args');
   return {
     host,
@@ -566,6 +661,8 @@ export async function parseCliArgs(argv: string[]): Promise<DashboardStaticServe
     staticDir,
     apiTarget: readValue('--api-target') ?? process.env.FRANKENBEAST_DASHBOARD_API_URL,
     operatorToken: await resolveDashboardOperatorToken(),
+    trustedProxyOrigin,
+    trustedProxyToken,
     buildCommand: readValue('--build-command'),
     buildArgs: buildArgStart >= 0 ? argv.slice(buildArgStart + 1) : undefined,
   };

--- a/packages/franken-orchestrator/src/http/dashboard-static-server.ts
+++ b/packages/franken-orchestrator/src/http/dashboard-static-server.ts
@@ -118,6 +118,11 @@ function parseTrustedProxyOrigin(value: string | undefined): URL | undefined {
   }
 }
 
+function parseForwardedOrigin(host: string | undefined, protocol: string | undefined): URL | undefined {
+  if (!host || !protocol) return undefined;
+  return parseTrustedProxyOrigin(`${protocol.toLowerCase()}://${host}`);
+}
+
 function isLoopbackAddress(value: string | null): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase().replace(/^\[|\]$/gu, '');
@@ -143,11 +148,12 @@ function trustedForwardedOrigin(
   const forwardedProto = firstForwardedValue(request.headers.get('x-forwarded-proto'));
   if (!forwardedHost && !forwardedProto) return undefined;
   const trustedOrigin = parseTrustedProxyOrigin(configuredOrigin);
+  const forwardedOrigin = parseForwardedOrigin(forwardedHost, forwardedProto);
   if (!trustedOrigin
+    || !forwardedOrigin
     || !isLoopbackAddress(request.headers.get(TRUSTED_REMOTE_ADDRESS_HEADER))
     || !secretsMatch(request.headers.get(TRUSTED_PROXY_TOKEN_HEADER), configuredToken)
-    || forwardedHost !== trustedOrigin.host
-    || `${forwardedProto}:` !== trustedOrigin.protocol) return undefined;
+    || forwardedOrigin.origin !== trustedOrigin.origin) return undefined;
   return trustedOrigin;
 }
 

--- a/packages/franken-orchestrator/src/network/services/managed-service-env.ts
+++ b/packages/franken-orchestrator/src/network/services/managed-service-env.ts
@@ -33,6 +33,11 @@ function ollamaEnvKeys(): string[] {
 
 const DASHBOARD_BUILD_ENV_KEYS = ['VITE_PROJECT_ID'] as const;
 
+const DASHBOARD_RUNTIME_ENV_KEYS = [
+  'FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_ORIGIN',
+  'FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN',
+] as const;
+
 const GITHUB_ENV_KEYS = [
   'GH_TOKEN',
   'GITHUB_TOKEN',
@@ -176,7 +181,7 @@ export function inheritedNetworkServiceEnvKeys(
     keys.push(...ollamaEnvKeys(), ...configuredCommsEnvRefs(config));
   }
   if (serviceId === 'dashboard-web') {
-    keys.push(...DASHBOARD_BUILD_ENV_KEYS);
+    keys.push(...DASHBOARD_BUILD_ENV_KEYS, ...DASHBOARD_RUNTIME_ENV_KEYS);
   }
 
   return [...new Set(keys)];

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
+import { connect } from 'node:net';
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { gzipSync } from 'node:zlib';
+import WebSocket, { WebSocketServer } from 'ws';
 import { createDashboardStaticResponse, parseCliArgs, resolveDashboardOperatorToken, startDashboardStaticServer } from '../../../src/http/dashboard-static-server.js';
 import { createSecretStore } from '../../../src/network/secret-store.js';
 
 import { testCredential } from '../../support/test-credentials.js';
 
 const TEST_OPERATOR_TOKEN = testCredential('TEST_OPERATOR_TOKEN');
+const TEST_PROXY_TOKEN = testCredential('TEST_PROXY_TOKEN');
 async function createDashboardDist(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'franken-dashboard-dist-'));
   await mkdir(join(dir, 'assets'), { recursive: true });
@@ -25,6 +28,7 @@ describe('dashboard static server', () => {
   const originalConfigFile = process.env.FRANKENBEAST_CONFIG_FILE;
   const originalConfigPath = process.env.FRANKENBEAST_CONFIG_PATH;
   const originalPassphrase = process.env.FRANKENBEAST_PASSPHRASE;
+  const originalTrustedProxyToken = process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN;
 
   afterEach(async () => {
     await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
@@ -37,6 +41,8 @@ describe('dashboard static server', () => {
     else process.env.FRANKENBEAST_CONFIG_PATH = originalConfigPath;
     if (originalPassphrase === undefined) delete process.env.FRANKENBEAST_PASSPHRASE;
     else process.env.FRANKENBEAST_PASSPHRASE = originalPassphrase;
+    if (originalTrustedProxyToken === undefined) delete process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN;
+    else process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN = originalTrustedProxyToken;
     vi.restoreAllMocks();
   });
 
@@ -150,6 +156,60 @@ describe('dashboard static server', () => {
     expect(headers.get('authorization')).toBe(`Bearer ${TEST_OPERATOR_TOKEN}`);
     expect(headers.get('x-forwarded-host')).toBe('dashboard.local');
     expect(headers.get('x-forwarded-proto')).toBe('http');
+  });
+
+  it('accepts same-origin browser requests forwarded by the authenticated HTTPS tunnel', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    globalThis.fetch = fetchMock;
+
+    const proxied = await createDashboardStaticResponse(
+      new Request('http://127.0.0.1:5190/v1/smart-swarm/providers', {
+        headers: {
+          origin: 'https://dashboard.example.com',
+          'x-forwarded-host': 'dashboard.example.com',
+          'x-forwarded-proto': 'https',
+          'x-frankenbeast-proxy-token': TEST_PROXY_TOKEN,
+          'x-frankenbeast-remote-address': '127.0.0.1',
+        },
+      }),
+      staticDir,
+      {
+        apiTarget: 'http://127.0.0.1:4242',
+        operatorToken: TEST_OPERATOR_TOKEN,
+        trustedProxyOrigin: 'https://dashboard.example.com',
+        trustedProxyToken: TEST_PROXY_TOKEN,
+      },
+    );
+
+    expect(proxied.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects spoofed forwarded origins without a trusted loopback proxy peer', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}'));
+    globalThis.fetch = fetchMock;
+
+    const proxied = await createDashboardStaticResponse(
+      new Request('http://127.0.0.1:5190/v1/smart-swarm/providers', {
+        headers: {
+          origin: 'https://dashboard.example.com',
+          'x-forwarded-host': 'dashboard.example.com',
+          'x-forwarded-proto': 'https',
+        },
+      }),
+      staticDir,
+      { apiTarget: 'http://127.0.0.1:4242', operatorToken: TEST_OPERATOR_TOKEN },
+    );
+
+    expect(proxied.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('forwards the static dashboard origin headers without requiring an operator token', async () => {
@@ -354,6 +414,8 @@ describe('dashboard static server', () => {
       staticDir,
       apiTarget: `http://127.0.0.1:${backendAddress.port}`,
       operatorToken: TEST_OPERATOR_TOKEN,
+      trustedProxyOrigin: 'https://dashboard.example.com',
+      trustedProxyToken: TEST_PROXY_TOKEN,
     });
     const dashboardAddress = dashboard.address();
     if (!dashboardAddress || typeof dashboardAddress === 'string') throw new Error('dashboard listen failed');
@@ -363,8 +425,10 @@ describe('dashboard static server', () => {
         method: 'PATCH',
         headers: {
           'content-type': 'application/json',
-          origin: `https://127.0.0.1:${dashboardAddress.port}`,
+          origin: 'https://dashboard.example.com',
+          'x-forwarded-host': 'dashboard.example.com',
           'x-forwarded-proto': 'https',
+          'x-frankenbeast-proxy-token': TEST_PROXY_TOKEN,
         },
         body: JSON.stringify({ hello: 'world' }),
       });
@@ -373,6 +437,169 @@ describe('dashboard static server', () => {
       expect(receivedBody).toBe('{"hello":"world"}');
     } finally {
       await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
+      await new Promise<void>((resolveClose) => backend.close(() => resolveClose()));
+    }
+  });
+
+  it('rejects forwarded WebSocket origins unless the public proxy origin is explicitly trusted', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const dashboard = await startDashboardStaticServer({
+      host: '127.0.0.1',
+      port: 0,
+      staticDir,
+      apiTarget: 'http://127.0.0.1:1',
+      operatorToken: TEST_OPERATOR_TOKEN,
+      trustedProxyOrigin: 'https://dashboard.example.com',
+    });
+    const dashboardAddress = dashboard.address();
+    if (!dashboardAddress || typeof dashboardAddress === 'string') throw new Error('dashboard listen failed');
+
+    const client = new WebSocket(`ws://127.0.0.1:${dashboardAddress.port}/v1/chat/ws`, {
+      headers: {
+        origin: 'https://dashboard.example.com',
+        'x-forwarded-host': 'dashboard.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    try {
+      const status = await new Promise<number>((resolveStatus, rejectStatus) => {
+        client.once('unexpected-response', (_request, response) => resolveStatus(response.statusCode ?? 0));
+        client.once('error', rejectStatus);
+      });
+      expect(status).toBe(403);
+    } finally {
+      client.close();
+      await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
+    }
+  });
+
+  it('rejects malformed forwarded WebSocket hosts without crashing the dashboard server', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const dashboard = await startDashboardStaticServer({
+      host: '127.0.0.1',
+      port: 0,
+      staticDir,
+      apiTarget: 'http://127.0.0.1:1',
+      operatorToken: TEST_OPERATOR_TOKEN,
+      trustedProxyOrigin: 'https://dashboard.example.com',
+    });
+    const dashboardAddress = dashboard.address();
+    if (!dashboardAddress || typeof dashboardAddress === 'string') throw new Error('dashboard listen failed');
+
+    const client = new WebSocket(`ws://127.0.0.1:${dashboardAddress.port}/v1/chat/ws`, {
+      headers: {
+        origin: 'https://dashboard.example.com',
+        'x-forwarded-host': '[',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    try {
+      const status = await new Promise<number>((resolveStatus, rejectStatus) => {
+        client.once('unexpected-response', (_request, response) => resolveStatus(response.statusCode ?? 0));
+        client.once('error', rejectStatus);
+      });
+      expect(status).toBe(403);
+      await expect(fetch(`http://127.0.0.1:${dashboardAddress.port}/`)).resolves.toMatchObject({ status: 200 });
+    } finally {
+      client.close();
+      await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
+    }
+  });
+
+  it('rejects malformed WebSocket Host headers without crashing the dashboard server', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const dashboard = await startDashboardStaticServer({
+      host: '127.0.0.1',
+      port: 0,
+      staticDir,
+      apiTarget: 'http://127.0.0.1:1',
+      operatorToken: TEST_OPERATOR_TOKEN,
+    });
+    const dashboardAddress = dashboard.address();
+    if (!dashboardAddress || typeof dashboardAddress === 'string') throw new Error('dashboard listen failed');
+
+    const statusLine = await new Promise<string>((resolveStatus, rejectStatus) => {
+      const socket = connect(dashboardAddress.port, '127.0.0.1');
+      let response = '';
+      socket.setEncoding('utf8');
+      socket.once('connect', () => {
+        socket.write('GET /v1/chat/ws HTTP/1.1\r\nHost: [\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n');
+      });
+      socket.on('data', (chunk) => {
+        response += chunk;
+        if (response.includes('\r\n')) {
+          socket.destroy();
+          resolveStatus(response.split('\r\n')[0] ?? '');
+        }
+      });
+      socket.once('error', rejectStatus);
+    });
+
+    try {
+      expect(statusLine).toBe('HTTP/1.1 400 Bad Request');
+      await expect(fetch(`http://127.0.0.1:${dashboardAddress.port}/`)).resolves.toMatchObject({ status: 200 });
+    } finally {
+      await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
+    }
+  });
+
+  it('proxies same-origin WebSocket upgrades forwarded by the authenticated HTTPS tunnel', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const backend = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    let forwardedHost: string | undefined;
+    let forwardedProto: string | undefined;
+    let authorization: string | undefined;
+    backend.on('upgrade', (request, socket, head) => {
+      forwardedHost = request.headers['x-forwarded-host'] as string | undefined;
+      forwardedProto = request.headers['x-forwarded-proto'] as string | undefined;
+      authorization = request.headers.authorization;
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocket.send('ready');
+      });
+    });
+    await new Promise<void>((resolveListen) => backend.listen(0, '127.0.0.1', resolveListen));
+    const backendAddress = backend.address();
+    if (!backendAddress || typeof backendAddress === 'string') throw new Error('backend listen failed');
+
+    const dashboard = await startDashboardStaticServer({
+      host: '127.0.0.1',
+      port: 0,
+      staticDir,
+      apiTarget: `http://127.0.0.1:${backendAddress.port}`,
+      operatorToken: TEST_OPERATOR_TOKEN,
+      trustedProxyOrigin: 'https://dashboard.example.com',
+      trustedProxyToken: TEST_PROXY_TOKEN,
+    });
+    const dashboardAddress = dashboard.address();
+    if (!dashboardAddress || typeof dashboardAddress === 'string') throw new Error('dashboard listen failed');
+
+    const client = new WebSocket(`ws://127.0.0.1:${dashboardAddress.port}/v1/chat/ws`, {
+      headers: {
+        origin: 'https://dashboard.example.com',
+        'x-forwarded-host': 'dashboard.example.com',
+        'x-forwarded-proto': 'https',
+        'x-frankenbeast-proxy-token': TEST_PROXY_TOKEN,
+      },
+    });
+    try {
+      const message = await new Promise<string>((resolveMessage, rejectMessage) => {
+        client.once('message', (data) => resolveMessage(data.toString()));
+        client.once('error', rejectMessage);
+      });
+
+      expect(message).toBe('ready');
+      expect(forwardedHost).toBe('dashboard.example.com');
+      expect(forwardedProto).toBe('https');
+      expect(authorization).toBe(`Bearer ${TEST_OPERATOR_TOKEN}`);
+    } finally {
+      client.close();
+      await new Promise<void>((resolveClose) => dashboard.close(() => resolveClose()));
+      websocketServer.close();
       await new Promise<void>((resolveClose) => backend.close(() => resolveClose()));
     }
   });
@@ -467,5 +694,31 @@ describe('dashboard static server', () => {
     await expect(parseCliArgs([])).resolves.toMatchObject({ port: 5173 });
     await expect(parseCliArgs(['--port', '5173'])).resolves.toMatchObject({ port: 5173 });
     await expect(parseCliArgs(['--port', '0'])).resolves.toMatchObject({ port: 0 });
+  });
+
+  it('requires a valid origin when the public reverse proxy is explicitly trusted', async () => {
+    process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN = TEST_PROXY_TOKEN;
+    await expect(parseCliArgs([
+      '--trusted-proxy-origin',
+      'https://dashboard.example.com',
+    ])).resolves.toMatchObject({
+      trustedProxyOrigin: 'https://dashboard.example.com',
+      trustedProxyToken: TEST_PROXY_TOKEN,
+    });
+    await expect(parseCliArgs([
+      '--trusted-proxy-origin',
+      'https://dashboard.example.com/path',
+    ])).rejects.toThrow(/Invalid --trusted-proxy-origin value/);
+  });
+
+  it('requires the trusted proxy origin and token to be configured together', async () => {
+    delete process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN;
+    await expect(parseCliArgs([
+      '--trusted-proxy-origin',
+      'https://dashboard.example.com',
+    ])).rejects.toThrow(/trusted proxy origin and token must be configured together/i);
+
+    process.env.FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN = TEST_PROXY_TOKEN;
+    await expect(parseCliArgs([])).rejects.toThrow(/trusted proxy origin and token must be configured together/i);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
+++ b/packages/franken-orchestrator/tests/unit/http/dashboard-static-server.test.ts
@@ -190,6 +190,35 @@ describe('dashboard static server', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it('normalizes an authenticated forwarded HTTPS origin before comparison', async () => {
+    const staticDir = await createDashboardDist();
+    dirs.push(staticDir);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}'));
+    globalThis.fetch = fetchMock;
+
+    const proxied = await createDashboardStaticResponse(
+      new Request('http://127.0.0.1:5190/v1/smart-swarm/providers', {
+        headers: {
+          origin: 'https://dashboard.example.com',
+          'x-forwarded-host': 'DASHBOARD.EXAMPLE.COM:443',
+          'x-forwarded-proto': 'HTTPS',
+          'x-frankenbeast-proxy-token': TEST_PROXY_TOKEN,
+          'x-frankenbeast-remote-address': '127.0.0.1',
+        },
+      }),
+      staticDir,
+      {
+        apiTarget: 'http://127.0.0.1:4242',
+        operatorToken: TEST_OPERATOR_TOKEN,
+        trustedProxyOrigin: 'https://dashboard.example.com',
+        trustedProxyToken: TEST_PROXY_TOKEN,
+      },
+    );
+
+    expect(proxied.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it('rejects spoofed forwarded origins without a trusted loopback proxy peer', async () => {
     const staticDir = await createDashboardDist();
     dirs.push(staticDir);

--- a/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/network/network-registry.test.ts
@@ -145,6 +145,16 @@ describe('network-registry', () => {
     expect(dashboard?.runtimeConfig.process?.inheritedEnvKeys).toContain('VITE_PROJECT_ID');
   });
 
+  it('preserves trusted proxy settings for the managed dashboard', () => {
+    const dashboard = resolveNetworkServices(defaultConfig(), context)
+      .find((service) => service.id === 'dashboard-web');
+
+    expect(dashboard?.runtimeConfig.process?.inheritedEnvKeys).toEqual(expect.arrayContaining([
+      'FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_ORIGIN',
+      'FRANKENBEAST_DASHBOARD_TRUSTED_PROXY_TOKEN',
+    ]));
+  });
+
   it('declares active 1Password session variables only for the 1Password backend', () => {
     vi.stubEnv('OP_SESSION_WORK', 'session-for-test');
     const config = defaultConfig();

--- a/tasks/cut-public-dashboard-reviewed-main-3857-progress.md
+++ b/tasks/cut-public-dashboard-reviewed-main-3857-progress.md
@@ -1,0 +1,39 @@
+# Issue #3857 — Reviewed-Main Live Dashboard Cutover Progress
+
+- [x] Read live issue #3857 and upstream handoffs; treat acceptance criteria and definition of done as authoritative.
+- [x] Verify isolated branch is clean at exact reviewed `origin/main` and Git identity is David Mendez <me@davidmendez.dev>.
+- [x] RED: reproduce stale/deleted `brain-vitals-stage` service provenance and dashboard HTTP 503 while backend/ngrok remain reachable.
+- [x] Build backend and web from exact reviewed main SHA and run focused tests plus the production build gate.
+- [x] Configure durable user services against the immutable reviewed-main checkout/artifact with explicit live Hermes home/database discovery.
+- [x] Preserve operator credentials, loopback-only bindings, authenticated HTTPS tunnel, redaction, and least privilege.
+- [ ] Restart services and verify backend, dashboard/BFF, tunnel, authenticated SSE, and restart survival after the proxy fix merges.
+- [ ] Prove local and public endpoints serve the same final recorded SHA and current genuine Hermes state without staging/fixture fallback.
+- [x] Document verified rollback/teardown without credentials.
+- [x] Independently review repository changes and remediate blocking findings.
+- [ ] Commit, push, and open a linked PR.
+- [ ] Complete bounded exact-head GitHub Codex review/remediation, green CI, and zero unresolved threads.
+- [ ] Guarded exact-head routine squash merge and record final deployment/issue evidence.
+
+## Initial RED evidence
+
+- Reviewed deployment floor and current branch SHA: `1d339b445fe8e285d9a139ddc67032f51c42d01f`.
+- Existing backend and dashboard services use deleted worktree `/home/pfkagent/dev/frankenbeast/.worktrees/brain-vitals-stage`.
+- Existing listeners: backend `127.0.0.1:3747`, dashboard `127.0.0.1:5190`, ngrok control `127.0.0.1:4040`.
+- Probe before cutover: backend `/health` HTTP 200, dashboard HTTP 503, ngrok control HTTP 200.
+- Old stage backend/dashboard/ngrok units remain enabled and active; their immutable artifact provenance cannot be proven.
+
+## Cutover and live validation evidence
+
+- Immutable detached deployment checkout initially built at reviewed main `1d339b445fe8e285d9a139ddc67032f51c42d01f`.
+- Canonical `frankenbeast-smart-swarm-live-{backend,dashboard,ngrok}.service` units are enabled and active; former `frankenbeast-brain-vitals-stage-*` units are disabled.
+- Backend and dashboard wrappers fail closed unless the checkout HEAD equals the configured reviewed SHA and the explicit live Hermes database is readable.
+- Authenticated local/public provider and Hermes snapshot APIs return HTTP 200; unauthenticated public access returns 401.
+- Local/public HTML SHA-256 matched (`22012030a8406f5c7855ccee0a3ed56fcd5facc8fa6f0a185706f19a9c180fc1`).
+- Genuine live snapshot exposed the current #3857 card, two current tasks, two workspaces, and two activity records; `design-interview` was absent.
+- Authenticated public Hermes SSE ticket/stream returned HTTP 200 with a live frame.
+- Browser validation exposed a real public-cutover defect: reverse-proxied WebSocket same-origin checks compared the public Origin with the loopback BFF URL and returned 403.
+- RED→GREEN regressions now cover explicitly configured forwarded HTTPS HTTP requests, reject untrusted/spoofed forwarded origins, reject malformed forwarded and raw WebSocket hosts without crashing, and proxy trusted forwarded WebSocket upgrades while preserving the configured public origin and server-side operator authentication.
+- A separate constant-time proxy-token check closes the loopback forwarded-header forgery gap; partial proxy configuration fails closed and the marker is stripped before upstream forwarding.
+- Focused static-server tests pass 32/32; orchestrator tests pass 4,969/4,969. Changed-file lint, package/full typecheck, and package/full builds pass. The full Turbo test command reached 4,969/4,969 orchestrator assertions but exited nonzero on a pre-existing unrelated `Codex app-server is unavailable` unhandled rejection; CI remains the clean-environment gate.
+- Independent Codex CLI review returned no actionable correctness findings after the proxy-token and malformed-Host remediations.
+- Durable rollback/teardown procedure: `docs/runbooks/smart-swarm-reviewed-main-cutover.md`.


### PR DESCRIPTION
## Summary
- authenticate trusted tunnel forwarding with a separate constant-time proxy marker
- preserve public HTTPS origin metadata for HTTP and WebSocket proxying while stripping internal trust headers upstream
- reject malformed WebSocket Host input without crashing and document immutable reviewed-main cutover/rollback

## Verification
- focused dashboard static-server tests: 32/32
- orchestrator package tests: 4,969/4,969
- changed-file lint: pass
- full lint/typecheck/build: pass
- independent Codex CLI review: no actionable findings
- full Turbo test reached 4,969/4,969 orchestrator assertions but the local process exited on an unrelated pre-existing Codex app-server unhandled rejection; GitHub CI is the clean-environment gate

Closes #3857