### PR TITLE
fix(critique): keep conciseness feedback non-blocking

### DIFF
--- a/packages/franken-critique/src/evaluators/conciseness.ts
+++ b/packages/franken-critique/src/evaluators/conciseness.ts
@@ -1023,7 +1023,7 @@ export class ConcisenessEvaluator implements Evaluator {
 
     return {
       evaluatorName: this.name,
-      verdict: findings.length === 0 ? 'pass' : 'fail',
+      verdict: 'pass',
       score,
       findings,
     };

--- a/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
+++ b/packages/franken-critique/tests/unit/evaluators/conciseness.test.ts
@@ -42,6 +42,25 @@ describe('ConcisenessEvaluator', () => {
     );
   });
 
+  it('keeps excessive-comment feedback informational and non-blocking', async () => {
+    const evaluator = new ConcisenessEvaluator();
+    const content = [
+      '// Explain the public contract.',
+      '// Document the supported edge case.',
+      'export const value = 1;',
+    ].join('\n');
+
+    const result = await evaluator.evaluate(createInput(content));
+
+    expect(result.verdict).toBe('pass');
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Excessive comment ratio: 67%'),
+        severity: 'info',
+      }),
+    ]);
+  });
+
   it('counts inline unresolved comments toward the comment ratio', async () => {
     const evaluator = new ConcisenessEvaluator();
     const pendingMarker = ['TO', 'DO'].join('');

--- a/tasks/issue-3835-progress.md
+++ b/tasks/issue-3835-progress.md
@@ -1,0 +1,28 @@
+# Issue #3835 progress
+
+- [x] Revalidate live issue, branch/base, and competing PR/branch ownership.
+- [x] Read shared lessons and locate evaluator/tests.
+- [x] Trace evaluator result/severity through pipeline and CI callers; inspect configuration surface.
+- [x] Run focused deterministic reproduction for threshold and failure behavior.
+- [x] Decide validity and record observed/expected/root-cause evidence before edits.
+- [x] If valid, add a failing regression test and implement the minimal deterministic fix.
+- [x] Run focused, package, root, and security quality gates.
+- [ ] Self-review, GitHub/Codex/CI closeout, merge or issue closure, and Kanban handoff.
+
+## Reproduction and root cause
+
+- Command: `npm test --workspace @franken/critique -- --run tests/unit/evaluators/conciseness.test.ts -t 'keeps excessive-comment feedback informational and non-blocking'`.
+- Input: two ordinary documentation comment lines plus one code line (deterministic 2/3 = 67%, above the documented default 50% threshold).
+- Observed before fix: the evaluator emitted an `info` finding but returned `verdict: 'fail'`; the focused regression failed with `expected 'fail' to be 'pass'`.
+- Expected: retain the deterministic style finding and score penalty without making informational feedback a blocking verdict.
+- Root cause: `ConcisenessEvaluator.evaluate()` derived `fail` from `findings.length`, ignoring that every conciseness finding is `info`. `CritiquePipeline` intentionally keeps `pass` + `info` non-blocking, while any evaluator `fail` makes the aggregate fail. The MCP adapter independently maps these findings to `warn`, confirming severity/verdict drift across consumers.
+- Existing configuration: `CritiquePipeline.run({ evaluatorNames })` and the HTTP/MCP surfaces can omit `conciseness`; there is no per-threshold evaluator option. Environment configuration is inappropriate for this pure deterministic evaluator, and a new threshold option is unnecessary once the existing `info` severity is honored.
+- Determinism probe: 100 evaluations of the same 67% input produced one unique result signature; the exact 50% boundary produced no finding. This is deterministic style feedback, not a flaky threshold.
+
+## Verification
+
+- Focused RED before implementation: 1 expected failure (`fail` versus expected `pass`).
+- Focused GREEN: regression 1/1 and pipeline tests 12/12 passed.
+- `@franken/critique`: tests 802/802, lint, typecheck, and build passed.
+- Root: build, lint, typecheck, `lint:security`, and `audit:security` passed; audit found 0 vulnerabilities.
+- Root test rerun executed 4,990 orchestrator assertions successfully but exited nonzero for an unrelated unhandled `Codex app-server is unavailable` rejection from `runtime-contract.test.ts`; that file passes 16/16 in isolation, and the two earlier load-sensitive timeout failures pass 2/2 in isolation. No changed path intersects the orchestrator runtime.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,9 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-30 — Evaluator severity must agree with blocking verdicts
+- A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.
+- Informational evaluator findings must not return a blocking `fail` verdict when the pipeline contract treats `pass` plus `info` as non-blocking. Preserve the finding and score signal, and fix the verdict/severity drift instead of adding environment configuration to pure evaluator logic.
+
 ## 2026-07-27 — Managed-service CLI visibility must use explicit operator paths
 - A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation. Validate home-derived entries as absolute and delimiter-free before adding them.
 - Audit nested child launchers after widening a managed PATH. Bare commands that were safe only under the old restricted PATH (such as a dashboard process spawning `npm`) must be replaced with already-resolved trusted executable/CLI paths, and fallback resolution must search the sanitized managed PATH rather than the parent process PATH.


### PR DESCRIPTION
## Summary
- preserve deterministic comment-ratio feedback and score penalties
- honor the existing `info` severity so style feedback cannot fail the critique pipeline
- document the exact reproduction, threshold determinism, and verification evidence

## Test plan
- `npm test --workspace @franken/critique` (802 passed)
- `npm run lint --workspace @franken/critique`
- `npm run typecheck --workspace @franken/critique`
- `npm run build --workspace @franken/critique`
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run lint:security`
- `npm run audit:security`

Root `npm run test` completed all 4,990 orchestrator assertions but the local aggregate process reported an unrelated unhandled `Codex app-server is unavailable` rejection; the named file passes 16/16 in isolation.

Closes #3835