### PR TITLE
fix(orchestrator): inject planning faculty clock

### DIFF
--- a/packages/franken-orchestrator/src/adapters/planning-faculty-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/planning-faculty-adapter.ts
@@ -9,8 +9,9 @@ import type { IPlannerModule, PlanGraph, PlanIntent, PlanTask } from '../deps.js
 import { consultFacultyLessons } from './faculty-learning.js';
 
 export interface PlanningFacultyAdapterOptions {
-  recordEpisodes?: boolean;
-  learning?: ILearningFaculty;
+  readonly recordEpisodes?: boolean;
+  readonly learning?: ILearningFaculty;
+  readonly clock?: () => Date;
 }
 
 /**
@@ -34,7 +35,7 @@ export class PlanningFacultyAdapter implements IPlannerModule, IPlanningFaculty 
         intent.goal,
         this.episodic,
         this.options.learning,
-        isoNow(),
+        this.now(),
       );
     }
     const plan = await this.delegate.createPlan(intent);
@@ -52,7 +53,7 @@ export class PlanningFacultyAdapter implements IPlannerModule, IPlanningFaculty 
         taskCount: plan.tasks.length,
         taskIds: plan.tasks.map((task) => task.id),
       },
-      createdAt: isoNow(),
+      createdAt: this.now(),
     });
   }
 
@@ -71,7 +72,7 @@ export class PlanningFacultyAdapter implements IPlannerModule, IPlanningFaculty 
       step: task.id,
       summary: `Planning step completed: ${task.objective}`,
       details: { category: 'planning-lifecycle', taskId: task.id },
-      createdAt: isoNow(),
+      createdAt: this.now(),
     });
   }
 
@@ -85,8 +86,12 @@ export class PlanningFacultyAdapter implements IPlannerModule, IPlanningFaculty 
         taskId: task.id,
         errorName: error instanceof Error ? error.name : 'Error',
       },
-      createdAt: isoNow(),
+      createdAt: this.now(),
     });
+  }
+
+  private now(): string {
+    return this.options.clock?.().toISOString() ?? isoNow();
   }
 
   private recordLifecycleEvent(event: EpisodicEvent): void {

--- a/packages/franken-orchestrator/src/cli/create-beast-deps.ts
+++ b/packages/franken-orchestrator/src/cli/create-beast-deps.ts
@@ -186,15 +186,16 @@ export function createBeastDeps(
 
   // 6. Adapters
   const firewall = new MiddlewareChainFirewallAdapter(middlewareChain);
+  const clock = existingDeps.clock ?? (() => new Date(deterministicNow()));
   const planning = new PlanningFacultyAdapter(existingDeps.planner, brain.episodic, {
     learning: brain.learning,
+    clock,
     ...(config.planning?.recordEpisodes !== undefined
       ? { recordEpisodes: config.planning.recordEpisodes }
       : {}),
   });
   brain.attachPlanningFaculty(planning);
   const memory = new SqliteBrainMemoryAdapter(brain);
-  const clock = existingDeps.clock ?? (() => new Date(deterministicNow()));
   const reasoningEnabled = config.reasoning?.enabled !== false
     && existingDeps.critique.configured !== false;
   const reasoning = reasoningEnabled

--- a/packages/franken-orchestrator/tests/integration/e2e-consolidated-deps.test.ts
+++ b/packages/franken-orchestrator/tests/integration/e2e-consolidated-deps.test.ts
@@ -219,6 +219,44 @@ describe('E2E: Consolidated deps through BeastLoop', () => {
     );
   });
 
+  it('uses the injected clock for every planning faculty episode', async () => {
+    const frozenNow = new Date('2026-07-30T12:34:56.789Z');
+    const deps = createBeastDeps(
+      { providers: [{ name: 'claude', type: 'claude-cli' }] },
+      {
+        ...mockExistingDeps(),
+        clock: () => frozenNow,
+      },
+    );
+
+    await deps.planner.createPlan({ goal: 'Replay deterministic planning' });
+    await deps.memory.recordTrace({
+      taskId: 'task-1',
+      objective: 'Complete deterministic planning',
+      summary: 'Planning step completed',
+      outcome: 'success',
+      timestamp: frozenNow.toISOString(),
+    });
+    await deps.memory.recordTrace({
+      taskId: 'task-2',
+      objective: 'Fail deterministic planning',
+      summary: 'Planning step failed',
+      outcome: 'failure',
+      timestamp: frozenNow.toISOString(),
+    });
+
+    const planningEpisodes = deps.sqliteBrain!.episodic.recent().filter((episode) =>
+      episode.step === 'planning:lesson-consultation'
+      || episode.details?.category === 'planning-lifecycle'
+    );
+    expect(planningEpisodes.map((episode) => episode.createdAt)).toEqual([
+      frozenNow.toISOString(),
+      frozenNow.toISOString(),
+      frozenNow.toISOString(),
+      frozenNow.toISOString(),
+    ]);
+  });
+
   it('provider registry has configured providers', () => {
     const deps = createBeastDeps(
       {

--- a/tasks/issue-3785-planning-faculty-clock-progress.md
+++ b/tasks/issue-3785-planning-faculty-clock-progress.md
@@ -1,0 +1,11 @@
+# Issue 3785 Planning Faculty Clock Progress
+
+- [x] Revalidate live issue, labels, adjacent #3784 scope, competing PR/branch ownership, worktree branch, and exact origin/main base.
+- [x] Read repository lessons and trace PlanningFacultyAdapter plus createBeastDeps clock wiring.
+- [x] Reproduce lifecycle and lesson-consultation wall-clock drift with a frozen injected clock on current main (expected `2026-07-30T12:34:56.789Z`; observed four wall-clock values around `2026-07-30T14:21:23Z`).
+- [x] Add a focused failing regression test for injected planning timestamps.
+- [x] Inject the established clock through PlanningFacultyAdapter and createBeastDeps without changing existing constructor call sites.
+- [x] Run focused adapter/dependency-factory tests, lint, typecheck, build, and relevant repository gates (root tests exposed unrelated pre-existing Codex runtime timing/unhandled-rejection failures; focused changed-path tests pass).
+- [x] Self-review the diff and append only reusable lessons.
+- [ ] Commit, push, open one PR closing #3785, and drive CI plus exact-head Codex review to clean.
+- [ ] Squash-merge only if routine exact-head gates pass; verify issue closure and complete the Kanban handoff.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-30 — Faculty clocks must be wired before adapter construction
+- Resolve the shared Beast clock before constructing any faculty adapter, then use that same source for lesson-consultation and every lifecycle timestamp. A frozen-clock dependency-factory regression should exercise planning, completion, and failure paths together so one remaining wall-clock call cannot hide behind otherwise deterministic reasoning/action behavior.
+
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.
 - Informational evaluator findings must not return a blocking `fail` verdict when the pipeline contract treats `pass` plus `info` as non-blocking. Preserve the finding and score signal, and fix the verdict/severity drift instead of adding environment configuration to pure evaluator logic.


### PR DESCRIPTION
## Summary
- inject the established Beast clock into `PlanningFacultyAdapter`
- timestamp lesson consultation and all planning lifecycle episodes from the same deterministic source
- add a frozen-clock dependency-factory regression across plan, completion, and failure paths

## Test plan
- `npm --workspace @franken/orchestrator test -- tests/unit/adapters/planning-faculty-adapter.test.ts tests/unit/cli/create-beast-deps.test.ts`
- `npm --workspace @franken/orchestrator run test:e2e -- tests/integration/e2e-consolidated-deps.test.ts -t "uses the injected clock for every planning faculty episode"`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` (unrelated pre-existing orchestrator Codex runtime timing/unhandled-rejection failures; 4,985 orchestrator tests passed and focused changed-path coverage is green)

Closes #3785