### PR TITLE
fix(web): announce network service status changes

### DIFF
--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -174,7 +174,10 @@ export function NetworkServiceList({
           <article key={service.id} className="network-services__item" role="listitem">
             <div>
               <strong>{service.id}</strong>
-              <p aria-atomic="true" aria-live="polite">{service.status}</p>
+              <p aria-atomic="true" aria-live="polite">
+                <span className="sr-only">{service.id} status: </span>
+                {service.status}
+              </p>
               {service.inProcess && <small>in-process</small>}
               {service.explanation && <span>{service.explanation}</span>}
               {service.url && <small>{service.url}</small>}

--- a/packages/franken-web/src/components/network-service-list.tsx
+++ b/packages/franken-web/src/components/network-service-list.tsx
@@ -164,17 +164,17 @@ export function NetworkServiceList({
       <div className="rail-card__header">
         <p className="eyebrow">Services</p>
       </div>
-      <div className="network-services__list">
+      <div aria-label="Network services" className="network-services__list" role="list">
         {services.map((service) => {
           const actionState = actionStateByService[service.id];
           const hasPendingAction = actionState?.status === 'pending';
           const startDisabled = hasPendingAction || !canStartService(service);
           const stopOrRestartDisabled = hasPendingAction || !canStopOrRestartService(service);
           return (
-          <article key={service.id} className="network-services__item">
+          <article key={service.id} className="network-services__item" role="listitem">
             <div>
               <strong>{service.id}</strong>
-              <p>{service.status}</p>
+              <p aria-atomic="true" aria-live="polite">{service.status}</p>
               {service.inProcess && <small>in-process</small>}
               {service.explanation && <span>{service.explanation}</span>}
               {service.url && <small>{service.url}</small>}

--- a/packages/franken-web/tests/components/network-service-list.test.tsx
+++ b/packages/franken-web/tests/components/network-service-list.test.tsx
@@ -75,32 +75,39 @@ describe('NetworkServiceList destructive action confirmations', () => {
 });
 
 describe('NetworkServiceList status announcements', () => {
-  it('announces an updated service status without making the entire list live', () => {
+  it('identifies the updated service without making the entire list live', () => {
     const handlers = {
       onSelectLogs: vi.fn(),
       onStart: vi.fn(),
       onStop: vi.fn(),
       onRestart: vi.fn(),
     };
+    const workerService = { id: 'worker-runtime', status: 'running' };
+    const services = [runningService, workerService];
     const { rerender } = render(
-      <NetworkServiceList services={[runningService]} {...handlers} />,
+      <NetworkServiceList services={services} {...handlers} />,
     );
 
     const serviceList = screen.getByRole('list', { name: 'Network services' });
     expect(serviceList.getAttribute('aria-live')).toBeNull();
-    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
 
-    const statusRegion = screen.getByText('running');
+    const statusRegion = screen.getAllByText('running')[0]!;
     expect(statusRegion.getAttribute('aria-live')).toBe('polite');
     expect(statusRegion.getAttribute('aria-atomic')).toBe('true');
+    expect(statusRegion.textContent).toBe('chat-gateway status: running');
 
     rerender(
       <NetworkServiceList
-        services={[{ ...runningService, status: 'degraded' }]}
+        services={[
+          { ...runningService, status: 'degraded' },
+          workerService,
+        ]}
         {...handlers}
       />,
     );
 
     expect(screen.getByText('degraded')).toBe(statusRegion);
+    expect(statusRegion.textContent).toBe('chat-gateway status: degraded');
   });
 });

--- a/packages/franken-web/tests/components/network-service-list.test.tsx
+++ b/packages/franken-web/tests/components/network-service-list.test.tsx
@@ -73,3 +73,34 @@ describe('NetworkServiceList destructive action confirmations', () => {
     expect(handlers.onRestart).toHaveBeenCalledWith('chat-gateway');
   });
 });
+
+describe('NetworkServiceList status announcements', () => {
+  it('announces an updated service status without making the entire list live', () => {
+    const handlers = {
+      onSelectLogs: vi.fn(),
+      onStart: vi.fn(),
+      onStop: vi.fn(),
+      onRestart: vi.fn(),
+    };
+    const { rerender } = render(
+      <NetworkServiceList services={[runningService]} {...handlers} />,
+    );
+
+    const serviceList = screen.getByRole('list', { name: 'Network services' });
+    expect(serviceList.getAttribute('aria-live')).toBeNull();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+
+    const statusRegion = screen.getByText('running');
+    expect(statusRegion.getAttribute('aria-live')).toBe('polite');
+    expect(statusRegion.getAttribute('aria-atomic')).toBe('true');
+
+    rerender(
+      <NetworkServiceList
+        services={[{ ...runningService, status: 'degraded' }]}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByText('degraded')).toBe(statusRegion);
+  });
+});

--- a/tasks/resolve-issue-3854-progress.md
+++ b/tasks/resolve-issue-3854-progress.md
@@ -8,6 +8,6 @@
   - Focused component suite: 3/3 passed.
   - Repository lint, typecheck, and build passed.
   - Repository tests passed all assertions on retry (including 4,983/4,983 orchestrator tests) but the orchestrator command still exited 1 for a pre-existing unhandled Codex app-server-unavailable rejection; the three implicated runtime files pass together (124/124).
-- [ ] Commit with the required author identity, push, and open a linked PR.
+- [x] Commit with the required author identity, push, and open linked PR #3926.
 - [ ] Reach green CI and an exact-head Codex clean result with zero unresolved threads.
 - [ ] Guarded squash-merge and verify issue closure.

--- a/tasks/resolve-issue-3854-progress.md
+++ b/tasks/resolve-issue-3854-progress.md
@@ -10,4 +10,5 @@
   - Repository tests passed all assertions on retry (including 4,983/4,983 orchestrator tests) but the orchestrator command still exited 1 for a pre-existing unhandled Codex app-server-unavailable rejection; the three implicated runtime files pass together (124/124).
 - [x] Commit with the required author identity, push, and open linked PR #3926.
 - [ ] Reach green CI and an exact-head Codex clean result with zero unresolved threads.
+  - Round 1 finding: status updates lacked the service name in multi-service lists; added a screen-reader-only identifier and multi-service regression.
 - [ ] Guarded squash-merge and verify issue closure.

--- a/tasks/resolve-issue-3854-progress.md
+++ b/tasks/resolve-issue-3854-progress.md
@@ -1,0 +1,13 @@
+# Issue 3854 progress
+
+- [x] Revalidate live issue state, open PRs, Kanban ownership, branch, and isolated worktree.
+- [x] Reproduce the missing status announcement with a focused failing accessibility test.
+- [x] Implement minimal list/live-region semantics without keyboard behavior or noisy duplicate announcements.
+- [x] Run focused component tests.
+- [x] Run repository test, lint, typecheck, and build gates.
+  - Focused component suite: 3/3 passed.
+  - Repository lint, typecheck, and build passed.
+  - Repository tests passed all assertions on retry (including 4,983/4,983 orchestrator tests) but the orchestrator command still exited 1 for a pre-existing unhandled Codex app-server-unavailable rejection; the three implicated runtime files pass together (124/124).
+- [ ] Commit with the required author identity, push, and open a linked PR.
+- [ ] Reach green CI and an exact-head Codex clean result with zero unresolved threads.
+- [ ] Guarded squash-merge and verify issue closure.


### PR DESCRIPTION
## Summary
- expose NetworkServiceList with explicit list/listitem semantics
- announce per-service status updates through polite atomic live regions
- add an accessibility regression covering rerendered status changes without making the whole list live

## Test plan
- `npm run test --workspace @franken/web -- --run tests/components/network-service-list.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` (all assertions pass on retry, but exits 1 on a pre-existing unhandled Codex app-server-unavailable rejection in orchestrator runtime tests; implicated files pass 124/124 when isolated)

Closes #3854