### PR TITLE
fix(orchestrator): preserve launch diagnostics and run design interviews unattended

### DIFF
--- a/packages/franken-orchestrator/src/beasts/definitions/design-interview-definition.ts
+++ b/packages/franken-orchestrator/src/beasts/definitions/design-interview-definition.ts
@@ -33,17 +33,28 @@ export const designInterviewDefinition: BeastDefinition = {
       required: true,
     },
   ],
-  buildProcessSpec: (config) => ({
-    command: process.execPath,
-    args: [
-      resolveCliEntrypoint(),
-      'interview',
-      '--goal', String(config.goal),
-      '--output', String(config.outputPath),
-    ],
-    env: spawnedCliEnv(),
-    cwd: String(config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd()),
-  }),
+  buildProcessSpec: (config) => {
+    const gitConfig = config.gitConfig;
+    const baseBranch = typeof gitConfig === 'object'
+      && gitConfig !== null
+      && 'baseBranch' in gitConfig
+      && typeof gitConfig.baseBranch === 'string'
+      ? gitConfig.baseBranch.trim()
+      : '';
+
+    return {
+      command: process.execPath,
+      args: [
+        resolveCliEntrypoint(),
+        'interview',
+        '--goal', String(config.goal),
+        '--output', String(config.outputPath),
+        ...(baseBranch ? ['--base-branch', baseBranch] : []),
+      ],
+      env: spawnedCliEnv(),
+      cwd: String(config.projectRoot ?? process.env.FBEAST_ROOT ?? process.cwd()),
+    };
+  },
   telemetryLabels: {
     family: 'design-interview',
   },

