### PR TITLE
fix(orchestrator): sanitize adapter error messages

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -31,9 +31,27 @@ type UnifiedResponse = {
 const MAX_OUTWARD_ERROR_CONTEXT_LENGTH = 1_000;
 
 function safeAdapterErrorContext(error: unknown): string {
-  const errorClass = error instanceof Error ? error.name : typeof error;
-  const message = error instanceof Error ? error.message : String(error);
-  const safeClass = redactSensitiveText(errorClass).replace(/\s+/gu, ' ').trim().slice(0, 100);
+  let errorClass: string = typeof error;
+  let message = 'No diagnostic available';
+  if (error instanceof Error) {
+    try {
+      errorClass = String(error.name);
+    } catch {
+      errorClass = 'Error';
+    }
+    try {
+      message = String(error.message);
+    } catch {
+      // Keep the fixed safe fallback when an untrusted error getter throws.
+    }
+  } else {
+    try {
+      message = String(error);
+    } catch {
+      // Keep the fixed safe fallback when an untrusted conversion throws.
+    }
+  }
+  const safeClass = redactSensitiveText(errorClass.replace(/\s+/gu, ' ')).trim().slice(0, 100);
   const safeMessage = redactSensitiveText(message.replace(/\s+/gu, ' '))
     .trim()
     .slice(0, MAX_OUTWARD_ERROR_CONTEXT_LENGTH);

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -33,14 +33,22 @@ const MAX_OUTWARD_ERROR_CONTEXT_LENGTH = 1_000;
 function safeAdapterErrorContext(error: unknown): string {
   let errorClass: string = typeof error;
   let message = 'No diagnostic available';
-  if (error instanceof Error) {
+  let errorValue: Error | undefined;
+  try {
+    if (error instanceof Error) {
+      errorValue = error;
+    }
+  } catch {
+    // Treat values with hostile prototype traps as opaque thrown values.
+  }
+  if (errorValue) {
     try {
-      errorClass = String(error.name);
+      errorClass = String(errorValue.name);
     } catch {
       errorClass = 'Error';
     }
     try {
-      message = String(error.message);
+      message = String(errorValue.message);
     } catch {
       // Keep the fixed safe fallback when an untrusted error getter throws.
     }
@@ -55,7 +63,9 @@ function safeAdapterErrorContext(error: unknown): string {
   const safeMessage = redactSensitiveText(message.replace(/\s+/gu, ' '))
     .trim()
     .slice(0, MAX_OUTWARD_ERROR_CONTEXT_LENGTH);
-  return `${safeClass || 'Error'}: ${safeMessage || 'No diagnostic available'}`;
+  return redactSensitiveText(
+    `${safeClass || 'Error'}: ${safeMessage || 'No diagnostic available'}`,
+  );
 }
 
 export interface IAdapter {

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -34,8 +34,7 @@ function safeAdapterErrorContext(error: unknown): string {
   const errorClass = error instanceof Error ? error.name : typeof error;
   const message = error instanceof Error ? error.message : String(error);
   const safeClass = redactSensitiveText(errorClass).replace(/\s+/gu, ' ').trim().slice(0, 100);
-  const safeMessage = redactSensitiveText(message)
-    .replace(/\s+/gu, ' ')
+  const safeMessage = redactSensitiveText(message.replace(/\s+/gu, ' '))
     .trim()
     .slice(0, MAX_OUTWARD_ERROR_CONTEXT_LENGTH);
   return `${safeClass || 'Error'}: ${safeMessage || 'No diagnostic available'}`;

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -1,5 +1,6 @@
 import type { ILlmClient, LlmCompletionOptions, LlmCompletionResult, ProviderContext, TokenUsage } from '@franken/types';
 import { randomUUID } from 'node:crypto';
+import { redactSensitiveText } from '../logging/redaction.js';
 
 type UnifiedRequest = {
   id: string;
@@ -26,6 +27,19 @@ type UnifiedResponse = {
   /** The CLI provider/model that actually served this completion, and any fallback that occurred. */
   providerContext?: ProviderContext;
 };
+
+const MAX_OUTWARD_ERROR_CONTEXT_LENGTH = 1_000;
+
+function safeAdapterErrorContext(error: unknown): string {
+  const errorClass = error instanceof Error ? error.name : typeof error;
+  const message = error instanceof Error ? error.message : String(error);
+  const safeClass = redactSensitiveText(errorClass).replace(/\s+/gu, ' ').trim().slice(0, 100);
+  const safeMessage = redactSensitiveText(message)
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .slice(0, MAX_OUTWARD_ERROR_CONTEXT_LENGTH);
+  return `${safeClass || 'Error'}: ${safeMessage || 'No diagnostic available'}`;
+}
 
 export interface IAdapter {
   transformRequest(request: UnifiedRequest): unknown;
@@ -132,9 +146,8 @@ export class AdapterLlmClient implements ILlmClient {
         usage = response.usage;
         providerContext = response.providerContext;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
         throw new AdapterLlmError(
-          `LLM adapter call failed for request ${requestId}: ${message}`,
+          `LLM adapter call failed for request ${requestId}: ${safeAdapterErrorContext(error)}`,
           requestId,
           { cause: error },
         );

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -73,6 +73,35 @@ describe('AdapterLlmClient', () => {
     expect((err as AdapterLlmError).cause).toBe(boom);
   });
 
+  it('redacts secrets from outward adapter errors while preserving safe context', async () => {
+    const privateMaterial = ['ghp', '1234567890abcdef'].join('_');
+    const boom = new Error(`provider unavailable: API_TOKEN=${privateMaterial}`);
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('provider unavailable');
+    expect((err as AdapterLlmError).message).toContain('API_TOKEN=<redacted>');
+    expect((err as AdapterLlmError).message).not.toContain(privateMaterial);
+    expect((err as AdapterLlmError).message).toContain((err as AdapterLlmError).requestId);
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
+  it('bounds outward adapter diagnostics and identifies the error class', async () => {
+    const boom = new TypeError(`invalid response ${'x'.repeat(2_000)}`);
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('TypeError: invalid response');
+    expect((err as AdapterLlmError).message.length).toBeLessThanOrEqual(1_100);
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
   it('wraps transformRequest/transformResponse failures', async () => {
     const client = new AdapterLlmClient(
       makeAdapter({ transformResponse: vi.fn(() => { throw new Error('bad payload'); }) }),

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -133,6 +133,35 @@ describe('AdapterLlmClient', () => {
     expect((err as AdapterLlmError).cause).toBe(boom);
   });
 
+  it('redacts secrets formed by composing the error name and message', async () => {
+    const privateMaterial = ['composed', 'private', 'material'].join('-');
+    const boom = new Error(privateMaterial);
+    boom.name = 'API_TOKEN';
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('API_TOKEN: <redacted>');
+    expect((err as AdapterLlmError).message).not.toContain(privateMaterial);
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
+  it('preserves the adapter wrapper when error classification throws', async () => {
+    const boom = new Proxy(new Error('provider unavailable'), {
+      getPrototypeOf: () => { throw new Error('prototype unavailable'); },
+    });
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).requestId).toBe('llm-123e4567-e89b-42d3-a456-426614174000');
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
   it('bounds outward adapter diagnostics and identifies the error class', async () => {
     const boom = new TypeError(`invalid response ${'x'.repeat(2_000)}`);
     const client = new AdapterLlmClient(

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -103,6 +103,36 @@ describe('AdapterLlmClient', () => {
     expect((err as AdapterLlmError).cause).toBe(boom);
   });
 
+  it('redacts header-style secrets before normalizing multiline error names', async () => {
+    const privateMaterial = ['multiline', 'class', 'material'].join('-');
+    const boom = new Error('provider unavailable');
+    boom.name = `API_TOKEN: ${privateMaterial}\n at execute`;
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('API_TOKEN: <redacted>');
+    expect((err as AdapterLlmError).message).not.toContain(privateMaterial);
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
+  it('preserves the adapter wrapper when reading an error name throws', async () => {
+    const boom = new Error('provider unavailable');
+    Object.defineProperty(boom, 'name', {
+      get: () => { throw new Error('name unavailable'); },
+    });
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('Error: provider unavailable');
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
   it('bounds outward adapter diagnostics and identifies the error class', async () => {
     const boom = new TypeError(`invalid response ${'x'.repeat(2_000)}`);
     const client = new AdapterLlmClient(

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -89,6 +89,20 @@ describe('AdapterLlmClient', () => {
     expect((err as AdapterLlmError).cause).toBe(boom);
   });
 
+  it('redacts header-style secrets before normalizing multiline adapter errors', async () => {
+    const privateMaterial = ['multiline', 'private', 'material'].join('-');
+    const boom = new Error(`API_TOKEN: ${privateMaterial}\n at execute`);
+    const client = new AdapterLlmClient(
+      makeAdapter({ execute: vi.fn(async () => { throw boom; }) }),
+    );
+
+    const err = await client.complete('prompt').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AdapterLlmError);
+    expect((err as AdapterLlmError).message).toContain('API_TOKEN: <redacted>');
+    expect((err as AdapterLlmError).message).not.toContain(privateMaterial);
+    expect((err as AdapterLlmError).cause).toBe(boom);
+  });
+
   it('bounds outward adapter diagnostics and identifies the error class', async () => {
     const boom = new TypeError(`invalid response ${'x'.repeat(2_000)}`);
     const client = new AdapterLlmClient(

--- a/tasks/sanitize-adapter-errors-progress.md
+++ b/tasks/sanitize-adapter-errors-progress.md
@@ -1,0 +1,12 @@
+# Sanitize adapter errors progress
+
+- [x] Revalidate issue #3662 is open, no duplicate open PR exists, and the isolated worktree is clean at the assigned base.
+- [x] Trace `AdapterLlmError` construction and identify raw provider error interpolation as the leak source.
+- [x] Add and run a failing regression test for secret redaction while preserving request context and `cause`.
+- [x] Implement the minimal redaction fix and make the regression test pass.
+- [x] Add and run a failing regression test for bounded outward error context.
+- [x] Implement the minimal bound and make focused tests pass.
+- [x] Run orchestrator and repository test, lint, typecheck, build, and secret-scan gates.
+- [ ] Commit with the required identity, push, and open one PR linked to issue #3662.
+- [ ] Resolve exact-head GitHub Codex findings, verify zero unresolved threads and green CI, then guarded squash-merge.
+- [ ] Verify issue #3662 closes and complete the Kanban handoff.

--- a/tasks/sanitize-adapter-errors-progress.md
+++ b/tasks/sanitize-adapter-errors-progress.md
@@ -7,6 +7,6 @@
 - [x] Add and run a failing regression test for bounded outward error context.
 - [x] Implement the minimal bound and make focused tests pass.
 - [x] Run orchestrator and repository test, lint, typecheck, build, and secret-scan gates.
-- [ ] Commit with the required identity, push, and open one PR linked to issue #3662.
+- [x] Commit with the required identity, push, and open one PR linked to issue #3662.
 - [ ] Resolve exact-head GitHub Codex findings, verify zero unresolved threads and green CI, then guarded squash-merge.
 - [ ] Verify issue #3662 closes and complete the Kanban handoff.


### PR DESCRIPTION
## Summary
- redact sensitive values before adapter failures cross the orchestrator boundary
- retain bounded error-class diagnostics, request correlation, and the original trusted `cause`
- add regressions for secret redaction and diagnostic length bounds

## Test plan
- `npm run test --workspace @franken/orchestrator -- --run tests/unit/adapters/adapter-llm-client.test.ts`
- `npm run test --workspace @franken/orchestrator`
- `npm run lint --workspace @franken/orchestrator`
- `npm run typecheck --workspace @franken/orchestrator`
- `npm run build --workspace @franken/orchestrator`
- `npm run lint:security`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #3662