### PR TITLE
fix(governor): authenticate approval responses before JSON parsing

### DIFF
--- a/packages/franken-governor/src/server/app.ts
+++ b/packages/franken-governor/src/server/app.ts
@@ -430,13 +430,13 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
   // POST /v1/approval/respond — respond to an approval request
   app.post('/v1/approval/respond', async (c) => {
     const rawBody = Buffer.from(await c.req.arrayBuffer());
-    const body = parseJsonBody(rawBody);
-    if (!body) {
-      return c.json({ error: { message: 'Malformed JSON body' } }, 400);
-    }
 
-    // Fail closed: unsigned approval responses are rejected unless a signing
-    // secret is configured (then verified) or an explicit test flag is set.
+    // Fail closed: authenticate the raw bytes with the governor signature
+    // BEFORE parsing JSON, so untrusted/unauthenticated input never reaches
+    // JSON.parse or registry dispatch. Unsigned approval responses are
+    // rejected unless a signing secret is configured (then verified) or an
+    // explicit test flag is set; the test-only unsigned path is still
+    // gated here, ahead of parsing.
     if (!options.signingSecret) {
       if (!options.allowUnsignedApprovalsForTests) {
         return c.json({ error: { message: 'Signing secret required for approval responses' } }, 401);
@@ -456,6 +456,11 @@ export function createGovernorApp(options: GovernorAppOptions = {}): Hono {
       if (!verification.ok) {
         return c.json({ error: { message: 'Invalid signature' } }, 401);
       }
+    }
+
+    const body = parseJsonBody(rawBody);
+    if (!body) {
+      return c.json({ error: { message: 'Malformed JSON body' } }, 400);
     }
 
     if (typeof body.requestId !== 'string' || typeof body.decision !== 'string') {

--- a/packages/franken-governor/tests/unit/server/app.test.ts
+++ b/packages/franken-governor/tests/unit/server/app.test.ts
@@ -592,6 +592,91 @@ describe('Governor Hono Server', () => {
       const body = await res.json();
       expect(body.error.message).toBe('Missing signature');
     });
+
+    // Regression coverage for issue #3722: the raw request bytes must be
+    // authenticated with the governor signing secret BEFORE JSON.parse ever
+    // runs, so an unauthenticated caller cannot force parsing of arbitrary
+    // bytes. Each case below sends a body that is not valid JSON; if
+    // authentication happened first (as it must), the handler never reaches
+    // JSON.parse and returns the auth-specific 401 below instead of the
+    // generic "Malformed JSON body" 400 that parsing failure would produce.
+    describe('authenticates before JSON parsing', () => {
+      const MALFORMED_JSON = '{not valid json';
+
+      it('rejects an unsigned malformed-JSON body before parsing when no signing secret is configured', async () => {
+        const app = createGovernorApp();
+        const res = await app.request('/v1/approval/respond', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: MALFORMED_JSON,
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error.message).toBe('Signing secret required for approval responses');
+      });
+
+      it('rejects a malformed-JSON body with a missing signature before parsing', async () => {
+        const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+        const res = await app.request('/v1/approval/respond', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: MALFORMED_JSON,
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error.message).toBe('Missing signature');
+      });
+
+      it('rejects a malformed-JSON body with a malformed signature header before parsing', async () => {
+        const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+        const res = await app.request('/v1/approval/respond', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-governor-signature': 'sha256=not-hex',
+          },
+          body: MALFORMED_JSON,
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error.message).toBe('Malformed signature');
+      });
+
+      it('rejects a malformed-JSON body with an invalid signature before parsing', async () => {
+        const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+        const res = await app.request('/v1/approval/respond', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-governor-signature': `sha256=${'0'.repeat(64)}`,
+          },
+          body: MALFORMED_JSON,
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.error.message).toBe('Invalid signature');
+      });
+
+      it('never dispatches to the registry when authentication fails, even with well-formed JSON', async () => {
+        const app = createGovernorApp({ signingSecret: SIGNING_FIXTURE });
+        await seedResponseApproval(app, 'req-auth-order', SIGNING_FIXTURE);
+
+        const res = await app.request('/v1/approval/respond', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ requestId: 'req-auth-order', decision: 'APPROVE' }),
+        });
+
+        expect(res.status).toBe(401);
+        const health = await app.request('/health');
+        const healthBody = await health.json();
+        expect(healthBody.pendingApprovals).toBe(1);
+      });
+    });
   });
 
   describe('POST /v1/approval/session/validate', () => {


### PR DESCRIPTION
## Summary

- `POST /v1/approval/respond` in `packages/franken-governor/src/server/app.ts` parsed the raw request body with `JSON.parse` before the governor HMAC signature was verified against those bytes, so unauthenticated callers could force JSON parsing of arbitrary input ahead of the fail-closed auth boundary.
- Reordered the handler to authenticate the raw bytes first (via `verifyGovernorSignature`, or the explicit `allowUnsignedApprovalsForTests` test-only path, still gated ahead of parsing) and only parse JSON once authentication succeeds — matching the ordering already used by `POST /v1/approval/request`.
- No behavior change for authenticated callers; only the ordering of auth vs. parse changed.

## Test plan

- [x] Added TDD regression tests in `packages/franken-governor/tests/unit/server/app.test.ts` (`authenticates before JSON parsing` describe block) sending a malformed-JSON body under four cases — unsigned, missing signature, malformed signature, invalid signature — asserting each is rejected with the signature-specific 401 rather than the generic "Malformed JSON body" 400 that parsing failure would produce. Confirmed these 4 tests failed against the pre-fix ordering (red), then passed after the fix (green).
- [x] Added a 5th regression test proving registry dispatch never occurs when authentication fails, even with well-formed JSON.
- [x] `npx turbo run test --filter=@franken/governor` — 25 test files, 347 tests passing.
- [x] `npx turbo run typecheck --filter=@franken/governor` — clean.

Closes #3722