### PR TITLE
fix(governor): expire stale approval requests

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -11,7 +11,38 @@ import { SessionTokenStore } from '../security/session-token-store.js';
 import { normalizeGovernorConfig } from '../core/config.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
-const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):(\d{2}))$/;
+
+function parseIso8601Timestamp(value: unknown): number {
+  if (typeof value !== 'string') return Number.NaN;
+  const match = ISO_8601_TIMESTAMP.exec(value);
+  if (!match) return Number.NaN;
+
+  const [
+    , year, month, day, hour, minute, second, fraction = '', zone,
+    offsetSign = '+', offsetHour = '0', offsetMinute = '0',
+  ] = match;
+  const timestampMs = Date.parse(value);
+  if (!Number.isFinite(timestampMs)) return Number.NaN;
+
+  const offsetHours = Number(offsetHour);
+  const offsetMinutes = Number(offsetMinute);
+  if (offsetHours > 23 || offsetMinutes > 59) return Number.NaN;
+  const signedOffsetMinutes = zone === 'Z'
+    ? 0
+    : (offsetSign === '-' ? -1 : 1) * (offsetHours * 60 + offsetMinutes);
+  const local = new Date(timestampMs + signedOffsetMinutes * 60_000);
+
+  return local.getUTCFullYear() === Number(year)
+    && local.getUTCMonth() + 1 === Number(month)
+    && local.getUTCDate() === Number(day)
+    && local.getUTCHours() === Number(hour)
+    && local.getUTCMinutes() === Number(minute)
+    && local.getUTCSeconds() === Number(second)
+    && local.getUTCMilliseconds() === Number(fraction.padEnd(3, '0'))
+    ? timestampMs
+    : Number.NaN;
+}
 
 export interface SlackEphemeralResponse {
   readonly response_type: 'ephemeral';
@@ -351,10 +382,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       );
     }
 
-    const timestampMs = typeof body.timestamp === 'string'
-      && ISO_8601_TIMESTAMP.test(body.timestamp)
-      ? Date.parse(body.timestamp)
-      : Number.NaN;
+    const timestampMs = parseIso8601Timestamp(body.timestamp);
     if (!Number.isFinite(timestampMs)) {
       return c.json({
         error: {

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -6,12 +6,12 @@ import {
   formatApprovalResponseSignaturePayload,
   SignatureVerifier,
 } from '../security/signature-verifier.js';
-import { now as deterministicNow } from '@franken/types';
+import { now as deterministicNow, wallClockNow } from '@franken/types';
 import { SessionTokenStore } from '../security/session-token-store.js';
 import { normalizeGovernorConfig } from '../core/config.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
-const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):(\d{2}))$/;
+const ISO_8601_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/;
 
 function parseIso8601Timestamp(value: unknown): number {
   if (typeof value !== 'string') return Number.NaN;
@@ -39,7 +39,7 @@ function parseIso8601Timestamp(value: unknown): number {
     && local.getUTCHours() === Number(hour)
     && local.getUTCMinutes() === Number(minute)
     && local.getUTCSeconds() === Number(second)
-    && local.getUTCMilliseconds() === Number(fraction.padEnd(3, '0'))
+    && local.getUTCMilliseconds() === Number(fraction.slice(0, 3).padEnd(3, '0'))
     ? timestampMs
     : Number.NaN;
 }
@@ -391,7 +391,7 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
         },
       }, 400);
     }
