### PR TITLE
fix(mcp-suite): roll back failed brain flushes

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -1766,6 +1766,54 @@ class SqliteWorkingMemory implements IWorkingMemory {
     return finalizeFlush;
   }
 
+  /** Persist one value atomically without exposing uncommitted runtime state. */
+  setAndFlush(key: string, value: unknown): void {
+    const previousState = {
+      store: new Map(this.store),
+      sizes: new Map(this.sizes),
+      serialized: new Map(this.serialized),
+      persistedSerialized: new Map(this.persistedSerialized),
+      dirtyKeys: new Set(this.dirtyKeys),
+      deletedKeys: new Set(this.deletedKeys),
+      replacePersistedState: this.replacePersistedState,
+      totalBytes: this.totalBytes,
+    };
+    let stage: 'set' | 'flush' = 'set';
+    let finalizeFlush: (() => void) | undefined;
+    const tx = this.db.transaction(() => {
+      this.set(key, value);
+      stage = 'flush';
+      finalizeFlush = this.flushToDb() ?? undefined;
+    });
+
+    try {
+      tx.immediate();
+    } catch (error) {
+      this.store = previousState.store;
+      this.sizes = previousState.sizes;
+      this.serialized = previousState.serialized;
+      this.persistedSerialized = previousState.persistedSerialized;
+      this.dirtyKeys = previousState.dirtyKeys;
+      this.deletedKeys = previousState.deletedKeys;
+      this.replacePersistedState = previousState.replacePersistedState;
+      this.totalBytes = previousState.totalBytes;
+      try {
+        this.audit?.({
+          operation: stage === 'set' ? 'working.set' : 'working.flush',
+          store: 'working',
+          key,
+          outcome: 'error',
+          details: { errorName: error instanceof Error ? error.name : 'Error' },
+        });
+      } catch {
+        // Audit failures must not replace the original persistence failure.
+      }
+      throw error;
+    }
+
+    finalizeFlush?.();
+  }
+
   persistKey(key: string, value: unknown): (() => void) | void {
     this.set(key, value);
     const serialized = this.serialized.get(key);

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -2758,6 +2758,52 @@ describe('SqliteBrain', () => {
       expect(brain.working.get('key')).toBe('value');
     });
 
+    it('keeps failed atomic stores clean without overwriting concurrent values later', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-brain-atomic-store-'));
+      const dbPath = join(dir, 'brain.db');
+      let stale: SqliteBrain | undefined;
+      let concurrent: SqliteBrain | undefined;
+      let reopened: SqliteBrain | undefined;
+
+      try {
+        stale = new SqliteBrain(dbPath);
+        stale.working.set('shared', 'initial value');
+        stale.flush();
+        concurrent = new SqliteBrain(dbPath);
+        concurrent.working.set('shared', 'concurrent value');
+        concurrent.flush();
+
+        const staleDb = (stale as unknown as { db: Database.Database }).db;
+        staleDb.exec(`
+          CREATE TRIGGER fail_atomic_working_store
+          BEFORE UPDATE ON working_memory
+          WHEN NEW.key = 'shared'
+          BEGIN
+            SELECT RAISE(ABORT, 'simulated atomic working store failure');
+          END;
+        `);
+
+        expect(() =>
+          stale!.working.setAndFlush('shared', 'rejected value'),
+        ).toThrow('simulated atomic working store failure');
+        expect(stale.working.snapshot()).toMatchObject({ shared: 'initial value' });
+
+        staleDb.exec('DROP TRIGGER fail_atomic_working_store');
+        stale!.working.setAndFlush('local', 'successful value');
+        stale.close();
+        stale = undefined;
+
+        reopened = new SqliteBrain(dbPath);
+        expect(reopened.working.get('shared')).toBe('concurrent value');
+        expect(reopened.working.get('local')).toBe('successful value');
+      } finally {
+        reopened?.close();
+        concurrent?.close();
+        stale?.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('accepts bounded printable working-memory keys', () => {
       const key = 'project:tenant/α β_1-@';
 

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -16,6 +16,7 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
       restore: ReturnType<typeof vi.fn>;
       snapshot: ReturnType<typeof vi.fn>;
       set: ReturnType<typeof vi.fn>;
+      setAndFlush: ReturnType<typeof vi.fn>;
       get: ReturnType<typeof vi.fn>;
       has: ReturnType<typeof vi.fn>;
       delete: ReturnType<typeof vi.fn>;
@@ -518,6 +519,7 @@ vi.mock("@franken/brain", () => ({
         }),
         snapshot: vi.fn(() => workingSnapshot),
         set: vi.fn(),
+        setAndFlush: vi.fn(),
         get: vi.fn((key: string) => workingSnapshot[key]),
         has: vi.fn(() => false),
         delete: vi.fn(),
@@ -816,11 +818,11 @@ describe("createBrainAdapter", () => {
     });
 
     const mockBrain = brainInstances[0];
-    expect(mockBrain.working.set).toHaveBeenCalledWith(
+    expect(mockBrain.working.setAndFlush).toHaveBeenCalledWith(
       "task-1",
       "working entry",
     );
-    expect(mockBrain.flush).toHaveBeenCalledOnce();
+    expect(mockBrain.flush).not.toHaveBeenCalled();
     expect(mockBrain.episodic.record).toHaveBeenCalledWith(
       expect.objectContaining({ summary: "evt-1: episode summary" }),
     );
@@ -851,20 +853,8 @@ describe("createBrainAdapter", () => {
       "task-1": "persisted value",
     };
     mockBrain.working.snapshot.mockImplementation(() => ({ ...workingState }));
-    mockBrain.working.has.mockImplementation((key: string) =>
-      Object.hasOwn(workingState, key),
-    );
-    mockBrain.working.get.mockImplementation((key: string) => workingState[key]);
-    mockBrain.working.set.mockImplementation((key: string, value: unknown) => {
-      workingState[key] = value;
-    });
-    mockBrain.working.delete.mockImplementation((key: string) => {
-      const existed = Object.hasOwn(workingState, key);
-      delete workingState[key];
-      return existed;
-    });
     const flushFailure = new Error("simulated working-memory flush failure");
-    mockBrain.flush.mockImplementationOnce(() => {
+    mockBrain.working.setAndFlush.mockImplementation(() => {
       throw flushFailure;
     });
 
@@ -883,10 +873,6 @@ describe("createBrainAdapter", () => {
     ]);
 
     delete workingState["task-1"];
-    mockBrain.flush.mockImplementationOnce(() => {
-      throw flushFailure;
-    });
-
     await expect(
       brain.store({ key: "task-2", value: "rejected new value", type: "working" }),
     ).rejects.toBe(flushFailure);
@@ -894,6 +880,12 @@ describe("createBrainAdapter", () => {
     await expect(
       brain.query({ query: "rejected new value", type: "working" }),
     ).resolves.toEqual([]);
+    expect(mockBrain.working.setAndFlush).toHaveBeenCalledTimes(2);
+    expect(mockBrain.working.has).not.toHaveBeenCalled();
+    expect(mockBrain.working.get).not.toHaveBeenCalled();
+    expect(mockBrain.working.set).not.toHaveBeenCalled();
+    expect(mockBrain.working.delete).not.toHaveBeenCalled();
+    expect(mockBrain.flush).not.toHaveBeenCalled();
   });
 
   it("stores temporary operational working facts with expiresAt metadata when ttlMs is provided", async () => {
@@ -904,13 +896,13 @@ describe("createBrainAdapter", () => {
       await brain.store({ key: "run:tmp", value: "short-lived status", type: "working", ttlMs: 60_000 });
 
       const mockBrain = brainInstances[0];
-      expect(mockBrain.working.set).toHaveBeenCalledWith("run:tmp", {
+      expect(mockBrain.working.setAndFlush).toHaveBeenCalledWith("run:tmp", {
         value: "short-lived status",
         category: "temporary-operational",
         sourceScope: "mcp-memory-store",
         expiresAt: "2026-01-01T00:01:00.000Z",
       });
-      expect(mockBrain.flush).toHaveBeenCalledOnce();
+      expect(mockBrain.flush).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -926,7 +918,7 @@ describe("createBrainAdapter", () => {
       ).rejects.toThrow("ttlMs must be a positive integer");
     }
 
-    expect(mockBrain.working.set).not.toHaveBeenCalled();
+    expect(mockBrain.working.setAndFlush).not.toHaveBeenCalled();
     expect(mockBrain.flush).not.toHaveBeenCalled();
   });
 
@@ -939,7 +931,7 @@ describe("createBrainAdapter", () => {
     ).rejects.toThrow("ttlMs is only supported for working memory");
 
     expect(mockBrain.episodic.record).not.toHaveBeenCalled();
-    expect(mockBrain.working.set).not.toHaveBeenCalled();
+    expect(mockBrain.working.setAndFlush).not.toHaveBeenCalled();
   });
 
   it("does not label durable working values with expiresAt fields as TTL-expiring", async () => {
@@ -1554,7 +1546,7 @@ describe("createBrainAdapter", () => {
     });
 
     const mockBrain = brainInstances[0];
-    expect(mockBrain.working.set).toHaveBeenCalledWith(
+    expect(mockBrain.working.setAndFlush).toHaveBeenCalledWith(
       "__fbeast_agent_memory__/Alpha%20Team!/task",
       {
         __fbeastMemoryScope: "fbeast:agent-memory",

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.test.ts
@@ -16,6 +16,7 @@ const { databaseInstances, brainInstances, workingMemoryRowsByPath } = vi.hoiste
       restore: ReturnType<typeof vi.fn>;
       snapshot: ReturnType<typeof vi.fn>;
       set: ReturnType<typeof vi.fn>;
+      get: ReturnType<typeof vi.fn>;
       has: ReturnType<typeof vi.fn>;
       delete: ReturnType<typeof vi.fn>;
     };
@@ -517,6 +518,7 @@ vi.mock("@franken/brain", () => ({
         }),
         snapshot: vi.fn(() => workingSnapshot),
         set: vi.fn(),
+        get: vi.fn((key: string) => workingSnapshot[key]),
         has: vi.fn(() => false),
         delete: vi.fn(),
       },
@@ -840,6 +842,58 @@ describe("createBrainAdapter", () => {
       limit: 5,
     });
     expect(episodicResult.some((row) => row.type === "episodic")).toBe(true);
+  });
+
+  it("restores the previous working-memory state when persistence fails", async () => {
+    const brain = createBrainAdapter("/tmp/beast.db");
+    const mockBrain = brainInstances[0];
+    const workingState: Record<string, unknown> = {
+      "task-1": "persisted value",
+    };
+    mockBrain.working.snapshot.mockImplementation(() => ({ ...workingState }));
+    mockBrain.working.has.mockImplementation((key: string) =>
+      Object.hasOwn(workingState, key),
+    );
+    mockBrain.working.get.mockImplementation((key: string) => workingState[key]);
+    mockBrain.working.set.mockImplementation((key: string, value: unknown) => {
+      workingState[key] = value;
+    });
+    mockBrain.working.delete.mockImplementation((key: string) => {
+      const existed = Object.hasOwn(workingState, key);
+      delete workingState[key];
+      return existed;
+    });
+    const flushFailure = new Error("simulated working-memory flush failure");
+    mockBrain.flush.mockImplementationOnce(() => {
+      throw flushFailure;
+    });
+
+    await expect(
+      brain.store({ key: "task-1", value: "rejected value", type: "working" }),
+    ).rejects.toBe(flushFailure);
+
+    expect(workingState).toEqual({ "task-1": "persisted value" });
+    await expect(
+      brain.query({ query: "rejected value", type: "working" }),
+    ).resolves.toEqual([]);
+    await expect(
+      brain.query({ query: "persisted value", type: "working" }),
+    ).resolves.toEqual([
+      { key: "task-1", value: "persisted value", type: "working" },
+    ]);
+
+    delete workingState["task-1"];
+    mockBrain.flush.mockImplementationOnce(() => {
+      throw flushFailure;
+    });
+
+    await expect(
+      brain.store({ key: "task-2", value: "rejected new value", type: "working" }),
+    ).rejects.toBe(flushFailure);
+    expect(workingState).toEqual({});
+    await expect(
+      brain.query({ query: "rejected new value", type: "working" }),
+    ).resolves.toEqual([]);
   });
 
   it("stores temporary operational working facts with expiresAt metadata when ttlMs is provided", async () => {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1292,22 +1292,10 @@ export function createBrainAdapter(
 
       const ttlMs = resolveOperationalTtlMs(input.ttlMs);
       const key = scopedWorkingKey(input.key, input.agentId);
-      const hadPreviousValue = brain.working.has(key);
-      const previousValue = hadPreviousValue ? brain.working.get(key) : undefined;
-      brain.working.set(key, scopedWorkingValue(input.value, input.agentId, ttlMs));
-      try {
-        brain.flush();
-      } catch (error) {
-        try {
-          if (hadPreviousValue) {
-            brain.working.set(key, previousValue);
-          } else {
-            brain.working.delete(key);
-          }
-        } finally {
-          throw error;
-        }
-      }
+      brain.working.setAndFlush(
+        key,
+        scopedWorkingValue(input.value, input.agentId, ttlMs),
+      );
     },
 
     async frontload(input = {}) {

--- a/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
+++ b/packages/franken-mcp-suite/src/adapters/brain-adapter.ts
@@ -1291,11 +1291,23 @@ export function createBrainAdapter(
       }
 
       const ttlMs = resolveOperationalTtlMs(input.ttlMs);
-      brain.working.set(
-        scopedWorkingKey(input.key, input.agentId),
-        scopedWorkingValue(input.value, input.agentId, ttlMs),
-      );
-      brain.flush();
+      const key = scopedWorkingKey(input.key, input.agentId);
+      const hadPreviousValue = brain.working.has(key);
+      const previousValue = hadPreviousValue ? brain.working.get(key) : undefined;
+      brain.working.set(key, scopedWorkingValue(input.value, input.agentId, ttlMs));
+      try {
+        brain.flush();
+      } catch (error) {
+        try {
+          if (hadPreviousValue) {
+            brain.working.set(key, previousValue);
+          } else {
+            brain.working.delete(key);
+          }
+        } finally {
+          throw error;
+        }
+      }
     },
 
     async frontload(input = {}) {

--- a/tasks/issue-3847-progress.md
+++ b/tasks/issue-3847-progress.md
@@ -1,0 +1,15 @@
+# Issue 3847 progress
+
+- [x] Revalidate Kanban ownership, clean issue branch, exact `origin/main`, issue state, competing PRs, and remote branches.
+- [x] Read shared and repository lessons.
+- [x] Trace `BrainAdapter.store`, its callers, `Brain.flush`, and working-memory rollback/persistence semantics.
+- [x] Add a focused regression test for `flush()` failure and confirm the exact symptom is RED.
+- [x] Implement the narrowest coherent fix while preserving the original error/cause.
+- [x] Confirm focused GREEN and post-failure in-memory state.
+- [x] Run relevant mcp-suite tests, lint, typecheck, build, and secret scan.
+- [x] Self-review the diff and verify no unrelated changes.
+- [x] Commit with configured identity and a Conventional Commit message.
+- [ ] Push, open one PR closing #3847, and verify local/remote/PR head equality.
+- [ ] Run current-head GitHub Codex review, resolve all findings, verify zero unresolved threads and green CI.
+- [ ] Squash merge only after all authorized gates; verify issue closure.
+- [ ] Append concise reusable lessons and complete the Kanban handoff.

--- a/tasks/issue-3847-progress.md
+++ b/tasks/issue-3847-progress.md
@@ -9,7 +9,7 @@
 - [x] Run relevant mcp-suite tests, lint, typecheck, build, and secret scan.
 - [x] Self-review the diff and verify no unrelated changes.
 - [x] Commit with configured identity and a Conventional Commit message.
-- [ ] Push, open one PR closing #3847, and verify local/remote/PR head equality.
+- [x] Push, open one PR closing #3847, and verify local/remote/PR head equality.
 - [ ] Run current-head GitHub Codex review, resolve all findings, verify zero unresolved threads and green CI.
 - [ ] Squash merge only after all authorized gates; verify issue closure.
 - [ ] Append concise reusable lessons and complete the Kanban handoff.


### PR DESCRIPTION
## Summary
- restore the prior in-memory working value when `BrainAdapter.store()` cannot flush
- remove newly-added in-memory values after a failed flush
- preserve the original flush error while preventing rejected stores from appearing successful later

## Test plan
- `npm run test --workspace @franken/mcp-suite -- src/adapters/brain-adapter.test.ts`
- `npm run test --workspace @franken/mcp-suite`
- `npm run lint --workspace @franken/mcp-suite -- --quiet`
- `npm run typecheck --workspace @franken/mcp-suite`
- `npm run build`
- `npm run lint:security`

Closes #3847