### PR TITLE
fix(test): stabilize public live acceptance

### DIFF
--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
@@ -252,6 +252,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
     const pageErrors: string[] = [];
     const unexpectedNetworkFailures: string[] = [];
     const expectedManagedSseFailures = new Map<string, number>();
+    let initialSseAllowanceAssigned = false;
     let networkPhase = 'initial';
     let latestSseRequest: Request | undefined;
 
@@ -273,6 +274,10 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
 
       page.on('request', (request) => {
         if (!isSmartSwarmSseRequest(request)) return;
+        if (networkPhase === 'initial' && !initialSseAllowanceAssigned) {
+          expectedManagedSseFailures.set(request.url(), 1);
+          initialSseAllowanceAssigned = true;
+        }
         latestSseRequest = request;
       });
       page.on('console', (message) => {
@@ -289,8 +294,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       page.on('requestfailed', (request) => {
         const errorText = request.failure()?.errorText ?? 'request failed';
         const expectedFailureCount = expectedManagedSseFailures.get(request.url()) ?? 0;
-        const expectedInitialSseFailure = networkPhase === 'initial' && isSmartSwarmSseRequest(request);
-        if ((expectedInitialSseFailure || expectedFailureCount > 0) && [
+        if (expectedFailureCount > 0 && [
           'net::ERR_ABORTED',
           'net::ERR_INCOMPLETE_CHUNKED_ENCODING',
         ].includes(errorText)) {
@@ -353,6 +357,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
         });
       }
       networkPhase = 'live';
+      expectedManagedSseFailures.clear();
       await expectBrowser(page.getByRole('region', { name: 'Runtime brain pulse' })).toBeVisible();
       expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
 
@@ -515,7 +520,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       expect(rawReplayEvent, 'The raw replayed SSE payload must be captured').toBeDefined();
       expectCredentialRedaction(rawReplayEvent, credential, 'raw replayed SSE payload');
       expect(objectKeys(rawReplayEvent).map((key) => key.toLowerCase())).not.toContain('authorization');
-      expect(expectedManagedSseFailures.size, 'The deliberate SSE failure allowance must be consumed').toBe(0);
+      expect(expectedManagedSseFailures.size, 'Every bounded SSE failure allowance must be consumed').toBe(0);
       networkPhase = 'post-replay';
       for (const viewport of [
         { width: 390, height: 844 },

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
@@ -216,6 +216,7 @@ async function expectNoHorizontalOverflow(page: Page): Promise<void> {
       clientWidth,
       scrollWidth: document.documentElement.scrollWidth,
       offenders: [...document.querySelectorAll<HTMLElement>('body *')]
+        .filter((element) => !element.closest('[aria-hidden="true"]'))
         .map((element) => ({
           className: element.className,
           left: Math.round(element.getBoundingClientRect().left),
@@ -250,8 +251,10 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
     const unexpectedNetworkFailures: string[] = [];
+    const expectedManagedSseUrls = new Set<string>();
+    let captureManagedSseRequests = true;
+    let networkPhase = 'initial';
     let latestSseRequest: Request | undefined;
-    let interruptedSseRequest: Request | undefined;
 
     try {
       const chromiumPath = chromium.executablePath();
@@ -270,7 +273,9 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       page = await context.newPage();
 
       page.on('request', (request) => {
-        if (isSmartSwarmSseRequest(request)) latestSseRequest = request;
+        if (!isSmartSwarmSseRequest(request)) return;
+        latestSseRequest = request;
+        if (captureManagedSseRequests) expectedManagedSseUrls.add(request.url());
       });
       page.on('console', (message) => {
         if (message.type() === 'error' && !message.text().startsWith('Failed to load resource:')) {
@@ -285,14 +290,13 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       });
       page.on('requestfailed', (request) => {
         const errorText = request.failure()?.errorText ?? 'request failed';
-        if (request === interruptedSseRequest && [
+        if (expectedManagedSseUrls.has(request.url()) && [
           'net::ERR_ABORTED',
           'net::ERR_INCOMPLETE_CHUNKED_ENCODING',
         ].includes(errorText)) {
-          interruptedSseRequest = undefined;
           return;
         }
-        unexpectedNetworkFailures.push(`${request.failure()?.errorText ?? 'request failed'} ${new URL(request.url()).pathname}`);
+        unexpectedNetworkFailures.push(`${networkPhase} ${request.failure()?.errorText ?? 'request failed'} ${new URL(request.url()).pathname}`);
       });
 
       const unauthenticatedContext = await playwrightRequest.newContext({
@@ -335,7 +339,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
         && response.url().includes('/v1/smart-swarm/providers/hermes/snapshot')
       ), { timeout: 30_000 });
       await page.goto(`${origin}/#/smart-swarm`, { waitUntil: 'domcontentloaded' });
-      await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm' })).toBeVisible();
+      await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 1 })).toBeVisible();
       if (await page.getByLabel('Runtime provider').inputValue() !== 'hermes') {
         await page.getByLabel('Runtime provider').selectOption('hermes');
       }
@@ -346,6 +350,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
           cause: error,
         });
       }
+      captureManagedSseRequests = false;
       await expectBrowser(page.getByRole('region', { name: 'Runtime brain pulse' })).toBeVisible();
       expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
 
@@ -458,32 +463,43 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       expect(sourceTaskExists(databasePath, governedProbeTaskId)).toBe(false);
 
       const reconnectStreamPattern = '**/v1/smart-swarm/providers/hermes/events/*';
-      let resolveHeldReconnect!: (route: Route) => void;
-      const heldReconnect = new Promise<Route>((resolve) => {
+      let resolveHeldReconnect!: (request: Request) => void;
+      const heldReconnect = new Promise<Request>((resolve) => {
         resolveHeldReconnect = resolve;
       });
-      await page.route(reconnectStreamPattern, async (route) => {
+      let releaseHeldReconnect!: () => void;
+      const reconnectRelease = new Promise<void>((resolve) => {
+        releaseHeldReconnect = resolve;
+      });
+      const holdReconnect = async (route: Route): Promise<void> => {
         if (new URL(route.request().url()).pathname.endsWith('/events/ticket')) {
           await route.continue();
           return;
         }
-        resolveHeldReconnect(route);
-      });
-      interruptedSseRequest = latestSseRequest;
-      expect(interruptedSseRequest, 'The deliberate interruption must target the active smart-swarm SSE request').toBeDefined();
+        resolveHeldReconnect(route.request());
+        await reconnectRelease;
+        await route.continue();
+      };
+      await page.route(reconnectStreamPattern, holdReconnect);
+      const interruptedSseUrl = latestSseRequest?.url();
+      if (!interruptedSseUrl) throw new Error('The deliberate interruption must target the active smart-swarm SSE request');
+      expectedManagedSseUrls.add(interruptedSseUrl);
+      captureManagedSseRequests = true;
+      networkPhase = 'interruption';
       expect(await page.evaluate('window.__interruptPublicAcceptanceEventSource()')).toBe(true);
       await expectBrowser(page.getByText('Connection lost · reconnecting')).toBeVisible({ timeout: 15_000 });
-      const reconnectRoute = await Promise.race([
+      const reconnectRequest = await Promise.race([
         heldReconnect,
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timed out holding reconnect SSE request')), 15_000)),
       ]);
-      expect(new URL(reconnectRoute.request().url()).searchParams.get('cursor')).toBeTruthy();
+      expectedManagedSseUrls.add(reconnectRequest.url());
+      expect(new URL(reconnectRequest.url()).searchParams.get('cursor')).toBeTruthy();
       const replayMarker = `#3858 cursor replay ${crypto.randomUUID()}`;
       await addAcceptanceComment(taskId, replayMarker, databasePath);
       const replaySource = sourceComment(databasePath, taskId, replayMarker);
-      await reconnectRoute.continue();
-      await page.unroute(reconnectStreamPattern);
+      releaseHeldReconnect();
       await expectBrowser(page.getByText('Live · connected')).toBeVisible({ timeout: 30_000 });
+      await page.unroute(reconnectStreamPattern, holdReconnect);
       await expect.poll(async () => await page!.getByText(replayMarker, { exact: true }).count(), {
         timeout: 20_000,
       }).toBe(2);
@@ -499,7 +515,8 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       expect(rawReplayEvent, 'The raw replayed SSE payload must be captured').toBeDefined();
       expectCredentialRedaction(rawReplayEvent, credential, 'raw replayed SSE payload');
       expect(objectKeys(rawReplayEvent).map((key) => key.toLowerCase())).not.toContain('authorization');
-
+      captureManagedSseRequests = false;
+      networkPhase = 'post-replay';
       for (const viewport of [
         { width: 390, height: 844 },
         { width: 768, height: 1024 },
@@ -507,7 +524,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       ]) {
         await page.setViewportSize(viewport);
         await expectNoHorizontalOverflow(page);
-        await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm' })).toBeVisible();
+        await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 1 })).toBeVisible();
       }
 
       expectCredentialRedaction(await page.content(), credential, 'rendered DOM');

--- a/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
+++ b/packages/franken-orchestrator/tests/e2e/smart-swarm-public-live.test.ts
@@ -251,8 +251,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
     const unexpectedNetworkFailures: string[] = [];
-    const expectedManagedSseUrls = new Set<string>();
-    let captureManagedSseRequests = true;
+    const expectedManagedSseFailures = new Map<string, number>();
     let networkPhase = 'initial';
     let latestSseRequest: Request | undefined;
 
@@ -275,7 +274,6 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       page.on('request', (request) => {
         if (!isSmartSwarmSseRequest(request)) return;
         latestSseRequest = request;
-        if (captureManagedSseRequests) expectedManagedSseUrls.add(request.url());
       });
       page.on('console', (message) => {
         if (message.type() === 'error' && !message.text().startsWith('Failed to load resource:')) {
@@ -290,10 +288,14 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       });
       page.on('requestfailed', (request) => {
         const errorText = request.failure()?.errorText ?? 'request failed';
-        if (expectedManagedSseUrls.has(request.url()) && [
+        const expectedFailureCount = expectedManagedSseFailures.get(request.url()) ?? 0;
+        const expectedInitialSseFailure = networkPhase === 'initial' && isSmartSwarmSseRequest(request);
+        if ((expectedInitialSseFailure || expectedFailureCount > 0) && [
           'net::ERR_ABORTED',
           'net::ERR_INCOMPLETE_CHUNKED_ENCODING',
         ].includes(errorText)) {
+          if (expectedFailureCount === 1) expectedManagedSseFailures.delete(request.url());
+          else if (expectedFailureCount > 1) expectedManagedSseFailures.set(request.url(), expectedFailureCount - 1);
           return;
         }
         unexpectedNetworkFailures.push(`${networkPhase} ${request.failure()?.errorText ?? 'request failed'} ${new URL(request.url()).pathname}`);
@@ -339,7 +341,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
         && response.url().includes('/v1/smart-swarm/providers/hermes/snapshot')
       ), { timeout: 30_000 });
       await page.goto(`${origin}/#/smart-swarm`, { waitUntil: 'domcontentloaded' });
-      await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 1 })).toBeVisible();
+      await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 2 })).toBeVisible();
       if (await page.getByLabel('Runtime provider').inputValue() !== 'hermes') {
         await page.getByLabel('Runtime provider').selectOption('hermes');
       }
@@ -350,7 +352,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
           cause: error,
         });
       }
-      captureManagedSseRequests = false;
+      networkPhase = 'live';
       await expectBrowser(page.getByRole('region', { name: 'Runtime brain pulse' })).toBeVisible();
       expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
 
@@ -483,8 +485,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       await page.route(reconnectStreamPattern, holdReconnect);
       const interruptedSseUrl = latestSseRequest?.url();
       if (!interruptedSseUrl) throw new Error('The deliberate interruption must target the active smart-swarm SSE request');
-      expectedManagedSseUrls.add(interruptedSseUrl);
-      captureManagedSseRequests = true;
+      expectedManagedSseFailures.set(interruptedSseUrl, 1);
       networkPhase = 'interruption';
       expect(await page.evaluate('window.__interruptPublicAcceptanceEventSource()')).toBe(true);
       await expectBrowser(page.getByText('Connection lost · reconnecting')).toBeVisible({ timeout: 15_000 });
@@ -492,7 +493,6 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
         heldReconnect,
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timed out holding reconnect SSE request')), 15_000)),
       ]);
-      expectedManagedSseUrls.add(reconnectRequest.url());
       expect(new URL(reconnectRequest.url()).searchParams.get('cursor')).toBeTruthy();
       const replayMarker = `#3858 cursor replay ${crypto.randomUUID()}`;
       await addAcceptanceComment(taskId, replayMarker, databasePath);
@@ -515,7 +515,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       expect(rawReplayEvent, 'The raw replayed SSE payload must be captured').toBeDefined();
       expectCredentialRedaction(rawReplayEvent, credential, 'raw replayed SSE payload');
       expect(objectKeys(rawReplayEvent).map((key) => key.toLowerCase())).not.toContain('authorization');
-      captureManagedSseRequests = false;
+      expect(expectedManagedSseFailures.size, 'The deliberate SSE failure allowance must be consumed').toBe(0);
       networkPhase = 'post-replay';
       for (const viewport of [
         { width: 390, height: 844 },
@@ -524,7 +524,7 @@ describe.runIf(enabled)('authenticated public smart-swarm against genuine live H
       ]) {
         await page.setViewportSize(viewport);
         await expectNoHorizontalOverflow(page);
-        await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 1 })).toBeVisible();
+        await expectBrowser(page.getByRole('heading', { name: 'Smart Swarm', level: 2 })).toBeVisible();
       }
 
       expectCredentialRedaction(await page.content(), credential, 'rendered DOM');

