### PR TITLE
fix(critique): reject non-finite costBudgetUsd in TokenBudgetBreaker

### DIFF
--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -1,6 +1,7 @@
 import type { CircuitBreaker, CircuitBreakerResult, LoopState, LoopConfig } from './circuit-breaker.js';
 import type { ObservabilityPort } from '../types/contracts.js';
 import { ConfigurationError } from '../errors/index.js';
+import { assertValidCostBudgetUsd } from '../loop/cost-budget.js';
 
 export class TokenBudgetBreaker implements CircuitBreaker {
   readonly name = 'token-budget';
@@ -26,6 +27,11 @@ export class TokenBudgetBreaker implements CircuitBreaker {
         { context: { tokenBudget: config.tokenBudget } },
       );
     }
+
+    // Validate before any async work so a misconfigured budget fails fast and
+    // cannot silently defeat enforcement (e.g. Infinity never compares as
+    // "over budget"). See #3843.
+    assertValidCostBudgetUsd(config.costBudgetUsd);
 
     const spend = await this.observability.getTokenSpend(config.sessionId);
 

--- a/packages/franken-critique/src/loop/cost-budget.ts
+++ b/packages/franken-critique/src/loop/cost-budget.ts
@@ -1,0 +1,21 @@
+import { ConfigurationError } from '../errors/index.js';
+
+/**
+ * Validates an optional USD cost budget. `undefined` means no cost budget is
+ * configured and is always valid. When set, the value must be a finite,
+ * non-negative number — `Infinity` (or `-Infinity`/`NaN`) must be rejected
+ * because `estimatedSpend > Infinity` never trips, silently disabling
+ * cost-budget enforcement and allowing unbounded spend (#3843).
+ */
+export function assertValidCostBudgetUsd(costBudgetUsd: number | undefined): void {
+  if (costBudgetUsd === undefined) {
+    return;
+  }
+
+  if (!Number.isFinite(costBudgetUsd) || costBudgetUsd < 0) {
+    throw new ConfigurationError(
+      `costBudgetUsd must be a finite, non-negative number, got ${costBudgetUsd}`,
+      { context: { costBudgetUsd } },
+    );
+  }
+}

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -168,5 +168,57 @@ describe('TokenBudgetBreaker', () => {
       });
       expect(result.tripped).toBe(false);
     });
+
+    // Regression for #3843: a non-finite costBudgetUsd (e.g. Infinity) silently
+    // disabled cost-budget enforcement, since `spend.estimatedCostUsd > Infinity`
+    // never trips. Reject non-finite / negative values up front instead.
+    it('rejects with ConfigurationError when costBudgetUsd is Infinity', async () => {
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_000_000_000));
+      await expect(
+        breaker.check(createState(1), {
+          ...createConfig(Number.POSITIVE_INFINITY),
+          costBudgetUsd: Number.POSITIVE_INFINITY,
+        }),
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('rejects with ConfigurationError when costBudgetUsd is -Infinity', async () => {
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+      await expect(
+        breaker.check(createState(1), {
+          ...createConfig(10000),
+          costBudgetUsd: Number.NEGATIVE_INFINITY,
+        }),
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('rejects with ConfigurationError when costBudgetUsd is NaN', async () => {
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+      await expect(
+        breaker.check(createState(1), {
+          ...createConfig(10000),
+          costBudgetUsd: Number.NaN,
+        }),
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('rejects with ConfigurationError when costBudgetUsd is negative', async () => {
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+      await expect(
+        breaker.check(createState(1), {
+          ...createConfig(10000),
+          costBudgetUsd: -1,
+        }),
+      ).rejects.toThrow(ConfigurationError);
+    });
+
+    it('does not reject a valid finite non-negative costBudgetUsd', async () => {
+      const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
+      const result = await breaker.check(createState(1), {
+        ...createConfig(10000),
+        costBudgetUsd: 5,
+      });
+      expect(result.tripped).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`TokenBudgetBreaker.check()` in `packages/franken-critique/src/breakers/token-budget.ts` compared `spend.estimatedCostUsd > config.costBudgetUsd` with no upfront validation of `costBudgetUsd`. A non-finite value (`Infinity`, `-Infinity`, `NaN`) or a negative value passed straight through — since `spend > Infinity` never trips, this silently disabled cost-budget enforcement and allowed unbounded spend.

- Added `assertValidCostBudgetUsd` in `packages/franken-critique/src/loop/cost-budget.ts`, which rejects any `costBudgetUsd` that isn't `undefined` or a finite, non-negative number, throwing `ConfigurationError` (the package's existing error type for invalid config).
- Called it at the top of `TokenBudgetBreaker.check()`, before the async `getTokenSpend` call, so a misconfigured budget fails fast.
- This mirrors the existing validation pattern used by `MaxIterationBreaker` / `assertValidMaxIterations` in `src/loop/iteration-limit.ts` — same package, same convention (dedicated `assertValidX` helper + `ConfigurationError`, tested at the breaker level).

## Test plan

- [x] Added failing tests first (TDD) covering `Infinity`, `-Infinity`, `NaN`, and negative `costBudgetUsd` all rejecting with `ConfigurationError`, plus a valid finite value continuing to pass through.
- [x] `npx vitest run tests/unit/breakers/token-budget.test.ts` — 16/16 passing.
- [x] `npx turbo run test --filter=@franken/critique` — 707 passing; the 3 failing suites (`reviewer.test.ts`, `logic-loop.test.ts`, `public-contracts.test.ts`) fail identically on unmodified `main` due to a missing `acorn-typescript` install, unrelated to this change (verified via `git stash`).
- [x] `npx turbo run typecheck --filter=@franken/critique` — same pre-existing failures (missing `acorn-typescript` types, stale `@franken/types` build cache) reproduced identically on unmodified `main`; no new errors from this change.

Closes #3843