### PR TITLE
test(docs): reject unresolved merge markers

### DIFF
--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -44,15 +44,24 @@ async function scanFile(path) {
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
     const openingMatch = openingMarkerPattern.exec(line);
     if (openingMatch) {
-      conflict = {
-        width: openingMatch[1].length,
-        sawSeparator: false,
-        findings: [{
-          path: toRepoPath(path),
-          line: index + 1,
-          marker: openingMatch[1],
-        }],
-      };
+      const finding = { path: toRepoPath(path), line: index + 1, marker: openingMatch[1] };
+      if (openingMatch[1].length >= 7) {
+        findings.push(finding);
+        conflict = null;
+      } else {
+        conflict = {
+          width: openingMatch[1].length,
+          sawSeparator: false,
+          findings: [finding],
+        };
+      }
+      continue;
+    }
+
+    const closingMatch = closingMarkerPattern.exec(line);
+    if (closingMatch?.[1].length >= 7) {
+      findings.push({ path: toRepoPath(path), line: index + 1, marker: closingMatch[1] });
+      conflict = null;
       continue;
     }
     if (!conflict) continue;
@@ -68,7 +77,6 @@ async function scanFile(path) {
       continue;
     }
 
-    const closingMatch = closingMarkerPattern.exec(line);
     if (closingMatch?.[1].length === conflict.width && conflict.sawSeparator) {
       conflict.findings.push({
         path: toRepoPath(path),

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { extname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,18 +13,29 @@ const separatorMarkerPattern = /^(={1,})(?:\s.*)?$/u;
 const closingMarkerPattern = /^(>{1,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
 
-async function readConfiguredNarrowMarkerWidths() {
+function readConfiguredMarkerWidths(paths) {
+  const repoPaths = paths.map(toRepoPath);
+  if (repoPaths.length === 0) return new Map();
+
+  let output;
   try {
-    const attributes = await readFile(join(root, '.gitattributes'), 'utf8');
-    return new Set(
-      [...attributes.matchAll(/(?:^|\s)conflict-marker-size=(\d+)(?=\s|$)/gmu)]
-        .map((match) => Number(match[1]))
-        .filter((width) => width < 3),
+    output = execFileSync(
+      'git',
+      ['check-attr', '-z', 'conflict-marker-size', '--', ...repoPaths],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     );
   } catch (error) {
-    if (error?.code === 'ENOENT') return new Set();
+    if (error?.status === 128) return new Map();
     throw error;
   }
+
+  const fields = output.split('\0');
+  const widths = new Map();
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const [path, , value] = fields.slice(index, index + 3);
+    if (/^\d+$/u.test(value)) widths.set(path, Number(value));
+  }
+  return widths;
 }
 
 function toRepoPath(path) {
@@ -51,7 +63,7 @@ async function* walkMarkdown(dir) {
   }
 }
 
-async function scanFile(path, configuredNarrowMarkerWidths) {
+async function scanFile(path, configuredMarkerWidth) {
   const source = (await readFile(path, 'utf8')).replace(/^\uFEFF/u, '');
   const findings = [];
   const conflicts = new Map();
@@ -60,7 +72,7 @@ async function scanFile(path, configuredNarrowMarkerWidths) {
     const openingMatch = openingMarkerPattern.exec(line);
     if (openingMatch) {
       const width = openingMatch[1].length;
-      if (width < 3 && !configuredNarrowMarkerWidths.has(width)) continue;
+      if (width < 7 && configuredMarkerWidth !== width) continue;
       const finding = { path: toRepoPath(path), line: index + 1, marker: openingMatch[1] };
       if (width >= 7) {
         findings.push(finding);
@@ -119,9 +131,11 @@ async function scanFile(path, configuredNarrowMarkerWidths) {
 }
 
 const findings = [];
-const configuredNarrowMarkerWidths = await readConfiguredNarrowMarkerWidths();
-for await (const path of walkMarkdown(docsRoot)) {
-  findings.push(...await scanFile(path, configuredNarrowMarkerWidths));
+const paths = [];
+for await (const path of walkMarkdown(docsRoot)) paths.push(path);
+const configuredMarkerWidths = readConfiguredMarkerWidths(paths);
+for (const path of paths) {
+  findings.push(...await scanFile(path, configuredMarkerWidths.get(toRepoPath(path))));
 }
 findings.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
 

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -6,7 +6,9 @@ import { fileURLToPath } from 'node:url';
 const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
 const root = process.env.FRANKENBEAST_DOCS_SCAN_ROOT ?? defaultRoot;
 const docsRoot = join(root, 'docs');
-const markerPattern = /^(<{7}|={7}|>{7})(?:\s.*)?$/u;
+const openingMarkerPattern = /^(<{7,})(?:\s.*)?$/u;
+const separatorMarkerPattern = /^(={7,})(?:\s.*)?$/u;
+const closingMarkerPattern = /^(>{7,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
 
 function toRepoPath(path) {
@@ -37,9 +39,14 @@ async function* walkMarkdown(dir) {
 async function scanFile(path) {
   const source = await readFile(path, 'utf8');
   const findings = [];
+  let insideConflict = false;
 
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
-    const match = markerPattern.exec(line);
+    const openingMatch = openingMarkerPattern.exec(line);
+    const closingMatch = closingMarkerPattern.exec(line);
+    const match = openingMatch
+      ?? closingMatch
+      ?? (insideConflict ? separatorMarkerPattern.exec(line) : null);
     if (match) {
       findings.push({
         path: toRepoPath(path),
@@ -47,6 +54,8 @@ async function scanFile(path) {
         marker: match[1],
       });
     }
+    if (openingMatch) insideConflict = true;
+    if (closingMatch) insideConflict = false;
   }
 
   return findings;

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -7,6 +7,7 @@ const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
 const root = process.env.FRANKENBEAST_DOCS_SCAN_ROOT ?? defaultRoot;
 const docsRoot = join(root, 'docs');
 const openingMarkerPattern = /^(<{1,})(?:\s.*)?$/u;
+const ancestorMarkerPattern = /^(\|{7,})(?:\s.*)?$/u;
 const separatorMarkerPattern = /^(={1,})(?:\s.*)?$/u;
 const closingMarkerPattern = /^(>{1,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
@@ -54,6 +55,12 @@ async function scanFile(path) {
           findings: [finding],
         });
       }
+      continue;
+    }
+
+    const ancestorMatch = ancestorMarkerPattern.exec(line);
+    if (ancestorMatch) {
+      findings.push({ path: toRepoPath(path), line: index + 1, marker: ancestorMatch[1] });
       continue;
     }
 

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -12,6 +12,20 @@ const separatorMarkerPattern = /^(={1,})(?:\s.*)?$/u;
 const closingMarkerPattern = /^(>{1,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
 
+async function readConfiguredNarrowMarkerWidths() {
+  try {
+    const attributes = await readFile(join(root, '.gitattributes'), 'utf8');
+    return new Set(
+      [...attributes.matchAll(/(?:^|\s)conflict-marker-size=(\d+)(?=\s|$)/gmu)]
+        .map((match) => Number(match[1]))
+        .filter((width) => width < 3),
+    );
+  } catch (error) {
+    if (error?.code === 'ENOENT') return new Set();
+    throw error;
+  }
+}
+
 function toRepoPath(path) {
   return relative(root, path).split(sep).join('/');
 }
@@ -37,7 +51,7 @@ async function* walkMarkdown(dir) {
   }
 }
 
-async function scanFile(path) {
+async function scanFile(path, configuredNarrowMarkerWidths) {
   const source = (await readFile(path, 'utf8')).replace(/^\uFEFF/u, '');
   const findings = [];
   const conflicts = new Map();
@@ -45,12 +59,14 @@ async function scanFile(path) {
   for (const [index, line] of source.split(/\r\n|\r|\n/u).entries()) {
     const openingMatch = openingMarkerPattern.exec(line);
     if (openingMatch) {
+      const width = openingMatch[1].length;
+      if (width < 3 && !configuredNarrowMarkerWidths.has(width)) continue;
       const finding = { path: toRepoPath(path), line: index + 1, marker: openingMatch[1] };
-      if (openingMatch[1].length >= 7) {
+      if (width >= 7) {
         findings.push(finding);
-      } else if (!conflicts.has(openingMatch[1].length)) {
-        conflicts.set(openingMatch[1].length, {
-          width: openingMatch[1].length,
+      } else if (!conflicts.has(width)) {
+        conflicts.set(width, {
+          width,
           sawSeparator: false,
           findings: [finding],
         });
@@ -103,8 +119,9 @@ async function scanFile(path) {
 }
 
 const findings = [];
+const configuredNarrowMarkerWidths = await readConfiguredNarrowMarkerWidths();
 for await (const path of walkMarkdown(docsRoot)) {
-  findings.push(...await scanFile(path));
+  findings.push(...await scanFile(path, configuredNarrowMarkerWidths));
 }
 findings.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
 

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -37,18 +37,17 @@ async function* walkMarkdown(dir) {
 }
 
 async function scanFile(path) {
-  const source = await readFile(path, 'utf8');
+  const source = (await readFile(path, 'utf8')).replace(/^\uFEFF/u, '');
   const findings = [];
   let conflict = null;
 
-  for (const [index, line] of source.split(/\r?\n/u).entries()) {
+  for (const [index, line] of source.split(/\r\n|\r|\n/u).entries()) {
     const openingMatch = openingMarkerPattern.exec(line);
     if (openingMatch) {
       const finding = { path: toRepoPath(path), line: index + 1, marker: openingMatch[1] };
       if (openingMatch[1].length >= 7) {
         findings.push(finding);
-        conflict = null;
-      } else {
+      } else if (!conflict?.sawSeparator) {
         conflict = {
           width: openingMatch[1].length,
           sawSeparator: false,

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -6,9 +6,9 @@ import { fileURLToPath } from 'node:url';
 const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
 const root = process.env.FRANKENBEAST_DOCS_SCAN_ROOT ?? defaultRoot;
 const docsRoot = join(root, 'docs');
-const openingMarkerPattern = /^(<{7,})(?:\s.*)?$/u;
-const separatorMarkerPattern = /^(={7,})(?:\s.*)?$/u;
-const closingMarkerPattern = /^(>{7,})(?:\s.*)?$/u;
+const openingMarkerPattern = /^(<{3,})(?:\s.*)?$/u;
+const separatorMarkerPattern = /^(={3,})(?:\s.*)?$/u;
+const closingMarkerPattern = /^(>{3,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
 
 function toRepoPath(path) {
@@ -39,23 +39,45 @@ async function* walkMarkdown(dir) {
 async function scanFile(path) {
   const source = await readFile(path, 'utf8');
   const findings = [];
-  let insideConflict = false;
+  let conflict = null;
 
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
     const openingMatch = openingMarkerPattern.exec(line);
-    const closingMatch = closingMarkerPattern.exec(line);
-    const match = openingMatch
-      ?? closingMatch
-      ?? (insideConflict ? separatorMarkerPattern.exec(line) : null);
-    if (match) {
-      findings.push({
+    if (openingMatch) {
+      conflict = {
+        width: openingMatch[1].length,
+        sawSeparator: false,
+        findings: [{
+          path: toRepoPath(path),
+          line: index + 1,
+          marker: openingMatch[1],
+        }],
+      };
+      continue;
+    }
+    if (!conflict) continue;
+
+    const separatorMatch = separatorMarkerPattern.exec(line);
+    if (separatorMatch?.[1].length === conflict.width) {
+      conflict.sawSeparator = true;
+      conflict.findings.push({
         path: toRepoPath(path),
         line: index + 1,
-        marker: match[1],
+        marker: separatorMatch[1],
       });
+      continue;
     }
-    if (openingMatch) insideConflict = true;
-    if (closingMatch) insideConflict = false;
+
+    const closingMatch = closingMarkerPattern.exec(line);
+    if (closingMatch?.[1].length === conflict.width && conflict.sawSeparator) {
+      conflict.findings.push({
+        path: toRepoPath(path),
+        line: index + 1,
+        marker: closingMatch[1],
+      });
+      findings.push(...conflict.findings);
+      conflict = null;
+    }
   }
 
   return findings;

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { extname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
+const root = process.env.FRANKENBEAST_DOCS_SCAN_ROOT ?? defaultRoot;
+const docsRoot = join(root, 'docs');
+const markerPattern = /^(<{7}|={7}|>{7})(?:\s.*)?$/u;
+const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
+
+function toRepoPath(path) {
+  return relative(root, path).split(sep).join('/');
+}
+
+async function* walkMarkdown(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        yield* walkMarkdown(path);
+      }
+    } else if (entry.isFile() && extname(entry.name).toLowerCase() === '.md') {
+      yield path;
+    }
+  }
+}
+
+async function scanFile(path) {
+  const source = await readFile(path, 'utf8');
+  const findings = [];
+
+  for (const [index, line] of source.split(/\r?\n/u).entries()) {
+    const match = markerPattern.exec(line);
+    if (match) {
+      findings.push({
+        path: toRepoPath(path),
+        line: index + 1,
+        marker: match[1],
+      });
+    }
+  }
+
+  return findings;
+}
+
+const findings = [];
+for await (const path of walkMarkdown(docsRoot)) {
+  findings.push(...await scanFile(path));
+}
+findings.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
+
+if (process.argv.includes('--json')) {
+  console.log(JSON.stringify({ scannedRoots: ['docs'], totalFindings: findings.length, findings }, null, 2));
+} else if (findings.length === 0) {
+  console.log('No unresolved merge markers found in maintained Markdown under docs/.');
+} else {
+  console.error(`Unresolved merge markers found in maintained Markdown (${findings.length}):`);
+  for (const finding of findings) {
+    console.error(`- ${finding.path}:${finding.line}: ${finding.marker}`);
+  }
+}
+
+if (findings.length > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/check-doc-integrity.mjs
+++ b/scripts/check-doc-integrity.mjs
@@ -6,9 +6,9 @@ import { fileURLToPath } from 'node:url';
 const defaultRoot = fileURLToPath(new URL('..', import.meta.url));
 const root = process.env.FRANKENBEAST_DOCS_SCAN_ROOT ?? defaultRoot;
 const docsRoot = join(root, 'docs');
-const openingMarkerPattern = /^(<{3,})(?:\s.*)?$/u;
-const separatorMarkerPattern = /^(={3,})(?:\s.*)?$/u;
-const closingMarkerPattern = /^(>{3,})(?:\s.*)?$/u;
+const openingMarkerPattern = /^(<{1,})(?:\s.*)?$/u;
+const separatorMarkerPattern = /^(={1,})(?:\s.*)?$/u;
+const closingMarkerPattern = /^(>{1,})(?:\s.*)?$/u;
 const ignoredDirectories = new Set(['generated', 'node_modules', 'vendor']);
 
 function toRepoPath(path) {
@@ -39,7 +39,7 @@ async function* walkMarkdown(dir) {
 async function scanFile(path) {
   const source = (await readFile(path, 'utf8')).replace(/^\uFEFF/u, '');
   const findings = [];
-  let conflict = null;
+  const conflicts = new Map();
 
   for (const [index, line] of source.split(/\r\n|\r|\n/u).entries()) {
     const openingMatch = openingMarkerPattern.exec(line);
@@ -47,12 +47,12 @@ async function scanFile(path) {
       const finding = { path: toRepoPath(path), line: index + 1, marker: openingMatch[1] };
       if (openingMatch[1].length >= 7) {
         findings.push(finding);
-      } else if (!conflict?.sawSeparator) {
-        conflict = {
+      } else if (!conflicts.has(openingMatch[1].length)) {
+        conflicts.set(openingMatch[1].length, {
           width: openingMatch[1].length,
           sawSeparator: false,
           findings: [finding],
-        };
+        });
       }
       continue;
     }
@@ -60,15 +60,17 @@ async function scanFile(path) {
     const closingMatch = closingMarkerPattern.exec(line);
     if (closingMatch?.[1].length >= 7) {
       findings.push({ path: toRepoPath(path), line: index + 1, marker: closingMatch[1] });
-      conflict = null;
+      conflicts.clear();
       continue;
     }
-    if (!conflict) continue;
 
     const separatorMatch = separatorMarkerPattern.exec(line);
-    if (separatorMatch?.[1].length === conflict.width) {
-      conflict.sawSeparator = true;
-      conflict.findings.push({
+    const separatorConflict = separatorMatch
+      ? conflicts.get(separatorMatch[1].length)
+      : undefined;
+    if (separatorConflict) {
+      separatorConflict.sawSeparator = true;
+      separatorConflict.findings.push({
         path: toRepoPath(path),
         line: index + 1,
         marker: separatorMatch[1],
@@ -76,14 +78,17 @@ async function scanFile(path) {
       continue;
     }
 
-    if (closingMatch?.[1].length === conflict.width && conflict.sawSeparator) {
-      conflict.findings.push({
+    const closingConflict = closingMatch
+      ? conflicts.get(closingMatch[1].length)
+      : undefined;
+    if (closingConflict?.sawSeparator) {
+      closingConflict.findings.push({
         path: toRepoPath(path),
         line: index + 1,
         marker: closingMatch[1],
       });
-      findings.push(...conflict.findings);
-      conflict = null;
+      findings.push(...closingConflict.findings);
+      conflicts.delete(closingMatch[1].length);
     }
   }
 

--- a/tasks/issue-3787-progress.md
+++ b/tasks/issue-3787-progress.md
@@ -1,0 +1,9 @@
+# Issue 3787 progress
+
+- [x] Revalidate issue, labels, base commit, branch/worktree ownership, and competing PRs.
+- [x] Prove maintained Markdown under `docs/` is currently free of unresolved merge markers.
+- [x] Add and run a focused RED fixture proving no repository guard rejects an unresolved marker.
+- [x] Implement the minimal maintained-docs integrity guard without scanning generated/vendor artifacts.
+- [x] Run focused and repository quality gates; inspect the final diff.
+- [ ] Commit, push, open one PR, and complete exact-head Codex/CI review gates.
+- [ ] Squash merge, verify issue closure, record reusable lessons, and complete the Kanban handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-30 — Maintained-docs conflict-marker integrity
-- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots and skip generated/vendor directories. Reject standard-width opening/closing remnants independently, but require a coherent same-width block for shorter configurable markers so custom Git conflicts are caught without misclassifying standalone Setext headings or Markdown blockquotes.
+- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots and skip generated/vendor directories. Reject standard-width opening/closing remnants independently, but require a coherent same-width block for shorter configurable markers so custom Git conflicts are caught without misclassifying standalone Setext headings or Markdown blockquotes. Preserve an active short block after its separator, normalize BOM and CR-only inputs, and test those parser boundaries directly.
 
 ## 2026-07-30 — Faculty clocks must be wired before adapter construction
 - Resolve the shared Beast clock before constructing any faculty adapter, then use that same source for lesson-consultation and every lifecycle timestamp. A frozen-clock dependency-factory regression should exercise planning, completion, and failure paths together so one remaining wall-clock call cannot hide behind otherwise deterministic reasoning/action behavior.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-30 — Maintained-docs conflict-marker integrity
-- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots, skip generated/vendor directories, and recognize coherent opening/separator/closing blocks at the same configurable width; block-level detection catches short custom Git markers without misclassifying standalone Setext headings or Markdown blockquotes.
+- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots and skip generated/vendor directories. Reject standard-width opening/closing remnants independently, but require a coherent same-width block for shorter configurable markers so custom Git conflicts are caught without misclassifying standalone Setext headings or Markdown blockquotes.
 
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-30 — Maintained-docs conflict-marker integrity
-- A docs integrity regression should combine a real repository scan with an isolated marker fixture so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots and explicitly skip generated/vendor directories instead of scanning dependency or generated artifacts.
+- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots, skip generated/vendor directories, accept configurable marker widths, and classify equals-only separators only inside conflict blocks so valid Setext headings remain allowed.
 
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-30 — Maintained-docs conflict-marker integrity
+- A docs integrity regression should combine a real repository scan with an isolated marker fixture so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots and explicitly skip generated/vendor directories instead of scanning dependency or generated artifacts.
+
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.
 - Informational evaluator findings must not return a blocking `fail` verdict when the pipeline contract treats `pass` plus `info` as non-blocking. Preserve the finding and score signal, and fix the verdict/severity drift instead of adding environment configuration to pure evaluator logic.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,7 +1,7 @@
 # Resolve Issues Shared Lessons
 
 ## 2026-07-30 — Maintained-docs conflict-marker integrity
-- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots, skip generated/vendor directories, accept configurable marker widths, and classify equals-only separators only inside conflict blocks so valid Setext headings remain allowed.
+- A docs integrity regression should combine a real repository scan with isolated fixtures so the suite proves both the current tree and the guard's red-capable behavior. Restrict traversal to maintained Markdown roots, skip generated/vendor directories, and recognize coherent opening/separator/closing blocks at the same configurable width; block-level detection catches short custom Git markers without misclassifying standalone Setext headings or Markdown blockquotes.
 
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -113,6 +113,21 @@ describe('maintained Markdown integrity', () => {
     expect(result.status).toBe(1);
   });
 
+  it('rejects complete conflict blocks with one-character markers', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/minimal.md', [
+      '< HEAD',
+      'current guide',
+      '=',
+      'incoming guide',
+      '> feature/guide',
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
   it('preserves a short conflict after an opening-like incoming line', () => {
     const root = makeFixtureRoot();
     writeFixture(root, 'docs/guide.md', [
@@ -121,6 +136,22 @@ describe('maintained Markdown integrity', () => {
       shortConflictMarker('='),
       `${shortConflictMarker('<')} example`,
       `${shortConflictMarker('>')} feature/guide`,
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
+  it('preserves an outer conflict before its separator', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/guide.md', [
+      '<<<< HEAD',
+      'current guide',
+      '<<< example',
+      '====',
+      'incoming guide',
+      '>>>> feature/guide',
     ].join('\n'));
 
     const result = runScanner(root);

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -16,6 +16,10 @@ function wideConflictMarker(character: '<' | '=' | '>'): string {
   return character.repeat(9);
 }
 
+function shortConflictMarker(character: '<' | '=' | '>'): string {
+  return character.repeat(3);
+}
+
 function makeFixtureRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'franken-doc-integrity-'));
   fixtureRoots.add(root);
@@ -87,6 +91,21 @@ describe('maintained Markdown integrity', () => {
       wideConflictMarker('='),
       'incoming architecture',
       `${wideConflictMarker('>')} feature/architecture`,
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects complete conflict blocks with marker widths below seven', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/guide.md', [
+      `${shortConflictMarker('<')} HEAD`,
+      'current guide',
+      shortConflictMarker('='),
+      'incoming guide',
+      `${shortConflictMarker('>')} feature/guide`,
     ].join('\n'));
 
     const result = runScanner(root);

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -201,6 +201,19 @@ describe('maintained Markdown integrity', () => {
     expect(report.totalFindings).toBe(2);
   });
 
+  it('rejects incomplete standard-width diff3 ancestor remnants', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/ancestor.md', [
+      '# Guide',
+      '||||||| base',
+      'ancestor text',
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
   it('allows valid Setext heading underlines outside conflict blocks', () => {
     const root = makeFixtureRoot();
     writeFixture(root, 'docs/guide.md', [

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -113,6 +113,51 @@ describe('maintained Markdown integrity', () => {
     expect(result.status).toBe(1);
   });
 
+  it('preserves a short conflict after an opening-like incoming line', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/guide.md', [
+      `${shortConflictMarker('<')} HEAD`,
+      'current guide',
+      shortConflictMarker('='),
+      `${shortConflictMarker('<')} example`,
+      `${shortConflictMarker('>')} feature/guide`,
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects conflicts in Markdown with CR-only line endings', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/legacy.md', [
+      `${conflictMarker('<')} HEAD`,
+      'current guide',
+      conflictMarker('='),
+      'incoming guide',
+      `${conflictMarker('>')} feature/guide`,
+    ].join('\r'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects a conflict whose opening marker follows a UTF-8 BOM', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/bom.md', [
+      `\uFEFF${shortConflictMarker('<')} HEAD`,
+      'current guide',
+      shortConflictMarker('='),
+      'incoming guide',
+      `${shortConflictMarker('>')} feature/guide`,
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
   it('rejects incomplete standard-width opening and closing remnants', () => {
     const root = makeFixtureRoot();
     writeFixture(root, 'docs/opening.md', `${conflictMarker('<')} HEAD\nunfinished\n`);

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -100,6 +100,8 @@ describe('maintained Markdown integrity', () => {
 
   it('rejects complete conflict blocks with marker widths below seven', () => {
     const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
+    writeFixture(root, '.gitattributes', '*.md conflict-marker-size=3\n');
     writeFixture(root, 'docs/guide.md', [
       `${shortConflictMarker('<')} HEAD`,
       'current guide',
@@ -113,8 +115,23 @@ describe('maintained Markdown integrity', () => {
     expect(result.status).toBe(1);
   });
 
+  it('allows three-character Markdown constructs without a configured marker width', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/valid.md', [
+      '<<< literal comparison notation',
+      'Architecture',
+      '===',
+      '>>> deeply nested quotation',
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+  });
+
   it('rejects complete conflict blocks with one-character markers', () => {
     const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
     writeFixture(root, '.gitattributes', '*.md conflict-marker-size=1\n');
     writeFixture(root, 'docs/minimal.md', [
       '< HEAD',
@@ -127,6 +144,38 @@ describe('maintained Markdown integrity', () => {
     const result = runScanner(root);
 
     expect(result.status).toBe(1);
+  });
+
+  it('resolves configured narrow marker widths for each Markdown path', () => {
+    const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
+    writeFixture(root, 'docs/.gitattributes', 'nested-conflict.md conflict-marker-size=1\n');
+    writeFixture(root, 'docs/nested-conflict.md', [
+      '< HEAD',
+      'current guide',
+      '=',
+      'incoming guide',
+      '> feature/guide',
+    ].join('\n'));
+    writeFixture(root, 'docs/unconfigured/valid.md', [
+      '< less-than prose',
+      'Title',
+      '=',
+      '> quoted prose',
+    ].join('\n'));
+
+    const result = runScanner(root);
+    const report = JSON.parse(result.stdout) as {
+      findings: Array<{ path: string }>;
+    };
+
+    expect(result.status).toBe(1);
+    expect(report.findings).toContainEqual(expect.objectContaining({
+      path: 'docs/nested-conflict.md',
+    }));
+    expect(report.findings).not.toContainEqual(expect.objectContaining({
+      path: 'docs/unconfigured/valid.md',
+    }));
   });
 
   it('allows unrelated one-character Markdown constructs without a configured marker width', () => {
@@ -145,6 +194,8 @@ describe('maintained Markdown integrity', () => {
 
   it('preserves a short conflict after an opening-like incoming line', () => {
     const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
+    writeFixture(root, '.gitattributes', '*.md conflict-marker-size=3\n');
     writeFixture(root, 'docs/guide.md', [
       `${shortConflictMarker('<')} HEAD`,
       'current guide',
@@ -160,6 +211,8 @@ describe('maintained Markdown integrity', () => {
 
   it('preserves an outer conflict before its separator', () => {
     const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
+    writeFixture(root, '.gitattributes', '*.md conflict-marker-size=4\n');
     writeFixture(root, 'docs/guide.md', [
       '<<<< HEAD',
       'current guide',
@@ -191,6 +244,8 @@ describe('maintained Markdown integrity', () => {
 
   it('rejects a conflict whose opening marker follows a UTF-8 BOM', () => {
     const root = makeFixtureRoot();
+    spawnSync('git', ['init', '--quiet'], { cwd: root });
+    writeFixture(root, '.gitattributes', '*.md conflict-marker-size=3\n');
     writeFixture(root, 'docs/bom.md', [
       `\uFEFF${shortConflictMarker('<')} HEAD`,
       'current guide',

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts/check-doc-integrity.mjs');
+const fixtureRoots = new Set<string>();
+
+function conflictMarker(character: '<' | '=' | '>'): string {
+  return character.repeat(7);
+}
+
+function makeFixtureRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'franken-doc-integrity-'));
+  fixtureRoots.add(root);
+  return root;
+}
+
+function writeFixture(root: string, relativePath: string, content: string): void {
+  const path = join(root, relativePath);
+  mkdirSync(resolve(path, '..'), { recursive: true });
+  writeFileSync(path, content, 'utf8');
+}
+
+function runScanner(root: string) {
+  return spawnSync(process.execPath, [SCRIPT, '--json'], {
+    cwd: ROOT,
+    env: { ...process.env, FRANKENBEAST_DOCS_SCAN_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { force: true, recursive: true });
+  }
+  fixtureRoots.clear();
+});
+
+describe('maintained Markdown integrity', () => {
+  it('passes for the repository maintained docs', () => {
+    const result = runScanner(ROOT);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ totalFindings: 0 });
+  });
+
+  it('rejects unresolved merge markers in maintained docs', () => {
+    const root = makeFixtureRoot();
+    writeFixture(
+      root,
+      'docs/onboarding/RAMP_UP.md',
+      [
+        '# Ramp up',
+        `${conflictMarker('<')} HEAD`,
+        'planning faculty wording',
+        conflictMarker('='),
+        'durable brain wording',
+        `${conflictMarker('>')} feature/docs`,
+      ].join('\n'),
+    );
+
+    const result = runScanner(root);
+    const report = JSON.parse(result.stdout) as {
+      findings: Array<{ line: number; path: string }>;
+    };
+
+    expect(result.status).toBe(1);
+    expect(report.findings).toContainEqual({
+      line: 2,
+      marker: conflictMarker('<'),
+      path: 'docs/onboarding/RAMP_UP.md',
+    });
+  });
+
+  it('does not scan generated or vendored Markdown artifacts', () => {
+    const root = makeFixtureRoot();
+    const unresolved = `${conflictMarker('<')} generated\n`;
+    writeFixture(root, 'docs/generated/reference.md', unresolved);
+    writeFixture(root, 'docs/vendor/upstream.md', unresolved);
+    writeFixture(root, 'docs/node_modules/package/README.md', unresolved);
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ totalFindings: 0 });
+  });
+});

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -113,6 +113,18 @@ describe('maintained Markdown integrity', () => {
     expect(result.status).toBe(1);
   });
 
+  it('rejects incomplete standard-width opening and closing remnants', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/opening.md', `${conflictMarker('<')} HEAD\nunfinished\n`);
+    writeFixture(root, 'docs/closing.md', `unfinished\n${conflictMarker('>')} feature/docs\n`);
+
+    const result = runScanner(root);
+    const report = JSON.parse(result.stdout) as { totalFindings: number };
+
+    expect(result.status).toBe(1);
+    expect(report.totalFindings).toBe(2);
+  });
+
   it('allows valid Setext heading underlines outside conflict blocks', () => {
     const root = makeFixtureRoot();
     writeFixture(root, 'docs/guide.md', [

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -115,6 +115,7 @@ describe('maintained Markdown integrity', () => {
 
   it('rejects complete conflict blocks with one-character markers', () => {
     const root = makeFixtureRoot();
+    writeFixture(root, '.gitattributes', '*.md conflict-marker-size=1\n');
     writeFixture(root, 'docs/minimal.md', [
       '< HEAD',
       'current guide',
@@ -126,6 +127,20 @@ describe('maintained Markdown integrity', () => {
     const result = runScanner(root);
 
     expect(result.status).toBe(1);
+  });
+
+  it('allows unrelated one-character Markdown constructs without a configured marker width', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/valid.md', [
+      '< less-than prose',
+      'Title',
+      '=',
+      '> quoted prose',
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
   });
 
   it('preserves a short conflict after an opening-like incoming line', () => {

--- a/tests/unit/doc-integrity.test.ts
+++ b/tests/unit/doc-integrity.test.ts
@@ -12,6 +12,10 @@ function conflictMarker(character: '<' | '=' | '>'): string {
   return character.repeat(7);
 }
 
+function wideConflictMarker(character: '<' | '=' | '>'): string {
+  return character.repeat(9);
+}
+
 function makeFixtureRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'franken-doc-integrity-'));
   fixtureRoots.add(root);
@@ -73,6 +77,33 @@ describe('maintained Markdown integrity', () => {
       marker: conflictMarker('<'),
       path: 'docs/onboarding/RAMP_UP.md',
     });
+  });
+
+  it('rejects configurable conflict-marker widths', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/ARCHITECTURE.md', [
+      `${wideConflictMarker('<')} HEAD`,
+      'current architecture',
+      wideConflictMarker('='),
+      'incoming architecture',
+      `${wideConflictMarker('>')} feature/architecture`,
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(1);
+  });
+
+  it('allows valid Setext heading underlines outside conflict blocks', () => {
+    const root = makeFixtureRoot();
+    writeFixture(root, 'docs/guide.md', [
+      'Architecture',
+      conflictMarker('='),
+    ].join('\n'));
+
+    const result = runScanner(root);
+
+    expect(result.status).toBe(0);
   });
 
   it('does not scan generated or vendored Markdown artifacts', () => {


### PR DESCRIPTION
## Summary
- scan maintained Markdown under `docs/` for unresolved merge markers
- fail the root repository test with precise file and line evidence
- exclude generated and vendored documentation artifacts

## Test plan
- [x] `npm run test:root -- tests/unit/doc-integrity.test.ts --reporter=verbose` (3 passed)
- [x] `node scripts/check-doc-integrity.mjs`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run lint:security`
- [x] `npm run audit:security` (0 vulnerabilities)
- [ ] `npm test` (all assertions passed, but an unrelated pre-existing Codex app-server unavailable unhandled rejection caused exit 1)
- [ ] `npm run test:root` (771 passed; one environment-sensitive required-port assertion failed because local port 4317 was occupied)

Closes #3787