--- a/tasks/prove-authenticated-public-dashboard-3858-progress.md
+++ b/tasks/prove-authenticated-public-dashboard-3858-progress.md
@@ -3,17 +3,17 @@
 - [x] Read the live issue, dependencies, upstream deployment handoff, and authoritative acceptance criteria.
 - [x] Verify the isolated branch is clean at exact reviewed `origin/main` and Git identity is David Mendez <me@davidmendez.dev>.
 - [x] Reproduce the pre-acceptance authenticated public browser/API/SSE/genuine-runtime path; the browser gate exposed a real 390 px horizontal-overflow defect after every earlier live criterion passed.
-- [ ] RED→GREEN: the new gated public-path acceptance test reached RED against deployed reviewed main at the responsive-layout assertion; the minimal CSS fix is implemented and awaits reviewed-main deployment for final GREEN.
+- [x] RED→GREEN: the gated public-path acceptance test reached RED against deployed reviewed main, then passed against the final reviewed-main deployment after responsive and reconnect-harness stabilization.
 - [x] Authenticate through the public HTTPS endpoint without credentials in URLs, logs, screenshots, payloads, source, or durable evidence; an independent unauthenticated context receives HTTP 401.
 - [x] Match public provider/workspace/task/run data to the current Hermes SQLite/CLI source state and prove `design-interview` is absent.
 - [x] Generate a genuine Hermes comment transition and observe timeline plus Brain Pulse update without refresh.
 - [x] Open bounded task/event detail and match entity, event ID, source task, and source timestamp against Hermes state.
 - [x] Execute a genuinely governed `policy.apply` probe against a verified nonexistent task and independently verify its audited rejection plus unchanged source state.
 - [x] Interrupt/recover the real EventSource stream and verify cursor replay with one event represented once in Brain Pulse and once in the timeline.
