### PR TITLE
fix(brain): bound faculty outcome scans

### DIFF
--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3342,10 +3342,13 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
   }
 
   /**
-   * Inspect at most the newest `n` decision rows while collecting faculty
-   * negative outcomes, so automatic consolidation has a finite raw-row budget.
+   * For non-negative limits, inspect at most the newest `n` decision rows while
+   * collecting faculty negative outcomes, so automatic consolidation has a
+   * finite raw-row budget. A negative limit preserves the retrieval API's
+   * existing unlimited-query convention.
    */
   recentFacultyNegativeOutcomes(n = 10): EpisodicEvent[] {
+    const rawScanLimit = n < 0 ? Number.POSITIVE_INFINITY : n;
     const quarantinedEventIds = new Set<number>();
     const stmt = this.db.prepare(
       `SELECT * FROM episodic_events WHERE type = 'decision'
@@ -3357,7 +3360,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       this.encryption,
       (eventId) => quarantinedEventIds.add(eventId),
       isConsolidatableFacultyNegativeOutcome,
-      n,
+      rawScanLimit,
     );
     this.audit?.({
       operation: 'episodic.recent',
@@ -3365,7 +3368,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       outcome: 'success',
       details: {
         limit: n,
-        rawScanLimit: n,
+        rawScanLimit: Number.isFinite(rawScanLimit) ? rawScanLimit : 'unbounded',
         count: result.length,
         ...(quarantinedEventIds.size > 0
           ? { quarantinedEventIds: [...quarantinedEventIds] }

--- a/packages/franken-brain/src/sqlite-brain.ts
+++ b/packages/franken-brain/src/sqlite-brain.ts
@@ -3341,6 +3341,10 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
     }
   }
 
+  /**
+   * Inspect at most the newest `n` decision rows while collecting faculty
+   * negative outcomes, so automatic consolidation has a finite raw-row budget.
+   */
   recentFacultyNegativeOutcomes(n = 10): EpisodicEvent[] {
     const quarantinedEventIds = new Set<number>();
     const stmt = this.db.prepare(
@@ -3353,6 +3357,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       this.encryption,
       (eventId) => quarantinedEventIds.add(eventId),
       isConsolidatableFacultyNegativeOutcome,
+      n,
     );
     this.audit?.({
       operation: 'episodic.recent',
@@ -3360,6 +3365,7 @@ class SqliteEpisodicMemory implements IEpisodicMemory {
       outcome: 'success',
       details: {
         limit: n,
+        rawScanLimit: n,
         count: result.length,
         ...(quarantinedEventIds.size > 0
           ? { quarantinedEventIds: [...quarantinedEventIds] }

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1877,6 +1877,28 @@ describe('SqliteBrain', () => {
       }
     });
 
+    it('preserves unlimited faculty-outcome retrieval for a negative limit', () => {
+      brain.episodic.record({
+        type: 'decision',
+        step: 'reasoning:critique',
+        summary: 'First unlimited faculty outcome',
+        details: { category: 'reasoning-lifecycle', outcome: 'negative', reward: -1 },
+        createdAt: '2026-01-01T00:00:00.000Z',
+      });
+      brain.episodic.record({
+        type: 'decision',
+        step: 'reasoning:critique',
+        summary: 'Second unlimited faculty outcome',
+        details: { category: 'reasoning-lifecycle', outcome: 'negative' },
+        createdAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      expect(brain.episodic.recentFacultyNegativeOutcomes(-1).map((item) => item.summary)).toEqual([
+        'Second unlimited faculty outcome',
+        'First unlimited faculty outcome',
+      ]);
+    });
+
     it('does not cluster skill-evolution review signals as generic lessons', () => {
       brain.episodic.recordSkillFailure({
         skillName: 'resolve-issues',

--- a/packages/franken-brain/tests/unit/sqlite-brain.test.ts
+++ b/packages/franken-brain/tests/unit/sqlite-brain.test.ts
@@ -1818,6 +1818,65 @@ describe('SqliteBrain', () => {
       expect(candidate?.value.evidenceEventIds).toEqual([2, 3]);
     });
 
+    it('bounds encrypted faculty-outcome discovery by raw decision rows', () => {
+      const encrypted = new SqliteBrain(':memory:', undefined, {
+        encryption: { enabled: true, key: 'faculty-outcome-scan-budget-key' },
+      });
+      try {
+        encrypted.episodic.record({
+          type: 'decision',
+          step: 'reasoning:critique',
+          summary: 'Reasoning verdict: fail — outside the scan budget',
+          details: {
+            category: 'reasoning-lifecycle',
+            outcome: 'negative',
+            lessonContext: 'faculty failure outside the scan budget',
+          },
+          createdAt: '2026-07-24T10:00:00.000Z',
+        });
+        for (const index of [1, 2, 3]) {
+          encrypted.episodic.record({
+            type: 'decision',
+            step: 'unrelated-decision',
+            summary: `Unrelated encrypted decision ${index}`,
+            details: { outcome: 'positive', privateContext: `encrypted-${index}` },
+            createdAt: `2026-07-24T10:0${index}:00.000Z`,
+          });
+        }
+
+        const db = (encrypted as unknown as { db: Database.Database }).db;
+        const storedDetails = db.prepare(
+          `SELECT details FROM episodic_events WHERE type = 'decision' ORDER BY id DESC LIMIT 1`,
+        ).pluck().get() as string;
+        expect(storedDetails).toMatch(/^enc:v1:/);
+
+        const originalPrepare = db.prepare.bind(db);
+        const decisionFetches: Array<{ limit: number; offset: number; rows: number }> = [];
+        db.prepare = ((sql: string) => {
+          const statement = originalPrepare(sql);
+          if (!sql.includes("WHERE type = 'decision'")) return statement;
+          const originalAll = statement.all.bind(statement);
+          statement.all = ((limit: number, offset: number) => {
+            const rows = originalAll(limit, offset);
+            decisionFetches.push({ limit, offset, rows: rows.length });
+            return rows;
+          }) as typeof statement.all;
+          return statement;
+        }) as typeof db.prepare;
+        let outcomes: EpisodicEvent[] = [];
+        try {
+          outcomes = encrypted.episodic.recentFacultyNegativeOutcomes(2);
+        } finally {
+          db.prepare = originalPrepare as typeof db.prepare;
+        }
+
+        expect(decisionFetches).toEqual([{ limit: 2, offset: 0, rows: 2 }]);
+        expect(outcomes).toEqual([]);
+      } finally {
+        encrypted.close();
+      }
+    });
+
     it('does not cluster skill-evolution review signals as generic lessons', () => {
       brain.episodic.recordSkillFailure({
         skillName: 'resolve-issues',

--- a/tasks/issue-3773-progress.md
+++ b/tasks/issue-3773-progress.md
@@ -7,6 +7,6 @@
 - [x] Apply the minimal finite raw-row scan budget while preserving timestamp/id order and corrupt-row handling.
 - [x] Run focused and package-level brain tests (499/499 passing).
 - [x] Run lint, typecheck, build, and relevant repository gates. Root lint/typecheck/build pass; root tests pass all assertions but remain non-zero on an unrelated pre-existing Codex app-server unhandled rejection in `runtime-contract.test.ts` (targeted reported failures pass in isolation).
-- [ ] Commit with the required identity, push, and open one PR closing #3773.
+- [x] Commit with the required identity, push, and open PR #3934 closing #3773.
 - [ ] Drive exact-head GitHub CI and Codex review to clean; resolve all findings.
 - [ ] Squash merge, verify issue closure, append reusable lessons, and close the Kanban task.

--- a/tasks/issue-3773-progress.md
+++ b/tasks/issue-3773-progress.md
@@ -1,0 +1,12 @@
+# Issue 3773 Progress
+
+- [x] Revalidate issue #3773, exact branch/base, labels, competing PRs, and Kanban ownership.
+- [x] Read repository instructions and shared lessons; inspect the faculty-outcome scan and adjacent bounded-scan pattern.
+- [x] Add an encrypted counting regression proving unrelated decision rows cannot expand work beyond the faculty lookback budget.
+- [x] Run the focused regression on unchanged code and record RED: one query fetched 4 rows with `LIMIT 100`; expected one query fetching 2 rows with `LIMIT 2`.
+- [x] Apply the minimal finite raw-row scan budget while preserving timestamp/id order and corrupt-row handling.
+- [x] Run focused and package-level brain tests (499/499 passing).
+- [x] Run lint, typecheck, build, and relevant repository gates. Root lint/typecheck/build pass; root tests pass all assertions but remain non-zero on an unrelated pre-existing Codex app-server unhandled rejection in `runtime-contract.test.ts` (targeted reported failures pass in isolation).
+- [ ] Commit with the required identity, push, and open one PR closing #3773.
+- [ ] Drive exact-head GitHub CI and Codex review to clean; resolve all findings.
+- [ ] Squash merge, verify issue closure, append reusable lessons, and close the Kanban task.

--- a/tasks/issue-3773-progress.md
+++ b/tasks/issue-3773-progress.md
@@ -5,8 +5,8 @@
 - [x] Add an encrypted counting regression proving unrelated decision rows cannot expand work beyond the faculty lookback budget.
 - [x] Run the focused regression on unchanged code and record RED: one query fetched 4 rows with `LIMIT 100`; expected one query fetching 2 rows with `LIMIT 2`.
 - [x] Apply the minimal finite raw-row scan budget while preserving timestamp/id order and corrupt-row handling.
-- [x] Run focused and package-level brain tests (499/499 passing).
+- [x] Run focused and package-level brain tests (500/500 passing after review feedback).
 - [x] Run lint, typecheck, build, and relevant repository gates. Root lint/typecheck/build pass; root tests pass all assertions but remain non-zero on an unrelated pre-existing Codex app-server unhandled rejection in `runtime-contract.test.ts` (targeted reported failures pass in isolation).
 - [x] Commit with the required identity, push, and open PR #3934 closing #3773.
-- [ ] Drive exact-head GitHub CI and Codex review to clean; resolve all findings.
-- [ ] Squash merge, verify issue closure, append reusable lessons, and close the Kanban task.
+- [x] Drive exact-head GitHub CI and Codex review to clean; resolve all findings. Codex P2 negative-limit feedback was fixed and covered; all CI checks passed on code head `bd20f2732` before the final lessons-only closeout commit.
+- [ ] Squash merge, verify issue closure, and close the Kanban task; reusable lessons are recorded.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-30 — Bound automatic scans without breaking unlimited retrieval
+- When an API uses negative limits to mean “all,” do not reuse that result limit directly as a finite raw-row budget: bound non-negative automatic lookbacks by rows examined, but preserve the explicit negative-limit convention (and label it `unbounded` in audit metadata). Add separate regressions for bounded filtered/encrypted scans and negative-limit ordering.
+
 ## 2026-07-30 — Evaluator severity must agree with blocking verdicts
 - A deterministic style threshold is not flaky merely because code edits cross it. Re-run identical boundary inputs and trace the result through aggregate consumers before changing the threshold.
 - Informational evaluator findings must not return a blocking `fail` verdict when the pipeline contract treats `pass` plus `info` as non-blocking. Preserve the finding and score signal, and fix the verdict/severity drift instead of adding environment configuration to pure evaluator logic.


### PR DESCRIPTION
## Summary
- cap faculty-negative-outcome discovery at the requested non-negative lookback raw decision rows
- preserve the established negative-limit unbounded retrieval convention
- expose finite versus unbounded raw scan limits in access-audit metadata
- add encrypted counting and negative-limit regressions

## Reproduction
Before the fix, a lookback of 2 issued one decision query with `LIMIT 100` and decoded all 4 fixture rows, reaching an eligible outcome outside the budget. After the fix it issues one query with `LIMIT 2`, reads exactly 2 rows, and does not touch the older eligible outcome.

## Test plan
- `npm --workspace @franken/brain test` (500 passed)
- `npm --workspace @franken/brain run lint`
- `npm --workspace @franken/brain run typecheck`
- `npm --workspace @franken/brain run build`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` (all assertions pass on rerun; exits non-zero on a pre-existing unrelated unhandled Codex app-server rejection in orchestrator `runtime-contract.test.ts`; the four initially timing-sensitive orchestrator assertions pass in isolation)

Closes #3773