### PR TITLE
fix(orchestrator): filter secret-shaped env vars before spawning LLM CLIs

### DIFF
--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -43,12 +43,15 @@ const SECRET_ENV_NAME_COMPOUND_PATTERN =
 /**
  * Env var names that would otherwise match the patterns above but are
  * capability/configuration pointers, not secrets themselves — e.g.
- * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket, and
- * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files. Stripping
- * these breaks legitimate CLI behavior (git/ssh via the user's agent, TLS
- * trust for provider HTTPS calls) without reducing secret exposure, since
- * none of them carry credential material in the variable itself. `PWD`
- * (present working directory) is included for the same reason.
+ * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket,
+ * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files, and
+ * `DOCKER_CERT_PATH` (see `network/services/managed-service-env.ts`) points
+ * at a directory of TLS client cert files for talking to a remote Docker
+ * daemon. Stripping these breaks legitimate CLI behavior (git/ssh via the
+ * user's agent, TLS trust for provider HTTPS calls, Docker client auth)
+ * without reducing secret exposure, since none of them carry credential
+ * material in the variable itself. `PWD` (present working directory) is
+ * included for the same reason.
  */
 const SAFE_ENV_NAME_EXCEPTIONS = new Set([
   'PWD',
@@ -57,11 +60,25 @@ const SAFE_ENV_NAME_EXCEPTIONS = new Set([
   'SSL_CERT_FILE',
   'SSL_CERT_DIR',
   'NODE_EXTRA_CA_CERTS',
+  'DOCKER_CERT_PATH',
 ]);
+
+/**
+ * Git's indexed runtime-config mechanism (`GIT_CONFIG_COUNT` plus
+ * `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` pairs) is how this repo
+ * itself injects config into spawned git commands (see
+ * `beasts/execution/docker-container-runtime.ts`). The `KEY` segment in
+ * `GIT_CONFIG_KEY_0` refers to a config key *name* (e.g. `safe.directory`),
+ * not a secret — stripping it silently breaks every git command the CLI
+ * runs. Exempt the whole indexed tuple by name shape rather than by value,
+ * since the mechanism is inherently non-secret.
+ */
+const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i];
 
 /** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
 export function isSecretEnvVarName(name: string): boolean {
   if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
+  if (SAFE_ENV_NAME_PATTERNS.some((pattern) => pattern.test(name))) return false;
   return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
 }
 
@@ -88,17 +105,40 @@ export function filterSecretEnvVars(
 }
 
 /**
+ * Vendor API key env vars for LiteLLM-supported backends aider can be
+ * pointed at via `providerOverrides.aider.model` (aider itself has no fixed
+ * backend — its default chat model is Claude Sonnet, but any LiteLLM model
+ * string is accepted). This can't be fully exhaustive — LiteLLM supports
+ * dozens of providers — but covers the common ones so overriding aider's
+ * model doesn't silently break auth. Extend this list if another backend is
+ * configured.
+ */
+const AIDER_LITELLM_BACKEND_AUTH_ENV_VARS: readonly string[] = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'AZURE_API_KEY',
+  'GEMINI_API_KEY',
+  'GROQ_API_KEY',
+  'MISTRAL_API_KEY',
+  'OPENROUTER_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'TOGETHER_API_KEY',
+  'COHERE_API_KEY',
+  'XAI_API_KEY',
+  'PERPLEXITY_API_KEY',
+  'FIREWORKS_API_KEY',
+];
+
+/**
  * Auth env var(s) each CLI provider needs preserved to authenticate itself,
  * even though the names are secret-shaped. `gemini` is intentionally absent:
  * its own `filterEnv()` already strips all `GEMINI*`/`GOOGLE*` vars, so it
- * doesn't rely on env-based auth surviving this filter. `aider`'s default
- * chat model runs on Claude but is user-configurable to any LiteLLM-backed
- * model, so both common vendor keys are preserved for it.
+ * doesn't rely on env-based auth surviving this filter.
  */
 const PROVIDER_AUTH_ENV_VAR_ALLOWLIST: Record<string, readonly string[]> = {
   claude: ['ANTHROPIC_API_KEY'],
   codex: ['OPENAI_API_KEY'],
-  aider: ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY'],
+  aider: AIDER_LITELLM_BACKEND_AUTH_ENV_VARS,
 };
 
 type CliCacheSessionHint = {

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -85,10 +85,14 @@ export function isSecretEnvVarName(name: string): boolean {
 /**
  * Returns a copy of `env` with any secret-shaped keys omitted, except for
  * names in `exemptNames` (case-insensitive) — used to let the actively
- * selected provider's own required auth var(s) (e.g. `ANTHROPIC_API_KEY` for
+ * selected provider's own required auth var(s) (from
+ * `ICliProvider.requiredAuthEnvVars()`, e.g. `ANTHROPIC_API_KEY` for
  * `claude`, `OPENAI_API_KEY` for `codex`) survive even though they are
  * themselves secret-shaped: they're the CLI's own designed auth channel, not
- * an unrelated ambient secret leaking through.
+ * an unrelated ambient secret leaking through. Declaring this on the
+ * provider (rather than a lookup table keyed by name here) means custom
+ * providers registered via `ProviderRegistry.register()` can preserve their
+ * own credentials too.
  */
 export function filterSecretEnvVars(
   env: Record<string, string>,
@@ -103,43 +107,6 @@ export function filterSecretEnvVars(
   }
   return filtered;
 }
-
-/**
- * Vendor API key env vars for LiteLLM-supported backends aider can be
- * pointed at via `providerOverrides.aider.model` (aider itself has no fixed
- * backend — its default chat model is Claude Sonnet, but any LiteLLM model
- * string is accepted). This can't be fully exhaustive — LiteLLM supports
- * dozens of providers — but covers the common ones so overriding aider's
- * model doesn't silently break auth. Extend this list if another backend is
- * configured.
- */
-const AIDER_LITELLM_BACKEND_AUTH_ENV_VARS: readonly string[] = [
-  'ANTHROPIC_API_KEY',
-  'OPENAI_API_KEY',
-  'AZURE_API_KEY',
-  'GEMINI_API_KEY',
-  'GROQ_API_KEY',
-  'MISTRAL_API_KEY',
-  'OPENROUTER_API_KEY',
-  'DEEPSEEK_API_KEY',
-  'TOGETHER_API_KEY',
-  'COHERE_API_KEY',
-  'XAI_API_KEY',
-  'PERPLEXITY_API_KEY',
-  'FIREWORKS_API_KEY',
-];
-
-/**
- * Auth env var(s) each CLI provider needs preserved to authenticate itself,
- * even though the names are secret-shaped. `gemini` is intentionally absent:
- * its own `filterEnv()` already strips all `GEMINI*`/`GOOGLE*` vars, so it
- * doesn't rely on env-based auth surviving this filter.
- */
-const PROVIDER_AUTH_ENV_VAR_ALLOWLIST: Record<string, readonly string[]> = {
-  claude: ['ANTHROPIC_API_KEY'],
-  codex: ['OPENAI_API_KEY'],
-  aider: AIDER_LITELLM_BACKEND_AUTH_ENV_VARS,
-};
 
 type CliCacheSessionHint = {
   key: string;
@@ -388,7 +355,7 @@ export class CliLlmAdapter implements IAdapter {
               : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),
           }),
-          env: provider.filterEnv(this.captureEnv(activeProvider)),
+          env: provider.filterEnv(this.captureEnv(provider)),
           prompt,
           signal,
           timeoutMs: Math.max(1, deadlineAt - Date.now()),
@@ -671,12 +638,12 @@ export class CliLlmAdapter implements IAdapter {
     return this.opts.providerOverrides?.[name]?.extraArgs;
   }
 
-  private captureEnv(providerName: string): Record<string, string> {
+  private captureEnv(provider: ICliProvider): Record<string, string> {
     const rawEnv: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) rawEnv[key] = value;
     }
-    const safeEnv = filterSecretEnvVars(rawEnv, PROVIDER_AUTH_ENV_VAR_ALLOWLIST[providerName]);
+    const safeEnv = filterSecretEnvVars(rawEnv, provider.requiredAuthEnvVars?.());
     if (isPlainOutput()) {
       safeEnv.NO_COLOR = safeEnv.NO_COLOR ?? '1';
       safeEnv.FORCE_COLOR = '0';

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -15,6 +15,40 @@ import {
 } from '../errors/command-failure.js';
 import { isPlainOutput, stripAnsi } from '../logging/beast-logger.js';
 
+/**
+ * Matches env var names that look like they carry a secret (API keys, tokens,
+ * passwords, credentials, certs, etc.), checked on underscore-delimited
+ * segments so unrelated names like `KEYBOARD_LAYOUT` or `PWD` are left alone.
+ *
+ * This is a denylist rather than a hand-maintained allowlist: the spawned CLI
+ * subprocesses (claude/codex/gemini/aider) need broad standard environment
+ * access to function (PATH, HOME, locale vars, npm/node config, etc.), so
+ * allowlisting would be brittle and prone to breaking legitimate CLI
+ * behavior. Only vars that look secret-shaped are stripped before the
+ * environment is handed to `spawn()`.
+ */
+const SECRET_ENV_NAME_PATTERN =
+  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK)(?:_|$)/i;
+
+/** Catches common secret-name segments written without a delimiter (e.g. `APIKEY`). */
+const SECRET_ENV_NAME_COMPOUND_PATTERN =
+  /(?:APIKEY|ACCESSKEY|SECRETKEY|PRIVATEKEY|AUTHTOKEN|CLIENTSECRET)/i;
+
+/** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
+export function isSecretEnvVarName(name: string): boolean {
+  return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
+}
+
+/** Returns a copy of `env` with any secret-shaped keys omitted. */
+export function filterSecretEnvVars(env: Record<string, string>): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isSecretEnvVarName(key)) continue;
+    filtered[key] = value;
+  }
+  return filtered;
+}
+
 type CliCacheSessionHint = {
   key: string;
   persist?: boolean;
@@ -550,11 +584,12 @@ export class CliLlmAdapter implements IAdapter {
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) rawEnv[key] = value;
     }
+    const safeEnv = filterSecretEnvVars(rawEnv);
     if (isPlainOutput()) {
-      rawEnv.NO_COLOR = rawEnv.NO_COLOR ?? '1';
-      rawEnv.FORCE_COLOR = '0';
+      safeEnv.NO_COLOR = safeEnv.NO_COLOR ?? '1';
+      safeEnv.FORCE_COLOR = '0';
     }
-    return rawEnv;
+    return safeEnv;
   }
 
   private resolveSleepMs(exhaustedProviders: Map<string, CommandFailure>): number {

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -18,7 +18,10 @@ import { isPlainOutput, stripAnsi } from '../logging/beast-logger.js';
 /**
  * Matches env var names that look like they carry a secret (API keys, tokens,
  * passwords, credentials, certs, etc.), checked on underscore-delimited
- * segments so unrelated names like `KEYBOARD_LAYOUT` or `PWD` are left alone.
+ * segments so unrelated names like `KEYBOARD_LAYOUT` are left alone. `PWD`
+ * (the shell's present-working-directory var) is included as a segment so
+ * `MYSQL_PWD` is caught, but the bare `PWD` name itself is special-cased as
+ * safe below.
  *
  * This is a denylist rather than a hand-maintained allowlist: the spawned CLI
  * subprocesses (claude/codex/gemini/aider) need broad standard environment
@@ -28,26 +31,75 @@ import { isPlainOutput, stripAnsi } from '../logging/beast-logger.js';
  * environment is handed to `spawn()`.
  */
 const SECRET_ENV_NAME_PATTERN =
-  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK)(?:_|$)/i;
+  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD)(?:_|$)/i;
 
-/** Catches common secret-name segments written without a delimiter (e.g. `APIKEY`). */
+/**
+ * Catches common secret-name segments written without a delimiter (e.g.
+ * `APIKEY`, `PGPASSWORD` — psql's undelimited password env var).
+ */
 const SECRET_ENV_NAME_COMPOUND_PATTERN =
-  /(?:APIKEY|ACCESSKEY|SECRETKEY|PRIVATEKEY|AUTHTOKEN|CLIENTSECRET)/i;
+  /(?:APIKEY|ACCESSKEY|SECRETKEY|PRIVATEKEY|AUTHTOKEN|CLIENTSECRET|PASSWORD)/i;
+
+/**
+ * Env var names that would otherwise match the patterns above but are
+ * capability/configuration pointers, not secrets themselves — e.g.
+ * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket, and
+ * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files. Stripping
+ * these breaks legitimate CLI behavior (git/ssh via the user's agent, TLS
+ * trust for provider HTTPS calls) without reducing secret exposure, since
+ * none of them carry credential material in the variable itself. `PWD`
+ * (present working directory) is included for the same reason.
+ */
+const SAFE_ENV_NAME_EXCEPTIONS = new Set([
+  'PWD',
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'NODE_EXTRA_CA_CERTS',
+]);
 
 /** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
 export function isSecretEnvVarName(name: string): boolean {
+  if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
   return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
 }
 
-/** Returns a copy of `env` with any secret-shaped keys omitted. */
-export function filterSecretEnvVars(env: Record<string, string>): Record<string, string> {
+/**
+ * Returns a copy of `env` with any secret-shaped keys omitted, except for
+ * names in `exemptNames` (case-insensitive) — used to let the actively
+ * selected provider's own required auth var(s) (e.g. `ANTHROPIC_API_KEY` for
+ * `claude`, `OPENAI_API_KEY` for `codex`) survive even though they are
+ * themselves secret-shaped: they're the CLI's own designed auth channel, not
+ * an unrelated ambient secret leaking through.
+ */
+export function filterSecretEnvVars(
+  env: Record<string, string>,
+  exemptNames?: readonly string[],
+): Record<string, string> {
+  const exempt = new Set((exemptNames ?? []).map((name) => name.toUpperCase()));
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (isSecretEnvVarName(key)) continue;
-    filtered[key] = value;
+    if (exempt.has(key.toUpperCase()) || !isSecretEnvVarName(key)) {
+      filtered[key] = value;
+    }
   }
   return filtered;
 }
+
+/**
+ * Auth env var(s) each CLI provider needs preserved to authenticate itself,
+ * even though the names are secret-shaped. `gemini` is intentionally absent:
+ * its own `filterEnv()` already strips all `GEMINI*`/`GOOGLE*` vars, so it
+ * doesn't rely on env-based auth surviving this filter. `aider`'s default
+ * chat model runs on Claude but is user-configurable to any LiteLLM-backed
+ * model, so both common vendor keys are preserved for it.
+ */
+const PROVIDER_AUTH_ENV_VAR_ALLOWLIST: Record<string, readonly string[]> = {
+  claude: ['ANTHROPIC_API_KEY'],
+  codex: ['OPENAI_API_KEY'],
+  aider: ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY'],
+};
 
 type CliCacheSessionHint = {
   key: string;
@@ -296,7 +348,7 @@ export class CliLlmAdapter implements IAdapter {
               : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),
           }),
-          env: provider.filterEnv(this.captureEnv()),
+          env: provider.filterEnv(this.captureEnv(activeProvider)),
           prompt,
           signal,
           timeoutMs: Math.max(1, deadlineAt - Date.now()),
@@ -579,12 +631,12 @@ export class CliLlmAdapter implements IAdapter {
     return this.opts.providerOverrides?.[name]?.extraArgs;
   }
 
-  private captureEnv(): Record<string, string> {
+  private captureEnv(providerName: string): Record<string, string> {
     const rawEnv: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) rawEnv[key] = value;
     }
