### PR TITLE
fix(web): announce empty activity state

### DIFF
--- a/packages/franken-web/src/components/activity-pane.test.tsx
+++ b/packages/franken-web/src/components/activity-pane.test.tsx
@@ -40,7 +40,7 @@ describe('ActivityPane', () => {
     const liveStatus = screen.getByRole('status');
     expect(liveStatus.getAttribute('aria-live')).toBe('polite');
     expect(liveStatus.getAttribute('aria-atomic')).toBe('true');
-    expect(liveStatus.textContent).toBe('');
+    expect(liveStatus.textContent).toBe('Waiting for execution events.');
 
     rerender(
       <ActivityPane
@@ -95,6 +95,26 @@ describe('ActivityPane', () => {
     );
 
     expect(screen.getByRole('status').textContent).toBe('');
+  });
+
+  it('announces when runtime activity becomes empty', () => {
+    const { rerender } = render(
+      <ActivityPane
+        events={[
+          {
+            type: 'turn.execution.complete',
+            data: { summary: 'Completed activity' },
+            timestamp: '2026-07-05T01:02:03.000Z',
+          },
+        ]}
+      />,
+    );
+
+    rerender(<ActivityPane events={[]} />);
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toBe('Waiting for execution events.');
+    expect(status.getAttribute('aria-live')).toBe('polite');
   });
 
   it('renders runtime activity as a readable timeline with status chips and artifact links', () => {

--- a/packages/franken-web/src/components/activity-pane.tsx
+++ b/packages/franken-web/src/components/activity-pane.tsx
@@ -177,6 +177,7 @@ function announcementForActivity(event: ActivityEvent, activityNumber: number): 
 }
 
 const UNABLE_TO_STRINGIFY_EVENT_DATA = '[unserializable event data]';
+const EMPTY_ACTIVITY_ANNOUNCEMENT = 'Waiting for execution events.';
 
 function formatEventData(data: Record<string, unknown>): string {
   const ancestors: object[] = [];
@@ -243,10 +244,14 @@ export function ActivityPane({ events, resetKey }: ActivityPaneProps) {
         <p className="eyebrow">Activity</p>
         <h2>Runtime Events</h2>
       </div>
-      <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-        {announcement}
+      <p
+        className={events.length === 0 ? 'rail-card__empty' : 'sr-only'}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {events.length === 0 ? EMPTY_ACTIVITY_ANNOUNCEMENT : announcement}
       </p>
-      {events.length === 0 && <p className="rail-card__empty">Waiting for execution events.</p>}
       <ol ref={containerRef} className="activity-list" aria-label="Runtime activity timeline" onScroll={handleScroll}>
         {events.map((event, index) => {
           const viewModel = viewModelForActivity(event);

--- a/tasks/issue-3845-activity-empty-live-region-progress.md
+++ b/tasks/issue-3845-activity-empty-live-region-progress.md
@@ -1,0 +1,14 @@
+# Issue #3845 ActivityPane empty live-region progress
+
+- [x] Read the live issue and shared/project lessons.
+- [x] Confirm branch is based exactly on current `origin/main` and no competing PR exists.
+- [x] Locate `ActivityPane` implementation, usages, and focused tests.
+- [x] Add a focused regression and observe the exact accessibility defect fail (RED).
+- [x] Record reproduction, observed/expected behavior, affected path, and root cause on the Kanban card.
+- [x] Implement the minimal issue-scoped fix and observe focused test pass (GREEN).
+- [x] Run relevant focused tests plus lint, typecheck, build, and repository gates.
+- [x] Self-review the diff and staged index.
+- [ ] Commit conventionally as David Mendez <me@davidmendez.dev>, push the issue branch, and open one PR closing #3845.
+- [ ] Drive exact-head GitHub CI and Codex review to clean with zero unresolved threads.
+- [ ] Squash merge only after all exact-head gates; verify issue closure.
+- [ ] Append only a reusable lesson and close the Kanban card.


### PR DESCRIPTION
## Summary
- make the visible ActivityPane empty state the pane's single polite, atomic status region
- preserve concise screen-reader-only announcements when runtime events exist
- add regression coverage for populated-to-empty transitions

## Test plan
- `npm test -- --run src/components/activity-pane.test.tsx tests/components/activity-pane.test.tsx` (12 passed)
- `npm test` in `packages/franken-web` (899 passed)
- `npm run lint` (passes; pre-existing warnings)
- `npm run typecheck` (passes)
- `npm run build` (passes)
- root `npm run test` had 3 unrelated timing failures in `codex-runtime-adapter.test.ts`; isolated rerun of that file plus `runtime-contract.test.ts` passed 71/71

Closes #3845