### PR TITLE
fix(mcp): redact bare credential-shaped values in post-tool payloads

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.test.ts
@@ -240,4 +240,49 @@ describe('runHook', () => {
     expect(metadata.decision).toBe('unknown');
     expect(JSON.stringify(metadata)).not.toContain('token=secret-value');
   });
+
+  it('redacts bare credential-shaped values from post-tool payloads with no secret-labeled key', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    // "result" is not a recognized credential label, so this only gets caught by
+    // value-shape (not key-label) detection. Regression test for #3838.
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ result: 'ghp_1234567890abcdefghijklmnopqrstuvwxyz' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('ghp_1234567890abcdefghijklmnopqrstuvwxyz');
+    expect(metadata.payload).toContain('[REDACTED]');
+  });
+
+  it('redacts credential-shaped values embedded in free-form post-tool text', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ message: 'here is AKIAIOSFODNN7EXAMPLE for aws access' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('AKIAIOSFODNN7EXAMPLE');
+  });
+
+  it('redacts sk-prefixed API keys nested under an unlabeled field', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ output: 'sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEF' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEF');
+  });
 });

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -87,6 +87,43 @@ const CREDENTIAL_URL_HINT = /\b[a-z][a-z0-9+.-]{0,31}:\/\/[^\s:/@]+:[^\s@/]+@/i;
 const CAMEL_CASE_SECRET_KEY_HINT = /[A-Za-z0-9](?:Authorization|Password|Passwd|Pwd|Secret|Token|Key|Cookie|Credentials?|Passphrase)\b/;
 const MAX_POST_TOOL_SECRET_SCAN_CHARS = 64 * 1024;
 
+/**
+ * Value-shape patterns for common credential formats (GitHub PATs, OpenAI/
+ * Anthropic/Stripe-style `sk-`/`pk-`/`rk-` keys, GitLab/Slack tokens, AWS access
+ * key IDs, Google API keys, PEM private key blocks). Unlike the redaction rules
+ * above, these match on the *value itself* rather than a nearby key label, so
+ * they catch secrets embedded under an innocuous key (e.g. `{"result":
+ * "ghp_..."}`) or in free-form text with no `token=`/`key:` hint at all. Mirrors
+ * the value-shape patterns already used for memory export redaction in
+ * `brain-adapter.ts` (`SECRET_EXPORT_VALUES`) so the two redaction paths agree
+ * on what counts as a secret-shaped value.
+ */
+const KNOWN_SECRET_VALUE_PATTERNS: RegExp[] = [
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{7,}\b/g,
+  /\b(?:sk|gh[opusr])_[A-Za-z0-9_]{8,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{8,}\b/g,
+  /\b(?:gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_-]{12,}\b/g,
+  /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+];
+
+function containsKnownSecretPattern(text: string): boolean {
+  return KNOWN_SECRET_VALUE_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}
+
+function redactKnownSecretValues(text: string): string {
+  let redacted = text;
+  for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
+    pattern.lastIndex = 0;
+    redacted = redacted.replace(pattern, '[REDACTED]');
+  }
+  return redacted;
+}
+
 function containsRawSecretHint(text: string): boolean {
   const lowerText = text.toLowerCase();
   return RAW_SECRET_HINTS.some((hint) => lowerText.includes(hint))
@@ -99,7 +136,8 @@ function containsOversizedSecretIndicator(text: string): boolean {
     || /\\*["']authorization\\*["']\s*,/i.test(text)
     || /\bbearer\s+\S+/i.test(text)
     || /--(?:authorization|password|passwd|pwd|secret|token|cookie|credentials|passphrase|api-?key|client-?secret|(?:access|refresh|id)-?token|access-?key)\s+\S+/i.test(text)
-    || CREDENTIAL_URL_HINT.test(text)) {
+    || CREDENTIAL_URL_HINT.test(text)
+    || containsKnownSecretPattern(text)) {
     return true;
   }
 
@@ -119,7 +157,8 @@ function containsOversizedSecretIndicator(text: string): boolean {
   return false;
 }
 
-function redactRawSecrets(text: string, preserveShellCommands = false): string {
+function redactRawSecrets(rawText: string, preserveShellCommands = false): string {
+  const text = redactKnownSecretValues(rawText);
   if (!containsRawSecretHint(text)) return text;
   let redacted = text
     .replace(/(authorization\s*:\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'(?:\\.|[^'\\$`]|\$(?!\())*')/gi, '$1[REDACTED]')


### PR DESCRIPTION
Closes #3838

## Summary

`runHook`'s post-tool branch already routes the observer log `payload` through `redactSecrets` (via `redactPostToolPayload`) before persisting it — so the literal fix suggested in the issue (call `redactSecrets` on the payload) was already in place on `main`. However, that redaction pipeline is entirely **key-label based**: it only redacts a value when it sits next to a recognized credential key name (`token=`, `apiKey:`, `Authorization:`, etc).

A secret embedded under an innocuous key — e.g. `{"result": "ghp_..."}` — or inline in free-form text with no label at all (e.g. `"here is AKIAIOSFODNN7EXAMPLE for aws"`) passed through **unredacted** and would land in observer logs. This is the real remaining gap behind the issue's stated impact ("secrets can be recorded in observable logs").

## Fix

Added value-shape detection to `packages/franken-mcp-suite/src/cli/hook.ts` (`KNOWN_SECRET_VALUE_PATTERNS`) that redacts common credential formats regardless of the surrounding key name or label:
- GitHub PATs (`ghp_`, `gho_`, `github_pat_`, `glpat-`, etc.)
- OpenAI/Anthropic/Stripe-style `sk-`/`pk-`/`rk-` prefixed keys
- AWS access key IDs (`AKIA…`/`ASIA…`)
- Google API keys (`AIza…`)
- PEM private key blocks

This pattern set mirrors the value-shape redaction already used by `packages/franken-mcp-suite/src/adapters/brain-adapter.ts`'s `SECRET_EXPORT_VALUES` (memory export redaction), so both redaction paths in the package now agree on what counts as a secret-shaped value. Wired into both `redactRawSecrets` (used by `redactSecrets`, the post-tool logging path and the pre-tool governor-context path) and `containsOversizedSecretIndicator` (the >64KB payload fast-path heuristic).

## Testing (TDD)

- Added 3 new tests in `hook.test.ts` covering post-tool payloads with bare credential-shaped values under non-credential keys and in free text. Verified red (all 3 fail) against the pre-fix code by temporarily stashing the `hook.ts` change, then green after restoring it.
- Full package suite: `npx turbo run test --filter=@franken/mcp-suite` → 40 files / 621 tests passing.
- `npx turbo run typecheck --filter=@franken/mcp-suite` → clean.

Scope is limited to `packages/franken-mcp-suite/src/cli/hook.ts` and its test file — no unrelated refactors.