-    const safeEnv = filterSecretEnvVars(rawEnv);
+    const safeEnv = filterSecretEnvVars(rawEnv, PROVIDER_AUTH_ENV_VAR_ALLOWLIST[providerName]);
     if (isPlainOutput()) {
       safeEnv.NO_COLOR = safeEnv.NO_COLOR ?? '1';
       safeEnv.FORCE_COLOR = '0';

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -14,99 +14,12 @@ import {
   type CommandFailure,
 } from '../errors/command-failure.js';
 import { isPlainOutput, stripAnsi } from '../logging/beast-logger.js';
+import { filterSecretEnvVars, isSecretEnvVarName } from '../security/env-filter.js';
 
-/**
- * Matches env var names that look like they carry a secret (API keys, tokens,
- * passwords, credentials, certs, etc.), checked on underscore-delimited
- * segments so unrelated names like `KEYBOARD_LAYOUT` are left alone. `PWD`
- * (the shell's present-working-directory var) is included as a segment so
- * `MYSQL_PWD` is caught, but the bare `PWD` name itself is special-cased as
- * safe below.
- *
- * This is a denylist rather than a hand-maintained allowlist: the spawned CLI
- * subprocesses (claude/codex/gemini/aider) need broad standard environment
- * access to function (PATH, HOME, locale vars, npm/node config, etc.), so
- * allowlisting would be brittle and prone to breaking legitimate CLI
- * behavior. Only vars that look secret-shaped are stripped before the
- * environment is handed to `spawn()`.
- */
-const SECRET_ENV_NAME_PATTERN =
-  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD)(?:_|$)/i;
-
-/**
- * Catches common secret-name segments written without a delimiter (e.g.
- * `APIKEY`, `PGPASSWORD` — psql's undelimited password env var).
- */
-const SECRET_ENV_NAME_COMPOUND_PATTERN =
-  /(?:APIKEY|ACCESSKEY|SECRETKEY|PRIVATEKEY|AUTHTOKEN|CLIENTSECRET|PASSWORD)/i;
-
-/**
- * Env var names that would otherwise match the patterns above but are
- * capability/configuration pointers, not secrets themselves — e.g.
- * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket,
- * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files, and
- * `DOCKER_CERT_PATH` (see `network/services/managed-service-env.ts`) points
- * at a directory of TLS client cert files for talking to a remote Docker
- * daemon. Stripping these breaks legitimate CLI behavior (git/ssh via the
- * user's agent, TLS trust for provider HTTPS calls, Docker client auth)
- * without reducing secret exposure, since none of them carry credential
- * material in the variable itself. `PWD` (present working directory) is
- * included for the same reason.
- */
-const SAFE_ENV_NAME_EXCEPTIONS = new Set([
-  'PWD',
-  'SSH_AUTH_SOCK',
-  'SSH_AGENT_PID',
-  'SSL_CERT_FILE',
-  'SSL_CERT_DIR',
-  'NODE_EXTRA_CA_CERTS',
-  'DOCKER_CERT_PATH',
-]);
-
-/**
- * Git's indexed runtime-config mechanism (`GIT_CONFIG_COUNT` plus
- * `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` pairs) is how this repo
- * itself injects config into spawned git commands (see
- * `beasts/execution/docker-container-runtime.ts`). The `KEY` segment in
- * `GIT_CONFIG_KEY_0` refers to a config key *name* (e.g. `safe.directory`),
- * not a secret — stripping it silently breaks every git command the CLI
- * runs. Exempt the whole indexed tuple by name shape rather than by value,
- * since the mechanism is inherently non-secret.
- */
-const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i];
-
-/** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
-export function isSecretEnvVarName(name: string): boolean {
-  if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
-  if (SAFE_ENV_NAME_PATTERNS.some((pattern) => pattern.test(name))) return false;
-  return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
-}
-
-/**
- * Returns a copy of `env` with any secret-shaped keys omitted, except for
- * names in `exemptNames` (case-insensitive) — used to let the actively
- * selected provider's own required auth var(s) (from
- * `ICliProvider.requiredAuthEnvVars()`, e.g. `ANTHROPIC_API_KEY` for
- * `claude`, `OPENAI_API_KEY` for `codex`) survive even though they are
- * themselves secret-shaped: they're the CLI's own designed auth channel, not
- * an unrelated ambient secret leaking through. Declaring this on the
- * provider (rather than a lookup table keyed by name here) means custom
- * providers registered via `ProviderRegistry.register()` can preserve their
- * own credentials too.
- */
-export function filterSecretEnvVars(
-  env: Record<string, string>,
-  exemptNames?: readonly string[],
-): Record<string, string> {
-  const exempt = new Set((exemptNames ?? []).map((name) => name.toUpperCase()));
-  const filtered: Record<string, string> = {};
-  for (const [key, value] of Object.entries(env)) {
-    if (exempt.has(key.toUpperCase()) || !isSecretEnvVarName(key)) {
-      filtered[key] = value;
-    }
-  }
-  return filtered;
-}
+// Re-exported for backward compatibility — the filtering logic now lives in
+// `security/env-filter.ts` so it can be shared with the Martin-loop spawn
+// path (`skills/martin-loop.ts`), which has its own `spawn()` call site.
+export { filterSecretEnvVars, isSecretEnvVarName };
 
 type CliCacheSessionHint = {
   key: string;
@@ -355,7 +268,7 @@ export class CliLlmAdapter implements IAdapter {
               : {}),
             extraArgs: this.resolveExtraArgs(activeProvider),
           }),
-          env: provider.filterEnv(this.captureEnv(provider)),
+          env: provider.filterEnv(this.captureEnv(provider, activeModel)),
           prompt,
           signal,
           timeoutMs: Math.max(1, deadlineAt - Date.now()),
@@ -638,12 +551,12 @@ export class CliLlmAdapter implements IAdapter {
     return this.opts.providerOverrides?.[name]?.extraArgs;
   }
 
-  private captureEnv(provider: ICliProvider): Record<string, string> {
+  private captureEnv(provider: ICliProvider, model: string | undefined): Record<string, string> {
     const rawEnv: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) rawEnv[key] = value;
     }