-- [ ] Verify browser console/page/network/auth errors, redaction, keyboard accessibility, responsive layouts, and reduced-motion behavior.
-- [ ] Capture deployed SHA, service health, endpoint health, artifact parity, and sanitized evidence.
+- [x] Verify browser console/page/network/auth errors, redaction, keyboard accessibility, responsive layouts, and reduced-motion behavior.
+- [x] Capture deployed SHA, service health, endpoint health, artifact parity, and sanitized evidence.
 - [x] Focused web tests (84/84), full repository tests, full lint, full typecheck, full build, dependency audit, and `git diff --check` pass.
 - [x] Final independent review is clean after remediating address classification, SSE route continuation, browser installation, timestamp normalization, and stale runbook prose with RED→GREEN coverage.
-- [x] Commit with required identity, push, and open issue-linked PR #3874.
-- [ ] Complete bounded exact-head GitHub Codex review/remediation, green CI, and fully paginated zero unresolved threads.
-- [ ] Guarded exact-head routine squash merge, replay public acceptance against reviewed main, and record durable sanitized issue/task evidence.
+- [x] Commit with required identity, push, and open issue-linked PR #3874; follow-up harness PR #3875 remains the current closeout vehicle.
+- [ ] Complete bounded exact-head GitHub Codex review/remediation, green CI, and fully paginated zero unresolved threads for PR #3875.
+- [ ] Guarded exact-head routine squash merge of PR #3875 and record durable sanitized issue/task evidence.


### PR DESCRIPTION
## Summary
- disambiguate the Smart Swarm page heading in strict Playwright locators
- exclude aria-hidden off-canvas navigation from overflow diagnostics
- scope expected SSE disconnect failures to exact initialization and replay-managed request URLs
- release held reconnect routes inside the handler to avoid route teardown races

## Verification
- genuine authenticated public acceptance: 1/1 passed against deployed reviewed main f9cc11b88bf55916c85efdf29719376e0e83c754
- orchestrator typecheck: passed
- targeted ESLint: passed
- independent local Codex review: no findings

Follow-up to #3874 and #3858.