-    if (Math.abs(deterministicNow() - timestampMs) > approvalRequestTimeoutMs) {
+    if (Math.abs(wallClockNow() - timestampMs) > approvalRequestTimeoutMs) {
       return c.json({
         error: {
           code: 'approval_request_expired',

--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -8,8 +8,10 @@ import {
 } from '../security/signature-verifier.js';
 import { now as deterministicNow } from '@franken/types';
 import { SessionTokenStore } from '../security/session-token-store.js';
+import { normalizeGovernorConfig } from '../core/config.js';
 
 const VALID_DECISIONS = new Set<string>(RESPONSE_CODES);
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export interface SlackEphemeralResponse {
   readonly response_type: 'ephemeral';
@@ -31,6 +33,8 @@ export interface GovernorAppOptions {
   slackResponsePoster?: SlackResponsePoster;
   slackWebhookUrl?: string;
   allowUnsignedApprovalsForTests?: boolean;
+  /** Maximum accepted age/skew for inbound approval-request timestamps. */
+  timeoutMs?: number;
   /**
    * Shared registry of pending approval waiters. Pass the same instance to
    * an `HttpApprovalChannel` (used by `ApprovalGateway`) so that a caller
@@ -259,6 +263,9 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   const slackApproverUserIds = new Set(options.slackApproverUserIds ?? []);
   const slackResponsePoster = options.slackResponsePoster ?? DEFAULT_SLACK_RESPONSE_POSTER;
   const approvalQueueBackpressure = normalizeApprovalQueueBackpressure(options.approvalQueueBackpressure);
+  const approvalRequestTimeoutMs = normalizeGovernorConfig(
+    options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs },
+  ).timeoutMs;
   let sessionTokenStore: SessionTokenStore | undefined = options.sessionTokenStore;
   if (!sessionTokenStore && options.sessionTokenStorePath) {
     try {
@@ -342,6 +349,27 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
         { error: { message: 'Missing required fields: requestId, taskId, summary' } },
         400,
       );
+    }
+
+    const timestampMs = typeof body.timestamp === 'string'
+      && ISO_8601_TIMESTAMP.test(body.timestamp)
+      ? Date.parse(body.timestamp)
+      : Number.NaN;
+    if (!Number.isFinite(timestampMs)) {
+      return c.json({
+        error: {
+          code: 'invalid_approval_request_timestamp',
+          message: 'Approval request timestamp must be a valid ISO-8601 string',
+        },
+      }, 400);
+    }
+    if (Math.abs(deterministicNow() - timestampMs) > approvalRequestTimeoutMs) {
+      return c.json({
+        error: {
+          code: 'approval_request_expired',
+          message: 'Approval request timestamp is outside the allowed window',
+        },
+      }, 400);
     }
 
     if (

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -104,6 +104,28 @@ describe('Governor Hono Server', () => {
       }
     });
 
+    it('accepts an approval request timestamp with microsecond precision', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-29T12:00:00.123Z'));
+        const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+        const res = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requestId: 'req-microseconds',
+            taskId: 'task-1',
+            summary: 'Deploy to production',
+            timestamp: '2026-07-29T12:00:00.123456Z',
+          }),
+        });
+
+        expect(res.status).toBe(201);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('rejects an approval request older than the configured timeout window', async () => {
       vi.useFakeTimers();
       try {
@@ -150,6 +172,29 @@ describe('Governor Hono Server', () => {
       expect(res.status).toBe(201);
       const body = await res.json();
       expect(body.status).toBe('pending');
+    });
+
+    it('uses the wall clock for request freshness in deterministic mode', async () => {
+      const previousSeed = process.env.FRANKENBEAST_SEED;
+      process.env.FRANKENBEAST_SEED = 'approval-freshness-test';
+      try {
+        const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+        const res = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requestId: 'req-deterministic-mode',
+            taskId: 'task-1',
+            summary: 'Deploy to production',
+            timestamp: new Date().toISOString(),
+          }),
+        });
+
+        expect(res.status).toBe(201);
+      } finally {
+        if (previousSeed === undefined) delete process.env.FRANKENBEAST_SEED;
+        else process.env.FRANKENBEAST_SEED = previousSeed;
+      }
     });
 
     it('creates a signed approval request when a signing secret is configured', async () => {

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -76,6 +76,34 @@ describe('Governor Hono Server', () => {
       }
     });
 
+    it('rejects an impossible calendar date in an approval request timestamp', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'));
+        const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+        const res = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requestId: 'req-invalid-calendar-date',
+            taskId: 'task-1',
+            summary: 'Deploy to production',
+            timestamp: '2026-02-29T00:00:00.000Z',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({
+          error: {
+            code: 'invalid_approval_request_timestamp',
+            message: 'Approval request timestamp must be a valid ISO-8601 string',
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('rejects an approval request older than the configured timeout window', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -27,6 +27,85 @@ describe('Governor Hono Server', () => {
   });
 
   describe('POST /v1/approval/request', () => {
+    it('rejects an approval request without a timestamp', async () => {
+      const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+      const res = await app.request('/v1/approval/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requestId: 'req-missing-timestamp',
+          taskId: 'task-1',
+          summary: 'Deploy to production',
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: {
+          code: 'invalid_approval_request_timestamp',
+          message: 'Approval request timestamp must be a valid ISO-8601 string',
+        },
+      });
+    });
+
+    it('rejects a date-only approval request timestamp as invalid', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-29T00:01:00.000Z'));
+        const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+        const res = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requestId: 'req-date-only',
+            taskId: 'task-1',
+            summary: 'Deploy to production',
+            timestamp: '2026-07-29',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({
+          error: {
+            code: 'invalid_approval_request_timestamp',
+            message: 'Approval request timestamp must be a valid ISO-8601 string',
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('rejects an approval request older than the configured timeout window', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-29T12:00:00.000Z'));
+        const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
+        const res = await app.request('/v1/approval/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requestId: 'req-stale',
+            taskId: 'task-1',
+            summary: 'Deploy to production',
+            timestamp: '2026-07-29T11:54:59.999Z',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({
+          error: {
+            code: 'approval_request_expired',
+            message: 'Approval request timestamp is outside the allowed window',
+          },
+        });
+        const healthBody = await (await app.request('/health')).json();
+        expect(healthBody.pendingApprovals).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('creates approval request', async () => {
       const app = createGovernorApp({ allowUnsignedApprovalsForTests: true });
       const res = await app.request('/v1/approval/request', {
@@ -36,6 +115,7 @@ describe('Governor Hono Server', () => {
           requestId: 'req-1',
           taskId: 'task-1',
           summary: 'Deploy to production',
+          timestamp: new Date().toISOString(),
         }),
       });
 
@@ -50,6 +130,7 @@ describe('Governor Hono Server', () => {
         requestId: 'req-signed',
         taskId: 'task-1',
         summary: 'Deploy to production',
+        timestamp: new Date().toISOString(),
       });
 
       const res = await app.request('/v1/approval/request', {
@@ -75,6 +156,7 @@ describe('Governor Hono Server', () => {
           requestId: 'req-unsigned',
           taskId: 'task-1',
           summary: 'Deploy to production',
+          timestamp: new Date().toISOString(),
         }),
       });
 
@@ -123,7 +205,12 @@ describe('Governor Hono Server', () => {
         const accepted = await app.request('/v1/approval/request', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ requestId, taskId: 'task-1', summary: 'Deploy' }),
+          body: JSON.stringify({
+            requestId,
+            taskId: 'task-1',
+            summary: 'Deploy',
+            timestamp: new Date().toISOString(),
+          }),
         });
         expect(accepted.status).toBe(201);
       }
@@ -131,7 +218,12 @@ describe('Governor Hono Server', () => {
       const rejected = await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ requestId: 'req-3', taskId: 'task-1', summary: 'Deploy' }),
+        body: JSON.stringify({
+          requestId: 'req-3',
+          taskId: 'task-1',
+          summary: 'Deploy',
+          timestamp: new Date().toISOString(),
+        }),
       });
 
       expect(rejected.status).toBe(429);
@@ -161,14 +253,24 @@ describe('Governor Hono Server', () => {
       const created = await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ requestId: 'req-1', taskId: 'task-1', summary: 'Deploy' }),
+        body: JSON.stringify({
+          requestId: 'req-1',
+          taskId: 'task-1',
+          summary: 'Deploy',
+          timestamp: new Date().toISOString(),
+        }),
       });
       expect(created.status).toBe(201);
 
       const refreshed = await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ requestId: 'req-1', taskId: 'task-1', summary: 'Updated summary' }),
+        body: JSON.stringify({
+          requestId: 'req-1',
+          taskId: 'task-1',
+          summary: 'Updated summary',
+          timestamp: new Date().toISOString(),
+        }),
       });
 
       expect(refreshed.status).toBe(201);
@@ -187,6 +289,7 @@ describe('Governor Hono Server', () => {
         requestId,
         taskId: 'task-1',
         summary: 'Deploy',
+        timestamp: new Date().toISOString(),
       });
       await app.request('/v1/approval/request', {
         method: 'POST',
@@ -209,6 +312,7 @@ describe('Governor Hono Server', () => {
           requestId: 'req-1',
           taskId: 'task-1',
           summary: 'Deploy',
+          timestamp: new Date().toISOString(),
         }),
       });
 
@@ -236,6 +340,7 @@ describe('Governor Hono Server', () => {
           requestId: 'req-invalid',
           taskId: 'task-1',
           summary: 'Deploy',
+          timestamp: new Date().toISOString(),
         }),
       });
 
@@ -644,7 +749,12 @@ describe('Governor Hono Server', () => {
       await app.request('/v1/approval/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ requestId, taskId: 'task-1', summary: 'Deploy' }),
+        body: JSON.stringify({
+          requestId,
+          taskId: 'task-1',
+          summary: 'Deploy',
+          timestamp: new Date().toISOString(),
+        }),
       });
     }
 

--- a/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
+++ b/packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts
@@ -289,6 +289,7 @@ describe('standalone governor HTTP app wired to real approval waiters', () => {
         requestId: 'req-early-backpressure-1',
         taskId: 'task-1',
         summary: 'Deploy retry',
+        timestamp: new Date().toISOString(),
       }),
     });
     expect(retry.status).toBe(201);

--- a/tasks/issue-3766-approval-timestamp-expiration-progress.md
+++ b/tasks/issue-3766-approval-timestamp-expiration-progress.md
@@ -8,7 +8,7 @@
 - [x] Add and run focused failing regression tests (RED).
 - [x] Implement the minimal root-cause fix and pass focused tests (GREEN).
 - [x] Run relevant governor tests, typecheck, lint, root checks/build, and inspect final diff. (Governor: 339 tests, typecheck/build/lint pass; root test/typecheck/build reached unrelated current-main orchestrator failures documented in the PR.)
-- [ ] Commit conventionally, push, and open one PR linked to #3766.
+- [x] Commit conventionally, push, and open one PR linked to #3766 (PR #3895).
 - [ ] Obtain current-head GitHub Codex clean result, zero unresolved Codex threads, and green exact-head CI.
 - [ ] Squash merge safely and verify issue closure plus current-main integration.
 - [ ] Append reusable lesson(s), publish Kanban/root handoff, and complete the card.

--- a/tasks/issue-3766-approval-timestamp-expiration-progress.md
+++ b/tasks/issue-3766-approval-timestamp-expiration-progress.md
@@ -1,0 +1,14 @@
+# Issue #3766 approval timestamp expiration progress
+
+- [x] Read live issue #3766, overlapping #3736/#3751, PM handoffs, and shared lessons.
+- [x] Confirm no existing open PR owns #3766 and issue is not labeled `good first issue`.
+- [x] Rebase task branch onto current `origin/main` and configure required Git identity.
+- [x] Reproduce or directly validate the reported stale approval-request acceptance on current `origin/main`.
+- [x] Trace timestamp/config/registry data flow and define narrow duplicate-safe scope.
+- [x] Add and run focused failing regression tests (RED).
+- [x] Implement the minimal root-cause fix and pass focused tests (GREEN).
+- [x] Run relevant governor tests, typecheck, lint, root checks/build, and inspect final diff. (Governor: 339 tests, typecheck/build/lint pass; root test/typecheck/build reached unrelated current-main orchestrator failures documented in the PR.)
+- [ ] Commit conventionally, push, and open one PR linked to #3766.
+- [ ] Obtain current-head GitHub Codex clean result, zero unresolved Codex threads, and green exact-head CI.
+- [ ] Squash merge safely and verify issue closure plus current-main integration.
+- [ ] Append reusable lesson(s), publish Kanban/root handoff, and complete the card.


### PR DESCRIPTION
## Summary
- require ISO-8601 timestamps on inbound Governor approval requests
- reject requests outside the configured `timeoutMs` window before registry insertion
- preserve current request/response and backpressure behavior with fresh timestamps

## Validation
- `npm test --workspace @franken/governor` (339 passed)
- `npm run typecheck --workspace @franken/governor`
- `npm run build --workspace @franken/governor`
- `npx eslint packages/franken-governor/src/server/app.ts packages/franken-governor/tests/unit/server/app.test.ts packages/franken-governor/tests/unit/server/http-approval-waiters.test.ts`
- Root `npm run typecheck` / `npm run build` reach pre-existing `packages/franken-orchestrator/src/chat/session-store.ts` implicit-any errors; root `npm test` reaches unrelated orchestrator timing failures. This PR does not modify orchestrator files.

Closes #3766