-    const safeEnv = filterSecretEnvVars(rawEnv, provider.requiredAuthEnvVars?.());
+    const safeEnv = filterSecretEnvVars(rawEnv, provider.requiredAuthEnvVars?.(model));
     if (isPlainOutput()) {
       safeEnv.NO_COLOR = safeEnv.NO_COLOR ?? '1';
       safeEnv.FORCE_COLOR = '0';

--- a/packages/franken-orchestrator/src/cli/run.ts
+++ b/packages/franken-orchestrator/src/cli/run.ts
@@ -9,6 +9,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 import { accessSync, constants, existsSync, lstatSync, readdirSync, statSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { parseArgs, printUsage } from './args.js';
 import type { CliArgs } from './args.js';
@@ -753,7 +754,13 @@ function scheduleDashboardCommandHealthProbe(command: string): void {
     checking: true,
   });
   try {
-    const proc = spawn(command, ['--version'], { stdio: 'ignore', timeout: 5_000 });
+    const proc = spawn(command, ['--version'], {
+      stdio: 'ignore',
+      timeout: 5_000,
+      // A --version probe never needs to authenticate, so no provider auth
+      // exemption — just strip anything secret-shaped from the ambient env.
+      env: filterSecretEnvVars(process.env as Record<string, string>),
+    });
     const finish = (available: boolean) => {
       dashboardCommandHealthCache.set(command, { available, checkedAt: Date.now(), checking: false });
     };

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -15,6 +15,7 @@ import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js';
 import { sanitizeRunConfigIntegrityEnv } from '../cli/run-config-integrity.js';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 
 function terminateRunningProcess(proc: ChildProcess): void {
   if (proc.exitCode === null && proc.signalCode === null) {
@@ -150,7 +151,10 @@ export class ClaudeCliAdapter implements ILlmProvider {
   }
 
   sanitizedEnv(): Record<string, string> {
-    const env = sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>);
+    const env = filterSecretEnvVars(
+      sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+      ['ANTHROPIC_API_KEY'],
+    );
     for (const key of Object.keys(env)) {
       if (key.startsWith('CLAUDE')) {
         delete env[key];

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -14,6 +14,7 @@ import { deterministicUuid } from '@franken/types';
 import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 import { sanitizeRunConfigIntegrityEnv } from '../cli/run-config-integrity.js';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 import { resolveCodexSandboxArgs } from './codex-args.js';
 
 function terminateRunningProcess(proc: ChildProcess): void {
@@ -45,14 +46,21 @@ export class CodexCliAdapter implements ILlmProvider {
 
   constructor(private options: CodexCliOptions = {}) {}
 
+  sanitizedEnv(): Record<string, string> {
+    return filterSecretEnvVars(
+      sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+      ['OPENAI_API_KEY'],
+    );
+  }
+
   async isAvailable(): Promise<boolean> {
-    return isCliAvailable(this.binaryPath, sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>));
+    return isCliAvailable(this.binaryPath, this.sanitizedEnv());
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
     const args = this.buildArgs(request);
     const proc = spawn(this.binaryPath, args, {
-      env: sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+      env: this.sanitizedEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
@@ -95,7 +103,7 @@ export class CodexCliAdapter implements ILlmProvider {
       const { stdout, exitCode } = await collectCliOutput(
         this.binaryPath,
         ['mcp', 'list', '--json'],
-        sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+        this.sanitizedEnv(),
       );
       if (exitCode !== 0 || !stdout.trim()) return [];
 

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -32,6 +32,7 @@ import { formatHandoff } from './format-handoff.js';
 import { collectCliOutput, extractAuthFields, isCliAvailable } from './discover-skills-helpers.js';
 import { tryExtractTextFromNode } from '../skills/providers/stream-json-utils.js';
 import { sanitizeRunConfigIntegrityEnv } from '../cli/run-config-integrity.js';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 
 const MANAGED_START = '<!-- FRANKENBEAST MANAGED SECTION - DO NOT EDIT -->';
 const MANAGED_END = '<!-- END FRANKENBEAST SECTION -->';
@@ -64,8 +65,16 @@ export class GeminiCliAdapter implements ILlmProvider {
 
   constructor(private options: GeminiCliOptions = {}) {}
 
+  // No auth-var exemption: gemini-provider.ts's own filterEnv() already
+  // strips all GEMINI*/GOOGLE* vars for the ICliProvider path, so this
+  // consolidated ILlmProvider path doesn't rely on env-based auth surviving
+  // this filter either.
+  sanitizedEnv(): Record<string, string> {
+    return filterSecretEnvVars(sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>));
+  }
+
   async isAvailable(): Promise<boolean> {
-    return isCliAvailable(this.binaryPath, sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>));
+    return isCliAvailable(this.binaryPath, this.sanitizedEnv());
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
@@ -97,7 +106,7 @@ export class GeminiCliAdapter implements ILlmProvider {
       const proc = spawn(this.binaryPath, args, {
         cwd: workspaceDir,
         env: {
-          ...sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+          ...this.sanitizedEnv(),
           GEMINI_CLI_SYSTEM_DEFAULTS_PATH: this.effectiveSystemDefaultsPath(),
           GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
         },
@@ -150,7 +159,7 @@ export class GeminiCliAdapter implements ILlmProvider {
       const { stdout, exitCode } = await collectCliOutput(
         this.binaryPath,
         ['tool', 'list', '--json'],
-        sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+        this.sanitizedEnv(),
       );
       if (exitCode !== 0 || !stdout.trim()) {
         return this.discoverFromSettingsFile();

--- a/packages/franken-orchestrator/src/runtime/codex/codex-app-server-client.ts
+++ b/packages/franken-orchestrator/src/runtime/codex/codex-app-server-client.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import type { CodexAppServerRequest, CodexAppServerRequestOptions } from './codex-runtime-adapter.js';
+import { filterSecretEnvVars } from '../../security/env-filter.js';
 
 export interface CodexAppServerClientOptions {
   command?: string | undefined;
@@ -180,7 +181,7 @@ export function createCodexAppServerRequest(
   const ensureServer = (): Promise<void> => {
     if (child !== null && initialization !== null) return initialization;
     const server = spawn(command, ['app-server', '--stdio'], {
-      env: options.env ?? process.env,
+      env: options.env ?? filterSecretEnvVars(process.env as Record<string, string>, ['OPENAI_API_KEY']),
       shell: false,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,

--- a/packages/franken-orchestrator/src/runtime/codex/codex-app-server-client.ts
+++ b/packages/franken-orchestrator/src/runtime/codex/codex-app-server-client.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import type { CodexAppServerRequest, CodexAppServerRequestOptions } from './codex-runtime-adapter.js';
 import { filterSecretEnvVars } from '../../security/env-filter.js';
+import { sanitizeRunConfigIntegrityEnv } from '../../cli/run-config-integrity.js';
 
 export interface CodexAppServerClientOptions {
   command?: string | undefined;
@@ -181,7 +182,10 @@ export function createCodexAppServerRequest(
   const ensureServer = (): Promise<void> => {
     if (child !== null && initialization !== null) return initialization;
     const server = spawn(command, ['app-server', '--stdio'], {
-      env: options.env ?? filterSecretEnvVars(process.env as Record<string, string>, ['OPENAI_API_KEY']),
+      env: options.env ?? filterSecretEnvVars(
+        sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
+        ['OPENAI_API_KEY'],
+      ),
       shell: false,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,

--- a/packages/franken-orchestrator/src/runtime/runtime-defaults.ts
+++ b/packages/franken-orchestrator/src/runtime/runtime-defaults.ts
@@ -2,6 +2,7 @@ import { CodexRuntimeAdapter, type CodexRuntimeAdapterOptions } from './codex/co
 import { HermesRuntimeAdapter, type HermesRuntimeAdapterOptions } from './hermes/hermes-runtime-adapter.js';
 import { OllamaRuntimeAdapter, type OllamaRuntimeAdapterOptions } from './ollama/ollama-runtime-adapter.js';
 import { RuntimeAdapterRegistry } from './runtime-adapter-registry.js';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 
 export interface RuntimeAdapterDefaultsOptions extends HermesRuntimeAdapterOptions, OllamaRuntimeAdapterOptions {
   codex?: CodexRuntimeAdapterOptions | undefined;
@@ -14,9 +15,15 @@ export function createDefaultRuntimeAdapterRegistry(
 ): RuntimeAdapterRegistry {
   const codexOptions: CodexRuntimeAdapterOptions = {
     ...options.codex,
+    // Merging the caller's partial override on top of the complete
+    // process.env (so an override like { PATH } doesn't drop everything
+    // else the CLI needs) re-introduces the exact ambient-secret-forwarding
+    // problem this filter exists to prevent — filter the merged result the
+    // same way codex-app-server-client.ts's own default path does, rather
+    // than assuming a caller-supplied env is automatically safe.
     env: options.codex?.env ?? (options.env === undefined
       ? undefined
-      : { ...process.env, ...options.env }),
+      : filterSecretEnvVars({ ...process.env, ...options.env } as Record<string, string>, ['OPENAI_API_KEY'])),
   };
   return new RuntimeAdapterRegistry([
     new HermesRuntimeAdapter(options),

--- a/packages/franken-orchestrator/src/security/env-filter.ts
+++ b/packages/franken-orchestrator/src/security/env-filter.ts
@@ -22,7 +22,7 @@
  * safe below.
  */
 const SECRET_ENV_NAME_PATTERN =
-  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD|PAT)(?:_|$)/i;
+  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD|PAT|JWT)(?:_|$)/i;
 
 /**
  * Catches common secret-name segments written without a delimiter (e.g.
@@ -83,7 +83,11 @@ const SAFE_ENV_NAME_EXCEPTIONS = new Set([
  * runs. Exempt the whole indexed tuple by name shape rather than by value,
  * since the mechanism is inherently non-secret.
  */
-const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i];
+const GIT_CONFIG_FAMILY_NAME_PATTERN = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i;
+const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [GIT_CONFIG_FAMILY_NAME_PATTERN];
+
+/** Matches just the `GIT_CONFIG_VALUE_<n>` half of the tuple, to scan for a secret-shaped value. */
+const GIT_CONFIG_VALUE_NAME_PATTERN = /^GIT_CONFIG_VALUE_\d+$/i;
 
 /**
  * Matches connection-string *values* with embedded `user:password@` userinfo
@@ -113,6 +117,14 @@ const AUTH_HEADER_VALUE_PATTERN = /^(?:authorization|proxy-authorization)\s*:\s*
 /** Matches a bare `Bearer <token>` / `Basic <token>` value (no header name prefix). */
 const BEARER_TOKEN_VALUE_PATTERN = /^(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}$/i;
 
+/**
+ * Matches a raw JWT value (three base64url segments joined by `.`) — e.g. CI
+ * systems commonly export a live credential under a name with no secret-shaped
+ * segment, like `CI_JOB_JWT`/`CI_JOB_JWT_V2`. Same three-segment shape this
+ * repo already treats as sensitive in `issues/issue-runner.ts`.
+ */
+const JWT_VALUE_PATTERN = /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}$/;
+
 /** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
 export function isSecretEnvVarName(name: string): boolean {
   if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
@@ -122,11 +134,12 @@ export function isSecretEnvVarName(name: string): boolean {
   return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
 }
 
-/** True if an env var's *value* looks like a connection string or auth header carrying embedded credentials. */
+/** True if an env var's *value* looks like a connection string, auth header, or raw JWT carrying embedded credentials. */
 export function isSecretEnvVarValue(value: string): boolean {
   return CREDENTIAL_URL_VALUE_PATTERN.test(value)
     || AUTH_HEADER_VALUE_PATTERN.test(value)
-    || BEARER_TOKEN_VALUE_PATTERN.test(value);
+    || BEARER_TOKEN_VALUE_PATTERN.test(value)
+    || JWT_VALUE_PATTERN.test(value);
 }
 
 /**
@@ -141,21 +154,37 @@ export function isSecretEnvVarValue(value: string): boolean {
  * here) means custom providers registered via `ProviderRegistry.register()`
  * can preserve their own credentials too.
  *
- * `exemptNames` is matched case-sensitively (unlike the general secret-name
- * detection above): env var names are case-sensitive on POSIX, and each
- * `exemptNames` entry names one specific, exact-case var the CLI actually
- * reads for auth — a differently-cased var of the same spelling is a
- * distinct variable that provider didn't declare and must still be filtered
- * on its own merits.
+ * `exemptNames` matching follows the OS's own env var name semantics: exact
+ * case on POSIX, where env var names are case-sensitive and a
+ * differently-cased var of the same spelling is a genuinely distinct
+ * variable the provider didn't declare; case-insensitive on Windows, where
+ * env var names themselves are case-insensitive (`OpenAI_API_Key` and
+ * `OPENAI_API_KEY` name the same variable, and the CLI would read either).
  */
 export function filterSecretEnvVars(
   env: Record<string, string>,
   exemptNames?: readonly string[],
 ): Record<string, string> {
-  const exempt = new Set(exemptNames ?? []);
+  const caseInsensitiveExempt = process.platform === 'win32';
+  const normalize = (name: string): string => (caseInsensitiveExempt ? name.toUpperCase() : name);
+  const exempt = new Set((exemptNames ?? []).map(normalize));
+
+  // GIT_CONFIG_KEY_<n>/VALUE_<n>/COUNT is git's genuine indexed
+  // config-injection mechanism (see SAFE_ENV_NAME_PATTERNS above) — but if
+  // any GIT_CONFIG_VALUE_<n> turns out to be secret-shaped (e.g. a smuggled
+  // Authorization header), dropping only that VALUE_<n> leaves a malformed
+  // tuple (COUNT and KEY_<n> present, VALUE_<n> missing) that makes git
+  // itself error out ("missing config value") on every command the CLI
+  // runs. Drop the whole GIT_CONFIG_* family atomically instead, so git
+  // simply doesn't see the mechanism at all rather than seeing it broken.
+  const dropGitConfigFamily = Object.entries(env).some(
+    ([key, value]) => GIT_CONFIG_VALUE_NAME_PATTERN.test(key) && isSecretEnvVarValue(value),
+  );
+
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (exempt.has(key)) {
+    if (dropGitConfigFamily && GIT_CONFIG_FAMILY_NAME_PATTERN.test(key)) continue;
+    if (exempt.has(normalize(key))) {
       filtered[key] = value;
       continue;
     }

--- a/packages/franken-orchestrator/src/security/env-filter.ts
+++ b/packages/franken-orchestrator/src/security/env-filter.ts
@@ -22,7 +22,7 @@
  * safe below.
  */
 const SECRET_ENV_NAME_PATTERN =
-  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD)(?:_|$)/i;
+  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD|PAT)(?:_|$)/i;
 
 /**
  * Catches common secret-name segments written without a delimiter (e.g.
@@ -95,6 +95,24 @@ const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [/^GIT_CONFIG_(?:COUNT|KEY_\d+
 const CREDENTIAL_URL_VALUE_PATTERN =
   /^(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?):\/\/[^:\s"'/@]*:[^@\s"']+@/i;
 
+/**
+ * Matches values shaped like a raw `Authorization`/`Proxy-Authorization`
+ * HTTP header. Needed because `GIT_CONFIG_KEY_<n>`/`VALUE_<n>` (see
+ * `SAFE_ENV_NAME_PATTERNS` below) is git's genuine indexed config-injection
+ * mechanism and its `GIT_CONFIG_VALUE_<n>` name is exempt by shape — but git
+ * supports `http.extraHeader`, so an attacker- or config-controlled tuple
+ * could set `GIT_CONFIG_KEY_0=http.extraHeader` /
+ * `GIT_CONFIG_VALUE_0=Authorization: Bearer <token>` to smuggle a live
+ * credential through under a name the filter otherwise trusts. The name
+ * exemption only bypasses `isSecretEnvVarName` — `filterSecretEnvVars` still
+ * runs `isSecretEnvVarValue` on every var regardless of its name, so this
+ * catches it independent of what the var happens to be called.
+ */
+const AUTH_HEADER_VALUE_PATTERN = /^(?:authorization|proxy-authorization)\s*:\s*\S+/i;
+
+/** Matches a bare `Bearer <token>` / `Basic <token>` value (no header name prefix). */
+const BEARER_TOKEN_VALUE_PATTERN = /^(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}$/i;
+
 /** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
 export function isSecretEnvVarName(name: string): boolean {
   if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
@@ -104,31 +122,40 @@ export function isSecretEnvVarName(name: string): boolean {
   return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
 }
 
-/** True if an env var's *value* looks like a connection string with embedded credentials. */
+/** True if an env var's *value* looks like a connection string or auth header carrying embedded credentials. */
 export function isSecretEnvVarValue(value: string): boolean {
-  return CREDENTIAL_URL_VALUE_PATTERN.test(value);
+  return CREDENTIAL_URL_VALUE_PATTERN.test(value)
+    || AUTH_HEADER_VALUE_PATTERN.test(value)
+    || BEARER_TOKEN_VALUE_PATTERN.test(value);
 }
 
 /**
  * Returns a copy of `env` with any secret-shaped keys (by name or, for
- * connection-string values, by value) omitted, except for names in
- * `exemptNames` (case-insensitive) — used to let the actively selected
- * provider's own required auth var(s) (from `ICliProvider.requiredAuthEnvVars()`,
- * e.g. `ANTHROPIC_API_KEY` for `claude`, `OPENAI_API_KEY` for `codex`)
- * survive even though they are themselves secret-shaped: they're the CLI's
- * own designed auth channel, not an unrelated ambient secret leaking
- * through. Declaring this on the provider (rather than a lookup table keyed
- * by name here) means custom providers registered via
- * `ProviderRegistry.register()` can preserve their own credentials too.
+ * connection-string/auth-header values, by value) omitted, except for names
+ * in `exemptNames` — used to let the actively selected provider's own
+ * required auth var(s) (from `ICliProvider.requiredAuthEnvVars()`, e.g.
+ * `ANTHROPIC_API_KEY` for `claude`, `OPENAI_API_KEY` for `codex`) survive
+ * even though they are themselves secret-shaped: they're the CLI's own
+ * designed auth channel, not an unrelated ambient secret leaking through.
+ * Declaring this on the provider (rather than a lookup table keyed by name
+ * here) means custom providers registered via `ProviderRegistry.register()`
+ * can preserve their own credentials too.
+ *
+ * `exemptNames` is matched case-sensitively (unlike the general secret-name
+ * detection above): env var names are case-sensitive on POSIX, and each
+ * `exemptNames` entry names one specific, exact-case var the CLI actually
+ * reads for auth — a differently-cased var of the same spelling is a
+ * distinct variable that provider didn't declare and must still be filtered
+ * on its own merits.
  */
 export function filterSecretEnvVars(
   env: Record<string, string>,
   exemptNames?: readonly string[],
 ): Record<string, string> {
-  const exempt = new Set((exemptNames ?? []).map((name) => name.toUpperCase()));
+  const exempt = new Set(exemptNames ?? []);
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (exempt.has(key.toUpperCase())) {
+    if (exempt.has(key)) {
       filtered[key] = value;
       continue;
     }

--- a/packages/franken-orchestrator/src/security/env-filter.ts
+++ b/packages/franken-orchestrator/src/security/env-filter.ts
@@ -14,6 +14,24 @@
  */
 
 /**
+ * True on Windows, where env var names are case-insensitive (`OpenAI_API_Key`
+ * and `OPENAI_API_KEY` name the same variable). False on POSIX, where they
+ * are genuinely distinct variables. Used only for the "is this literally the
+ * same well-known variable" checks below (safe-name exceptions, provider
+ * auth exemptions) — the general secret-*shape* detection patterns stay
+ * unconditionally case-insensitive, since they're guarding against secrets
+ * in any casing, not matching a specific known variable.
+ */
+function isWindowsPlatform(): boolean {
+  return process.platform === 'win32';
+}
+
+/** Normalizes an env var name for exact-identity comparisons, per OS env-var-name case semantics. */
+function normalizeEnvVarName(name: string): string {
+  return isWindowsPlatform() ? name.toUpperCase() : name;
+}
+
+/**
  * Matches env var names that look like they carry a secret (API keys, tokens,
  * passwords, credentials, certs, etc.), checked on underscore-delimited
  * segments so unrelated names like `KEYBOARD_LAYOUT` are left alone. `PWD`
@@ -51,17 +69,24 @@ const KNOWN_SECRET_ENV_NAMES = new Set(['BW_SESSION']);
 const SECRET_ENV_NAME_ADDITIONAL_PATTERNS: readonly RegExp[] = [/^OP_SESSION_[A-Za-z0-9_]+$/i];
 
 /**
- * Env var names that would otherwise match the patterns above but are
- * capability/configuration pointers, not secrets themselves — e.g.
- * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket,
- * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files, and
- * `DOCKER_CERT_PATH` (see `network/services/managed-service-env.ts`) points
- * at a directory of TLS client cert files for talking to a remote Docker
- * daemon. Stripping these breaks legitimate CLI behavior (git/ssh via the
- * user's agent, TLS trust for provider HTTPS calls, Docker client auth)
- * without reducing secret exposure, since none of them carry credential
- * material in the variable itself. `PWD` (present working directory) is
- * included for the same reason.
+ * Env var names (in their canonical, real-world case) that would otherwise
+ * match the patterns above but are capability/configuration pointers, not
+ * secrets themselves — e.g. `SSH_AUTH_SOCK` is a path to the running
+ * ssh-agent's socket, `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS`/`PIP_CERT` point
+ * at CA bundle files, and `DOCKER_CERT_PATH` (see
+ * `network/services/managed-service-env.ts`) points at a directory of TLS
+ * client cert files for talking to a remote Docker daemon. Stripping these
+ * breaks legitimate CLI behavior (git/ssh via the user's agent, TLS trust
+ * for provider HTTPS/pip calls, Docker client auth) without reducing secret
+ * exposure, since none of them carry credential material in the variable
+ * itself. `PWD` (present working directory) is included for the same
+ * reason.
+ *
+ * Matched via `normalizeEnvVarName` (exact case on POSIX, case-insensitive
+ * on Windows) — a differently-cased var on POSIX (e.g. `ssh_auth_sock`) is a
+ * genuinely distinct variable and must still be checked against the
+ * denylist patterns below, not waved through just because it collides
+ * case-insensitively with a well-known safe name.
  */
 const SAFE_ENV_NAME_EXCEPTIONS = new Set([
   'PWD',
@@ -71,6 +96,7 @@ const SAFE_ENV_NAME_EXCEPTIONS = new Set([
   'SSL_CERT_DIR',
   'NODE_EXTRA_CA_CERTS',
   'DOCKER_CERT_PATH',
+  'PIP_CERT',
 ]);
 
 /**
@@ -81,36 +107,52 @@ const SAFE_ENV_NAME_EXCEPTIONS = new Set([
  * `GIT_CONFIG_KEY_0` refers to a config key *name* (e.g. `safe.directory`),
  * not a secret — stripping it silently breaks every git command the CLI
  * runs. Exempt the whole indexed tuple by name shape rather than by value,
- * since the mechanism is inherently non-secret.
+ * since the mechanism is inherently non-secret (values are checked
+ * separately below regardless of this exemption).
+ *
+ * Written in canonical uppercase and matched via `normalizeEnvVarName`, same
+ * case semantics as `SAFE_ENV_NAME_EXCEPTIONS` above.
  */
-const GIT_CONFIG_FAMILY_NAME_PATTERN = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i;
+const GIT_CONFIG_FAMILY_NAME_PATTERN = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/;
 const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [GIT_CONFIG_FAMILY_NAME_PATTERN];
 
-/** Matches just the `GIT_CONFIG_VALUE_<n>` half of the tuple, to scan for a secret-shaped value. */
-const GIT_CONFIG_VALUE_NAME_PATTERN = /^GIT_CONFIG_VALUE_\d+$/i;
+/** Matches just the `GIT_CONFIG_VALUE_<n>` half of the tuple, capturing the index. */
+const GIT_CONFIG_VALUE_NAME_PATTERN = /^GIT_CONFIG_VALUE_(\d+)$/;
+/** Matches just the `GIT_CONFIG_KEY_<n>` half of the tuple, capturing the index. */
+const GIT_CONFIG_KEY_NAME_PATTERN = /^GIT_CONFIG_KEY_(\d+)$/;
+
+/**
+ * Git config keys whose *value* injects an arbitrary HTTP header (or similar
+ * free-form config) into every request git makes — e.g. `http.extraHeader`
+ * accepts literally any header, including `PRIVATE-TOKEN: glpat-...`
+ * (GitLab), `JOB-TOKEN: ...`, or a custom bearer scheme, not just
+ * `Authorization:`. Enumerating every possible credential header *name* is
+ * unbounded, so instead treat any `GIT_CONFIG_VALUE_<n>` paired with one of
+ * these *keys* as inherently secret-shaped regardless of its literal
+ * content. Git config key names are themselves case-insensitive, so this
+ * comparison is deliberately case-insensitive regardless of OS — it's about
+ * git's own semantics, not the env var name.
+ */
+const GIT_CONFIG_CREDENTIAL_BEARING_KEYS = new Set(['http.extraheader']);
 
 /**
  * Matches connection-string *values* with embedded `user:password@` userinfo
- * for common database schemes — e.g. `DATABASE_URL=postgres://user:pass@host/db`.
- * The var name (`DATABASE_URL`, `REDIS_URL`, ...) doesn't look secret-shaped
- * by itself, so this checks the value directly. Same scheme list this repo
- * already treats as sensitive in `logging/redaction.ts`.
+ * for any URL scheme (not just databases) — e.g.
+ * `DATABASE_URL=postgres://user:pass@host/db` or
+ * `PIP_INDEX_URL=https://user:pass@packages.example/simple`. The var name
+ * doesn't look secret-shaped by itself, so this checks the value directly.
+ * Same userinfo-in-any-scheme treatment this repo already applies in
+ * `logging/redaction.ts`. URL schemes are case-insensitive per RFC 3986
+ * regardless of OS, so this stays unconditionally case-insensitive.
  */
 const CREDENTIAL_URL_VALUE_PATTERN =
-  /^(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?):\/\/[^:\s"'/@]*:[^@\s"']+@/i;
+  /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^:\s"'/@]*:[^@\s"']+@/i;
 
 /**
  * Matches values shaped like a raw `Authorization`/`Proxy-Authorization`
- * HTTP header. Needed because `GIT_CONFIG_KEY_<n>`/`VALUE_<n>` (see
- * `SAFE_ENV_NAME_PATTERNS` below) is git's genuine indexed config-injection
- * mechanism and its `GIT_CONFIG_VALUE_<n>` name is exempt by shape — but git
- * supports `http.extraHeader`, so an attacker- or config-controlled tuple
- * could set `GIT_CONFIG_KEY_0=http.extraHeader` /
- * `GIT_CONFIG_VALUE_0=Authorization: Bearer <token>` to smuggle a live
- * credential through under a name the filter otherwise trusts. The name
- * exemption only bypasses `isSecretEnvVarName` — `filterSecretEnvVars` still
- * runs `isSecretEnvVarValue` on every var regardless of its name, so this
- * catches it independent of what the var happens to be called.
+ * HTTP header (a fallback for header-injection vectors not covered by the
+ * `GIT_CONFIG_CREDENTIAL_BEARING_KEYS` check above — e.g. the header value
+ * shows up under some other var name entirely).
  */
 const AUTH_HEADER_VALUE_PATTERN = /^(?:authorization|proxy-authorization)\s*:\s*\S+/i;
 
@@ -127,8 +169,9 @@ const JWT_VALUE_PATTERN = /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-
 
 /** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
 export function isSecretEnvVarName(name: string): boolean {
-  if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
-  if (SAFE_ENV_NAME_PATTERNS.some((pattern) => pattern.test(name))) return false;
+  const normalized = normalizeEnvVarName(name);
+  if (SAFE_ENV_NAME_EXCEPTIONS.has(normalized)) return false;
+  if (SAFE_ENV_NAME_PATTERNS.some((pattern) => pattern.test(normalized))) return false;
   if (KNOWN_SECRET_ENV_NAMES.has(name.toUpperCase())) return true;
   if (SECRET_ENV_NAME_ADDITIONAL_PATTERNS.some((pattern) => pattern.test(name))) return true;
   return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
@@ -154,37 +197,48 @@ export function isSecretEnvVarValue(value: string): boolean {
  * here) means custom providers registered via `ProviderRegistry.register()`
  * can preserve their own credentials too.
  *
- * `exemptNames` matching follows the OS's own env var name semantics: exact
- * case on POSIX, where env var names are case-sensitive and a
- * differently-cased var of the same spelling is a genuinely distinct
- * variable the provider didn't declare; case-insensitive on Windows, where
- * env var names themselves are case-insensitive (`OpenAI_API_Key` and
- * `OPENAI_API_KEY` name the same variable, and the CLI would read either).
+ * `exemptNames` matching follows the OS's own env var name semantics via
+ * `normalizeEnvVarName`: exact case on POSIX, case-insensitive on Windows.
  */
 export function filterSecretEnvVars(
   env: Record<string, string>,
   exemptNames?: readonly string[],
 ): Record<string, string> {
-  const caseInsensitiveExempt = process.platform === 'win32';
-  const normalize = (name: string): string => (caseInsensitiveExempt ? name.toUpperCase() : name);
-  const exempt = new Set((exemptNames ?? []).map(normalize));
+  const exempt = new Set((exemptNames ?? []).map(normalizeEnvVarName));
 
   // GIT_CONFIG_KEY_<n>/VALUE_<n>/COUNT is git's genuine indexed
-  // config-injection mechanism (see SAFE_ENV_NAME_PATTERNS above) — but if
-  // any GIT_CONFIG_VALUE_<n> turns out to be secret-shaped (e.g. a smuggled
-  // Authorization header), dropping only that VALUE_<n> leaves a malformed
-  // tuple (COUNT and KEY_<n> present, VALUE_<n> missing) that makes git
-  // itself error out ("missing config value") on every command the CLI
-  // runs. Drop the whole GIT_CONFIG_* family atomically instead, so git
-  // simply doesn't see the mechanism at all rather than seeing it broken.
-  const dropGitConfigFamily = Object.entries(env).some(
-    ([key, value]) => GIT_CONFIG_VALUE_NAME_PATTERN.test(key) && isSecretEnvVarValue(value),
-  );
+  // config-injection mechanism (see SAFE_ENV_NAME_PATTERNS above), but two
+  // distinct ways it can smuggle a live credential through under a name the
+  // filter otherwise trusts: (a) GIT_CONFIG_VALUE_<n> literally looks
+  // secret-shaped (e.g. "Authorization: Bearer ..."), or (b) its paired
+  // GIT_CONFIG_KEY_<n> names a credential-bearing config key like
+  // `http.extraHeader`, whose value is credential-shaped by construction
+  // regardless of what that value literally contains (GitLab's
+  // "PRIVATE-TOKEN: ...", "JOB-TOKEN: ...", or any other custom header).
+  //
+  // Either way, dropping only the offending VALUE_<n> would leave a
+  // malformed tuple (COUNT/KEY_<n> present, VALUE_<n> missing) that makes
+  // git itself error out ("missing config value") on every command the CLI
+  // runs — so the whole GIT_CONFIG_* family is dropped atomically instead,
+  // so git simply doesn't see the mechanism at all rather than seeing it
+  // broken.
+  const keyByIndex = new Map<string, string>();
+  for (const [key, value] of Object.entries(env)) {
+    const keyMatch = GIT_CONFIG_KEY_NAME_PATTERN.exec(key);
+    if (keyMatch) keyByIndex.set(keyMatch[1]!, value);
+  }
+  const dropGitConfigFamily = Object.entries(env).some(([key, value]) => {
+    const valueMatch = GIT_CONFIG_VALUE_NAME_PATTERN.exec(key);
+    if (!valueMatch) return false;
+    if (isSecretEnvVarValue(value)) return true;
+    const pairedKey = keyByIndex.get(valueMatch[1]!);
+    return pairedKey !== undefined && GIT_CONFIG_CREDENTIAL_BEARING_KEYS.has(pairedKey.toLowerCase());
+  });
 
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (dropGitConfigFamily && GIT_CONFIG_FAMILY_NAME_PATTERN.test(key)) continue;
-    if (exempt.has(normalize(key))) {
+    if (dropGitConfigFamily && GIT_CONFIG_FAMILY_NAME_PATTERN.test(normalizeEnvVarName(key))) continue;
+    if (exempt.has(normalizeEnvVarName(key))) {
       filtered[key] = value;
       continue;
     }

--- a/packages/franken-orchestrator/src/security/env-filter.ts
+++ b/packages/franken-orchestrator/src/security/env-filter.ts
@@ -1,0 +1,139 @@
+/**
+ * Filters secret-shaped environment variables out of an env map before it is
+ * handed to `spawn()` for a CLI subprocess (LLM provider CLIs in
+ * `adapters/cli-llm-adapter.ts`, Martin-loop iterations in
+ * `skills/martin-loop.ts`). Shared so both spawn paths apply the same rules
+ * instead of drifting independently.
+ *
+ * This is a denylist rather than a hand-maintained allowlist: spawned CLI
+ * subprocesses (claude/codex/gemini/aider) need broad standard environment
+ * access to function (PATH, HOME, locale vars, npm/node config, etc.), so
+ * allowlisting would be brittle and prone to breaking legitimate CLI
+ * behavior. Only vars that look secret-shaped (by name or, for a small set of
+ * known connection-string schemes, by value) are stripped.
+ */
+
+/**
+ * Matches env var names that look like they carry a secret (API keys, tokens,
+ * passwords, credentials, certs, etc.), checked on underscore-delimited
+ * segments so unrelated names like `KEYBOARD_LAYOUT` are left alone. `PWD`
+ * (the shell's present-working-directory var) is included as a segment so
+ * `MYSQL_PWD` is caught, but the bare `PWD` name itself is special-cased as
+ * safe below.
+ */
+const SECRET_ENV_NAME_PATTERN =
+  /(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PASSPHRASE|CREDENTIALS?|AUTH|AUTHORIZATION|COOKIE|CERT|CERTIFICATE|WEBHOOK|PWD)(?:_|$)/i;
+
+/**
+ * Catches common secret-name segments written without a delimiter (e.g.
+ * `APIKEY`, `PGPASSWORD` — psql's undelimited password env var).
+ */
+const SECRET_ENV_NAME_COMPOUND_PATTERN =
+  /(?:APIKEY|ACCESSKEY|SECRETKEY|PRIVATEKEY|AUTHTOKEN|CLIENTSECRET|PASSWORD)/i;
+
+/**
+ * Exact names that don't match the generic patterns above but are secret
+ * session tokens for external secret managers — a live one can unlock every
+ * secret in the vault, so it must never reach a spawned CLI. `BW_SESSION` is
+ * Bitwarden's session token; see `network/services/managed-service-env.ts`,
+ * which deliberately forwards it to *trusted* managed services only.
+ */
+const KNOWN_SECRET_ENV_NAMES = new Set(['BW_SESSION']);
+
+/**
+ * Name patterns for secret-manager session tokens that are per-account and
+ * so can't be listed as exact names — `OP_SESSION_<account>` is 1Password's
+ * CLI session token, forwarded the same way (see managed-service-env.ts).
+ * Deliberately narrow (not a bare `SESSION` segment): ordinary desktop/X11
+ * session vars (`XDG_SESSION_ID`, `DESKTOP_SESSION`, `SESSION_MANAGER`,
+ * `DBUS_SESSION_BUS_ADDRESS`, ...) are not secrets and must keep flowing.
+ */
+const SECRET_ENV_NAME_ADDITIONAL_PATTERNS: readonly RegExp[] = [/^OP_SESSION_[A-Za-z0-9_]+$/i];
+
+/**
+ * Env var names that would otherwise match the patterns above but are
+ * capability/configuration pointers, not secrets themselves — e.g.
+ * `SSH_AUTH_SOCK` is a path to the running ssh-agent's socket,
+ * `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` point at CA bundle files, and
+ * `DOCKER_CERT_PATH` (see `network/services/managed-service-env.ts`) points
+ * at a directory of TLS client cert files for talking to a remote Docker
+ * daemon. Stripping these breaks legitimate CLI behavior (git/ssh via the
+ * user's agent, TLS trust for provider HTTPS calls, Docker client auth)
+ * without reducing secret exposure, since none of them carry credential
+ * material in the variable itself. `PWD` (present working directory) is
+ * included for the same reason.
+ */
+const SAFE_ENV_NAME_EXCEPTIONS = new Set([
+  'PWD',
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'NODE_EXTRA_CA_CERTS',
+  'DOCKER_CERT_PATH',
+]);
+
+/**
+ * Git's indexed runtime-config mechanism (`GIT_CONFIG_COUNT` plus
+ * `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` pairs) is how this repo
+ * itself injects config into spawned git commands (see
+ * `beasts/execution/docker-container-runtime.ts`). The `KEY` segment in
+ * `GIT_CONFIG_KEY_0` refers to a config key *name* (e.g. `safe.directory`),
+ * not a secret — stripping it silently breaks every git command the CLI
+ * runs. Exempt the whole indexed tuple by name shape rather than by value,
+ * since the mechanism is inherently non-secret.
+ */
+const SAFE_ENV_NAME_PATTERNS: readonly RegExp[] = [/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/i];
+
+/**
+ * Matches connection-string *values* with embedded `user:password@` userinfo
+ * for common database schemes — e.g. `DATABASE_URL=postgres://user:pass@host/db`.
+ * The var name (`DATABASE_URL`, `REDIS_URL`, ...) doesn't look secret-shaped
+ * by itself, so this checks the value directly. Same scheme list this repo
+ * already treats as sensitive in `logging/redaction.ts`.
+ */
+const CREDENTIAL_URL_VALUE_PATTERN =
+  /^(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?):\/\/[^:\s"'/@]*:[^@\s"']+@/i;
+
+/** True if an env var name matches a common secret-name pattern (*_KEY, *_TOKEN, *_SECRET, etc.). */
+export function isSecretEnvVarName(name: string): boolean {
+  if (SAFE_ENV_NAME_EXCEPTIONS.has(name.toUpperCase())) return false;
+  if (SAFE_ENV_NAME_PATTERNS.some((pattern) => pattern.test(name))) return false;
+  if (KNOWN_SECRET_ENV_NAMES.has(name.toUpperCase())) return true;
+  if (SECRET_ENV_NAME_ADDITIONAL_PATTERNS.some((pattern) => pattern.test(name))) return true;
+  return SECRET_ENV_NAME_PATTERN.test(name) || SECRET_ENV_NAME_COMPOUND_PATTERN.test(name);
+}
+
+/** True if an env var's *value* looks like a connection string with embedded credentials. */
+export function isSecretEnvVarValue(value: string): boolean {
+  return CREDENTIAL_URL_VALUE_PATTERN.test(value);
+}
+
+/**
+ * Returns a copy of `env` with any secret-shaped keys (by name or, for
+ * connection-string values, by value) omitted, except for names in
+ * `exemptNames` (case-insensitive) — used to let the actively selected
+ * provider's own required auth var(s) (from `ICliProvider.requiredAuthEnvVars()`,
+ * e.g. `ANTHROPIC_API_KEY` for `claude`, `OPENAI_API_KEY` for `codex`)
+ * survive even though they are themselves secret-shaped: they're the CLI's
+ * own designed auth channel, not an unrelated ambient secret leaking
+ * through. Declaring this on the provider (rather than a lookup table keyed
+ * by name here) means custom providers registered via
+ * `ProviderRegistry.register()` can preserve their own credentials too.
+ */
+export function filterSecretEnvVars(
+  env: Record<string, string>,
+  exemptNames?: readonly string[],
+): Record<string, string> {
+  const exempt = new Set((exemptNames ?? []).map((name) => name.toUpperCase()));
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (exempt.has(key.toUpperCase())) {
+      filtered[key] = value;
+      continue;
+    }
+    if (isSecretEnvVarName(key) || isSecretEnvVarValue(value)) continue;
+    filtered[key] = value;
+  }
+  return filtered;
+}

--- a/packages/franken-orchestrator/src/skills/martin-loop.ts
+++ b/packages/franken-orchestrator/src/skills/martin-loop.ts
@@ -32,6 +32,7 @@ import {
   type CommandFailure,
 } from '../errors/command-failure.js';
 import { redactSensitiveText } from '../logging/redaction.js';
+import { filterSecretEnvVars } from '../security/env-filter.js';
 
 const MAX_RATE_LIMIT_WARNING_STDERR_CHARS = 256;
 const MAX_RATE_LIMIT_WARNING_DIAGNOSTICS_CHARS = 768;
@@ -314,7 +315,11 @@ function spawnIteration(
       ? [...providerArgs, '--', prompt]
       : [...providerArgs, prompt];
 
-    const env = { ...provider.filterEnv(process.env as Record<string, string>) };
+    const env = {
+      ...provider.filterEnv(
+        filterSecretEnvVars(process.env as Record<string, string>, provider.requiredAuthEnvVars?.(model)),
+      ),
+    };
     const plain = isPlainOutput();
     if (plain) {
       env.NO_COLOR = env.NO_COLOR ?? '1';

--- a/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
@@ -11,6 +11,58 @@ import { sanitizeRunConfigIntegrityEnv } from '../../cli/run-config-integrity.js
 
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
 
+/**
+ * All vendor keys aider can plausibly need across LiteLLM-supported
+ * backends, used as a fallback when the active model string doesn't match a
+ * known prefix (unrecognized backend, or no model configured at all). This
+ * can't be fully exhaustive — LiteLLM supports dozens of providers — but
+ * covers the common ones. Extend if another backend is configured.
+ */
+const ALL_KNOWN_VENDOR_AUTH_ENV_VARS: readonly string[] = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'AZURE_API_KEY',
+  'GEMINI_API_KEY',
+  'GROQ_API_KEY',
+  'MISTRAL_API_KEY',
+  'OPENROUTER_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'TOGETHER_API_KEY',
+  'COHERE_API_KEY',
+  'XAI_API_KEY',
+  'PERPLEXITY_API_KEY',
+  'FIREWORKS_API_KEY',
+];
+
+/**
+ * Maps a LiteLLM model-string prefix (`<provider>/<model>`, per LiteLLM's
+ * own convention) to the vendor env var it needs. Bare model names with no
+ * `provider/` prefix are OpenAI's convention (`gpt-4o`, `o1-mini`, ...).
+ */
+const LITELLM_PREFIX_AUTH_ENV_VAR: ReadonlyArray<readonly [prefix: string, envVar: string]> = [
+  ['anthropic/', 'ANTHROPIC_API_KEY'],
+  ['claude', 'ANTHROPIC_API_KEY'],
+  ['openai/', 'OPENAI_API_KEY'],
+  ['gpt-', 'OPENAI_API_KEY'],
+  ['o1', 'OPENAI_API_KEY'],
+  ['o3', 'OPENAI_API_KEY'],
+  ['azure/', 'AZURE_API_KEY'],
+  ['gemini/', 'GEMINI_API_KEY'],
+  ['vertex_ai/', 'GEMINI_API_KEY'],
+  ['groq/', 'GROQ_API_KEY'],
+  ['mistral/', 'MISTRAL_API_KEY'],
+  ['openrouter/', 'OPENROUTER_API_KEY'],
+  ['deepseek/', 'DEEPSEEK_API_KEY'],
+  ['together_ai/', 'TOGETHER_API_KEY'],
+  ['together/', 'TOGETHER_API_KEY'],
+  ['cohere/', 'COHERE_API_KEY'],
+  ['cohere_chat/', 'COHERE_API_KEY'],
+  ['xai/', 'XAI_API_KEY'],
+  ['perplexity/', 'PERPLEXITY_API_KEY'],
+  ['fireworks_ai/', 'FIREWORKS_API_KEY'],
+  ['fireworks/', 'FIREWORKS_API_KEY'],
+];
+
 export class AiderProvider implements ICliProvider {
   readonly name = 'aider';
   readonly command = 'aider';
@@ -56,27 +108,22 @@ export class AiderProvider implements ICliProvider {
   /**
    * Aider has no fixed backend — its default chat model is Claude Sonnet,
    * but `--model` (and `providerOverrides.aider.model`) accepts any
-   * LiteLLM-supported model string, each with its own vendor API key. This
-   * can't be fully exhaustive (LiteLLM supports dozens of providers), but
-   * covers the common ones so overriding aider's model doesn't silently
-   * break auth. Extend this list if another backend is configured.
+   * LiteLLM-supported model string, each with its own vendor API key.
+   * Resolve only the *active* backend's key from the model string when it
+   * matches a known LiteLLM prefix, so an aider invocation on one backend
+   * doesn't also receive every other configured vendor's credentials. Falls
+   * back to the full known-vendor list when the model is unset or doesn't
+   * match a recognized prefix, favoring a working (if slightly
+   * over-permissive) invocation over a silently broken one.
    */
-  requiredAuthEnvVars(): readonly string[] {
-    return [
-      'ANTHROPIC_API_KEY',
-      'OPENAI_API_KEY',
-      'AZURE_API_KEY',
-      'GEMINI_API_KEY',
-      'GROQ_API_KEY',
-      'MISTRAL_API_KEY',
-      'OPENROUTER_API_KEY',
-      'DEEPSEEK_API_KEY',
-      'TOGETHER_API_KEY',
-      'COHERE_API_KEY',
-      'XAI_API_KEY',
-      'PERPLEXITY_API_KEY',
-      'FIREWORKS_API_KEY',
-    ];
+  requiredAuthEnvVars(model?: string): readonly string[] {
+    const resolved = (model ?? this.chatModel ?? '').toLowerCase();
+    for (const [prefix, envVar] of LITELLM_PREFIX_AUTH_ENV_VAR) {
+      if (resolved.startsWith(prefix)) {
+        return [envVar];
+      }
+    }
+    return ALL_KNOWN_VENDOR_AUTH_ENV_VARS;
   }
 
   supportsStreamJson(): boolean {

--- a/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
@@ -53,6 +53,32 @@ export class AiderProvider implements ICliProvider {
     return filtered;
   }
 
+  /**
+   * Aider has no fixed backend — its default chat model is Claude Sonnet,
+   * but `--model` (and `providerOverrides.aider.model`) accepts any
+   * LiteLLM-supported model string, each with its own vendor API key. This
+   * can't be fully exhaustive (LiteLLM supports dozens of providers), but
+   * covers the common ones so overriding aider's model doesn't silently
+   * break auth. Extend this list if another backend is configured.
+   */
+  requiredAuthEnvVars(): readonly string[] {
+    return [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'AZURE_API_KEY',
+      'GEMINI_API_KEY',
+      'GROQ_API_KEY',
+      'MISTRAL_API_KEY',
+      'OPENROUTER_API_KEY',
+      'DEEPSEEK_API_KEY',
+      'TOGETHER_API_KEY',
+      'COHERE_API_KEY',
+      'XAI_API_KEY',
+      'PERPLEXITY_API_KEY',
+      'FIREWORKS_API_KEY',
+    ];
+  }
+
   supportsStreamJson(): boolean {
     return false;
   }

--- a/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
@@ -32,43 +32,51 @@ const ALL_KNOWN_VENDOR_AUTH_ENV_VARS: readonly string[] = [
   'XAI_API_KEY',
   'PERPLEXITY_API_KEY',
   'FIREWORKS_API_KEY',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
 ];
 
 /**
  * Maps a LiteLLM model-string prefix (`<provider>/<model>`, per LiteLLM's
- * own convention) to the vendor env var it needs. Bare model names with no
- * `provider/` prefix are OpenAI's convention (`gpt-4o`, `o1-mini`, ...).
+ * own convention) to the vendor env var(s) it needs. Bare model names with
+ * no `provider/` prefix are OpenAI's convention (`gpt-4o`, `o1-mini`, ...).
+ * Bedrock/SageMaker authenticate via the standard AWS credential trio
+ * (access key + secret + optional session token for temporary credentials),
+ * not a single API key.
  */
-const LITELLM_PREFIX_AUTH_ENV_VAR: ReadonlyArray<readonly [prefix: string, envVar: string]> = [
-  ['anthropic/', 'ANTHROPIC_API_KEY'],
-  ['claude', 'ANTHROPIC_API_KEY'],
+const LITELLM_PREFIX_AUTH_ENV_VARS: ReadonlyArray<readonly [prefix: string, envVars: readonly string[]]> = [
+  ['anthropic/', ['ANTHROPIC_API_KEY']],
+  ['claude', ['ANTHROPIC_API_KEY']],
   // Bare Claude model-family shorthand — this class's own default
   // `chatModel` is the literal string 'sonnet' (see below), which reaches
   // requiredAuthEnvVars() as-is when no explicit model is configured, so it
   // must resolve to Anthropic rather than falling through to the full
   // multi-vendor list.
-  ['sonnet', 'ANTHROPIC_API_KEY'],
-  ['opus', 'ANTHROPIC_API_KEY'],
-  ['haiku', 'ANTHROPIC_API_KEY'],
-  ['openai/', 'OPENAI_API_KEY'],
-  ['gpt-', 'OPENAI_API_KEY'],
-  ['o1', 'OPENAI_API_KEY'],
-  ['o3', 'OPENAI_API_KEY'],
-  ['azure/', 'AZURE_API_KEY'],
-  ['gemini/', 'GEMINI_API_KEY'],
-  ['vertex_ai/', 'GEMINI_API_KEY'],
-  ['groq/', 'GROQ_API_KEY'],
-  ['mistral/', 'MISTRAL_API_KEY'],
-  ['openrouter/', 'OPENROUTER_API_KEY'],
-  ['deepseek/', 'DEEPSEEK_API_KEY'],
-  ['together_ai/', 'TOGETHER_API_KEY'],
-  ['together/', 'TOGETHER_API_KEY'],
-  ['cohere/', 'COHERE_API_KEY'],
-  ['cohere_chat/', 'COHERE_API_KEY'],
-  ['xai/', 'XAI_API_KEY'],
-  ['perplexity/', 'PERPLEXITY_API_KEY'],
-  ['fireworks_ai/', 'FIREWORKS_API_KEY'],
-  ['fireworks/', 'FIREWORKS_API_KEY'],
+  ['sonnet', ['ANTHROPIC_API_KEY']],
+  ['opus', ['ANTHROPIC_API_KEY']],
+  ['haiku', ['ANTHROPIC_API_KEY']],
+  ['openai/', ['OPENAI_API_KEY']],
+  ['gpt-', ['OPENAI_API_KEY']],
+  ['o1', ['OPENAI_API_KEY']],
+  ['o3', ['OPENAI_API_KEY']],
+  ['azure/', ['AZURE_API_KEY']],
+  ['gemini/', ['GEMINI_API_KEY']],
+  ['vertex_ai/', ['GEMINI_API_KEY']],
+  ['groq/', ['GROQ_API_KEY']],
+  ['mistral/', ['MISTRAL_API_KEY']],
+  ['openrouter/', ['OPENROUTER_API_KEY']],
+  ['deepseek/', ['DEEPSEEK_API_KEY']],
+  ['together_ai/', ['TOGETHER_API_KEY']],
+  ['together/', ['TOGETHER_API_KEY']],
+  ['cohere/', ['COHERE_API_KEY']],
+  ['cohere_chat/', ['COHERE_API_KEY']],
+  ['xai/', ['XAI_API_KEY']],
+  ['perplexity/', ['PERPLEXITY_API_KEY']],
+  ['fireworks_ai/', ['FIREWORKS_API_KEY']],
+  ['fireworks/', ['FIREWORKS_API_KEY']],
+  ['bedrock/', ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']],
+  ['sagemaker/', ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']],
 ];
 
 export class AiderProvider implements ICliProvider {
@@ -126,9 +134,9 @@ export class AiderProvider implements ICliProvider {
    */
   requiredAuthEnvVars(model?: string): readonly string[] {
     const resolved = (model ?? this.chatModel ?? '').toLowerCase();
-    for (const [prefix, envVar] of LITELLM_PREFIX_AUTH_ENV_VAR) {
+    for (const [prefix, envVars] of LITELLM_PREFIX_AUTH_ENV_VARS) {
       if (resolved.startsWith(prefix)) {
-        return [envVar];
+        return envVars;
       }
     }
     return ALL_KNOWN_VENDOR_AUTH_ENV_VARS;

--- a/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/aider-provider.ts
@@ -42,6 +42,14 @@ const ALL_KNOWN_VENDOR_AUTH_ENV_VARS: readonly string[] = [
 const LITELLM_PREFIX_AUTH_ENV_VAR: ReadonlyArray<readonly [prefix: string, envVar: string]> = [
   ['anthropic/', 'ANTHROPIC_API_KEY'],
   ['claude', 'ANTHROPIC_API_KEY'],
+  // Bare Claude model-family shorthand — this class's own default
+  // `chatModel` is the literal string 'sonnet' (see below), which reaches
+  // requiredAuthEnvVars() as-is when no explicit model is configured, so it
+  // must resolve to Anthropic rather than falling through to the full
+  // multi-vendor list.
+  ['sonnet', 'ANTHROPIC_API_KEY'],
+  ['opus', 'ANTHROPIC_API_KEY'],
+  ['haiku', 'ANTHROPIC_API_KEY'],
   ['openai/', 'OPENAI_API_KEY'],
   ['gpt-', 'OPENAI_API_KEY'],
   ['o1', 'OPENAI_API_KEY'],

--- a/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/claude-provider.ts
@@ -156,6 +156,10 @@ export class ClaudeProvider implements ICliProvider {
     return filtered;
   }
 
+  requiredAuthEnvVars(): readonly string[] {
+    return ['ANTHROPIC_API_KEY'];
+  }
+
   supportsStreamJson(): boolean {
     return true;
   }

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -79,15 +79,18 @@ export interface ICliProvider {
   /**
    * Env var name(s) this provider's own CLI needs to authenticate itself
    * (e.g. `ANTHROPIC_API_KEY` for claude), even though the names are
-   * secret-shaped. `CliLlmAdapter` strips secret-shaped ambient env vars
-   * before spawning the CLI (see `filterSecretEnvVars` in
-   * `adapters/cli-llm-adapter.ts`) to avoid leaking unrelated credentials —
-   * this lets a provider (built-in or custom, via `ProviderRegistry`)
-   * declare which of its own vars must survive that filter. Optional:
-   * providers that don't rely on env-based auth (or whose `filterEnv()`
-   * already strips their own vendor vars, like Gemini) simply omit it.
+   * secret-shaped. `CliLlmAdapter`/`spawnIteration` strip secret-shaped
+   * ambient env vars before spawning the CLI (see `security/env-filter.ts`)
+   * to avoid leaking unrelated credentials — this lets a provider (built-in
+   * or custom, via `ProviderRegistry`) declare which of its own vars must
+   * survive that filter. `model` is the resolved model string for this
+   * invocation, when known (e.g. so a multi-backend provider like Aider can
+   * return only its *active* backend's key instead of every vendor it could
+   * ever be pointed at). Optional: providers that don't rely on env-based
+   * auth (or whose `filterEnv()` already strips their own vendor vars, like
+   * Gemini) simply omit it.
    */
-  requiredAuthEnvVars?(): readonly string[];
+  requiredAuthEnvVars?(model?: string): readonly string[];
 }
 
 export function resolveProviderCacheCapabilities(provider: ICliProvider): ProviderCacheCapabilities {

--- a/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/cli-provider.ts
@@ -76,6 +76,18 @@ export interface ICliProvider {
    * exposes this (Codex's `--json` output never reports a model field).
    */
   extractModel?(raw: string): string | undefined;
+  /**
+   * Env var name(s) this provider's own CLI needs to authenticate itself
+   * (e.g. `ANTHROPIC_API_KEY` for claude), even though the names are
+   * secret-shaped. `CliLlmAdapter` strips secret-shaped ambient env vars
+   * before spawning the CLI (see `filterSecretEnvVars` in
+   * `adapters/cli-llm-adapter.ts`) to avoid leaking unrelated credentials —
+   * this lets a provider (built-in or custom, via `ProviderRegistry`)
+   * declare which of its own vars must survive that filter. Optional:
+   * providers that don't rely on env-based auth (or whose `filterEnv()`
+   * already strips their own vendor vars, like Gemini) simply omit it.
+   */
+  requiredAuthEnvVars?(): readonly string[];
 }
 
 export function resolveProviderCacheCapabilities(provider: ICliProvider): ProviderCacheCapabilities {

--- a/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
+++ b/packages/franken-orchestrator/src/skills/providers/codex-provider.ts
@@ -98,6 +98,10 @@ export class CodexProvider implements ICliProvider {
     };
   }
 
+  requiredAuthEnvVars(): readonly string[] {
+    return ['OPENAI_API_KEY'];
+  }
+
   supportsStreamJson(): boolean {
     return false;
   }

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -617,7 +617,7 @@ describe('CliLlmAdapter', () => {
         }
       });
 
-      it('preserves common LiteLLM vendor keys for aider when overridden to a non-default backend', async () => {
+      it('falls back to the full known-vendor list for aider when the backend model is unknown/unset', async () => {
         const originalEnv = process.env;
         process.env = {
           ...originalEnv,
@@ -637,6 +637,35 @@ describe('CliLlmAdapter', () => {
           expect(env['GROQ_API_KEY']).toBe('groq-secret');
           expect(env['MISTRAL_API_KEY']).toBe('mistral-secret');
           expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves only the active backend vendor key for aider when its model is explicitly overridden', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          GROQ_API_KEY: 'groq-secret',
+          OPENROUTER_API_KEY: 'openrouter-secret',
+          ANTHROPIC_API_KEY: 'anthropic-secret',
+          OPENAI_API_KEY: 'openai-secret',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(
+            aiderProvider,
+            { ...baseOpts, providerOverrides: { aider: { model: 'groq/llama-3.1-70b-versatile' } } },
+            spawnFn,
+          );
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['GROQ_API_KEY']).toBe('groq-secret');
+          expect(env['OPENROUTER_API_KEY']).toBeUndefined();
+          expect(env['ANTHROPIC_API_KEY']).toBeUndefined();
+          expect(env['OPENAI_API_KEY']).toBeUndefined();
         } finally {
           process.env = originalEnv;
         }
@@ -1852,90 +1881,19 @@ describe('CliLlmAdapter', () => {
     });
   });
 
-  describe('isSecretEnvVarName / filterSecretEnvVars', () => {
-    it('flags common secret-shaped env var names', () => {
-      const secretNames = [
-        'SOME_API_KEY',
-        'OPENAI_API_KEY',
-        'ANTHROPIC_API_KEY',
-        'AWS_SECRET_ACCESS_KEY',
-        'AWS_SESSION_TOKEN',
-        'GITHUB_TOKEN',
-        'GH_TOKEN',
-        'NPM_TOKEN',
-        'DATABASE_PASSWORD',
-        'DB_PASSWD',
-        'MY_APP_SECRET',
-        'CLIENT_SECRET',
-        'PRIVATE_KEY',
-        'ENCRYPTION_KEY',
-        'BASIC_AUTH',
-        'SESSION_COOKIE',
-        'TLS_CERTIFICATE',
-        'SLACK_WEBHOOK_URL',
-        'GOOGLE_APPLICATION_CREDENTIALS',
-        'PGPASSWORD',
-        'MYSQL_PWD',
-      ];
-      for (const name of secretNames) {
-        expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
-      }
+  // Full coverage of the filtering rules lives in
+  // tests/unit/security/env-filter.test.ts, against the module directly.
+  // This just smoke-tests that cli-llm-adapter.js still re-exports the same
+  // implementation (for backward compatibility with existing importers).
+  describe('isSecretEnvVarName / filterSecretEnvVars (re-export smoke test)', () => {
+    it('re-exports the same secret-detection behavior as security/env-filter.js', () => {
+      expect(isSecretEnvVarName('SOME_API_KEY')).toBe(true);
+      expect(isSecretEnvVarName('PATH')).toBe(false);
     });
 
-    it('does not flag ordinary CLI/runtime env var names', () => {
-      const safeNames = [
-        'PATH',
-        'HOME',
-        'SHELL',
-        'LANG',
-        'LC_ALL',
-        'TERM',
-        'PWD',
-        'TMPDIR',
-        'USER',
-        'EDITOR',
-        'CI',
-        'NODE_ENV',
-        'NO_COLOR',
-        'FORCE_COLOR',
-        'npm_config_registry',
-        'KEYBOARD_LAYOUT',
-        'XDG_CONFIG_HOME',
-        'SSH_AUTH_SOCK',
-        'SSH_AGENT_PID',
-        'SSL_CERT_FILE',
-        'SSL_CERT_DIR',
-        'NODE_EXTRA_CA_CERTS',
-        'DOCKER_CERT_PATH',
-        'GIT_CONFIG_COUNT',
-        'GIT_CONFIG_KEY_0',
-        'GIT_CONFIG_VALUE_0',
-        'GIT_CONFIG_KEY_12',
-      ];
-      for (const name of safeNames) {
-        expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
-      }
-    });
-
-    it('filterSecretEnvVars removes only secret-shaped keys and preserves the rest', () => {
-      const input = {
-        PATH: '/usr/bin',
-        HOME: '/home/test',
-        SOME_API_KEY: 'sk-secret',
-        DATABASE_PASSWORD: 'hunter2',
-      };
-      const filtered = filterSecretEnvVars(input);
-      expect(filtered).toEqual({ PATH: '/usr/bin', HOME: '/home/test' });
-    });
-
-    it('filterSecretEnvVars preserves keys listed in exemptNames despite looking secret-shaped', () => {
-      const input = {
-        PATH: '/usr/bin',
-        ANTHROPIC_API_KEY: 'anthropic-secret',
-        OPENAI_API_KEY: 'openai-secret',
-      };
-      const filtered = filterSecretEnvVars(input, ['ANTHROPIC_API_KEY']);
-      expect(filtered).toEqual({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'anthropic-secret' });
+    it('re-exports filterSecretEnvVars with the same filtering behavior', () => {
+      const filtered = filterSecretEnvVars({ PATH: '/usr/bin', SOME_API_KEY: 'sk-secret' });
+      expect(filtered).toEqual({ PATH: '/usr/bin' });
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
-import { CliLlmAdapter } from '../../../src/adapters/cli-llm-adapter.js';
+import { CliLlmAdapter, filterSecretEnvVars, isSecretEnvVarName } from '../../../src/adapters/cli-llm-adapter.js';
 import { setPlainOutput } from '../../../src/logging/beast-logger.js';
 import { AiderProvider } from '../../../src/skills/providers/aider-provider.js';
 import { ClaudeProvider } from '../../../src/skills/providers/claude-provider.js';
@@ -404,6 +404,68 @@ describe('CliLlmAdapter', () => {
           expect(env['CLAUDECODE_PLUGIN']).toBeUndefined();
           expect(env['PATH']).toBe('/usr/bin');
           expect(env['HOME']).toBe('/home/test');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+    });
+
+    describe('secret env var filtering (captureEnv)', () => {
+      it('does not forward env vars whose names look like secrets to the spawned CLI', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          SOME_API_KEY: 'sk-super-secret-value',
+          AWS_SECRET_ACCESS_KEY: 'aws-secret-value',
+          ANTHROPIC_API_KEY: 'anthropic-secret-value',
+          GITHUB_TOKEN: 'ghp_leaked_token',
+          DATABASE_PASSWORD: 'hunter2',
+          NPM_TOKEN: 'npm-secret-token',
+          PATH: '/usr/bin',
+          HOME: '/home/test',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['SOME_API_KEY']).toBeUndefined();
+          expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+          expect(env['ANTHROPIC_API_KEY']).toBeUndefined();
+          expect(env['GITHUB_TOKEN']).toBeUndefined();
+          expect(env['DATABASE_PASSWORD']).toBeUndefined();
+          expect(env['NPM_TOKEN']).toBeUndefined();
+          expect(env['PATH']).toBe('/usr/bin');
+          expect(env['HOME']).toBe('/home/test');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('still forwards non-secret environment configuration the CLI needs to run', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          PATH: '/usr/bin:/bin',
+          HOME: '/home/test',
+          LANG: 'en_US.UTF-8',
+          TERM: 'xterm-256color',
+          npm_config_registry: 'https://registry.npmjs.org/',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(codexProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['PATH']).toBe('/usr/bin:/bin');
+          expect(env['HOME']).toBe('/home/test');
+          expect(env['LANG']).toBe('en_US.UTF-8');
+          expect(env['TERM']).toBe('xterm-256color');
+          expect(env['npm_config_registry']).toBe('https://registry.npmjs.org/');
         } finally {
           process.env = originalEnv;
         }
@@ -1581,6 +1643,71 @@ describe('CliLlmAdapter', () => {
       const rawResponse = await adapter.execute(transformed);
       const response = adapter.transformResponse(rawResponse, 'req-2');
       expect(response.content).toBe('codex says 42');
+    });
+  });
+
+  describe('isSecretEnvVarName / filterSecretEnvVars', () => {
+    it('flags common secret-shaped env var names', () => {
+      const secretNames = [
+        'SOME_API_KEY',
+        'OPENAI_API_KEY',
+        'ANTHROPIC_API_KEY',
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_SESSION_TOKEN',
+        'GITHUB_TOKEN',
+        'GH_TOKEN',
+        'NPM_TOKEN',
+        'DATABASE_PASSWORD',
+        'DB_PASSWD',
+        'MY_APP_SECRET',
+        'CLIENT_SECRET',
+        'PRIVATE_KEY',
+        'ENCRYPTION_KEY',
+        'BASIC_AUTH',
+        'SESSION_COOKIE',
+        'TLS_CERTIFICATE',
+        'SLACK_WEBHOOK_URL',
+        'GOOGLE_APPLICATION_CREDENTIALS',
+      ];
+      for (const name of secretNames) {
+        expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
+      }
+    });
+
+    it('does not flag ordinary CLI/runtime env var names', () => {
+      const safeNames = [
+        'PATH',
+        'HOME',
+        'SHELL',
+        'LANG',
+        'LC_ALL',
+        'TERM',
+        'PWD',
+        'TMPDIR',
+        'USER',
+        'EDITOR',
+        'CI',
+        'NODE_ENV',
+        'NO_COLOR',
+        'FORCE_COLOR',
+        'npm_config_registry',
+        'KEYBOARD_LAYOUT',
+        'XDG_CONFIG_HOME',
+      ];
+      for (const name of safeNames) {
+        expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
+      }
+    });
+
+    it('filterSecretEnvVars removes only secret-shaped keys and preserves the rest', () => {
+      const input = {
+        PATH: '/usr/bin',
+        HOME: '/home/test',
+        SOME_API_KEY: 'sk-secret',
+        DATABASE_PASSWORD: 'hunter2',
+      };
+      const filtered = filterSecretEnvVars(input);
+      expect(filtered).toEqual({ PATH: '/usr/bin', HOME: '/home/test' });
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -617,7 +617,34 @@ describe('CliLlmAdapter', () => {
         }
       });
 
-      it('falls back to the full known-vendor list for aider when the backend model is unknown/unset', async () => {
+      it('preserves only ANTHROPIC_API_KEY for aider with no explicit model (default chatModel is Sonnet)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          ANTHROPIC_API_KEY: 'anthropic-secret',
+          OPENROUTER_API_KEY: 'openrouter-secret',
+          GROQ_API_KEY: 'groq-secret',
+          MISTRAL_API_KEY: 'mistral-secret',
+          SOME_UNRELATED_API_KEY: 'unrelated-secret',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(aiderProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['ANTHROPIC_API_KEY']).toBe('anthropic-secret');
+          expect(env['OPENROUTER_API_KEY']).toBeUndefined();
+          expect(env['GROQ_API_KEY']).toBeUndefined();
+          expect(env['MISTRAL_API_KEY']).toBeUndefined();
+          expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('falls back to the full known-vendor list for aider when the model string is unrecognized', async () => {
         const originalEnv = process.env;
         process.env = {
           ...originalEnv,
@@ -629,7 +656,11 @@ describe('CliLlmAdapter', () => {
 
         try {
           const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
-          const adapter = new CliLlmAdapter(aiderProvider, baseOpts, spawnFn);
+          const adapter = new CliLlmAdapter(
+            aiderProvider,
+            { ...baseOpts, providerOverrides: { aider: { model: 'some-unrecognized-custom-model' } } },
+            spawnFn,
+          );
           await adapter.execute({ prompt: 'test', maxTurns: 1 });
 
           const env = calls[0]!.options.env as Record<string, string>;

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -7,6 +7,7 @@ import { setPlainOutput } from '../../../src/logging/beast-logger.js';
 import { AiderProvider } from '../../../src/skills/providers/aider-provider.js';
 import { ClaudeProvider } from '../../../src/skills/providers/claude-provider.js';
 import { CodexProvider } from '../../../src/skills/providers/codex-provider.js';
+import type { ICliProvider } from '../../../src/skills/providers/cli-provider.js';
 
 // --- Mock spawn infrastructure ---
 
@@ -635,6 +636,41 @@ describe('CliLlmAdapter', () => {
           expect(env['OPENROUTER_API_KEY']).toBe('openrouter-secret');
           expect(env['GROQ_API_KEY']).toBe('groq-secret');
           expect(env['MISTRAL_API_KEY']).toBe('mistral-secret');
+          expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('lets a custom (pluggable) ICliProvider preserve its own declared auth var', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          CUSTOM_PROVIDER_API_KEY: 'custom-secret-value',
+          SOME_UNRELATED_API_KEY: 'unrelated-secret',
+        };
+
+        try {
+          const customProvider: ICliProvider = {
+            name: 'custom',
+            command: 'custom-cli',
+            buildArgs: () => [],
+            normalizeOutput: (raw: string) => raw,
+            estimateTokens: (text: string) => Math.ceil(text.length / 4),
+            isRateLimited: () => false,
+            parseRetryAfter: () => undefined,
+            filterEnv: (env: Record<string, string>) => env,
+            supportsStreamJson: () => false,
+            supportsNativeSessionResume: () => false,
+            defaultContextWindowTokens: () => 128_000,
+            requiredAuthEnvVars: () => ['CUSTOM_PROVIDER_API_KEY'],
+          };
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(customProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['CUSTOM_PROVIDER_API_KEY']).toBe('custom-secret-value');
           expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
         } finally {
           process.env = originalEnv;

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -573,6 +573,73 @@ describe('CliLlmAdapter', () => {
           process.env = originalEnv;
         }
       });
+
+      it('preserves DOCKER_CERT_PATH (a directory path, not a secret)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          DOCKER_CERT_PATH: '/home/test/.docker/certs',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['DOCKER_CERT_PATH']).toBe('/home/test/.docker/certs');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves the indexed GIT_CONFIG_COUNT/KEY_n/VALUE_n tuple used to inject git config', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'safe.directory',
+          GIT_CONFIG_VALUE_0: '/workspace',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['GIT_CONFIG_COUNT']).toBe('1');
+          expect(env['GIT_CONFIG_KEY_0']).toBe('safe.directory');
+          expect(env['GIT_CONFIG_VALUE_0']).toBe('/workspace');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves common LiteLLM vendor keys for aider when overridden to a non-default backend', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          OPENROUTER_API_KEY: 'openrouter-secret',
+          GROQ_API_KEY: 'groq-secret',
+          MISTRAL_API_KEY: 'mistral-secret',
+          SOME_UNRELATED_API_KEY: 'unrelated-secret',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(aiderProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['OPENROUTER_API_KEY']).toBe('openrouter-secret');
+          expect(env['GROQ_API_KEY']).toBe('groq-secret');
+          expect(env['MISTRAL_API_KEY']).toBe('mistral-secret');
+          expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
     });
 
     describe('with CodexProvider', () => {
@@ -1803,6 +1870,11 @@ describe('CliLlmAdapter', () => {
         'SSL_CERT_FILE',
         'SSL_CERT_DIR',
         'NODE_EXTRA_CA_CERTS',
+        'DOCKER_CERT_PATH',
+        'GIT_CONFIG_COUNT',
+        'GIT_CONFIG_KEY_0',
+        'GIT_CONFIG_VALUE_0',
+        'GIT_CONFIG_KEY_12',
       ];
       for (const name of safeNames) {
         expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);

--- a/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/cli-llm-adapter.test.ts
@@ -417,7 +417,6 @@ describe('CliLlmAdapter', () => {
           ...originalEnv,
           SOME_API_KEY: 'sk-super-secret-value',
           AWS_SECRET_ACCESS_KEY: 'aws-secret-value',
-          ANTHROPIC_API_KEY: 'anthropic-secret-value',
           GITHUB_TOKEN: 'ghp_leaked_token',
           DATABASE_PASSWORD: 'hunter2',
           NPM_TOKEN: 'npm-secret-token',
@@ -433,7 +432,6 @@ describe('CliLlmAdapter', () => {
           const env = calls[0]!.options.env as Record<string, string>;
           expect(env['SOME_API_KEY']).toBeUndefined();
           expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
-          expect(env['ANTHROPIC_API_KEY']).toBeUndefined();
           expect(env['GITHUB_TOKEN']).toBeUndefined();
           expect(env['DATABASE_PASSWORD']).toBeUndefined();
           expect(env['NPM_TOKEN']).toBeUndefined();
@@ -466,6 +464,111 @@ describe('CliLlmAdapter', () => {
           expect(env['LANG']).toBe('en_US.UTF-8');
           expect(env['TERM']).toBe('xterm-256color');
           expect(env['npm_config_registry']).toBe('https://registry.npmjs.org/');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves ANTHROPIC_API_KEY for the claude provider (its own required auth var)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          ANTHROPIC_API_KEY: 'anthropic-secret-value',
+          SOME_UNRELATED_API_KEY: 'unrelated-secret-value',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['ANTHROPIC_API_KEY']).toBe('anthropic-secret-value');
+          expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves OPENAI_API_KEY for the codex provider (its own required auth var)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          OPENAI_API_KEY: 'openai-secret-value',
+          SOME_UNRELATED_API_KEY: 'unrelated-secret-value',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(codexProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['OPENAI_API_KEY']).toBe('openai-secret-value');
+          expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('does not leak OPENAI_API_KEY to the claude provider (not its required auth var)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          OPENAI_API_KEY: 'openai-secret-value',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['OPENAI_API_KEY']).toBeUndefined();
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('filters undelimited PGPASSWORD and MYSQL_PWD but keeps plain PWD', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          PGPASSWORD: 'pg-secret-value',
+          MYSQL_PWD: 'mysql-secret-value',
+          PWD: '/home/test/project',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['PGPASSWORD']).toBeUndefined();
+          expect(env['MYSQL_PWD']).toBeUndefined();
+          expect(env['PWD']).toBe('/home/test/project');
+        } finally {
+          process.env = originalEnv;
+        }
+      });
+
+      it('preserves SSH_AUTH_SOCK and SSL_CERT_FILE (capability/config paths, not secrets)', async () => {
+        const originalEnv = process.env;
+        process.env = {
+          ...originalEnv,
+          SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+          SSL_CERT_FILE: '/etc/ssl/certs/ca-bundle.crt',
+        };
+
+        try {
+          const { spawnFn, calls } = createMockSpawn({ stdout: 'ok', exitCode: 0 });
+          const adapter = new CliLlmAdapter(claudeProvider, baseOpts, spawnFn);
+          await adapter.execute({ prompt: 'test', maxTurns: 1 });
+
+          const env = calls[0]!.options.env as Record<string, string>;
+          expect(env['SSH_AUTH_SOCK']).toBe('/tmp/ssh-agent.sock');
+          expect(env['SSL_CERT_FILE']).toBe('/etc/ssl/certs/ca-bundle.crt');
         } finally {
           process.env = originalEnv;
         }
@@ -1668,6 +1771,8 @@ describe('CliLlmAdapter', () => {
         'TLS_CERTIFICATE',
         'SLACK_WEBHOOK_URL',
         'GOOGLE_APPLICATION_CREDENTIALS',
+        'PGPASSWORD',
+        'MYSQL_PWD',
       ];
       for (const name of secretNames) {
         expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
@@ -1693,6 +1798,11 @@ describe('CliLlmAdapter', () => {
         'npm_config_registry',
         'KEYBOARD_LAYOUT',
         'XDG_CONFIG_HOME',
+        'SSH_AUTH_SOCK',
+        'SSH_AGENT_PID',
+        'SSL_CERT_FILE',
+        'SSL_CERT_DIR',
+        'NODE_EXTRA_CA_CERTS',
       ];
       for (const name of safeNames) {
         expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
@@ -1708,6 +1818,16 @@ describe('CliLlmAdapter', () => {
       };
       const filtered = filterSecretEnvVars(input);
       expect(filtered).toEqual({ PATH: '/usr/bin', HOME: '/home/test' });
+    });
+
+    it('filterSecretEnvVars preserves keys listed in exemptNames despite looking secret-shaped', () => {
+      const input = {
+        PATH: '/usr/bin',
+        ANTHROPIC_API_KEY: 'anthropic-secret',
+        OPENAI_API_KEY: 'openai-secret',
+      };
+      const filtered = filterSecretEnvVars(input, ['ANTHROPIC_API_KEY']);
+      expect(filtered).toEqual({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'anthropic-secret' });
     });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/claude-cli-adapter.test.ts
@@ -190,6 +190,19 @@ describe('ClaudeCliAdapter', () => {
       expect(env['FRANKENBEAST_SPAWNED']).toBe('1');
     });
 
+    it('strips unrelated secret-shaped env vars but preserves ANTHROPIC_API_KEY', () => {
+      process.env['SOME_UNRELATED_API_KEY'] = 'unrelated-secret';
+      process.env['ANTHROPIC_API_KEY'] = 'anthropic-secret';
+      try {
+        const env = adapter.sanitizedEnv();
+        expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        expect(env['ANTHROPIC_API_KEY']).toBe('anthropic-secret');
+      } finally {
+        delete process.env['SOME_UNRELATED_API_KEY'];
+        delete process.env['ANTHROPIC_API_KEY'];
+      }
+    });
+
     it('strips runtime config integrity state', () => {
       const originalManifest = process.env[RUN_CONFIG_INTEGRITY_ENV];
       const originalSecret = process.env[RUN_CONFIG_INTEGRITY_SECRET_ENV];

--- a/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/codex-cli-adapter.test.ts
@@ -207,6 +207,21 @@ describe('CodexCliAdapter', () => {
     });
   });
 
+  describe('sanitizedEnv()', () => {
+    it('strips unrelated secret-shaped env vars but preserves OPENAI_API_KEY', () => {
+      process.env['SOME_UNRELATED_API_KEY'] = 'unrelated-secret';
+      process.env['OPENAI_API_KEY'] = 'openai-secret';
+      try {
+        const env = adapter.sanitizedEnv();
+        expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+        expect(env['OPENAI_API_KEY']).toBe('openai-secret');
+      } finally {
+        delete process.env['SOME_UNRELATED_API_KEY'];
+        delete process.env['OPENAI_API_KEY'];
+      }
+    });
+  });
+
   describe('isAvailable()', () => {
     it('does not expose runtime config integrity state to the Codex availability probe', async () => {
       const originalManifest = process.env[RUN_CONFIG_INTEGRITY_ENV];

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-cli-adapter.test.ts
@@ -297,6 +297,18 @@ describe('GeminiCliAdapter', () => {
     });
   });
 
+  describe('sanitizedEnv()', () => {
+    it('strips unrelated secret-shaped env vars', () => {
+      process.env['SOME_UNRELATED_API_KEY'] = 'unrelated-secret';
+      try {
+        const env = adapter.sanitizedEnv();
+        expect(env['SOME_UNRELATED_API_KEY']).toBeUndefined();
+      } finally {
+        delete process.env['SOME_UNRELATED_API_KEY'];
+      }
+    });
+  });
+
   describe('isAvailable()', () => {
     it('does not expose runtime config integrity state to the Gemini availability probe', async () => {
       const originalManifest = process.env[RUN_CONFIG_INTEGRITY_ENV];

--- a/packages/franken-orchestrator/tests/unit/runtime/codex/codex-app-server-client-env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/codex/codex-app-server-client-env-filter.test.ts
@@ -8,6 +8,11 @@ vi.mock('node:child_process', () => ({
 }));
 import { spawn } from 'node:child_process';
 import { createCodexAppServerRequest } from '../../../../src/runtime/codex/codex-app-server-client.js';
+import {
+  RUN_CONFIG_INTEGRITY_ENV,
+  RUN_CONFIG_INTEGRITY_SECRET_ENV,
+  RUN_CONFIG_INTEGRITY_BYPASS_ENV,
+} from '../../../../src/cli/run-config-integrity.js';
 
 function mockChildProcess(): ChildProcess {
   const proc = new EventEmitter() as ChildProcess;
@@ -47,6 +52,29 @@ describe('createCodexAppServerRequest env filtering', () => {
     } finally {
       delete process.env['SOME_UNRELATED_API_KEY'];
       delete process.env['OPENAI_API_KEY'];
+    }
+  });
+
+  it('strips runtime config integrity state from the default (non-override) spawned env, matching every other provider spawn path', () => {
+    process.env[RUN_CONFIG_INTEGRITY_ENV] = '/tmp/run-config.integrity';
+    process.env[RUN_CONFIG_INTEGRITY_SECRET_ENV] = 'signing-key';
+    process.env[RUN_CONFIG_INTEGRITY_BYPASS_ENV] = '1';
+
+    try {
+      const proc = mockChildProcess();
+      (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+
+      const request = createCodexAppServerRequest({});
+      request('someMethod', {}, { timeoutMs: 10 }).catch(() => undefined);
+
+      const spawnEnv = (spawn as ReturnType<typeof vi.fn>).mock.calls[0][2].env as Record<string, string>;
+      expect(spawnEnv[RUN_CONFIG_INTEGRITY_ENV]).toBeUndefined();
+      expect(spawnEnv[RUN_CONFIG_INTEGRITY_SECRET_ENV]).toBeUndefined();
+      expect(spawnEnv[RUN_CONFIG_INTEGRITY_BYPASS_ENV]).toBeUndefined();
+    } finally {
+      delete process.env[RUN_CONFIG_INTEGRITY_ENV];
+      delete process.env[RUN_CONFIG_INTEGRITY_SECRET_ENV];
+      delete process.env[RUN_CONFIG_INTEGRITY_BYPASS_ENV];
     }
   });
 

--- a/packages/franken-orchestrator/tests/unit/runtime/codex/codex-app-server-client-env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/codex/codex-app-server-client-env-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+import { spawn } from 'node:child_process';
+import { createCodexAppServerRequest } from '../../../../src/runtime/codex/codex-app-server-client.js';
+
+function mockChildProcess(): ChildProcess {
+  const proc = new EventEmitter() as ChildProcess;
+  Object.defineProperty(proc, 'stdin', { value: new PassThrough() });
+  Object.defineProperty(proc, 'stdout', { value: new PassThrough() });
+  Object.defineProperty(proc, 'stderr', { value: new PassThrough() });
+  Object.defineProperty(proc, 'pid', { value: 4242 });
+  Object.defineProperty(proc, 'exitCode', { value: null, writable: true });
+  Object.defineProperty(proc, 'kill', { value: vi.fn(() => true) });
+  Object.defineProperty(proc, 'unref', { value: vi.fn() });
+  return proc;
+}
+
+describe('createCodexAppServerRequest env filtering', () => {
+  beforeEach(() => {
+    (spawn as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('does not forward secret-shaped ambient env vars to the spawned codex app-server, but preserves OPENAI_API_KEY when no explicit env override is given', () => {
+    process.env['SOME_UNRELATED_API_KEY'] = 'unrelated-secret';
+    process.env['OPENAI_API_KEY'] = 'openai-secret';
+
+    try {
+      const proc = mockChildProcess();
+      (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+
+      const request = createCodexAppServerRequest({});
+      // Fire and forget: we only need to inspect the synchronous spawn() call
+      // made by ensureServer(); the request itself will time out in the
+      // background since the mock child never responds.
+      request('someMethod', {}, { timeoutMs: 10 }).catch(() => undefined);
+
+      expect(spawn).toHaveBeenCalledTimes(1);
+      const spawnEnv = (spawn as ReturnType<typeof vi.fn>).mock.calls[0][2].env as Record<string, string>;
+      expect(spawnEnv['SOME_UNRELATED_API_KEY']).toBeUndefined();
+      expect(spawnEnv['OPENAI_API_KEY']).toBe('openai-secret');
+    } finally {
+      delete process.env['SOME_UNRELATED_API_KEY'];
+      delete process.env['OPENAI_API_KEY'];
+    }
+  });
+
+  it('uses the caller-supplied env override as-is when one is explicitly provided', () => {
+    const proc = mockChildProcess();
+    (spawn as ReturnType<typeof vi.fn>).mockReturnValue(proc);
+
+    const explicitEnv = { PATH: '/custom/bin', CUSTOM_TEST_VAR: 'value' };
+    const request = createCodexAppServerRequest({ env: explicitEnv });
+    request('someMethod', {}, { timeoutMs: 10 }).catch(() => undefined);
+
+    const spawnEnv = (spawn as ReturnType<typeof vi.fn>).mock.calls[0][2].env;
+    expect(spawnEnv).toBe(explicitEnv);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/runtime/runtime-defaults-env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/runtime/runtime-defaults-env-filter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { createCodexAppServerRequestMock } = vi.hoisted(() => ({
+  createCodexAppServerRequestMock: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../../src/runtime/codex/codex-app-server-client.js', () => ({
+  createCodexAppServerRequest: createCodexAppServerRequestMock,
+}));
+
+import { createDefaultRuntimeAdapterRegistry } from '../../../src/runtime/runtime-defaults.js';
+
+describe('createDefaultRuntimeAdapterRegistry env filtering', () => {
+  beforeEach(() => {
+    createCodexAppServerRequestMock.mockClear();
+  });
+
+  it('filters secret-shaped ambient env vars out of the process.env merged with a caller-supplied override', () => {
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      SOME_UNRELATED_API_KEY: 'unrelated-secret',
+      OPENAI_API_KEY: 'openai-secret',
+    };
+
+    try {
+      createDefaultRuntimeAdapterRegistry({ env: { PATH: '/custom/bin' } });
+
+      expect(createCodexAppServerRequestMock).toHaveBeenCalledTimes(1);
+      const passedEnv = createCodexAppServerRequestMock.mock.calls[0]![0].env as Record<string, string>;
+      expect(passedEnv['SOME_UNRELATED_API_KEY']).toBeUndefined();
+      expect(passedEnv['OPENAI_API_KEY']).toBe('openai-secret');
+      expect(passedEnv['PATH']).toBe('/custom/bin');
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  it('passes env: undefined through untouched when no override is supplied (codex-app-server-client applies its own default filtering)', () => {
+    createDefaultRuntimeAdapterRegistry({});
+
+    expect(createCodexAppServerRequestMock).toHaveBeenCalledTimes(1);
+    expect(createCodexAppServerRequestMock.mock.calls[0]![0].env).toBeUndefined();
+  });
+
+  it('uses options.codex.env as-is when explicitly provided, bypassing the merge entirely', () => {
+    const explicitEnv = { PATH: '/explicit/bin' };
+    createDefaultRuntimeAdapterRegistry({ codex: { env: explicitEnv } });
+
+    expect(createCodexAppServerRequestMock.mock.calls[0]![0].env).toBe(explicitEnv);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterSecretEnvVars,
+  isSecretEnvVarName,
+  isSecretEnvVarValue,
+} from '../../../src/security/env-filter.js';
+
+describe('isSecretEnvVarName', () => {
+  it('flags common secret-shaped env var names', () => {
+    const secretNames = [
+      'SOME_API_KEY',
+      'OPENAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'AWS_SECRET_ACCESS_KEY',
+      'AWS_SESSION_TOKEN',
+      'GITHUB_TOKEN',
+      'GH_TOKEN',
+      'NPM_TOKEN',
+      'DATABASE_PASSWORD',
+      'DB_PASSWD',
+      'MY_APP_SECRET',
+      'CLIENT_SECRET',
+      'PRIVATE_KEY',
+      'ENCRYPTION_KEY',
+      'BASIC_AUTH',
+      'SESSION_COOKIE',
+      'TLS_CERTIFICATE',
+      'SLACK_WEBHOOK_URL',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'PGPASSWORD',
+      'MYSQL_PWD',
+    ];
+    for (const name of secretNames) {
+      expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
+    }
+  });
+
+  it('flags secret-manager session tokens (BW_SESSION, OP_SESSION_<account>)', () => {
+    expect(isSecretEnvVarName('BW_SESSION')).toBe(true);
+    expect(isSecretEnvVarName('bw_session')).toBe(true);
+    expect(isSecretEnvVarName('OP_SESSION_my_account')).toBe(true);
+    expect(isSecretEnvVarName('OP_SESSION_ABC123')).toBe(true);
+  });
+
+  it('does not flag ordinary desktop/X11 session env vars', () => {
+    const desktopSessionNames = [
+      'XDG_SESSION_ID',
+      'XDG_SESSION_TYPE',
+      'DESKTOP_SESSION',
+      'SESSION_MANAGER',
+      'DBUS_SESSION_BUS_ADDRESS',
+      'GDMSESSION',
+    ];
+    for (const name of desktopSessionNames) {
+      expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
+    }
+  });
+
+  it('does not flag ordinary CLI/runtime env var names', () => {
+    const safeNames = [
+      'PATH',
+      'HOME',
+      'SHELL',
+      'LANG',
+      'LC_ALL',
+      'TERM',
+      'PWD',
+      'TMPDIR',
+      'USER',
+      'EDITOR',
+      'CI',
+      'NODE_ENV',
+      'NO_COLOR',
+      'FORCE_COLOR',
+      'npm_config_registry',
+      'KEYBOARD_LAYOUT',
+      'XDG_CONFIG_HOME',
+      'SSH_AUTH_SOCK',
+      'SSH_AGENT_PID',
+      'SSL_CERT_FILE',
+      'SSL_CERT_DIR',
+      'NODE_EXTRA_CA_CERTS',
+      'DOCKER_CERT_PATH',
+      'GIT_CONFIG_COUNT',
+      'GIT_CONFIG_KEY_0',
+      'GIT_CONFIG_VALUE_0',
+      'GIT_CONFIG_KEY_12',
+    ];
+    for (const name of safeNames) {
+      expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
+    }
+  });
+});
+
+describe('isSecretEnvVarValue', () => {
+  it('flags database connection strings with embedded credentials', () => {
+    expect(isSecretEnvVarValue('postgres://user:hunter2@db.example.com:5432/app')).toBe(true);
+    expect(isSecretEnvVarValue('postgresql://user:hunter2@db.example.com/app')).toBe(true);
+    expect(isSecretEnvVarValue('mysql://root:pw@localhost/db')).toBe(true);
+    expect(isSecretEnvVarValue('mariadb://root:pw@localhost/db')).toBe(true);
+    expect(isSecretEnvVarValue('mongodb://user:pw@cluster0.mongodb.net/app')).toBe(true);
+    expect(isSecretEnvVarValue('mongodb+srv://user:pw@cluster0.mongodb.net/app')).toBe(true);
+    expect(isSecretEnvVarValue('redis://user:pw@localhost:6379')).toBe(true);
+    expect(isSecretEnvVarValue('rediss://user:pw@localhost:6379')).toBe(true);
+  });
+
+  it('does not flag connection strings without embedded credentials or ordinary values', () => {
+    expect(isSecretEnvVarValue('postgres://db.example.com:5432/app')).toBe(false);
+    expect(isSecretEnvVarValue('/usr/bin:/bin')).toBe(false);
+    expect(isSecretEnvVarValue('en_US.UTF-8')).toBe(false);
+    expect(isSecretEnvVarValue('https://api.example.com')).toBe(false);
+    expect(isSecretEnvVarValue('')).toBe(false);
+  });
+});
+
+describe('filterSecretEnvVars', () => {
+  it('removes secret-shaped keys and preserves the rest', () => {
+    const input = {
+      PATH: '/usr/bin',
+      HOME: '/home/test',
+      SOME_API_KEY: 'sk-secret',
+      DATABASE_PASSWORD: 'hunter2',
+    };
+    expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin', HOME: '/home/test' });
+  });
+
+  it('removes vars whose value looks like a credential connection string, even with a non-secret-shaped name', () => {
+    const input = {
+      PATH: '/usr/bin',
+      DATABASE_URL: 'postgres://user:hunter2@db.example.com:5432/app',
+      REDIS_URL: 'redis://user:pw@localhost:6379',
+      PUBLIC_API_URL: 'https://api.example.com',
+    };
+    expect(filterSecretEnvVars(input)).toEqual({
+      PATH: '/usr/bin',
+      PUBLIC_API_URL: 'https://api.example.com',
+    });
+  });
+
+  it('removes secret-manager session tokens', () => {
+    const input = {
+      PATH: '/usr/bin',
+      BW_SESSION: 'live-vault-session-token',
+      OP_SESSION_my_account: 'live-1password-session-token',
+      XDG_SESSION_ID: '3',
+    };
+    expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin', XDG_SESSION_ID: '3' });
+  });
+
+  it('preserves keys listed in exemptNames despite looking secret-shaped', () => {
+    const input = {
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'anthropic-secret',
+      OPENAI_API_KEY: 'openai-secret',
+    };
+    expect(filterSecretEnvVars(input, ['ANTHROPIC_API_KEY'])).toEqual({
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'anthropic-secret',
+    });
+  });
+
+  it('exemptNames bypasses the value-based check too (trusted by name)', () => {
+    const input = {
+      TRUSTED_DB_URL: 'postgres://user:hunter2@db.example.com/app',
+    };
+    expect(filterSecretEnvVars(input, ['TRUSTED_DB_URL'])).toEqual(input);
+  });
+});

--- a/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
@@ -89,10 +89,36 @@ describe('isSecretEnvVarName', () => {
       'GIT_CONFIG_KEY_0',
       'GIT_CONFIG_VALUE_0',
       'GIT_CONFIG_KEY_12',
+      'PIP_CERT',
     ];
     for (const name of safeNames) {
       expect(isSecretEnvVarName(name), `expected ${name} to NOT be flagged as secret`).toBe(false);
     }
+  });
+
+  describe('safe-name matching follows OS env-var case semantics', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('on POSIX, a differently-cased collision with a safe name is still flagged as secret', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      // ssh_auth_sock (lowercase) is a genuinely distinct variable from
+      // SSH_AUTH_SOCK on POSIX and matches the AUTH segment — it must not
+      // be waved through just because it collides case-insensitively with
+      // the well-known safe name.
+      expect(isSecretEnvVarName('ssh_auth_sock')).toBe(true);
+      expect(isSecretEnvVarName('SSH_AUTH_SOCK')).toBe(false);
+    });
+
+    it('on Windows, a differently-cased collision with a safe name is still treated as safe', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      // On Windows, ssh_auth_sock and SSH_AUTH_SOCK name the same variable.
+      expect(isSecretEnvVarName('ssh_auth_sock')).toBe(false);
+      expect(isSecretEnvVarName('SSH_AUTH_SOCK')).toBe(false);
+    });
   });
 });
 
@@ -114,6 +140,12 @@ describe('isSecretEnvVarValue', () => {
     expect(isSecretEnvVarValue('en_US.UTF-8')).toBe(false);
     expect(isSecretEnvVarValue('https://api.example.com')).toBe(false);
     expect(isSecretEnvVarValue('')).toBe(false);
+  });
+
+  it('flags credentials embedded in non-database URL schemes (pip index, generic proxy, etc.)', () => {
+    expect(isSecretEnvVarValue('https://user:hunter2@packages.example.com/simple')).toBe(true);
+    expect(isSecretEnvVarValue('http://proxyuser:proxypass@proxy.example.com:8080')).toBe(true);
+    expect(isSecretEnvVarValue('ftp://user:pass@ftp.example.com')).toBe(true);
   });
 
   it('flags Authorization/Proxy-Authorization header-shaped values', () => {
@@ -160,6 +192,7 @@ describe('filterSecretEnvVars', () => {
       PATH: '/usr/bin',
       DATABASE_URL: 'postgres://user:hunter2@db.example.com:5432/app',
       REDIS_URL: 'redis://user:pw@localhost:6379',
+      PIP_INDEX_URL: 'https://user:hunter2@packages.example.com/simple',
       PUBLIC_API_URL: 'https://api.example.com',
     };
     expect(filterSecretEnvVars(input)).toEqual({
@@ -234,6 +267,21 @@ describe('filterSecretEnvVars', () => {
       GIT_CONFIG_VALUE_0: '/workspace',
       GIT_CONFIG_KEY_1: 'http.extraHeader',
       GIT_CONFIG_VALUE_1: 'Authorization: Bearer super-secret-live-token',
+    };
+    expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin' });
+  });
+
+  it('drops the family when a credential-bearing config key carries a non-Authorization header (e.g. GitLab PRIVATE-TOKEN)', () => {
+    // http.extraHeader accepts *any* header name, not just Authorization —
+    // GitLab's PRIVATE-TOKEN/JOB-TOKEN, or any custom scheme, are just as
+    // capable of carrying a live credential. Detected via the paired
+    // GIT_CONFIG_KEY_<n> being a known credential-bearing config key, not by
+    // pattern-matching every possible header name in the value.
+    const input = {
+      PATH: '/usr/bin',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.extraHeader',
+      GIT_CONFIG_VALUE_0: 'PRIVATE-TOKEN: glpat-super-secret-live-token',
     };
     expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin' });
   });

--- a/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
@@ -29,6 +29,8 @@ describe('isSecretEnvVarName', () => {
       'GOOGLE_APPLICATION_CREDENTIALS',
       'PGPASSWORD',
       'MYSQL_PWD',
+      'GITHUB_PAT',
+      'SERVICE_PAT',
     ];
     for (const name of secretNames) {
       expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
@@ -111,6 +113,23 @@ describe('isSecretEnvVarValue', () => {
     expect(isSecretEnvVarValue('https://api.example.com')).toBe(false);
     expect(isSecretEnvVarValue('')).toBe(false);
   });
+
+  it('flags Authorization/Proxy-Authorization header-shaped values', () => {
+    expect(isSecretEnvVarValue('Authorization: Bearer sometoken12345678')).toBe(true);
+    expect(isSecretEnvVarValue('authorization: Basic dXNlcjpwYXNz')).toBe(true);
+    expect(isSecretEnvVarValue('Proxy-Authorization: Bearer sometoken12345678')).toBe(true);
+  });
+
+  it('flags bare Bearer/Basic token values', () => {
+    expect(isSecretEnvVarValue('Bearer sometoken12345678')).toBe(true);
+    expect(isSecretEnvVarValue('Basic dXNlcjpwYXNzd29yZA==')).toBe(true);
+  });
+
+  it('does not flag ordinary git config values used by the safe-name-exempt tuple', () => {
+    expect(isSecretEnvVarValue('safe.directory')).toBe(false);
+    expect(isSecretEnvVarValue('/workspace')).toBe(false);
+    expect(isSecretEnvVarValue('1')).toBe(false);
+  });
 });
 
 describe('filterSecretEnvVars', () => {
@@ -164,5 +183,43 @@ describe('filterSecretEnvVars', () => {
       TRUSTED_DB_URL: 'postgres://user:hunter2@db.example.com/app',
     };
     expect(filterSecretEnvVars(input, ['TRUSTED_DB_URL'])).toEqual(input);
+  });
+
+  it('matches exemptNames case-sensitively so a differently-cased var is still filtered', () => {
+    const input = {
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'real-anthropic-secret',
+      anthropic_api_key: 'a-different-secret-with-the-same-spelling',
+    };
+    expect(filterSecretEnvVars(input, ['ANTHROPIC_API_KEY'])).toEqual({
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'real-anthropic-secret',
+    });
+  });
+
+  it('strips a credential smuggled through the git-config-tuple name exemption via its value', () => {
+    // GIT_CONFIG_KEY_<n>/VALUE_<n>/COUNT are exempt by name (git's own
+    // indexed config-injection mechanism), but git supports
+    // `http.extraHeader`, so GIT_CONFIG_VALUE_<n> could carry a live
+    // Authorization header. The name exemption must not blind the
+    // value-based check.
+    const input = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.extraHeader',
+      GIT_CONFIG_VALUE_0: 'Authorization: Bearer super-secret-live-token',
+    };
+    const filtered = filterSecretEnvVars(input);
+    expect(filtered['GIT_CONFIG_COUNT']).toBe('1');
+    expect(filtered['GIT_CONFIG_KEY_0']).toBe('http.extraHeader');
+    expect(filtered['GIT_CONFIG_VALUE_0']).toBeUndefined();
+  });
+
+  it('still preserves an ordinary (non-credential) git-config tuple', () => {
+    const input = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'safe.directory',
+      GIT_CONFIG_VALUE_0: '/workspace',
+    };
+    expect(filterSecretEnvVars(input)).toEqual(input);
   });
 });

--- a/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/security/env-filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   filterSecretEnvVars,
   isSecretEnvVarName,
@@ -31,6 +31,8 @@ describe('isSecretEnvVarName', () => {
       'MYSQL_PWD',
       'GITHUB_PAT',
       'SERVICE_PAT',
+      'CI_JOB_JWT',
+      'CI_JOB_JWT_V2',
     ];
     for (const name of secretNames) {
       expect(isSecretEnvVarName(name), `expected ${name} to be flagged as secret`).toBe(true);
@@ -130,6 +132,16 @@ describe('isSecretEnvVarValue', () => {
     expect(isSecretEnvVarValue('/workspace')).toBe(false);
     expect(isSecretEnvVarValue('1')).toBe(false);
   });
+
+  it('flags raw JWT-shaped values (three base64url segments)', () => {
+    const fakeJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    expect(isSecretEnvVarValue(fakeJwt)).toBe(true);
+  });
+
+  it('does not flag ordinary dotted values that are not JWT-shaped', () => {
+    expect(isSecretEnvVarValue('1.2.3')).toBe(false);
+    expect(isSecretEnvVarValue('en_US.UTF-8')).toBe(false);
+  });
 });
 
 describe('filterSecretEnvVars', () => {
@@ -197,21 +209,33 @@ describe('filterSecretEnvVars', () => {
     });
   });
 
-  it('strips a credential smuggled through the git-config-tuple name exemption via its value', () => {
+  it('drops the whole GIT_CONFIG_* family atomically when a credential is smuggled through it', () => {
     // GIT_CONFIG_KEY_<n>/VALUE_<n>/COUNT are exempt by name (git's own
     // indexed config-injection mechanism), but git supports
     // `http.extraHeader`, so GIT_CONFIG_VALUE_<n> could carry a live
-    // Authorization header. The name exemption must not blind the
-    // value-based check.
+    // Authorization header. Dropping only VALUE_0 would leave a malformed
+    // tuple (COUNT says 1, KEY_0 present, VALUE_0 missing) that makes git
+    // itself error with "missing config value" on every command — so the
+    // whole family must go together, not just the offending value.
     const input = {
+      PATH: '/usr/bin',
       GIT_CONFIG_COUNT: '1',
       GIT_CONFIG_KEY_0: 'http.extraHeader',
       GIT_CONFIG_VALUE_0: 'Authorization: Bearer super-secret-live-token',
     };
-    const filtered = filterSecretEnvVars(input);
-    expect(filtered['GIT_CONFIG_COUNT']).toBe('1');
-    expect(filtered['GIT_CONFIG_KEY_0']).toBe('http.extraHeader');
-    expect(filtered['GIT_CONFIG_VALUE_0']).toBeUndefined();
+    expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin' });
+  });
+
+  it('drops every indexed pair in the family, not just the offending index, when count > 1', () => {
+    const input = {
+      PATH: '/usr/bin',
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'safe.directory',
+      GIT_CONFIG_VALUE_0: '/workspace',
+      GIT_CONFIG_KEY_1: 'http.extraHeader',
+      GIT_CONFIG_VALUE_1: 'Authorization: Bearer super-secret-live-token',
+    };
+    expect(filterSecretEnvVars(input)).toEqual({ PATH: '/usr/bin' });
   });
 
   it('still preserves an ordinary (non-credential) git-config tuple', () => {
@@ -221,5 +245,32 @@ describe('filterSecretEnvVars', () => {
       GIT_CONFIG_VALUE_0: '/workspace',
     };
     expect(filterSecretEnvVars(input)).toEqual(input);
+  });
+
+  describe('exemptNames matching follows OS env-var case semantics', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      vi.restoreAllMocks();
+    });
+
+    it('on Windows, exemptNames matches case-insensitively', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const input = {
+        PATH: 'C:\\bin',
+        OpenAI_API_Key: 'openai-secret',
+      };
+      expect(filterSecretEnvVars(input, ['OPENAI_API_KEY'])).toEqual(input);
+    });
+
+    it('on POSIX platforms, exemptNames still matches exact-case only', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      const input = {
+        PATH: '/usr/bin',
+        OpenAI_API_Key: 'openai-secret',
+      };
+      expect(filterSecretEnvVars(input, ['OPENAI_API_KEY'])).toEqual({ PATH: '/usr/bin' });
+    });
   });
 });

--- a/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/martin-loop.test.ts
@@ -632,6 +632,23 @@ describe('MartinLoop', () => {
     delete process.env['CLAUDECODE'];
   });
 
+  it('strips secret-shaped ambient env vars while preserving the provider auth var (spawnIteration path)', async () => {
+    process.env['SOME_UNRELATED_API_KEY'] = 'unrelated-secret';
+    process.env['ANTHROPIC_API_KEY'] = 'anthropic-secret';
+
+    queueMock({ stdout: 'ok\n<promise>IMPL_X_DONE</promise>', exitCode: 0 });
+
+    const loop = new MartinLoop();
+    await loop.run(baseConfig({ provider: 'claude' }));
+
+    const spawnEnv = (mockSpawn.mock.calls[0] as unknown[])[2] as { env: Record<string, string> };
+    expect(spawnEnv.env).not.toHaveProperty('SOME_UNRELATED_API_KEY');
+    expect(spawnEnv.env).toHaveProperty('ANTHROPIC_API_KEY', 'anthropic-secret');
+
+    delete process.env['SOME_UNRELATED_API_KEY'];
+    delete process.env['ANTHROPIC_API_KEY'];
+  });
+
   // ── 11. Token estimation via provider ──
 
   it('estimates tokens via provider: /4 for claude, /16 for codex', async () => {

--- a/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
@@ -96,6 +96,19 @@ describe('AiderProvider', () => {
     expect(vars).toContain('MISTRAL_API_KEY');
   });
 
+  it('requiredAuthEnvVars resolves to the AWS credential trio for Bedrock/SageMaker backends', () => {
+    expect(provider.requiredAuthEnvVars?.('bedrock/anthropic.claude-3-sonnet')).toEqual([
+      'AWS_ACCESS_KEY_ID',
+      'AWS_SECRET_ACCESS_KEY',
+      'AWS_SESSION_TOKEN',
+    ]);
+    expect(provider.requiredAuthEnvVars?.('sagemaker/my-endpoint')).toEqual([
+      'AWS_ACCESS_KEY_ID',
+      'AWS_SECRET_ACCESS_KEY',
+      'AWS_SESSION_TOKEN',
+    ]);
+  });
+
   // -- isRateLimited -------------------------------------------------------
 
   it('isRateLimited always returns false (LiteLLM handles retries)', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
@@ -74,6 +74,17 @@ describe('AiderProvider', () => {
     expect(filtered).not.toBe(env);
   });
 
+  // -- requiredAuthEnvVars --------------------------------------------------
+
+  it('requiredAuthEnvVars declares common LiteLLM-backed vendor keys (aider has no fixed backend)', () => {
+    const vars = provider.requiredAuthEnvVars?.() ?? [];
+    expect(vars).toContain('ANTHROPIC_API_KEY');
+    expect(vars).toContain('OPENAI_API_KEY');
+    expect(vars).toContain('OPENROUTER_API_KEY');
+    expect(vars).toContain('GROQ_API_KEY');
+    expect(vars).toContain('MISTRAL_API_KEY');
+  });
+
   // -- isRateLimited -------------------------------------------------------
 
   it('isRateLimited always returns false (LiteLLM handles retries)', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/aider-provider.test.ts
@@ -76,8 +76,19 @@ describe('AiderProvider', () => {
 
   // -- requiredAuthEnvVars --------------------------------------------------
 
-  it('requiredAuthEnvVars declares common LiteLLM-backed vendor keys (aider has no fixed backend)', () => {
-    const vars = provider.requiredAuthEnvVars?.() ?? [];
+  it('requiredAuthEnvVars resolves to just ANTHROPIC_API_KEY by default (default chatModel is Sonnet)', () => {
+    expect(provider.requiredAuthEnvVars?.()).toEqual(['ANTHROPIC_API_KEY']);
+    expect(provider.requiredAuthEnvVars?.('sonnet')).toEqual(['ANTHROPIC_API_KEY']);
+  });
+
+  it('requiredAuthEnvVars resolves to just the active backend key for a recognized LiteLLM prefix', () => {
+    expect(provider.requiredAuthEnvVars?.('groq/llama-3.1-70b-versatile')).toEqual(['GROQ_API_KEY']);
+    expect(provider.requiredAuthEnvVars?.('openrouter/anthropic/claude-3.5-sonnet')).toEqual(['OPENROUTER_API_KEY']);
+    expect(provider.requiredAuthEnvVars?.('gpt-4o')).toEqual(['OPENAI_API_KEY']);
+  });
+
+  it('requiredAuthEnvVars falls back to the full known-vendor list for an unrecognized model string', () => {
+    const vars = provider.requiredAuthEnvVars?.('some-unrecognized-custom-model') ?? [];
     expect(vars).toContain('ANTHROPIC_API_KEY');
     expect(vars).toContain('OPENAI_API_KEY');
     expect(vars).toContain('OPENROUTER_API_KEY');

--- a/packages/franken-orchestrator/tests/unit/skills/providers/claude-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/claude-provider.test.ts
@@ -87,6 +87,12 @@ describe('ClaudeProvider', () => {
     expect(filtered).not.toBe(env);
   });
 
+  // -- requiredAuthEnvVars --------------------------------------------------
+
+  it('requiredAuthEnvVars declares ANTHROPIC_API_KEY', () => {
+    expect(provider.requiredAuthEnvVars?.()).toEqual(['ANTHROPIC_API_KEY']);
+  });
+
   // -- isRateLimited -------------------------------------------------------
 
   it('isRateLimited detects rate limit patterns', () => {

--- a/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
+++ b/packages/franken-orchestrator/tests/unit/skills/providers/codex-provider.test.ts
@@ -121,6 +121,12 @@ describe('CodexProvider', () => {
     });
   });
 
+  // -- requiredAuthEnvVars --------------------------------------------------
+
+  it('requiredAuthEnvVars declares OPENAI_API_KEY', () => {
+    expect(provider.requiredAuthEnvVars?.()).toEqual(['OPENAI_API_KEY']);
+  });
+
   // -- isRateLimited -------------------------------------------------------
 
   it('isRateLimited detects rate limit patterns', () => {


### PR DESCRIPTION
## Summary
- `CliLlmAdapter.captureEnv()` forwarded the entire `process.env` to spawned LLM provider CLI subprocesses (claude/codex/gemini/aider) unfiltered, risking leakage of API keys, tokens, passwords, and other secrets present in the runtime environment to external services or logs.
- Added `filterSecretEnvVars()` / `isSecretEnvVarName()` in `cli-llm-adapter.ts`: a denylist-by-pattern filter matched on underscore-delimited name segments (`KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `CREDENTIAL(S)`, `AUTH`, `CERT(IFICATE)`, `COOKIE`, `WEBHOOK`, plus common no-delimiter compounds like `APIKEY`/`AUTHTOKEN`) so vars like `SOME_API_KEY`, `AWS_SECRET_ACCESS_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, and `DATABASE_PASSWORD` are stripped before spawn.
- `captureEnv()` now applies this filter before `provider.filterEnv()` runs, so all four CLI providers get it uniformly.
- Chose a denylist over a hand-maintained allowlist: the CLI subprocesses need broad standard environment access (`PATH`, `HOME`, locale vars, `npm_config_*`, etc.) to function correctly, so enumerating every legitimate var would be brittle and prone to breaking real CLI behavior. Word-boundary matching (segments split on `_`) avoids false positives like `KEYBOARD_LAYOUT` or `PWD`.
- Checked `franken-mcp-suite`'s `brain-adapter.ts` redaction utilities first — those redact secret-shaped *values* inside free-text/log content for export, a different concern from filtering an env var *map* by key name before subprocess spawn, so a dedicated filter was added here instead of reusing that code.

## Test plan
- [x] Added failing tests first (TDD) proving `SOME_API_KEY`, `AWS_SECRET_ACCESS_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, `DATABASE_PASSWORD` were forwarded to the spawned CLI process before the fix.
- [x] Added tests confirming non-secret vars the CLI needs (`PATH`, `HOME`, `LANG`, `TERM`, `npm_config_registry`) still pass through.
- [x] Added unit tests for `isSecretEnvVarName` / `filterSecretEnvVars` covering common secret name shapes and common safe names (including the `KEYBOARD_LAYOUT` / `PWD` false-positive edge cases).
- [x] `npx vitest run tests/unit/adapters/cli-llm-adapter.test.ts` — 81/81 passing.
- [x] `npx turbo run typecheck --filter=@franken/orchestrator` — clean.
- [x] `npx turbo run test --filter=@franken/orchestrator` — full suite passes aside from two known-flaky, unrelated tests (a process-timeout test and a codex-app-server-unavailable test) that each pass individually in isolation and are unaffected by this change.

Closes #3714