### PR TITLE
fix(mcp): redact bare credential-shaped values in post-tool payloads

### DIFF
--- a/packages/franken-mcp-suite/src/cli/hook.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.test.ts
@@ -124,6 +124,46 @@ describe('runHook', () => {
     expect(log.mock.calls.map((call) => JSON.stringify(call)).join('\n')).not.toContain('private memory payload');
   });
 
+  it('preserves a legitimate agentId that happens to look like a short secret-shaped value', async () => {
+    const { deps, log } = hookDeps();
+    deps.readContext = () => JSON.stringify({
+      args: {
+        agentId: 'sk-platform',
+        profile: 'default',
+        repo: 'djm204/frankenbeast',
+        type: 'working',
+      },
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'fbeast_memory_query',
+      '{"ok":true,"content":[{"type":"text","text":"safe"}]}',
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    // "sk-platform" is a plausible real agentId, not a secret; audit tooling
+    // elsewhere (brain-adapter.ts) filters access reports by its *exact*
+    // value, so over-redacting it would silently break attribution.
+    expect(metadata.args.agentId).toBe('sk-platform');
+  });
+
+  it('still redacts a genuine long sk-prefixed secret in a post-tool payload (regression guard for the agentId fix)', async () => {
+    const { deps, log } = hookDeps();
+    const secret = `sk-${'a'.repeat(40)}`;
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ result: secret }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain(secret);
+  });
+
   it('uses the hook tool name to redact direct memory args without type hints', async () => {
     const { deps, log } = hookDeps();
     deps.readContext = () => JSON.stringify({

--- a/packages/franken-mcp-suite/src/cli/hook.test.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.test.ts
@@ -240,4 +240,49 @@ describe('runHook', () => {
     expect(metadata.decision).toBe('unknown');
     expect(JSON.stringify(metadata)).not.toContain('token=secret-value');
   });
+
+  it('redacts bare credential-shaped values from post-tool payloads with no secret-labeled key', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    // "result" is not a recognized credential label, so this only gets caught by
+    // value-shape (not key-label) detection. Regression test for #3838.
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ result: 'ghp_1234567890abcdefghijklmnopqrstuvwxyz' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('ghp_1234567890abcdefghijklmnopqrstuvwxyz');
+    expect(metadata.payload).toContain('[REDACTED]');
+  });
+
+  it('redacts credential-shaped values embedded in free-form post-tool text', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ message: 'here is AKIAIOSFODNN7EXAMPLE for aws access' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('AKIAIOSFODNN7EXAMPLE');
+  });
+
+  it('redacts sk-prefixed API keys nested under an unlabeled field', async () => {
+    const { deps, log } = hookDeps();
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHook([
+      'post-tool',
+      'some_tool',
+      JSON.stringify({ output: 'sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEF' }),
+    ], deps);
+
+    const metadata = JSON.parse(log.mock.calls[0]![0].metadata);
+    expect(JSON.stringify(metadata)).not.toContain('sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEF');
+  });
 });

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -108,9 +108,21 @@ const MAX_POST_TOOL_SECRET_SCAN_CHARS = 64 * 1024;
  * PEM private-key blocks are handled separately, below, via a linear scan
  * rather than a regex here — see `redactPemPrivateKeyBlocks` /
  * `containsPemPrivateKeyBlock`.
+ *
+ * The sk-/pk-/rk- pattern requires a 20+ char suffix (real OpenAI/Anthropic/
+ * Stripe-style keys are typically 40-100+ chars) rather than the 8-char floor
+ * the other patterns use, because "sk-"/"pk-"/"rk-" are common 2-letter
+ * prefixes that legitimate short structured identifiers can coincidentally
+ * start with (e.g. an `agentId` of "sk-platform"). Those identifiers flow
+ * through this same value-shape check via `redactSecrets` on the pre-tool
+ * governor context (`hookArgsFromContext`), and audit tooling elsewhere
+ * (`brain-adapter.ts`) filters on their *exact* value, so over-redacting one
+ * silently breaks that attribution — a higher floor for this specific prefix
+ * trades a little recall on unusually short real keys (none of the vendors
+ * above issue keys that short) for not corrupting unrelated identifiers.
  */
 const KNOWN_SECRET_VALUE_PATTERNS: RegExp[] = [
-  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{7,}(?![A-Za-z0-9_-])/g,
+  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{19,}(?![A-Za-z0-9_-])/g,
   /\b(?:sk|gh[opusr])_[A-Za-z0-9_]{8,}\b/g,
   /\bgithub_pat_[A-Za-z0-9_]{8,}\b/g,
   /\b(?:gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_-]{12,}(?![A-Za-z0-9_-])/g,
@@ -147,7 +159,29 @@ function pemMarkerEnd(text: string, start: number): number {
  * anywhere after it, `indexOf` has already scanned to the end of the text
  * exactly once, and we stop immediately rather than repeating that scan for
  * every remaining header — bounding total work to O(n).
+ *
+ * A block can contain an unrelated "-----END X-----" marker before its real
+ * footer (e.g. a certificate embedded between a PRIVATE KEY header and
+ * footer). `findPemFooter` keeps advancing past each non-matching "-----END "
+ * occurrence in an inner loop rather than falling back out to the outer
+ * header search — abandoning the header there would orphan it and miss the
+ * real footer that follows. The inner loop still only ever moves forward, so
+ * this stays O(n) overall: once no valid footer exists anywhere in the rest
+ * of the text (for *any* candidate footer position), none of the remaining
+ * text can contain one for a later header either, so both callers return/stop
+ * immediately instead of continuing to search.
  */
+function findPemFooter(text: string, searchFrom: number): number {
+  let cursor = searchFrom;
+  for (;;) {
+    const footerIdx = text.indexOf('-----END ', cursor);
+    if (footerIdx === -1) return -1;
+    const footerEnd = pemMarkerEnd(text, footerIdx);
+    if (footerEnd !== -1) return footerEnd;
+    cursor = footerIdx + 9;
+  }
+}
+
 function containsPemPrivateKeyBlock(text: string): boolean {
   if (!text.includes('PRIVATE KEY-----')) return false;
   let cursor = 0;
@@ -159,13 +193,7 @@ function containsPemPrivateKeyBlock(text: string): boolean {
       cursor = headerIdx + 11;
       continue;
     }
-    const footerIdx = text.indexOf('-----END ', headerEnd);
-    if (footerIdx === -1) return false;
-    const footerEnd = pemMarkerEnd(text, footerIdx);
-    if (footerEnd === -1) {
-      cursor = footerIdx + 9;
-      continue;
-    }
+    if (findPemFooter(text, headerEnd) === -1) return false;
     return true;
   }
 }
@@ -184,14 +212,8 @@ function redactPemPrivateKeyBlocks(text: string): string {
       cursor = headerIdx + 11;
       continue;
     }
-    const footerIdx = text.indexOf('-----END ', headerEnd);
-    if (footerIdx === -1) break;
-    const footerEnd = pemMarkerEnd(text, footerIdx);
-    if (footerEnd === -1) {
-      result += text.slice(cursor, footerIdx + 9);
-      cursor = footerIdx + 9;
-      continue;
-    }
+    const footerEnd = findPemFooter(text, headerEnd);
+    if (footerEnd === -1) break;
     result += text.slice(cursor, headerIdx) + '[REDACTED]';
     cursor = footerEnd;
   }
@@ -223,13 +245,75 @@ function containsRawSecretHint(text: string): boolean {
     || CREDENTIAL_URL_HINT.test(text);
 }
 
+// Defensive cap on the number of JSON.parse tree nodes the oversized-payload
+// scan below will visit. A legitimate tool payload will not nest this deeply
+// or this wide; this exists purely to bound worst-case work (proportional to
+// node count, itself bounded by text length) rather than to reject anything
+// real.
+const MAX_OVERSIZED_JSON_SCAN_NODES = 200_000;
+
+/**
+ * Walks a JSON.parse()'d value looking for a secret-shaped string, either as
+ * a leaf value or (mirroring the JSON-property-name fix in redactJsonSecrets)
+ * as an object key. Iterative (explicit stack) rather than recursive so a
+ * maliciously deep payload can't blow the call stack.
+ */
+function containsSecretInParsedJson(root: unknown): boolean {
+  const stack: unknown[] = [root];
+  let visited = 0;
+  while (stack.length > 0) {
+    if (++visited > MAX_OVERSIZED_JSON_SCAN_NODES) return false;
+    const value = stack.pop();
+    if (typeof value === 'string') {
+      if (containsKnownSecretPattern(value)) return true;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) stack.push(item);
+      continue;
+    }
+    if (value !== null && typeof value === 'object') {
+      for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+        if (containsKnownSecretPattern(entryKey)) return true;
+        stack.push(entryValue);
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * For oversized payloads, `containsOversizedSecretIndicator` otherwise only
+ * pattern-matches the raw source text. A credential can be written with valid
+ * JSON string escapes (e.g. `"ghp_aa..."`), which decode to the
+ * secret's real characters but contain no contiguous alphanumeric run in the
+ * raw source — so it matches none of `KNOWN_SECRET_VALUE_PATTERNS` and, with
+ * no key-label hint either, evades detection entirely and the whole payload
+ * is persisted. Attempting `JSON.parse` here and scanning the *decoded*
+ * string values closes that gap; parse failures (non-JSON oversized payloads,
+ * the majority case — plain tool output) just fall through to the existing
+ * raw-text heuristics below, unchanged. `JSON.parse` and the node-count-bounded
+ * walk above are both O(n) in the payload size, so this preserves the linear
+ * cost this fast path exists to guarantee.
+ */
+function containsOversizedJsonEscapedSecret(text: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  return containsSecretInParsedJson(parsed);
+}
+
 function containsOversizedSecretIndicator(text: string): boolean {
   if (/\bauthorization\b\s*[:=]/i.test(text)
     || /\\*["']authorization\\*["']\s*,/i.test(text)
     || /\bbearer\s+\S+/i.test(text)
     || /--(?:authorization|password|passwd|pwd|secret|token|cookie|credentials|passphrase|api-?key|client-?secret|(?:access|refresh|id)-?token|access-?key)\s+\S+/i.test(text)
     || CREDENTIAL_URL_HINT.test(text)
-    || containsKnownSecretPattern(text)) {
+    || containsKnownSecretPattern(text)
+    || containsOversizedJsonEscapedSecret(text)) {
     return true;
   }
 

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -87,6 +87,43 @@ const CREDENTIAL_URL_HINT = /\b[a-z][a-z0-9+.-]{0,31}:\/\/[^\s:/@]+:[^\s@/]+@/i;
 const CAMEL_CASE_SECRET_KEY_HINT = /[A-Za-z0-9](?:Authorization|Password|Passwd|Pwd|Secret|Token|Key|Cookie|Credentials?|Passphrase)\b/;
 const MAX_POST_TOOL_SECRET_SCAN_CHARS = 64 * 1024;
 
+/**
+ * Value-shape patterns for common credential formats (GitHub PATs, OpenAI/
+ * Anthropic/Stripe-style `sk-`/`pk-`/`rk-` keys, GitLab/Slack tokens, AWS access
+ * key IDs, Google API keys, PEM private key blocks). Unlike the redaction rules
+ * above, these match on the *value itself* rather than a nearby key label, so
+ * they catch secrets embedded under an innocuous key (e.g. `{"result":
+ * "ghp_..."}`) or in free-form text with no `token=`/`key:` hint at all. Mirrors
+ * the value-shape patterns already used for memory export redaction in
+ * `brain-adapter.ts` (`SECRET_EXPORT_VALUES`) so the two redaction paths agree
+ * on what counts as a secret-shaped value.
+ */
+const KNOWN_SECRET_VALUE_PATTERNS: RegExp[] = [
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{7,}\b/g,
+  /\b(?:sk|gh[opusr])_[A-Za-z0-9_]{8,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{8,}\b/g,
+  /\b(?:gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_-]{12,}\b/g,
+  /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+];
+
+function containsKnownSecretPattern(text: string): boolean {
+  return KNOWN_SECRET_VALUE_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}
+
+function redactKnownSecretValues(text: string): string {
+  let redacted = text;
+  for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
+    pattern.lastIndex = 0;
+    redacted = redacted.replace(pattern, '[REDACTED]');
+  }
+  return redacted;
+}
+
 function containsRawSecretHint(text: string): boolean {
   const lowerText = text.toLowerCase();
   return RAW_SECRET_HINTS.some((hint) => lowerText.includes(hint))
@@ -99,7 +136,8 @@ function containsOversizedSecretIndicator(text: string): boolean {
     || /\\*["']authorization\\*["']\s*,/i.test(text)
     || /\bbearer\s+\S+/i.test(text)
     || /--(?:authorization|password|passwd|pwd|secret|token|cookie|credentials|passphrase|api-?key|client-?secret|(?:access|refresh|id)-?token|access-?key)\s+\S+/i.test(text)
-    || CREDENTIAL_URL_HINT.test(text)) {
+    || CREDENTIAL_URL_HINT.test(text)
+    || containsKnownSecretPattern(text)) {
     return true;
   }
 
@@ -119,7 +157,8 @@ function containsOversizedSecretIndicator(text: string): boolean {
   return false;
 }
 
-function redactRawSecrets(text: string, preserveShellCommands = false): string {
+function redactRawSecrets(rawText: string, preserveShellCommands = false): string {
+  const text = redactKnownSecretValues(rawText);
   if (!containsRawSecretHint(text)) return text;
   let redacted = text
     .replace(/(authorization\s*:\s*)("(?:\\.|[^"\\$`]|\$(?!\())*"|'(?:\\.|[^'\\$`]|\$(?!\())*')/gi, '$1[REDACTED]')

--- a/packages/franken-mcp-suite/src/cli/hook.ts
+++ b/packages/franken-mcp-suite/src/cli/hook.ts
@@ -90,33 +90,125 @@ const MAX_POST_TOOL_SECRET_SCAN_CHARS = 64 * 1024;
 /**
  * Value-shape patterns for common credential formats (GitHub PATs, OpenAI/
  * Anthropic/Stripe-style `sk-`/`pk-`/`rk-` keys, GitLab/Slack tokens, AWS access
- * key IDs, Google API keys, PEM private key blocks). Unlike the redaction rules
- * above, these match on the *value itself* rather than a nearby key label, so
- * they catch secrets embedded under an innocuous key (e.g. `{"result":
- * "ghp_..."}`) or in free-form text with no `token=`/`key:` hint at all. Mirrors
- * the value-shape patterns already used for memory export redaction in
- * `brain-adapter.ts` (`SECRET_EXPORT_VALUES`) so the two redaction paths agree
- * on what counts as a secret-shaped value.
+ * key IDs, Google API keys). Unlike the redaction rules above, these match on
+ * the *value itself* rather than a nearby key label, so they catch secrets
+ * embedded under an innocuous key (e.g. `{"result": "ghp_..."}`) or in
+ * free-form text with no `token=`/`key:` hint at all. Mirrors the value-shape
+ * patterns already used for memory export redaction in `brain-adapter.ts`
+ * (`SECRET_EXPORT_VALUES`) so the two redaction paths agree on what counts as
+ * a secret-shaped value.
+ *
+ * A trailing `(?![0-9A-Za-z_-])` guard is used instead of `\b` wherever the
+ * value's own charset includes `-`/`_`: `\b` requires a word/non-word
+ * transition, so it silently fails to match when a legitimately
+ * hyphen/underscore-terminated key (e.g. a Google API key ending in `-`) is
+ * itself followed by a non-word character such as `"` or whitespace — both
+ * sides are then non-word and no boundary exists, leaving the key unredacted.
+ *
+ * PEM private-key blocks are handled separately, below, via a linear scan
+ * rather than a regex here — see `redactPemPrivateKeyBlocks` /
+ * `containsPemPrivateKeyBlock`.
  */
 const KNOWN_SECRET_VALUE_PATTERNS: RegExp[] = [
-  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
-  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{7,}\b/g,
+  /\b(?:sk|pk|rk)-[A-Za-z0-9][A-Za-z0-9_-]{7,}(?![A-Za-z0-9_-])/g,
   /\b(?:sk|gh[opusr])_[A-Za-z0-9_]{8,}\b/g,
   /\bgithub_pat_[A-Za-z0-9_]{8,}\b/g,
-  /\b(?:gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_-]{12,}\b/g,
+  /\b(?:gho|ghp|glpat|xox[baprs])-[A-Za-z0-9_-]{12,}(?![A-Za-z0-9_-])/g,
   /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
-  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}(?![A-Za-z0-9_-])/g,
 ];
 
+const PEM_MARKER_WINDOW = /^-----(?:BEGIN|END) [A-Z0-9 ]{0,32}PRIVATE KEY-----/;
+
+/**
+ * Finds the end index of a "-----BEGIN|END ...PRIVATE KEY-----" marker
+ * starting exactly at `start`, bounded to a short fixed-size lookahead window
+ * so matching never scans a span of text proportional to the overall input.
+ */
+function pemMarkerEnd(text: string, start: number): number {
+  const window = text.slice(start, start + 60);
+  const match = PEM_MARKER_WINDOW.exec(window);
+  return match ? start + match[0].length : -1;
+}
+
+/**
+ * Linear-time (single forward pass) detection of a PEM private-key block.
+ *
+ * The straightforward regex for this, `-----BEGIN...[\s\S]*?...END-----`, is
+ * quadratic on adversarial input: when a `-----BEGIN ... PRIVATE KEY-----`
+ * marker has no matching END anywhere in the text, the lazy `[\s\S]*?` scans
+ * all the way to the end of the string before failing, and a global regex
+ * then repeats that full scan from every subsequent BEGIN marker. A payload
+ * with many BEGIN markers and no END markers turns an O(n) check into O(n²) —
+ * a real DoS risk, since this runs on the unbounded oversized-payload fast
+ * path before observer logging (`containsOversizedSecretIndicator`).
+ *
+ * This scans forward with `indexOf` instead: once a header has no footer
+ * anywhere after it, `indexOf` has already scanned to the end of the text
+ * exactly once, and we stop immediately rather than repeating that scan for
+ * every remaining header — bounding total work to O(n).
+ */
+function containsPemPrivateKeyBlock(text: string): boolean {
+  if (!text.includes('PRIVATE KEY-----')) return false;
+  let cursor = 0;
+  for (;;) {
+    const headerIdx = text.indexOf('-----BEGIN ', cursor);
+    if (headerIdx === -1) return false;
+    const headerEnd = pemMarkerEnd(text, headerIdx);
+    if (headerEnd === -1) {
+      cursor = headerIdx + 11;
+      continue;
+    }
+    const footerIdx = text.indexOf('-----END ', headerEnd);
+    if (footerIdx === -1) return false;
+    const footerEnd = pemMarkerEnd(text, footerIdx);
+    if (footerEnd === -1) {
+      cursor = footerIdx + 9;
+      continue;
+    }
+    return true;
+  }
+}
+
+/** Redacting counterpart of `containsPemPrivateKeyBlock`; same linear-scan shape. */
+function redactPemPrivateKeyBlocks(text: string): string {
+  if (!text.includes('PRIVATE KEY-----')) return text;
+  let result = '';
+  let cursor = 0;
+  for (;;) {
+    const headerIdx = text.indexOf('-----BEGIN ', cursor);
+    if (headerIdx === -1) break;
+    const headerEnd = pemMarkerEnd(text, headerIdx);
+    if (headerEnd === -1) {
+      result += text.slice(cursor, headerIdx + 11);
+      cursor = headerIdx + 11;
+      continue;
+    }
+    const footerIdx = text.indexOf('-----END ', headerEnd);
+    if (footerIdx === -1) break;
+    const footerEnd = pemMarkerEnd(text, footerIdx);
+    if (footerEnd === -1) {
+      result += text.slice(cursor, footerIdx + 9);
+      cursor = footerIdx + 9;
+      continue;
+    }
+    result += text.slice(cursor, headerIdx) + '[REDACTED]';
+    cursor = footerEnd;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
 function containsKnownSecretPattern(text: string): boolean {
-  return KNOWN_SECRET_VALUE_PATTERNS.some((pattern) => {
-    pattern.lastIndex = 0;
-    return pattern.test(text);
-  });
+  return containsPemPrivateKeyBlock(text)
+    || KNOWN_SECRET_VALUE_PATTERNS.some((pattern) => {
+      pattern.lastIndex = 0;
+      return pattern.test(text);
+    });
 }
 
 function redactKnownSecretValues(text: string): string {
-  let redacted = text;
+  let redacted = redactPemPrivateKeyBlocks(text);
   for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
     pattern.lastIndex = 0;
     redacted = redacted.replace(pattern, '[REDACTED]');
@@ -217,15 +309,27 @@ function redactJsonSecrets(value: unknown, state: { changed: boolean }, key?: st
       .find((candidate): candidate is string => typeof candidate === 'string' && isSensitiveAssignmentKey(candidate));
     return Object.fromEntries(
       Object.entries(record)
-        .map(([entryKey, entryValue]) => [
-          entryKey,
-          redactJsonSecrets(
-            entryValue,
-            state,
-            entryKey === 'value' && pairName ? pairName : entryKey,
-            preserveShellCommands,
-          ),
-        ]),
+        .map(([entryKey, entryValue]) => {
+          // The key label allowlist above (isSensitiveAssignmentKey) only
+          // catches secrets carried in a *value* under a recognized key name.
+          // A credential can also be used as the property name itself, e.g.
+          // `{"ghp_...": "active"}` — that literal key is otherwise never
+          // passed through any redaction pass and would survive untouched in
+          // the reconstructed object (independent of whatever the value is).
+          const redactedKey = containsKnownSecretPattern(entryKey)
+            ? redactKnownSecretValues(entryKey)
+            : entryKey;
+          if (redactedKey !== entryKey) state.changed = true;
+          return [
+            redactedKey,
+            redactJsonSecrets(
+              entryValue,
+              state,
+              entryKey === 'value' && pairName ? pairName : entryKey,
+              preserveShellCommands,
+            ),
+          ];
+        }),
     );
   }
   return value;

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -662,6 +662,46 @@ describe('fbeast-hook runtime', () => {
     expect(result.observerLogs[0]!.metadata).not.toContain(keyBody);
   });
 
+  it('detects an oversized PEM private-key block with an unrelated END marker before its real footer', async () => {
+    // A certificate (or any other "-----END X-----" marker) embedded between a
+    // PRIVATE KEY header and its real footer must not cause the scanner to
+    // abandon the header it already found. Regression test for a Codex
+    // finding on PR #3891 (issue #3838).
+    const certBody = Array.from({ length: 10 }, (_, i) => `certline${i}`).join('\n');
+    const keyBody = Array.from({ length: 40 }, (_, i) => `line${i}base64`).join('\n');
+    const pemBlock = [
+      '-----BEGIN PRIVATE KEY-----',
+      keyBody,
+      '-----BEGIN CERTIFICATE-----',
+      certBody,
+      '-----END CERTIFICATE-----',
+      '-----END PRIVATE KEY-----',
+    ].join('\n');
+    const payload = JSON.stringify({ output: 'x'.repeat(70_000), key: pemBlock });
+
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+
+    expect(metadata.payload).toBe('[post-tool-payload-redacted]');
+    expect(result.observerLogs[0]!.metadata).not.toContain(keyBody);
+  });
+
+  it('detects a JSON-unicode-escaped credential in an oversized payload', async () => {
+    // The raw source bytes of a `\uXXXX`-escaped secret contain no contiguous
+    // alphanumeric run, so they match no KNOWN_SECRET_VALUE_PATTERNS entry —
+    // decoding via JSON.parse before scanning is required to catch this.
+    // Regression test for a Codex finding on PR #3891 (issue #3838).
+    const secret = `ghp_${'a'.repeat(24)}`;
+    const escapedSecret = secret.replace(/./g, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
+    const payload = `{"result":"${escapedSecret}","padding":"${'x'.repeat(70_000)}"}`;
+
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+
+    expect(metadata.payload).toBe('[post-tool-payload-redacted]');
+    expect(result.observerLogs[0]!.metadata).not.toContain(secret);
+  });
+
   it('redacts a Google API key that legally ends in a hyphen even with no key-label context', async () => {
     // Google API keys are "AIza" + 35 chars from [0-9A-Za-z_-], which can
     // legally end in '-'. A trailing `\b` requires a word/non-word

--- a/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
+++ b/packages/franken-mcp-suite/src/integration/hook.integration.test.ts
@@ -621,6 +621,80 @@ describe('fbeast-hook runtime', () => {
     expect(result.observerLogs[0]!.metadata).not.toContain(secret);
   });
 
+  it('scans oversized payloads with many unterminated PEM markers in linear time', async () => {
+    // Many "-----BEGIN ... PRIVATE KEY-----" markers with no matching END
+    // anywhere (so there is no complete key to redact — this payload is
+    // correctly left untouched by both the pre-fix and post-fix scanner).
+    // What differs is the cost of reaching that answer: a lazy `[\s\S]*?`
+    // regex re-scans from every marker out to the end of the string before
+    // failing, making the check itself O(n^2) on this input shape — at
+    // 15,000 markers over ~440KB the pre-fix scanner took just over 3s, and
+    // at 30,000 markers over ~860KB it took nearly 12s (verified locally by
+    // timing `containsOversizedSecretIndicator`'s regex directly), scaling
+    // to a genuine hang on a crafted payload. This runs on the *unbounded*
+    // oversized-payload fast path (before observer logging), so an attacker
+    // controlling tool output could use it to stall the hook. Regression
+    // test for a Codex finding on PR #3891 (issue #3838); the fixed scanner
+    // does the same 15,000-marker check in low single-digit milliseconds.
+    const beginMarker = '-----BEGIN PRIVATE KEY-----';
+    const payload = `${Array.from({ length: 15_000 }, () => beginMarker).join(' ')} ${'x'.repeat(20_000)}`;
+
+    const start = Date.now();
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const elapsedMs = Date.now() - start;
+
+    // No complete BEGIN...END block exists, so nothing gets redacted — the
+    // point of this test is that the check completes quickly regardless.
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+    expect(metadata.payload).toBe(payload);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it('redacts a complete oversized PEM private-key block', async () => {
+    const keyBody = Array.from({ length: 40 }, (_, i) => `line${i}base64`).join('\n');
+    const pemBlock = `-----BEGIN RSA PRIVATE KEY-----\n${keyBody}\n-----END RSA PRIVATE KEY-----`;
+    const payload = JSON.stringify({ output: 'x'.repeat(70_000), key: pemBlock });
+
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+
+    expect(metadata.payload).toBe('[post-tool-payload-redacted]');
+    expect(result.observerLogs[0]!.metadata).not.toContain(keyBody);
+  });
+
+  it('redacts a Google API key that legally ends in a hyphen even with no key-label context', async () => {
+    // Google API keys are "AIza" + 35 chars from [0-9A-Za-z_-], which can
+    // legally end in '-'. A trailing `\b` requires a word/non-word
+    // transition, so when the key is immediately followed by another
+    // non-word character (e.g. the closing '"' here) no boundary exists and
+    // the match silently fails. Regression test for a Codex finding on PR
+    // #3891 (issue #3838).
+    const key = `AIza${'x'.repeat(34)}-`;
+    const payload = JSON.stringify({ result: key });
+
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+
+    expect(metadata.payload).not.toContain(key);
+  });
+
+  it('redacts a credential-shaped JSON property name even when another field also triggers redaction', async () => {
+    // The key-label allowlist only redacts a *value* under a recognized key
+    // name; a credential used as the property name itself (e.g.
+    // `{"ghp_...": "active"}`) was never checked. Once another field (here,
+    // "password") already flips state.changed, the raw-text fallback that
+    // would otherwise have caught it via substring matching is skipped, so
+    // the key survived untouched. Regression test for a Codex finding on PR
+    // #3891 (issue #3838).
+    const secretKeyName = `ghp_${'a'.repeat(20)}`;
+    const payload = JSON.stringify({ password: 'unrelated-secret', [secretKeyName]: 'active' });
+
+    const result = await runHookForTest(['post-tool', 'read_file', payload]);
+    const metadata = JSON.parse(result.observerLogs[0]!.metadata) as { payload: string };
+
+    expect(metadata.payload).not.toContain(secretKeyName);
+  });
+
   it('preserves raw non-JSON pre-tool whitespace for governor policy matching', async () => {
     const result = await runHookForTest(['pre-tool', '--', 'Bash'], {
       context: 'rm\t-rf /tmp/nope',


### PR DESCRIPTION
Closes #3838

## Summary

`runHook`'s post-tool branch already routes the observer log `payload` through `redactSecrets` (via `redactPostToolPayload`) before persisting it — so the literal fix suggested in the issue (call `redactSecrets` on the payload) was already in place on `main`. However, that redaction pipeline is entirely **key-label based**: it only redacts a value when it sits next to a recognized credential key name (`token=`, `apiKey:`, `Authorization:`, etc).

A secret embedded under an innocuous key — e.g. `{"result": "ghp_..."}` — or inline in free-form text with no label at all (e.g. `"here is AKIAIOSFODNN7EXAMPLE for aws"`) passed through **unredacted** and would land in observer logs. This is the real remaining gap behind the issue's stated impact ("secrets can be recorded in observable logs").

## Fix

Added value-shape detection to `packages/franken-mcp-suite/src/cli/hook.ts` (`KNOWN_SECRET_VALUE_PATTERNS`) that redacts common credential formats regardless of the surrounding key name or label:
- GitHub PATs (`ghp_`, `gho_`, `github_pat_`, `glpat-`, etc.)
- OpenAI/Anthropic/Stripe-style `sk-`/`pk-`/`rk-` prefixed keys
- AWS access key IDs (`AKIA…`/`ASIA…`)
- Google API keys (`AIza…`)
- PEM private key blocks

This pattern set mirrors the value-shape redaction already used by `packages/franken-mcp-suite/src/adapters/brain-adapter.ts`'s `SECRET_EXPORT_VALUES` (memory export redaction), so both redaction paths in the package now agree on what counts as a secret-shaped value. Wired into both `redactRawSecrets` (used by `redactSecrets`, the post-tool logging path and the pre-tool governor-context path) and `containsOversizedSecretIndicator` (the >64KB payload fast-path heuristic).

## Testing (TDD)

- Added 3 new tests in `hook.test.ts` covering post-tool payloads with bare credential-shaped values under non-credential keys and in free text. Verified red (all 3 fail) against the pre-fix code by temporarily stashing the `hook.ts` change, then green after restoring it.
- Full package suite: `npx turbo run test --filter=@franken/mcp-suite` → 40 files / 621 tests passing.
- `npx turbo run typecheck --filter=@franken/mcp-suite` → clean.

Scope is limited to `packages/franken-mcp-suite/src/cli/hook.ts` and its test file — no unrelated refactors.

