### PR TITLE
fix(orchestrator): bound adapter LLM requests

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -29,6 +29,30 @@ type UnifiedResponse = {
 };
 
 const MAX_OUTWARD_ERROR_CONTEXT_LENGTH = 1_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
+
+function normalizeRequestTimeout(timeoutMs: number | undefined): number {
+  const normalized = timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    throw new Error('LLM request timeoutMs must be a finite positive number');
+  }
+  if (normalized > MAX_REQUEST_TIMEOUT_MS) {
+    throw new Error(`LLM request timeoutMs must be less than or equal to ${MAX_REQUEST_TIMEOUT_MS}`);
+  }
+  return normalized;
+}
+
+function settleOrAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const rejectOnAbort = (): void => reject(signal.reason);
+    signal.addEventListener('abort', rejectOnAbort, { once: true });
+    operation.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', rejectOnAbort);
+    });
+  });
+}
 
 function safeAdapterErrorContext(error: unknown): string {
   let errorClass: string = typeof error;
@@ -69,8 +93,10 @@ function safeAdapterErrorContext(error: unknown): string {
 }
 
 export interface IAdapter {
+  /** Set only when execute() enforces request.timeoutMs and cancels its underlying work. */
+  readonly managesRequestTimeout?: boolean;
   transformRequest(request: UnifiedRequest): unknown;
-  execute(providerRequest: unknown): Promise<unknown>;
+  execute(providerRequest: unknown, signal?: AbortSignal): Promise<unknown>;
   transformResponse(providerResponse: unknown, requestId: string): UnifiedResponse;
   validateCapabilities(feature: string): boolean;
 }
@@ -143,6 +169,27 @@ export class AdapterLlmClient implements ILlmClient {
   ): Promise<{ content: string; usage?: TokenUsage; providerContext?: ProviderContext }> {
     const requestId = `llm-${randomUUID()}`;
     const model = this.defaultModel;
+    const timeoutMs = normalizeRequestTimeout(options?.timeoutMs);
+    const controller = new AbortController();
+    const abortFromCaller = (): void => {
+      controller.abort(
+        options?.signal?.reason instanceof Error
+          ? options.signal.reason
+          : new Error('LLM request cancelled'),
+      );
+    };
+    if (options?.signal?.aborted) {
+      abortFromCaller();
+    } else {
+      options?.signal?.addEventListener('abort', abortFromCaller, { once: true });
+    }
+    const timeout = this.adapter.managesRequestTimeout || controller.signal.aborted
+      ? undefined
+      : setTimeout(() => {
+          controller.abort(
+            Object.assign(new Error(`LLM request timeout after ${timeoutMs}ms`), { code: 'ETIMEDOUT' }),
+          );
+        }, timeoutMs);
 
     const request: UnifiedRequest = {
       id: requestId,
@@ -151,8 +198,8 @@ export class AdapterLlmClient implements ILlmClient {
       messages: [{ role: 'user', content: prompt }],
       ...(options?.sessionId ? { session_id: options.sessionId } : {}),
       ...(options?.sessionContinue !== undefined ? { sessionContinue: options.sessionContinue } : {}),
-      ...(options?.signal ? { signal: options.signal } : {}),
-      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      signal: controller.signal,
+      ...(!this.adapter.managesRequestTimeout || options?.timeoutMs !== undefined ? { timeoutMs } : {}),
     };
 
     let span: any;
@@ -166,8 +213,12 @@ export class AdapterLlmClient implements ILlmClient {
       let usage: TokenUsage | undefined;
       let providerContext: ProviderContext | undefined;
       try {
+        if (controller.signal.aborted) throw controller.signal.reason;
         const providerRequest = this.adapter.transformRequest(request);
-        const providerResponse = await this.adapter.execute(providerRequest);
+        const providerResponse = await settleOrAbort(
+          this.adapter.execute(providerRequest, controller.signal),
+          controller.signal,
+        );
         const response = this.adapter.transformResponse(providerResponse, requestId);
         content = response.content;
         usage = response.usage;
@@ -218,6 +269,8 @@ export class AdapterLlmClient implements ILlmClient {
       failed = true;
       throw error;
     } finally {
+      if (timeout) clearTimeout(timeout);
+      options?.signal?.removeEventListener('abort', abortFromCaller);
       if (this.observer && span) {
         this.observer.endSpan(span, { status: failed ? 'error' : 'completed' });
       }

--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -203,12 +203,11 @@ export class AdapterLlmClient implements ILlmClient {
     };
 
     let span: any;
-    if (this.observer) {
-      span = this.observer.startSpan(this.observer.trace, { name: `llm-complete:${requestId}` });
-    }
-
     let failed = false;
     try {
+      if (this.observer) {
+        span = this.observer.startSpan(this.observer.trace, { name: `llm-complete:${requestId}` });
+      }
       let content: string | null;
       let usage: TokenUsage | undefined;
       let providerContext: ProviderContext | undefined;

--- a/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/cli-llm-adapter.ts
@@ -93,6 +93,7 @@ export interface CliLlmAdapterOpts {
 }
 
 export class CliLlmAdapter implements IAdapter {
+  readonly managesRequestTimeout = true;
   private readonly provider: ICliProvider;
   private readonly opts: {
     workingDir: string;
@@ -179,7 +180,7 @@ export class CliLlmAdapter implements IAdapter {
     return transformed;
   }
 
-  async execute(providerRequest: unknown): Promise<string> {
+  async execute(providerRequest: unknown, _executionSignal?: AbortSignal): Promise<string> {
     const {
       prompt,
       maxTurns,

--- a/packages/franken-orchestrator/src/adapters/provider-registry-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/provider-registry-adapter.ts
@@ -21,6 +21,7 @@ export class ProviderRegistryIAdapter implements IAdapter {
     const req = request as {
       messages: Array<{ role: string; content: string }>;
       system?: string;
+      signal?: AbortSignal;
     };
     const raw: LlmRequest = {
       systemPrompt: req.system ?? '',
@@ -29,12 +30,15 @@ export class ProviderRegistryIAdapter implements IAdapter {
         content: m.content,
       })),
       tools: [],
+      ...(req.signal ? { signal: req.signal } : {}),
     };
-    return this.middleware ? this.middleware.processRequest(raw) : raw;
+    const processed = this.middleware ? this.middleware.processRequest(raw) : raw;
+    return req.signal ? { ...processed, signal: req.signal } : processed;
   }
 
-  async execute(providerRequest: unknown): Promise<string> {
-    const request = providerRequest as LlmRequest;
+  async execute(providerRequest: unknown, signal?: AbortSignal): Promise<string> {
+    const originalRequest = providerRequest as LlmRequest;
+    const request: LlmRequest = signal ? { ...originalRequest, signal } : originalRequest;
     const chunks: string[] = [];
     for await (const event of this.registry.execute(request)) {
       if (event.type === 'text') chunks.push(event.content);

--- a/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/anthropic-api-adapter.ts
@@ -59,6 +59,7 @@ export class AnthropicApiAdapter implements ILlmProvider {
       request.maxTokens ?? this.options.maxTokens ?? 4096;
 
     try {
+      request.signal?.throwIfAborted();
       const params: Anthropic.MessageStreamParams = {
         model,
         max_tokens: maxTokens,
@@ -71,10 +72,14 @@ export class AnthropicApiAdapter implements ILlmProvider {
       if (request.temperature !== undefined) {
         params.temperature = request.temperature;
       }
-      const stream = this.client.messages.stream(params);
+      const stream = this.client.messages.stream(
+        params,
+        request.signal ? { signal: request.signal } : undefined,
+      );
       const translate = this.createEventTranslator();
 
       for await (const event of stream) {
+        request.signal?.throwIfAborted();
         const translated = translate(event);
         if (translated) yield translated;
       }

--- a/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/claude-cli-adapter.ts
@@ -51,10 +51,12 @@ export class ClaudeCliAdapter implements ILlmProvider {
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
+    request.signal?.throwIfAborted();
     const args = this.buildArgs(request);
     const proc = spawn(this.binaryPath, args, {
       env: this.sanitizedEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(request.signal ? { signal: request.signal } : {}),
     });
 
     const spawnState: {

--- a/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/codex-cli-adapter.ts
@@ -50,10 +50,12 @@ export class CodexCliAdapter implements ILlmProvider {
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
+    request.signal?.throwIfAborted();
     const args = this.buildArgs(request);
     const proc = spawn(this.binaryPath, args, {
       env: sanitizeRunConfigIntegrityEnv(process.env as Record<string, string>),
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(request.signal ? { signal: request.signal } : {}),
     });
 
     const spawnState: {

--- a/packages/franken-orchestrator/src/providers/gemini-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-api-adapter.ts
@@ -71,10 +71,12 @@ export class GeminiApiAdapter implements ILlmProvider {
     const model = this.options.model ?? 'gemini-2.5-flash';
 
     try {
+      request.signal?.throwIfAborted();
       const config: Record<string, unknown> = {
         systemInstruction: request.systemPrompt,
         maxOutputTokens:
           request.maxTokens ?? this.options.maxTokens ?? 4096,
+        ...(request.signal ? { abortSignal: request.signal } : {}),
       };
       if (request.tools) {
         config['tools'] = [
@@ -94,6 +96,7 @@ export class GeminiApiAdapter implements ILlmProvider {
       let totalOutputTokens = 0;
 
       for await (const chunk of response) {
+        request.signal?.throwIfAborted();
         if (chunk.text) {
           yield { type: 'text', content: chunk.text };
         }

--- a/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/gemini-cli-adapter.ts
@@ -69,6 +69,7 @@ export class GeminiCliAdapter implements ILlmProvider {
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
+    request.signal?.throwIfAborted();
     const workspaceDir = resolve(this.workingDir);
     let contextWorkingDir: string | undefined;
     let settingsWorkingDir: string | undefined;
@@ -94,6 +95,7 @@ export class GeminiCliAdapter implements ILlmProvider {
       }
 
       const args = this.buildArgs(request);
+      request.signal?.throwIfAborted();
       const proc = spawn(this.binaryPath, args, {
         cwd: workspaceDir,
         env: {
@@ -102,6 +104,7 @@ export class GeminiCliAdapter implements ILlmProvider {
           GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
         },
         stdio: ['pipe', 'pipe', 'pipe'],
+        ...(request.signal ? { signal: request.signal } : {}),
       });
 
       const spawnState: {

--- a/packages/franken-orchestrator/src/providers/openai-api-adapter.ts
+++ b/packages/franken-orchestrator/src/providers/openai-api-adapter.ts
@@ -68,6 +68,7 @@ export class OpenAiApiAdapter implements ILlmProvider {
     const model = this.options.model ?? 'gpt-4o';
 
     try {
+      request.signal?.throwIfAborted();
       const params: OpenAI.ChatCompletionCreateParamsStreaming = {
         model,
         max_tokens: request.maxTokens ?? this.options.maxTokens ?? 4096,
@@ -81,7 +82,10 @@ export class OpenAiApiAdapter implements ILlmProvider {
       if (request.temperature !== undefined) {
         params.temperature = request.temperature;
       }
-      const stream = await this.getClient().chat.completions.create(params);
+      const stream = await this.getClient().chat.completions.create(
+        params,
+        request.signal ? { signal: request.signal } : undefined,
+      );
 
       const toolCallAccumulators = new Map<
         number,
@@ -89,6 +93,7 @@ export class OpenAiApiAdapter implements ILlmProvider {
       >();
 
       for await (const chunk of stream) {
+        request.signal?.throwIfAborted();
         const choice = chunk.choices[0];
         if (choice) {
           const delta = choice.delta;

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -621,7 +621,7 @@ export class ProviderRegistry {
       ) {
         let failureAlreadyRecorded = false;
         let terminalEventObserved = false;
-        const halfOpenProbeReserved = this.hasReservedHalfOpenProbe(provider);
+        const halfOpenProbeReserved = availabilityProbeReserved;
         try {
           throwIfRequestAborted(effectiveRequest);
           const stream = provider.execute(effectiveRequest);

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -533,7 +533,13 @@ export class ProviderRegistry {
       const providerIndex = providerOrder[i]!;
       const provider = this.providers[providerIndex]!;
 
+      const probeCountBeforeReservation = this.providerHealth.get(
+        this.providerKey(provider),
+      )?.halfOpenProbeCount ?? 0;
       const circuitError = this.reserveCircuitBreakerProbe(provider);
+      const availabilityProbeReserved = (
+        this.providerHealth.get(this.providerKey(provider))?.halfOpenProbeCount ?? 0
+      ) > probeCountBeforeReservation;
       if (circuitError) {
         unavailableProviders.push(provider.name);
         circuitErrors.push(circuitError.message);
@@ -554,7 +560,9 @@ export class ProviderRegistry {
         providerAvailable = await awaitWithRequestAbort(provider.isAvailable(), request);
       } catch (error) {
         if (request.signal?.aborted) {
-          this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-availability-aborted');
+          if (availabilityProbeReserved) {
+            this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-availability-aborted');
+          }
           throw request.signal.reason;
         }
         throw error;

--- a/packages/franken-orchestrator/src/providers/provider-registry.ts
+++ b/packages/franken-orchestrator/src/providers/provider-registry.ts
@@ -214,6 +214,23 @@ function shouldRecordProviderHealthFailure(error: Error | string): boolean {
   return classifyProviderError(error) !== 'request_error';
 }
 
+function throwIfRequestAborted(request: LlmRequest): void {
+  request.signal?.throwIfAborted();
+}
+
+async function awaitWithRequestAbort<T>(operation: Promise<T>, request: LlmRequest): Promise<T> {
+  const signal = request.signal;
+  if (!signal) return operation;
+  signal.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const rejectOnAbort = (): void => reject(signal.reason);
+    signal.addEventListener('abort', rejectOnAbort, { once: true });
+    operation.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', rejectOnAbort);
+    });
+  });
+}
+
 export class ProviderRegistry {
   private providers: ILlmProvider[];
   private brain: IBrain;
@@ -501,6 +518,7 @@ export class ProviderRegistry {
   }
 
   async *execute(request: LlmRequest): AsyncGenerator<LlmStreamEvent> {
+    throwIfRequestAborted(request);
     let lastError: Error | undefined;
     let terminalError: Error | undefined;
     let lastFailedProviderName: string | undefined;
@@ -511,6 +529,7 @@ export class ProviderRegistry {
 
     const providerOrder = this.getProviderIterationOrder();
     for (let i = 0; i < providerOrder.length; i++) {
+      throwIfRequestAborted(request);
       const providerIndex = providerOrder[i]!;
       const provider = this.providers[providerIndex]!;
 
@@ -530,7 +549,17 @@ export class ProviderRegistry {
         continue;
       }
 
-      if (!(await provider.isAvailable())) {
+      let providerAvailable: boolean;
+      try {
+        providerAvailable = await awaitWithRequestAbort(provider.isAvailable(), request);
+      } catch (error) {
+        if (request.signal?.aborted) {
+          this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-availability-aborted');
+          throw request.signal.reason;
+        }
+        throw error;
+      }
+      if (!providerAvailable) {
         unavailableProviders.push(provider.name);
         const availabilityError = new Error(`Provider ${provider.name} is unavailable`);
         availabilityErrors.push(availabilityError.message);
@@ -586,11 +615,13 @@ export class ProviderRegistry {
         let terminalEventObserved = false;
         const halfOpenProbeReserved = this.hasReservedHalfOpenProbe(provider);
         try {
+          throwIfRequestAborted(effectiveRequest);
           const stream = provider.execute(effectiveRequest);
           let retried = false;
           const buffer: LlmStreamEvent[] = [];
 
           for await (const event of stream) {
+            throwIfRequestAborted(effectiveRequest);
             if (
               event.type === 'error' &&
               event.retryable &&
@@ -610,7 +641,7 @@ export class ProviderRegistry {
                 Math.pow(this.opts.backoffMultiplier, retry),
                 this.opts.maxRetryDelayMs,
               );
-              await this.opts.sleep(delay);
+              await awaitWithRequestAbort(this.opts.sleep(delay), effectiveRequest);
               retried = true;
               break; // discard buffer, retry same provider
             }
@@ -663,6 +694,13 @@ export class ProviderRegistry {
           lastFailedProviderName = provider.name;
           break; // stream ended without done — failover
         } catch (error) {
+          if (effectiveRequest.signal?.aborted) {
+            if (halfOpenProbeReserved) {
+              this.releaseHalfOpenProbeWithoutHealthFailure(provider, 'half-open-probe-execution-aborted');
+              terminalEventObserved = true;
+            }
+            throw effectiveRequest.signal.reason;
+          }
           lastError =
             error instanceof Error ? error : new Error(String(error));
           if (!failureAlreadyRecorded) {

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -44,8 +44,23 @@ describe('AdapterLlmClient', () => {
   });
 
   it('returns adapter content on success', async () => {
-    const client = new AdapterLlmClient(makeAdapter());
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
     await expect(client.complete('prompt')).resolves.toBe('hello');
+    expect(adapter.transformRequest).toHaveBeenCalledWith(expect.objectContaining({
+      signal: expect.any(AbortSignal),
+      timeoutMs: 30_000,
+    }));
+  });
+
+  it('rejects timeout overrides above the Node timer limit', async () => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await expect(client.complete('prompt', { timeoutMs: 2_147_483_648 })).rejects.toThrow(
+      'timeoutMs must be less than or equal to 2147483647',
+    );
+    expect(adapter.execute).not.toHaveBeenCalled();
   });
 
   it('forwards cancellation and deadline options to the adapter request', async () => {
@@ -56,9 +71,77 @@ describe('AdapterLlmClient', () => {
     await client.complete('prompt', { signal: controller.signal, timeoutMs: 42 });
 
     expect(adapter.transformRequest).toHaveBeenCalledWith(expect.objectContaining({
-      signal: controller.signal,
+      signal: expect.any(AbortSignal),
       timeoutMs: 42,
     }));
+    const transformedRequest = vi.mocked(adapter.transformRequest).mock.calls[0]![0];
+    expect(adapter.execute).toHaveBeenCalledWith(
+      transformedRequest,
+      (transformedRequest as { signal: AbortSignal }).signal,
+    );
+  });
+
+  it('rejects at the requested deadline and cancels adapter work that would otherwise never settle', async () => {
+    vi.useFakeTimers();
+    let workCancelled = false;
+    const adapter = makeAdapter({
+      execute: vi.fn((_request: unknown, signal?: AbortSignal) => new Promise<never>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          workCancelled = true;
+          reject(signal.reason);
+        }, { once: true });
+      })),
+    });
+    const client = new AdapterLlmClient(adapter);
+
+    try {
+      const completion = client.complete('prompt', { timeoutMs: 10 })
+        .catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(10);
+      const outcome = await completion;
+
+      expect(outcome).toBeInstanceOf(AdapterLlmError);
+      expect((outcome as AdapterLlmError).message).toContain('timeout after 10ms');
+      expect(workCancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not add a second timer when the adapter manages request deadlines', async () => {
+    const adapter = makeAdapter({ managesRequestTimeout: true });
+    const client = new AdapterLlmClient(adapter);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    try {
+      await client.complete('prompt', { timeoutMs: 42 });
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it('preserves a timeout-managing adapter default when no request override is supplied', async () => {
+    const adapter = makeAdapter({ managesRequestTimeout: true });
+    const client = new AdapterLlmClient(adapter);
+
+    await client.complete('prompt');
+
+    expect(adapter.transformRequest).toHaveBeenCalledWith(
+      expect.not.objectContaining({ timeoutMs: expect.anything() }),
+    );
+  });
+
+  it('does not start adapter work when the caller signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('cancel before start'));
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await expect(client.complete('prompt', { signal: controller.signal }))
+      .rejects.toThrow('cancel before start');
+    expect(adapter.transformRequest).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
   });
 
   it('wraps adapter execute() failures in AdapterLlmError with the cause attached', async () => {

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -291,6 +291,23 @@ describe('AdapterLlmClient', () => {
     expect(observer.recordTokenUsage).not.toHaveBeenCalled();
   });
 
+  it('cleans up its deadline when observer span creation throws', async () => {
+    vi.useFakeTimers();
+    try {
+      const observer = makeObserver();
+      vi.mocked(observer.startSpan).mockImplementation(() => {
+        throw new Error('trace ended');
+      });
+      const client = new AdapterLlmClient(makeAdapter(), observer);
+
+      await expect(client.complete('prompt')).rejects.toThrow('trace ended');
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('ends the observer span with completed status and records usage on success', async () => {
     const observer = makeObserver();
     const client = new AdapterLlmClient(makeAdapter(), observer);

--- a/packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts
@@ -43,6 +43,13 @@ describe('ProviderRegistryIAdapter', () => {
       });
     });
 
+    it('preserves the request cancellation signal through middleware mapping', () => {
+      const signal = new AbortController().signal;
+      const adapter = new ProviderRegistryIAdapter(makeRegistry(() => textEvents('hi')));
+
+      expect(adapter.transformRequest({ ...makeRequest(), signal })).toEqual(expect.objectContaining({ signal }));
+    });
+
     it('applies middleware processRequest when provided', () => {
       const processRequest = vi.fn((req: any) => ({ ...req, systemPrompt: 'SANITIZED' }));
       const middleware = { processRequest, processResponse: vi.fn((r: any) => r) };
@@ -91,6 +98,33 @@ describe('ProviderRegistryIAdapter', () => {
         messages: [{ role: 'user', content: 'Hello' }],
         tools: [],
       })).rejects.toThrow('Rate limited');
+    });
+
+    it('propagates the execution signal to provider work for cooperative cancellation', async () => {
+      let cancelled = false;
+      const registry = {
+        execute: vi.fn((request: { signal?: AbortSignal }) => (async function* () {
+          await new Promise<void>((_resolve, reject) => {
+            request.signal?.addEventListener('abort', () => {
+              cancelled = true;
+              reject(request.signal?.reason);
+            }, { once: true });
+          });
+          yield { type: 'text' as const, content: 'unreachable' };
+        })()),
+      } as unknown as ProviderRegistry;
+      const adapter = new ProviderRegistryIAdapter(registry);
+      const controller = new AbortController();
+      const completion = adapter.execute({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: 'Hello' }],
+        tools: [],
+      }, controller.signal);
+
+      controller.abort(new Error('deadline reached'));
+
+      await expect(completion).rejects.toThrow('deadline reached');
+      expect(cancelled).toBe(true);
     });
   });
 

--- a/packages/franken-orchestrator/tests/unit/providers/gemini-api-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/gemini-api-adapter.test.ts
@@ -181,6 +181,25 @@ describe('GeminiApiAdapter', () => {
       expect(events[2]).toEqual({ type: 'done', usage: { inputTokens: 40, outputTokens: 20, totalTokens: 60 } });
     });
 
+    it('passes cancellation through the request-scoped Gemini config', async () => {
+      const adapter = new GeminiApiAdapter({ apiKey: 'test-key' });
+      const generateContentStream = vi.fn().mockResolvedValue((async function* () {
+        yield { text: 'done', functionCalls: null, usageMetadata: null };
+      })());
+      (adapter as any).client = { models: { generateContentStream } };
+      const signal = new AbortController().signal;
+
+      await collectEvents(adapter.execute({
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'Hi' }],
+        signal,
+      }));
+
+      expect(generateContentStream).toHaveBeenCalledWith(expect.objectContaining({
+        config: expect.objectContaining({ abortSignal: signal }),
+      }));
+    });
+
     it('translates function call chunks', async () => {
       const adapter = new GeminiApiAdapter({ apiKey: 'test-key' });
       (adapter as any).client = {

--- a/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
+++ b/packages/franken-orchestrator/tests/unit/providers/provider-registry.test.ts
@@ -933,6 +933,77 @@ describe('ProviderRegistry', () => {
       expect(registry.getProviderHealth('primary')).toMatchObject({ halfOpenProbeCount: 1 });
     });
 
+    it('releases a half-open probe when cancellation interrupts availability checking', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let availabilityResolve: ((available: boolean) => void) | undefined;
+      const p1 = mockProvider('primary', { failOnExecute: new Error('outage') });
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      vi.mocked(p1.isAvailable).mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+        availabilityResolve = resolve;
+      }));
+      const controller = new AbortController();
+      const completion = collectEvents(registry.execute({ ...makeRequest(), signal: controller.signal }))
+        .catch((error: unknown) => error);
+      await vi.waitFor(() => expect(p1.isAvailable).toHaveBeenCalledTimes(2));
+
+      controller.abort(new Error('deadline reached'));
+
+      await expect(completion).resolves.toEqual(expect.objectContaining({ message: 'deadline reached' }));
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'half-open',
+        halfOpenProbeCount: 0,
+      });
+      availabilityResolve?.(true);
+    });
+
+    it('releases a half-open probe without a health penalty when its stream is cancelled', async () => {
+      let now = Date.UTC(2026, 0, 1);
+      let mode: 'outage' | 'pending' = 'outage';
+      const p1: ILlmProvider = {
+        ...mockProvider('primary'),
+        execute: vi.fn(async function* (request: LlmRequest) {
+          if (mode === 'outage') throw new Error('outage');
+          await new Promise<void>((_resolve, reject) => {
+            request.signal?.addEventListener('abort', () => reject(request.signal?.reason), { once: true });
+          });
+          yield { type: 'text' as const, content: 'unreachable' };
+        }),
+      };
+      const p2 = mockProvider('fallback');
+      const registry = new ProviderRegistry([p1, p2], mockBrain(), {
+        circuitBreakerFailureThreshold: 1,
+        circuitBreakerCooldownMs: 10_000,
+        circuitBreakerCooldownJitterRatio: 0,
+        now: () => now,
+      });
+
+      await collectEvents(registry.execute(makeRequest()));
+      now += 10_001;
+      mode = 'pending';
+      const controller = new AbortController();
+      const completion = collectEvents(registry.execute({ ...makeRequest(), signal: controller.signal }))
+        .catch((error: unknown) => error);
+      await vi.waitFor(() => expect(p1.execute).toHaveBeenCalledTimes(2));
+
+      controller.abort(new Error('deadline reached'));
+
+      await expect(completion).resolves.toEqual(expect.objectContaining({ message: 'deadline reached' }));
+      expect(registry.getProviderHealth('primary')).toMatchObject({
+        state: 'half-open',
+        halfOpenProbeCount: 0,
+        failures: 1,
+      });
+    });
+
     it('releases request-error event probes and reschedules idle half-open providers', async () => {
       let now = Date.UTC(2026, 0, 1);
       let mode: 'outage' | 'request-error' | 'success' = 'outage';

--- a/packages/franken-types/src/provider.ts
+++ b/packages/franken-types/src/provider.ts
@@ -67,6 +67,8 @@ export interface LlmRequest {
   tools?: ToolDefinition[];
   maxTokens?: number;
   temperature?: number;
+  /** Cancels provider retries, streams, and subprocesses for this request. */
+  signal?: AbortSignal;
 }
 
 export interface LlmMessage {

--- a/tasks/issue-3829-adapter-llm-timeout-progress.md
+++ b/tasks/issue-3829-adapter-llm-timeout-progress.md
@@ -1,0 +1,12 @@
+# Issue #3829 AdapterLlmClient timeout validation progress
+
+- [x] Revalidate live issue, labels, exact `origin/main`, branch, Git identity, and open-PR overlap.
+- [x] Read shared lessons and inspect `AdapterLlmClient` plus its focused tests.
+- [x] Trace `LlmCompletionOptions`, transformed request fields, adapter execution, provider/process deadline layers, and all production constructors/callers.
+- [x] Build and run a focused red-capable reproduction of the alleged unbounded wait; observed `still-pending` after 100ms for a 10ms request because `AdapterLlmClient` only forwarded timeout metadata and never enforced it.
+- [x] Add the failing regression first, then implement a bounded 30s default/request override, cooperative abort propagation through registry/API/CLI providers, timeout-aware adapter capability to avoid duplicate client timers, and cancellation-safe half-open circuit handling.
+- [x] Run focused cancellation/deadline tests and all 4,999 orchestrator assertions; run the affected `runtime-contract.test.ts` independently (16/16 passing) to isolate its unrelated full-suite `Codex app-server is unavailable` unhandled rejection.
+- [x] Run repository typecheck, lint, build, dependency/security audit, hard-coded-secret/plain-HTTP/TODO scans, and `git diff --check` successfully.
+- [x] Complete bounded local Codex review rounds and resolve timeout range, pre-abort, provider propagation, Gemini request scoping, and half-open probe findings.
+- [ ] Commit, push, open PR, and complete exact-head Codex/CI/merge/issue-closure gates.
+- [ ] Append compact reusable lessons and terminalize Kanban handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -4,6 +4,11 @@
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.
 - Informational evaluator findings must not return a blocking `fail` verdict when the pipeline contract treats `pass` plus `info` as non-blocking. Preserve the finding and score signal, and fix the verdict/severity drift instead of adding environment configuration to pure evaluator logic.
 
+## 2026-07-30 — Adapter-level deadlines need one owner and one cancellation signal
+- A client wrapper that only forwards `timeoutMs` remains unbounded for generic adapters. Enforce a default/request deadline at the wrapper, pass the same abort signal through both request transformation and `execute()`, and race completion against that signal so the caller returns even when adapter work stalls.
+- Let adapters that already enforce and clean up their own deadline explicitly advertise that capability; the wrapper should forward the normalized timeout but skip its extra timer. Timeout-aware process adapters must abort their child process, while generic adapters receive the wrapper signal for cooperative cleanup.
+- Propagate cancellation through provider registries into SDK request options and child-process spawn signals. Caller cancellation must release half-open circuit-breaker reservations without recording provider failures, and timer inputs must be capped at Node's signed 32-bit delay limit.
+
 ## 2026-07-27 — Managed-service CLI visibility must use explicit operator paths
 - A managed service that rebuilds `PATH` should add only explicit conventional operator locations (for example `$HOME/.local/bin` and `/usr/local/bin`) beside the runtime/system directories; never copy the parent shell's `PATH`, because arbitrary inherited entries would undo process isolation. Validate home-derived entries as absolute and delimiter-free before adding them.
 - Audit nested child launchers after widening a managed PATH. Bare commands that were safe only under the old restricted PATH (such as a dashboard process spawning `npm`) must be replaced with already-resolved trusted executable/CLI paths, and fallback resolution must search the sanitized managed PATH rather than the parent process PATH.


### PR DESCRIPTION
## Summary
- enforce a bounded 30-second default deadline in AdapterLlmClient while preserving timeout-owning adapter defaults
- propagate cancellation through provider registries, SDK request options, and CLI child processes
- keep caller cancellations from penalizing half-open provider health and add deadline/cancellation regressions

## Test plan
- [x] 316 focused adapter/provider tests
- [x] 4,999 orchestrator assertions (the full run reports one unrelated Codex app-server unhandled rejection; isolated runtime-contract suite passes 16/16)
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] npm run audit:security
- [x] npm run lint:security

Closes #3829