### PR TITLE
fix(critique): report lesson persistence failures

### DIFF
--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -2076,7 +2076,6 @@ export class LessonRecorder {
         }
       }
 
-      let persistenceAttempted = false;
       try {
         const contradictionContext = await this.createContradictionContext(
           lesson,
@@ -2097,8 +2096,13 @@ export class LessonRecorder {
             admittedBaseLesson.timestamp,
           ),
         };
-        persistenceAttempted = true;
-        await this.memory.recordLesson(admittedLesson);
+        try {
+          await this.memory.recordLesson(admittedLesson);
+        } catch {
+          admissionSettled?.(false);
+          reportLessonRecordingFailure(admittedLesson);
+          return;
+        }
         recordingResult.recorded += 1;
         this.commitFailureClusterObservation(admittedLesson, recordingResult);
         this.commitBlockerPatternObservations(lesson);
@@ -2119,9 +2123,6 @@ export class LessonRecorder {
         admissionSettled?.(true);
       } catch {
         admissionSettled?.(false);
-        if (persistenceAttempted) {
-          reportLessonRecordingFailure(lesson);
-        }
       } finally {
         if (
           cooldownKey &&

--- a/packages/franken-critique/src/memory/lesson-recorder.ts
+++ b/packages/franken-critique/src/memory/lesson-recorder.ts
@@ -46,6 +46,9 @@ const LESSON_TRACEABILITY_VERIFICATION_COMMAND =
   'npm run test --workspace @franken/critique -- --run tests/unit/memory/lesson-recorder.test.ts';
 const LESSON_CONTRADICTION_VERIFICATION_COMMAND =
   LESSON_TRACEABILITY_VERIFICATION_COMMAND;
+const LESSON_RECORD_FAILURE_CODE = 'CRITIQUE_LESSON_RECORD_FAILED';
+const LESSON_RECORD_FAILURE_GUIDANCE =
+  'Inspect the memory adapter and retry the critique run after persistence recovers.';
 
 const DEFAULT_LESSON_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const MAX_LESSON_COOLDOWN_MS = 100 * 365 * 24 * 60 * 60 * 1000;
@@ -2073,6 +2076,7 @@ export class LessonRecorder {
         }
       }
 
+      let persistenceAttempted = false;
       try {
         const contradictionContext = await this.createContradictionContext(
           lesson,
@@ -2093,6 +2097,7 @@ export class LessonRecorder {
             admittedBaseLesson.timestamp,
           ),
         };
+        persistenceAttempted = true;
         await this.memory.recordLesson(admittedLesson);
         recordingResult.recorded += 1;
         this.commitFailureClusterObservation(admittedLesson, recordingResult);
@@ -2114,7 +2119,9 @@ export class LessonRecorder {
         admissionSettled?.(true);
       } catch {
         admissionSettled?.(false);
-        // Non-fatal: log failure but don't disrupt the critique flow
+        if (persistenceAttempted) {
+          reportLessonRecordingFailure(lesson);
+        }
       } finally {
         if (
           cooldownKey &&
@@ -4443,6 +4450,25 @@ function findRedactionSpans(
 
 function stableHash(value: string): string {
   return createHash('sha256').update(value).digest('base64url');
+}
+
+function reportLessonRecordingFailure(lesson: CritiqueLesson): void {
+  const lessonId =
+    lesson.testTraceability?.[0]?.lessonId ??
+    `${lesson.taskId}\u0000${lesson.evaluatorName}`;
+  try {
+    console.warn('Lesson recording failed', {
+      code: LESSON_RECORD_FAILURE_CODE,
+      operation: 'memory.recordLesson',
+      taskIdHash: stableHash(lesson.taskId).slice(0, 16),
+      lessonIdHash: stableHash(lessonId).slice(0, 16),
+      evaluatorNameHash: stableHash(lesson.evaluatorName).slice(0, 16),
+      retryable: true,
+      guidance: LESSON_RECORD_FAILURE_GUIDANCE,
+    });
+  } catch {
+    // Diagnostic output is best-effort so persistence failures remain non-fatal.
+  }
 }
 
 function sanitizeLessonIdPart(value: string): string {

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -2244,29 +2244,33 @@ describe('LessonRecorder', () => {
       ],
     };
 
-    const recording = await recorder.record(
-      result,
-      `task-${sensitiveFailure}`,
-    );
+    try {
+      const recording = await recorder.record(
+        result,
+        `task-${sensitiveFailure}`,
+      );
 
-    expect(recording.recorded).toBe(0);
-    expect(logged).toHaveBeenCalledWith('Lesson recording failed', {
-      code: 'CRITIQUE_LESSON_RECORD_FAILED',
-      operation: 'memory.recordLesson',
-      taskIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
-      lessonIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
-      evaluatorNameHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
-      retryable: true,
-      guidance:
-        'Inspect the memory adapter and retry the critique run after persistence recovers.',
-    });
-    expect(JSON.stringify(logged.mock.calls)).not.toContain(sensitiveFailure);
+      expect(recording.recorded).toBe(0);
+      expect(logged).toHaveBeenCalledWith('Lesson recording failed', {
+        code: 'CRITIQUE_LESSON_RECORD_FAILED',
+        operation: 'memory.recordLesson',
+        taskIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+        lessonIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+        evaluatorNameHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+        retryable: true,
+        guidance:
+          'Inspect the memory adapter and retry the critique run after persistence recovers.',
+      });
+      expect(JSON.stringify(logged.mock.calls)).not.toContain(sensitiveFailure);
+    } finally {
+      logged.mockRestore();
+    }
   });
 
   it('keeps lesson persistence failures non-fatal when warning output fails', async () => {
     const port = createMockMemoryPort();
     port.recordLesson = vi.fn().mockRejectedValue(new Error('DB unavailable'));
-    vi.spyOn(console, 'warn').mockImplementation(() => {
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {
       throw new Error('warning sink unavailable');
     });
     const recorder = new LessonRecorder(port);
@@ -2280,9 +2284,45 @@ describe('LessonRecorder', () => {
       ],
     };
 
-    await expect(recorder.record(result, 'warning-failure-task')).resolves.toMatchObject({
-      recorded: 0,
-    });
+    try {
+      await expect(
+        recorder.record(result, 'warning-failure-task'),
+      ).resolves.toMatchObject({
+        recorded: 0,
+      });
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it('does not classify post-persistence bookkeeping failures as record failures', async () => {
+    const port = createMockMemoryPort();
+    const cooldownStore = new (class extends Map<string, number> {
+      override set(): this {
+        throw new Error('cooldown bookkeeping unavailable');
+      }
+    })();
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = new LessonRecorder(port, { cooldownStore });
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'memory-safety', [
+          { message: 'Persist the recovered lesson', severity: 'critical' },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    try {
+      await expect(
+        recorder.record(result, 'bookkeeping-failure-task'),
+      ).resolves.toMatchObject({ recorded: 1 });
+      expect(port.recordLesson).toHaveBeenCalledTimes(1);
+      expect(logged).not.toHaveBeenCalled();
+    } finally {
+      logged.mockRestore();
+    }
   });
 
   it('redacts secrets before recording critique lessons', async () => {
@@ -5949,6 +5989,7 @@ describe('LessonRecorder', () => {
 
   it('does not suppress a concurrent duplicate when the admitting persistence fails', async () => {
     const port = createMockMemoryPort();
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let rejectFirstPersistence!: (error: Error) => void;
     const firstPersistenceStarted = new Promise<void>((resolve) => {
       (port.recordLesson as ReturnType<typeof vi.fn>)
@@ -6005,6 +6046,7 @@ describe('LessonRecorder', () => {
       suppressedByCooldown: [],
       minedBlockerPatterns: [],
     });
+    logged.mockRestore();
   });
 
   it('keeps multiline finding boundaries distinct in cooldown keys', async () => {
@@ -6428,6 +6470,7 @@ describe('LessonRecorder', () => {
 
   it('rolls back blocker observations when lesson persistence fails', async () => {
     const port = createMockMemoryPort();
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
     (port.recordLesson as ReturnType<typeof vi.fn>)
       .mockRejectedValueOnce(new Error('transient memory failure'))
       .mockResolvedValue(undefined);
@@ -6463,6 +6506,7 @@ describe('LessonRecorder', () => {
       suppressedByCooldown: [],
       minedBlockerPatterns: [],
     });
+    logged.mockRestore();
   });
 
   it('does not mine blocker patterns from repeated observations on the same task', async () => {
@@ -8638,6 +8682,7 @@ describe('LessonRecorder', () => {
 
   it('swallows errors from MemoryPort gracefully', async () => {
     const port = createMockMemoryPort();
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
     (port.recordLesson as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('DB down'),
     );
@@ -8659,5 +8704,6 @@ describe('LessonRecorder', () => {
       suppressedByCooldown: [],
       minedBlockerPatterns: [],
     });
+    logged.mockRestore();
   });
 });

--- a/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
+++ b/packages/franken-critique/tests/unit/memory/lesson-recorder.test.ts
@@ -2223,6 +2223,68 @@ describe('LessonRecorder', () => {
     expect(port.recordLesson).not.toHaveBeenCalled();
   });
 
+  it('reports lesson persistence failures without exposing raw failure data', async () => {
+    const port = createMockMemoryPort();
+    const sensitiveFailure = ['storage', 'credential', 'must-not-leak'].join('-');
+    port.recordLesson = vi
+      .fn()
+      .mockRejectedValue(new Error(sensitiveFailure));
+    const logged = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', `memory-${sensitiveFailure}`, [
+          {
+            message: 'Persist the recovered lesson',
+            severity: 'critical',
+          },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    const recording = await recorder.record(
+      result,
+      `task-${sensitiveFailure}`,
+    );
+
+    expect(recording.recorded).toBe(0);
+    expect(logged).toHaveBeenCalledWith('Lesson recording failed', {
+      code: 'CRITIQUE_LESSON_RECORD_FAILED',
+      operation: 'memory.recordLesson',
+      taskIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+      lessonIdHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+      evaluatorNameHash: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+      retryable: true,
+      guidance:
+        'Inspect the memory adapter and retry the critique run after persistence recovers.',
+    });
+    expect(JSON.stringify(logged.mock.calls)).not.toContain(sensitiveFailure);
+  });
+
+  it('keeps lesson persistence failures non-fatal when warning output fails', async () => {
+    const port = createMockMemoryPort();
+    port.recordLesson = vi.fn().mockRejectedValue(new Error('DB unavailable'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      throw new Error('warning sink unavailable');
+    });
+    const recorder = new LessonRecorder(port);
+    const result: CritiqueLoopResult = {
+      verdict: 'pass',
+      iterations: [
+        createIteration(0, 'fail', 'memory-safety', [
+          { message: 'Persist the recovered lesson', severity: 'critical' },
+        ]),
+        createIteration(1, 'pass'),
+      ],
+    };
+
+    await expect(recorder.record(result, 'warning-failure-task')).resolves.toMatchObject({
+      recorded: 0,
+    });
+  });
+
   it('redacts secrets before recording critique lessons', async () => {
     const port = createMockMemoryPort();
     const recorder = new LessonRecorder(port);

--- a/tasks/issue-3848-report-lesson-recorder-failures-progress.md
+++ b/tasks/issue-3848-report-lesson-recorder-failures-progress.md
@@ -1,0 +1,14 @@
+# Issue 3848 — Report LessonRecorder failures safely
+
+- [x] Revalidate issue state, labels, branch/worktree ownership, competing PRs/branches, base SHA, and Git identity.
+- [x] Read shared lessons and inspect LessonRecorder implementation plus neighboring logging patterns.
+- [x] Build and run a focused red-capable regression for a rejected `memory.recordLesson` call.
+- [x] Record reproduction, observed/expected behavior, affected path, and root cause on the Kanban card.
+- [x] Implement the narrowest safe non-fatal operator diagnostic without raw lesson/error payloads.
+- [x] Run focused tests, package lint/typecheck/build/tests, repository gates, and secret scanning.
+  - `@franken/critique`: 800 tests pass; lint, typecheck, and build pass.
+  - Root lint, typecheck, and build pass. Root tests pass all assertions on retry but remain non-zero because an unrelated orchestrator runtime-contract test leaves a Codex app-server rejection unhandled; the implicated runtime test file passes 55/55 in isolation.
+- [x] Self-review the diff; no public API or architecture documentation change is warranted.
+- [ ] Commit conventionally as David Mendez, push, open the one issue PR, and verify exact local/remote/PR head equality.
+- [ ] Drive CI and the real GitHub Codex connector to current-head clean with zero unresolved threads.
+- [ ] Squash-merge the immutable gated head, verify issue closure, and terminalize the Kanban card.

--- a/tasks/issue-3848-report-lesson-recorder-failures-progress.md
+++ b/tasks/issue-3848-report-lesson-recorder-failures-progress.md
@@ -6,9 +6,10 @@
 - [x] Record reproduction, observed/expected behavior, affected path, and root cause on the Kanban card.
 - [x] Implement the narrowest safe non-fatal operator diagnostic without raw lesson/error payloads.
 - [x] Run focused tests, package lint/typecheck/build/tests, repository gates, and secret scanning.
-  - `@franken/critique`: 800 tests pass; lint, typecheck, and build pass.
+  - `@franken/critique`: 801 tests pass; lint, typecheck, and build pass.
   - Root lint, typecheck, and build pass. Root tests pass all assertions on retry but remain non-zero because an unrelated orchestrator runtime-contract test leaves a Codex app-server rejection unhandled; the implicated runtime test file passes 55/55 in isolation.
 - [x] Self-review the diff; no public API or architecture documentation change is warranted.
-- [ ] Commit conventionally as David Mendez, push, open the one issue PR, and verify exact local/remote/PR head equality.
+- [x] Commit conventionally as David Mendez.
+- [x] Push, open the one issue PR, and verify exact local/remote/PR head equality.
 - [ ] Drive CI and the real GitHub Codex connector to current-head clean with zero unresolved threads.
 - [ ] Squash-merge the immutable gated head, verify issue closure, and terminalize the Kanban card.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -569,3 +569,6 @@
 
 ## 2026-07-25 — Shared memory inherits local safety semantics
 - A cross-agent SQLite memory substrate needs more than namespace isolation: retain bounded rows, filter entry kinds before read limits, keep database metadata authoritative over payload fields, revoke rejected/never-store candidates, propagate right-to-forget for owned entries, avoid plaintext publication from encrypted brains, and include hive state in encrypted DR backups.
+
+## 2026-07-30 — Best-effort persistence diagnostics
+- Emit persistence-failure diagnostics only around the failing adapter call, keep diagnostic sinks best-effort, log bounded hashes instead of raw payloads/errors, and restore console spies so rejection tests remain isolated and warning-free.


### PR DESCRIPTION
## Summary
- emit a stable operator-facing warning when `memory.recordLesson` rejects
- hash task, lesson, and evaluator identifiers so diagnostics do not expose raw payloads or adapter errors
- keep persistence and warning-sink failures non-fatal to the critique flow

## Test plan
- `npm run test --workspace @franken/critique` (800 passed)
- `npm run lint --workspace @franken/critique`
- `npm run typecheck --workspace @franken/critique`
- `npm run build --workspace @franken/critique`
- `npm run lint:security`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` (all assertions pass on retry; command remains non-zero from an unrelated unhandled Codex app-server rejection in orchestrator runtime-contract tests; the implicated runtime adapter test passes 55/55 in isolation)

Closes #3848