--- a/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
+++ b/packages/franken-orchestrator/src/beasts/execution/process-beast-executor.ts
@@ -506,6 +506,19 @@ export class ProcessBeastExecutor implements BeastExecutor {
   ) {}
 
   async start(run: BeastRun, definition: BeastDefinition): Promise<BeastRunAttempt> {
+    let prepared: PreparedBeastStartResources;
+    try {
+      prepared = this.prepareStartResources(run, definition);
+    } catch (error) {
+      const configuredSecrets = collectConfiguredSecretValues(run.configSnapshot);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await this.appendSystemLogSafely(
+        run.id,
+        'stderr',
+        `process launch preparation failed: ${redactSpawnErrorMessage(errorMessage, configuredSecrets)}`,
+      );
+      throw error;
+    }
     const {
       processSpec,
       worktree,
@@ -513,7 +526,7 @@ export class ProcessBeastExecutor implements BeastExecutor {
       configManifestPath,
       spawnedSpec,
       configuredSecrets,
-    } = this.prepareStartResources(run, definition);
+    } = prepared;
 
     // eslint-disable-next-line prefer-const -- reassigned after attempt creation (line 162)
     let attemptId: string | undefined;
@@ -565,6 +578,19 @@ export class ProcessBeastExecutor implements BeastExecutor {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const errorCode = normalizeSpawnErrorCode(error);
       const failedAt = new Date(wallClockNow()).toISOString();
+
+      for (const line of earlyOutputLines(earlyStdout)) {
+        await this.appendSystemLogSafely(run.id, 'stdout', line, failedAt);
+      }
+      for (const line of earlyOutputLines(earlyStderr)) {
+        await this.appendSystemLogSafely(run.id, 'stderr', line, failedAt);
+      }
+      await this.appendSystemLogSafely(
+        run.id,
+        'stderr',
+        `process spawn failed before attempt creation (code=${errorCode})`,
+        failedAt,
+      );
 
       try {
         this.options.onSpawnFailureDebug?.({
@@ -785,6 +811,23 @@ export class ProcessBeastExecutor implements BeastExecutor {
       data: { runId: run.id, attemptId: attempt.id, stream: 'stdout', line: startLogLine, createdAt: startedAt },
     });
     return attempt;
+  }
+
+  private async appendSystemLogSafely(
+    runId: string,
+    stream: 'stdout' | 'stderr',
+    line: string,
+    createdAt = new Date(wallClockNow()).toISOString(),
+  ): Promise<void> {
+    try {
+      await this.logs.append(runId, 'system', stream, line, createdAt);
+      this.options.eventBus?.publish({
+        type: 'run.log',
+        data: { runId, attemptId: 'system', stream, line, createdAt },
+      });
+    } catch {
+      // Startup logging is best-effort and must never prevent process launch.
+    }
   }
 
   async cleanupPendingRun(runId: string): Promise<boolean> {

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -1803,6 +1803,8 @@ export async function main(): Promise<void> {
     entryPhase,
     ...(exitAfter !== undefined ? { exitAfter } : {}),
     ...(args.designDoc !== undefined ? { designDocPath: args.designDoc } : {}),
+    ...(args.interviewGoal !== undefined ? { interviewGoal: args.interviewGoal } : {}),
+    ...(args.interviewOutput !== undefined ? { interviewOutput: args.interviewOutput } : {}),
     ...(planDirOverride !== undefined
       ? { planDirOverride }
       : {}),

--- a/packages/franken-orchestrator/src/cli/session.ts
+++ b/packages/franken-orchestrator/src/cli/session.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'node:fs';
+import { closeSync, constants, fstatSync, ftruncateSync, openSync, readFileSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { relative } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 import { resolveContainedExistingPath } from '@franken/types/path-containment';
 import { tmpdir } from 'node:os';
 import { ZodError } from 'zod';
@@ -47,6 +47,40 @@ export type SessionPhase = 'interview' | 'plan' | 'execute';
 function appendPromptContext(value: string, promptText: string | undefined): string {
   if (!promptText || promptText.trim().length === 0) return value;
   return `${value}\n\nAdditional prompt context:\n${promptText.trim()}`;
+}
+
+function writeContainedDesignDoc(root: string, requestedPath: string, content: string): string {
+  const outputDirectory = resolveContainedExistingPath(
+    root,
+    dirname(requestedPath),
+    'interviewOutputDirectory',
+  );
+  const noFollow = 'O_NOFOLLOW' in constants ? constants.O_NOFOLLOW : 0;
+  const directoryOnly = 'O_DIRECTORY' in constants ? constants.O_DIRECTORY : 0;
+  const directoryFd = openSync(outputDirectory, constants.O_RDONLY | noFollow | directoryOnly);
+
+  try {
+    resolveContainedExistingPath(root, `/proc/self/fd/${directoryFd}`, 'interviewOutputDirectory');
+    const outputName = basename(requestedPath);
+    const designPath = resolve(outputDirectory, outputName);
+    const anchoredPath = `/proc/self/fd/${directoryFd}/${outputName}`;
+    const outputFd = openSync(
+      anchoredPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_NONBLOCK | noFollow,
+      0o600,
+    );
+    try {
+      if (!fstatSync(outputFd).isFile()) throw new Error('interviewOutput must be a regular file');
+      resolveContainedExistingPath(root, `/proc/self/fd/${directoryFd}`, 'interviewOutputDirectory');
+      ftruncateSync(outputFd, 0);
+      writeFileSync(outputFd, content, 'utf-8');
+    } finally {
+      closeSync(outputFd);
+    }
+    return designPath;
+  } finally {
+    closeSync(directoryFd);
+  }
 }
 
 function shellQuote(value: string): string {
@@ -96,6 +130,10 @@ export interface SessionConfig {
   exitAfter?: SessionPhase;
   /** Pre-existing design doc path (--design-doc flag) */
   designDocPath?: string;
+  /** Goal supplied to the non-interactive interview subcommand. */
+  interviewGoal?: string | undefined;
+  /** Output path for a non-interactive interview design document. */
+  interviewOutput?: string | undefined;
   /** Pre-existing plan dir (--plan-dir flag) */
   planDirOverride?: string;
   /** Maximum plan-critique iterations before escalation */
@@ -257,6 +295,7 @@ export class Session {
     const { paths, io } = this.config;
     const interviewOpts = this.buildDepOptions();
     interviewOpts.adapterWorkingDir = tmpdir();
+    interviewOpts.chatMode = true;
     const { cliLlmAdapter, finalize } = await createCliDeps(interviewOpts);
 
     try {
@@ -284,11 +323,23 @@ export class Session {
       };
 
       const promptConfig = loadPromptConfigFromEnv();
-      const capturingInterview = new InterviewLoop(progressLlm, interviewIo, capturingGraphBuilder);
-      await capturingInterview.build({ goal: appendPromptContext('Gather requirements', promptConfig?.text) });
+      if (this.config.interviewGoal) {
+        capturedDesignDoc = await progressLlm.complete(appendPromptContext(
+          `Generate a complete design document for the following goal. Include Problem, Goal, Architecture, Components, Data Flow, and Success Criteria sections.\n\nGoal: ${this.config.interviewGoal}`,
+          promptConfig?.text,
+        ));
+      } else {
+        const capturingInterview = new InterviewLoop(progressLlm, interviewIo, capturingGraphBuilder);
+        await capturingInterview.build({ goal: appendPromptContext('Gather requirements', promptConfig?.text) });
+      }
 
       const displayDesignCard = (designDoc: string): string => {
-        const designPath = writeDesignDoc(paths, designDoc);
+        let designPath: string;
+        if (this.config.interviewOutput) {
+          designPath = writeContainedDesignDoc(paths.root, this.config.interviewOutput, designDoc);
+        } else {
+          designPath = writeDesignDoc(paths, designDoc);
+        }
         io.display(formatDesignCard({
           ...extractDesignSummary(designDoc),
           filePath: designPath,
@@ -297,6 +348,8 @@ export class Session {
       };
 
       displayDesignCard(capturedDesignDoc);
+
+      if (this.config.interviewGoal) return 'exit';
 
       while (true) {
         const noOp = isNoOpDesign(capturedDesignDoc);

--- a/packages/franken-orchestrator/tests/unit/beasts/definitions/design-interview-definition.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/definitions/design-interview-definition.test.ts
@@ -38,6 +38,17 @@ describe('designInterviewDefinition', () => {
       expect(spec.args[idx + 1]).toBe('/tmp/design-doc.md');
     });
 
+    it('passes the configured base branch to avoid prompting in a spawned run', () => {
+      const spec = designInterviewDefinition.buildProcessSpec({
+        ...validConfig,
+        gitConfig: { baseBranch: 'develop' },
+      });
+      const idx = spec.args.indexOf('--base-branch');
+
+      expect(idx).toBeGreaterThan(-1);
+      expect(spec.args[idx + 1]).toBe('develop');
+    });
+
     it('sets FRANKENBEAST_SPAWNED=1 in env', () => {
       const spec = designInterviewDefinition.buildProcessSpec(validConfig);
       expect(spec.env).toEqual({ FRANKENBEAST_SPAWNED: '1' });

--- a/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
+++ b/packages/franken-orchestrator/tests/unit/beasts/process-beast-executor.test.ts
@@ -2006,6 +2006,55 @@ describe('ProcessBeastExecutor', () => {
   });
 
   describe('spawn failure handling', () => {
+    it('persists launch preparation failures to the system log', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const supervisor = createSupervisorMock();
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor);
+      const run = createTestRun(repo);
+      const invalidDefinition = {
+        ...martinLoopDefinition,
+        buildProcessSpec: () => {
+          throw new Error('invalid launch config');
+        },
+      } satisfies BeastDefinition;
+
+      await expect(executor.start(run, invalidDefinition)).rejects.toThrow('invalid launch config');
+
+      const systemLogs = await logs.read(run.id, 'system');
+      expect(systemLogs).toContainEqual(
+        expect.stringContaining('process launch preparation failed: invalid launch config'),
+      );
+      expect(supervisor.spawn).not.toHaveBeenCalled();
+    });
+
+    it('persists output emitted before a spawn failure to the system log', async () => {
+      workDir = await createTempWorkDir();
+      const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));
+      const logs = new BeastLogStore(join(workDir, 'logs'));
+      const supervisor = {
+        spawn: vi.fn(async (_spec: unknown, callbacks: unknown) => {
+          const cb = callbacks as ProcessCallbacks;
+          cb.onStdout('pre-spawn stdout');
+          cb.onStderr('pre-spawn stderr');
+          throw Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' });
+        }),
+        stop: vi.fn(async () => {}),
+        kill: vi.fn(async () => {}),
+      };
+      const executor = new ProcessBeastExecutor(repo, logs, supervisor);
+      const run = createTestRun(repo);
+
+      await expect(executor.start(run, martinLoopDefinition)).rejects.toThrow(SAFE_DISPATCH_FAILURE_MESSAGE);
+
+      const systemLogs = await logs.read(run.id, 'system');
+      expect(systemLogs).toEqual(expect.arrayContaining([
+        expect.stringContaining('pre-spawn stdout'),
+        expect.stringContaining('pre-spawn stderr'),
+      ]));
+    });
+
     it('sets run to failed with spawn_failed stop reason', async () => {
       workDir = await createTempWorkDir();
       const repo = new SQLiteBeastRepository(join(workDir, 'beasts.db'));

--- a/packages/franken-orchestrator/tests/unit/cli/run.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/run.test.ts
@@ -1397,6 +1397,22 @@ describe('main() execution', () => {
     expect(mockSessionStart).toHaveBeenCalled();
   });
 
+  it('passes interview goal and output arguments into the Session config', async () => {
+    mockParseArgs.mockReturnValue({
+      ...(mockParseArgs() as Record<string, unknown>),
+      subcommand: 'interview',
+      interviewGoal: 'Create a todo list',
+      interviewOutput: '/mock/project/.fbeast/design-docs/run.md',
+    } as unknown as ReturnType<typeof mockParseArgs>);
+
+    await main();
+
+    expect(MockSession).toHaveBeenCalledWith(expect.objectContaining({
+      interviewGoal: 'Create a todo list',
+      interviewOutput: '/mock/project/.fbeast/design-docs/run.md',
+    }));
+  });
+
   it('closes the session readline interface after successful execution', async () => {
     await main();
 

--- a/packages/franken-orchestrator/tests/unit/cli/session-interview-ux.test.ts
+++ b/packages/franken-orchestrator/tests/unit/cli/session-interview-ux.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -206,6 +206,74 @@ describe('Session interview UX', () => {
     expect(askRaw).toHaveBeenCalledWith('Approve?');
     expect(io.ask).not.toHaveBeenCalledWith('Approve?');
     expect(io.cancelQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses chat-mode provider arguments for interview prompts from the isolated working directory', async () => {
+    const io = createIO(['x']);
+    const { Session } = await import('../../../src/cli/session.js');
+    const { createCliDeps } = await import('../../../src/cli/dep-factory.js');
+
+    await new Session(createConfig(paths, io, { provider: 'codex', exitAfter: 'interview' })).start();
+
+    expect(vi.mocked(createCliDeps).mock.calls[0]?.[0]).toMatchObject({
+      adapterWorkingDir: tmpdir(),
+      chatMode: true,
+    });
+  });
+
+  it('generates a design without stdin prompts when an interview goal is provided', async () => {
+    const io = createIO([]);
+    mkdirSync(resolve(testDir, '.fbeast', 'design-docs'), { recursive: true });
+    const outputPath = resolve(testDir, '.fbeast', 'design-docs', 'run.md');
+    const { Session } = await import('../../../src/cli/session.js');
+
+    await new Session(createConfig(paths, io, {
+      interviewGoal: 'Create a todo list',
+      interviewOutput: outputPath,
+      exitAfter: 'interview',
+    })).start();
+
+    expect(mockAdapterComplete).toHaveBeenCalledWith(expect.stringContaining('Create a todo list'));
+    expect(io.ask).not.toHaveBeenCalled();
+    expect(readFileSync(outputPath, 'utf-8')).toBe(currentDesignDoc);
+  });
+
+  it('refuses a symlink output for a non-interactive interview', async () => {
+    const io = createIO([]);
+    const outputDirectory = resolve(testDir, '.fbeast', 'design-docs');
+    const outsidePath = resolve(testDir, 'outside.md');
+    const outputPath = resolve(outputDirectory, 'run.md');
+    mkdirSync(outputDirectory, { recursive: true });
+    writeFileSync(outsidePath, 'original', 'utf-8');
+    symlinkSync(outsidePath, outputPath);
+    const { Session } = await import('../../../src/cli/session.js');
+
+    await expect(new Session(createConfig(paths, io, {
+      interviewGoal: 'Create a todo list',
+      interviewOutput: outputPath,
+      exitAfter: 'interview',
+    })).start()).rejects.toThrow();
+
+    expect(readFileSync(outsidePath, 'utf-8')).toBe('original');
+  });
+
+  it('refuses a same-directory symlink output for a non-interactive interview', async () => {
+    const io = createIO([]);
+    const outputDirectory = resolve(testDir, '.fbeast', 'design-docs');
+    const victimPath = resolve(outputDirectory, 'victim.md');
+    const outputPath = resolve(outputDirectory, 'run.md');
+    mkdirSync(outputDirectory, { recursive: true });
+    writeFileSync(victimPath, 'original', 'utf-8');
+    symlinkSync(victimPath, outputPath);
+    const { Session } = await import('../../../src/cli/session.js');
+
+    await expect(new Session(createConfig(paths, io, {
+      interviewGoal: 'Create a todo list',
+      interviewOutput: outputPath,
+      exitAfter: 'interview',
+    })).start()).rejects.toThrow();
+
+    expect(readFileSync(victimPath, 'utf-8')).toBe('original');
   });
 
   it('wraps AdapterLlmClient with ProgressLlmClient and shows a summary card', async () => {

--- a/tasks/beast-launch-failure-logs-progress.md
+++ b/tasks/beast-launch-failure-logs-progress.md
@@ -1,0 +1,12 @@
+# Beast launch failure log capture progress
+
+- [x] Trace the deployment request through process launch, Pulse ingestion, and log persistence.
+- [x] Reproduce the missing-log failure with a focused automated test.
+- [x] Confirm the root cause and compare with working process-log capture paths.
+- [x] Implement immediate stdout/stderr capture for attempted beast launches, including startup failures.
+- [x] Verify focused tests and relevant typecheck/build gates.
+- [x] Review the final diff and document any remaining limitations.
+
+## Verification note
+
+- All 4,976 orchestrator tests passed. The full command still exited non-zero because an unrelated Codex app-server availability rejection was reported after the tests; its isolated 16-test runtime contract suite passed.

--- a/tasks/jonny-design-interview-exit-progress.md
+++ b/tasks/jonny-design-interview-exit-progress.md
@@ -1,0 +1,13 @@
+# Jonny design-interview premature exit progress
+
+- [x] Inspect the live run record and complete captured log.
+- [x] Trace the unexpected base-branch prompt to its CLI source.
+- [x] Confirm the design-interview process spec omits the configured base branch.
+- [x] Add and run a failing regression test for non-interactive base-branch selection.
+- [x] Pass the configured base branch to the spawned interview CLI.
+- [x] Verify focused tests, lint, typecheck, and build.
+- [x] Rebuild and restart the local Frankenbeast network.
+- [x] Rerun Jonny and verify it advances beyond base-branch resolution.
+- [x] Confirm the resulting run status and output artifact.
+
+Live attempt 8 completed successfully without the base-branch prompt, Codex trusted-directory error, or closed-stdin error. It wrote a 4,928-byte design document to the configured worktree output path.


### PR DESCRIPTION
## Summary
- persist safe pre-attempt launch failures and early process output to run logs and Pulse
- pass configured base branches into design-interview processes
- use chat-mode provider arguments and goal-driven non-interactive design generation
- write requested design output through a contained no-follow file descriptor

## Verification
- 4,982 orchestrator tests passed; a separate rerun hit only the known transient Codex app-server teardown rejection after all tests passed
- repository typecheck: 17/17 tasks passed
- repository build: 10/10 packages passed
- orchestrator lint passed
- live Jonny attempt 8 completed without branch, trusted-directory, or closed-stdin prompts and wrote a 4,928-byte design artifact
- independent security review passed after adding same-directory symlink coverage