### PR TITLE
fix(orchestrator): secure adapter request IDs

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -1,5 +1,5 @@
 import type { ILlmClient, LlmCompletionOptions, LlmCompletionResult, ProviderContext, TokenUsage } from '@franken/types';
-import { now as deterministicNow, seededRandom } from '@franken/types';
+import { randomUUID } from 'node:crypto';
 
 type UnifiedRequest = {
   id: string;
@@ -100,7 +100,7 @@ export class AdapterLlmClient implements ILlmClient {
     prompt: string,
     options?: LlmCompletionOptions & { sessionContinue?: boolean; sessionId?: string },
   ): Promise<{ content: string; usage?: TokenUsage; providerContext?: ProviderContext }> {
-    const requestId = `llm-${deterministicNow()}-${seededRandom.random().toString(16).slice(2)}`;
+    const requestId = `llm-${randomUUID()}`;
     const model = this.defaultModel;
 
     const request: UnifiedRequest = {

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AdapterLlmClient, AdapterLlmError, type IAdapter, type ILlmObserver } from '../../../src/adapters/adapter-llm-client.js';
 
+const { randomUUID } = vi.hoisted(() => ({
+  randomUUID: vi.fn(() => '123e4567-e89b-42d3-a456-426614174000'),
+}));
+
+vi.mock('node:crypto', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:crypto')>(),
+  randomUUID,
+}));
+
 function makeAdapter(overrides: Partial<IAdapter> = {}): IAdapter {
   return {
     transformRequest: vi.fn((req) => req),
@@ -22,6 +31,18 @@ function makeObserver(): ILlmObserver {
 }
 
 describe('AdapterLlmClient', () => {
+  it('uses randomUUID for the prefixed request ID and response correlation', async () => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await client.complete('prompt');
+
+    const requestId = 'llm-123e4567-e89b-42d3-a456-426614174000';
+    expect(randomUUID).toHaveBeenCalledOnce();
+    expect(adapter.transformRequest).toHaveBeenCalledWith(expect.objectContaining({ id: requestId }));
+    expect(adapter.transformResponse).toHaveBeenCalledWith({ raw: true }, requestId);
+  });
+
   it('returns adapter content on success', async () => {
     const client = new AdapterLlmClient(makeAdapter());
     await expect(client.complete('prompt')).resolves.toBe('hello');

--- a/tasks/issue-3830-secure-adapter-request-ids-progress.md
+++ b/tasks/issue-3830-secure-adapter-request-ids-progress.md
@@ -8,9 +8,9 @@
 - [x] Run the focused regression test with the read-only-cache-safe Vitest config loader.
 - [x] Run the complete `adapter-llm-client` unit test file with the read-only-cache-safe Vitest config loader.
 - [x] Run focused tests and package lint; attempt full tests, typecheck, and build (blocked only by unrelated current-main failures documented in the PR).
-- [ ] Commit the issue changes.
-- [ ] Push the issue branch.
-- [ ] Open the pull request.
+- [x] Commit the issue changes.
+- [x] Push the issue branch.
+- [x] Open pull request #3894 linked to issue #3830.
 - [ ] Obtain exact-head CI and Codex review.
 - [ ] Merge the pull request.
 - [ ] Close issue #3830.

--- a/tasks/issue-3830-secure-adapter-request-ids-progress.md
+++ b/tasks/issue-3830-secure-adapter-request-ids-progress.md
@@ -1,0 +1,18 @@
+- [x] Read repository guidance, the adapter implementation, and its unit test.
+- [x] Confirm issue scope and acceptance criteria for secure adapter request IDs.
+- [x] Add one behavior-focused regression test for `randomUUID` request IDs and correlation.
+- [x] Run only the focused regression test and independently confirm the expected RED-phase failure (`randomUUID` received 0 calls).
+- [x] Replace deterministic request-ID generation with Node's cryptographically secure `randomUUID`.
+- [x] Retain the `llm-` prefix and reuse the same request ID through request transformation, response transformation, observer spans, and errors.
+- [x] Remove imports made unused by the production change without altering deterministic utilities globally.
+- [x] Run the focused regression test with the read-only-cache-safe Vitest config loader.
+- [x] Run the complete `adapter-llm-client` unit test file with the read-only-cache-safe Vitest config loader.
+- [x] Run focused tests and package lint; attempt full tests, typecheck, and build (blocked only by unrelated current-main failures documented in the PR).
+- [ ] Commit the issue changes.
+- [ ] Push the issue branch.
+- [ ] Open the pull request.
+- [ ] Obtain exact-head CI and Codex review.
+- [ ] Merge the pull request.
+- [ ] Close issue #3830.
+- [ ] Record durable lessons in `tasks/lessons.md`.
+- [ ] Complete the Kanban handoff.


### PR DESCRIPTION
## Summary
- generate AdapterLlmClient request IDs with Node crypto.randomUUID
- preserve the llm- prefix and request/response correlation
- add a deterministic regression test for the secure RNG path

## Validation
- PASS: `npm test --workspace @franken/orchestrator -- --configLoader runner tests/unit/adapters/adapter-llm-client.test.ts` (15/15)
- PASS: `npm run lint --workspace @franken/orchestrator` (0 errors; pre-existing warnings)
- PASS: local `codex review --uncommitted` (no findings)
- ATTEMPTED: `npm test` (unrelated current-main failures: 3 orchestrator timing/runtime tests; 4,980 orchestrator tests passed)
- ATTEMPTED: `npm run typecheck` and `npm run build` (unrelated current-main `session-store.ts` implicit-any errors at lines 475, 478, and 482)

Closes #3830