### PR TITLE
fix(critique): reject non-finite token budgets

### DIFF
--- a/packages/franken-critique/src/breakers/token-budget.ts
+++ b/packages/franken-critique/src/breakers/token-budget.ts
@@ -1,5 +1,6 @@
 import type { CircuitBreaker, CircuitBreakerResult, LoopState, LoopConfig } from './circuit-breaker.js';
 import type { ObservabilityPort } from '../types/contracts.js';
+import { ConfigurationError } from '../errors/index.js';
 
 export class TokenBudgetBreaker implements CircuitBreaker {
   readonly name = 'token-budget';
@@ -15,6 +16,17 @@ export class TokenBudgetBreaker implements CircuitBreaker {
   }
 
   async check(_state: LoopState, config: LoopConfig): Promise<CircuitBreakerResult> {
+    // tokenBudget must always be finite and positive, even when costBudgetUsd
+    // is also set — a non-finite value must never be usable as an "unbounded"
+    // sentinel (see dep-factory.ts, which now uses a finite effectively-
+    // unbounded sentinel instead of Infinity for that case).
+    if (!Number.isFinite(config.tokenBudget) || config.tokenBudget <= 0) {
+      throw new ConfigurationError(
+        `tokenBudget must be a finite positive number, got ${config.tokenBudget}`,
+        { context: { tokenBudget: config.tokenBudget } },
+      );
+    }
+
     const spend = await this.observability.getTokenSpend(config.sessionId);
 
     // A dollar-denominated budget (e.g. the CLI `--budget <usd>` flag) must be

--- a/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
+++ b/packages/franken-critique/tests/unit/breakers/token-budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TokenBudgetBreaker } from '../../../src/breakers/token-budget.js';
+import { ConfigurationError } from '../../../src/errors/index.js';
 import type { ObservabilityPort } from '../../../src/types/contracts.js';
 import type { LoopState, LoopConfig } from '../../../src/types/loop.js';
 
@@ -82,12 +83,49 @@ describe('TokenBudgetBreaker', () => {
     expect(breaker.phase).toBe('both');
   });
 
+  describe('non-finite tokenBudget (regression for #3800)', () => {
+    it('rejects +Infinity with ConfigurationError before calling getTokenSpend', async () => {
+      const port = createMockObservabilityPort(0);
+      const breaker = new TokenBudgetBreaker(port);
+      await expect(
+        breaker.check(createState(0), createConfig(Number.POSITIVE_INFINITY)),
+      ).rejects.toThrow(ConfigurationError);
+      expect(port.getTokenSpend).not.toHaveBeenCalled();
+    });
+
+    it('rejects -Infinity with ConfigurationError before calling getTokenSpend', async () => {
+      const port = createMockObservabilityPort(0);
+      const breaker = new TokenBudgetBreaker(port);
+      await expect(
+        breaker.check(createState(0), createConfig(Number.NEGATIVE_INFINITY)),
+      ).rejects.toThrow(ConfigurationError);
+      expect(port.getTokenSpend).not.toHaveBeenCalled();
+    });
+
+    it('rejects +Infinity with ConfigurationError even when costBudgetUsd is a valid finite value', async () => {
+      const port = createMockObservabilityPort(0);
+      const breaker = new TokenBudgetBreaker(port);
+      await expect(
+        breaker.check(createState(0), {
+          ...createConfig(Number.POSITIVE_INFINITY),
+          costBudgetUsd: 10,
+        }),
+      ).rejects.toThrow(ConfigurationError);
+      expect(port.getTokenSpend).not.toHaveBeenCalled();
+    });
+  });
+
   describe('cost budget (USD)', () => {
+    // tokenBudget must be finite (see the regression block above), so a
+    // cost-only budget is expressed with a finite, effectively-unbounded
+    // sentinel instead of Infinity — matching dep-factory.ts's CLI wiring.
+    const EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET = Number.MAX_SAFE_INTEGER;
+
     it('trips on estimatedCostUsd, not token count, when costBudgetUsd is set', async () => {
       // 1,500,000 tokens at $0.00001/token = $15.00 estimated cost, over the $10 budget.
       const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_500_000));
       const result = await breaker.check(createState(1), {
-        ...createConfig(Number.POSITIVE_INFINITY),
+        ...createConfig(EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET),
         costBudgetUsd: 10,
       });
       expect(result.tripped).toBe(true);
@@ -102,7 +140,7 @@ describe('TokenBudgetBreaker', () => {
       // breaker treats equality as within budget; the critique breaker must too.
       const breaker = new TokenBudgetBreaker(createMockObservabilityPort(1_000_000));
       const result = await breaker.check(createState(1), {
-        ...createConfig(Number.POSITIVE_INFINITY),
+        ...createConfig(EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET),
         costBudgetUsd: 10,
       });
       expect(result.tripped).toBe(false);
@@ -113,7 +151,7 @@ describe('TokenBudgetBreaker', () => {
       // any critique work could run.
       const breaker = new TokenBudgetBreaker(createMockObservabilityPort(0));
       const result = await breaker.check(createState(1), {
-        ...createConfig(Number.POSITIVE_INFINITY),
+        ...createConfig(EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET),
         costBudgetUsd: 0,
       });
       expect(result.tripped).toBe(false);
@@ -125,7 +163,7 @@ describe('TokenBudgetBreaker', () => {
       // (~$0.0005) is far under $10 and must not trip.
       const breaker = new TokenBudgetBreaker(createMockObservabilityPort(50));
       const result = await breaker.check(createState(1), {
-        ...createConfig(Number.POSITIVE_INFINITY),
+        ...createConfig(EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET),
         costBudgetUsd: 10,
       });
       expect(result.tripped).toBe(false);

--- a/packages/franken-orchestrator/src/cli/dep-factory.ts
+++ b/packages/franken-orchestrator/src/cli/dep-factory.ts
@@ -794,6 +794,11 @@ function resolveMissingSafetyModule<T>(moduleName: string, stub: T, logger: Beas
   );
 }
 
+// TokenBudgetBreaker requires a finite, positive tokenBudget (Infinity is
+// rejected as a fail-open bypass), so a cost-only budget needs a finite
+// sentinel that no real token count will reach.
+const EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET = Number.MAX_SAFE_INTEGER;
+
 async function createCritiqueDeps(
   options: CliDepOptions,
   config: EffectiveCliConfig,
@@ -832,9 +837,9 @@ async function createCritiqueDeps(
     config: {
       maxIterations: options.critiqueMaxIterations ?? 3,
       // `config.budget` is the CLI `--budget <usd>` dollar limit, so enforce it
-      // as a cost budget. The token budget is left unbounded; the dollar budget
-      // is the single budget the CLI exposes.
-      tokenBudget: Number.POSITIVE_INFINITY,
+      // as a cost budget. The token budget is left effectively unbounded; the
+      // dollar budget is the single budget the CLI exposes.
+      tokenBudget: EFFECTIVELY_UNBOUNDED_TOKEN_BUDGET,
       costBudgetUsd: config.budget,
       consensusThreshold: options.critiqueConsensusThreshold ?? 0.7,
       sessionId: `cli-critique-${deterministicNow()}`,


### PR DESCRIPTION
## Summary
- Reject non-finite and non-positive `tokenBudget` values before querying token spend
- Cover positive/negative Infinity and the cost-budget coexistence path with regression tests
- Replace the CLI cost-budget path's Infinity token sentinel with a finite effectively-unbounded value
- Leave `costBudgetUsd` validation to the separate #3843 / PR #3886 work

## Test plan
- [x] `npx vitest run tests/unit/breakers/token-budget.test.ts` (14/14)
- [x] `npx turbo run test --filter=@franken/critique` (798/798)
- [x] `npx turbo run typecheck lint --filter=@franken/critique`
- [x] `npx turbo run test --filter=@franken/orchestrator` (4982/4982)
- [x] `npx turbo run typecheck lint --filter=@franken/orchestrator` (0 errors; existing warnings)
- [x] `npm run build`

Closes #3800