### PR TITLE
fix(orchestrator): validate completion token limits

### DIFF
--- a/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
+++ b/packages/franken-orchestrator/src/adapters/adapter-llm-client.ts
@@ -32,6 +32,12 @@ const MAX_OUTWARD_ERROR_CONTEXT_LENGTH = 1_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
 
+function validateMaxTokens(maxTokens: number | undefined): void {
+  if (maxTokens !== undefined && (!Number.isSafeInteger(maxTokens) || maxTokens <= 0)) {
+    throw new TypeError('LLM request maxTokens must be a positive safe integer');
+  }
+}
+
 function normalizeRequestTimeout(timeoutMs: number | undefined): number {
   const normalized = timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   if (!Number.isFinite(normalized) || normalized <= 0) {
@@ -169,6 +175,7 @@ export class AdapterLlmClient implements ILlmClient {
   ): Promise<{ content: string; usage?: TokenUsage; providerContext?: ProviderContext }> {
     const requestId = `llm-${randomUUID()}`;
     const model = this.defaultModel;
+    validateMaxTokens(options?.maxTokens);
     const timeoutMs = normalizeRequestTimeout(options?.timeoutMs);
     const controller = new AbortController();
     const abortFromCaller = (): void => {
@@ -196,6 +203,7 @@ export class AdapterLlmClient implements ILlmClient {
       provider: 'adapter',
       model,
       messages: [{ role: 'user', content: prompt }],
+      ...(options?.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
       ...(options?.sessionId ? { session_id: options.sessionId } : {}),
       ...(options?.sessionContinue !== undefined ? { sessionContinue: options.sessionContinue } : {}),
       signal: controller.signal,

--- a/packages/franken-orchestrator/src/adapters/provider-registry-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/provider-registry-adapter.ts
@@ -21,6 +21,7 @@ export class ProviderRegistryIAdapter implements IAdapter {
     const req = request as {
       messages: Array<{ role: string; content: string }>;
       system?: string;
+      max_tokens?: number;
       signal?: AbortSignal;
     };
     const raw: LlmRequest = {
@@ -30,6 +31,7 @@ export class ProviderRegistryIAdapter implements IAdapter {
         content: m.content,
       })),
       tools: [],
+      ...(req.max_tokens !== undefined ? { maxTokens: req.max_tokens } : {}),
       ...(req.signal ? { signal: req.signal } : {}),
     };
     const processed = this.middleware ? this.middleware.processRequest(raw) : raw;

--- a/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts
@@ -63,6 +63,45 @@ describe('AdapterLlmClient', () => {
     expect(adapter.execute).not.toHaveBeenCalled();
   });
 
+  it('rejects a negative maxTokens value before starting adapter work', async () => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await expect(client.complete('prompt', { maxTokens: -1 })).rejects.toThrow(
+      'maxTokens must be a positive safe integer',
+    );
+    expect(adapter.transformRequest).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['zero', 0],
+    ['a fraction', 1.5],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['an unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+  ])('rejects %s as maxTokens before starting adapter work', async (_description, maxTokens) => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await expect(client.complete('prompt', { maxTokens })).rejects.toThrow(
+      'maxTokens must be a positive safe integer',
+    );
+    expect(adapter.transformRequest).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid maxTokens value to the unified adapter request', async () => {
+    const adapter = makeAdapter();
+    const client = new AdapterLlmClient(adapter);
+
+    await client.complete('prompt', { maxTokens: 8_192 });
+
+    expect(adapter.transformRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 8_192 }),
+    );
+  });
+
   it('forwards cancellation and deadline options to the adapter request', async () => {
     const adapter = makeAdapter();
     const client = new AdapterLlmClient(adapter);

--- a/packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts
@@ -50,6 +50,14 @@ describe('ProviderRegistryIAdapter', () => {
       expect(adapter.transformRequest({ ...makeRequest(), signal })).toEqual(expect.objectContaining({ signal }));
     });
 
+    it('maps the unified max_tokens limit to the provider maxTokens field', () => {
+      const adapter = new ProviderRegistryIAdapter(makeRegistry(() => textEvents('hi')));
+
+      expect(adapter.transformRequest({ ...makeRequest(), max_tokens: 8_192 })).toEqual(
+        expect.objectContaining({ maxTokens: 8_192 }),
+      );
+    });
+
     it('applies middleware processRequest when provided', () => {
       const processRequest = vi.fn((req: any) => ({ ...req, systemPrompt: 'SANITIZED' }));
       const middleware = { processRequest, processResponse: vi.fn((r: any) => r) };

--- a/packages/franken-types/src/llm.ts
+++ b/packages/franken-types/src/llm.ts
@@ -7,6 +7,8 @@ import type { ProviderContext } from './api-contracts.js';
  * Returns plain string — caller handles parsing.
  */
 export interface LlmCompletionOptions {
+  /** Maximum completion tokens requested from providers that support the limit. */
+  maxTokens?: number | undefined;
   /** Cancels the logical completion, including any provider process or retry wait. */
   signal?: AbortSignal | undefined;
   /** Maximum time for this logical completion, including provider fallback/retries. */

--- a/tasks/issue-3851-adapter-llm-max-tokens-progress.md
+++ b/tasks/issue-3851-adapter-llm-max-tokens-progress.md
@@ -1,0 +1,13 @@
+# Issue #3851 — AdapterLlmClient maxTokens validation progress
+
+- [x] Revalidate live issue #3851 and overlapping issues #3849/#3846.
+- [x] Verify the isolated branch is clean and exactly based on freshly fetched `origin/main`.
+- [x] Read shared issue-resolution lessons and trace `AdapterLlmClient`, `LlmCompletionOptions`, and adapter request transformations.
+- [x] Add a focused failing regression proving invalid runtime `maxTokens` reaches adapter work instead of failing at the trust boundary.
+- [x] Add minimal runtime validation and request forwarding for valid `maxTokens` values.
+- [x] Cover zero, negative, fractional, non-finite, unsafe, and valid values.
+- [x] Run focused tests, package tests/typecheck/lint/build, and repository gates. (`npm run test` has one unrelated pre-existing Codex app-server unhandled rejection after all 5,009 orchestrator assertions pass; the isolated source test passes.)
+- [x] Self-review the exact diff and append a concise reusable lesson.
+- [ ] Commit, push, open a one-issue PR with `Closes #3851`, and verify exact head equality.
+- [ ] Drive exact-head CI and the GitHub Codex review loop to clean with zero unresolved threads.
+- [ ] Guarded squash-merge and verify issue closure, or block with exact terminal evidence.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -1,5 +1,8 @@
 # Resolve Issues Shared Lessons
 
+## 2026-07-30 — Completion token limits must cross every adapter boundary
+- Put provider-agnostic completion limits on the shared `LlmCompletionOptions` contract, reject non-positive or unsafe integers before adapter work starts, and explicitly map the unified request's `max_tokens` field into provider-facing `LlmRequest.maxTokens`; declaring a field on an intermediate request type alone neither validates nor forwards it.
+
 ## 2026-07-30 — Faculty clocks must be wired before adapter construction
 - Resolve the shared Beast clock before constructing any faculty adapter, then use that same source for lesson-consultation and every lifecycle timestamp. A frozen-clock dependency-factory regression should exercise planning, completion, and failure paths together so one remaining wall-clock call cannot hide behind otherwise deterministic reasoning/action behavior.
 


### PR DESCRIPTION
## Summary
- expose `maxTokens` on the shared completion options contract
- reject non-positive, fractional, non-finite, and unsafe token limits before adapter work
- forward valid limits through the unified request into provider `LlmRequest.maxTokens`

## Test Plan
- `npx vitest run packages/franken-orchestrator/tests/unit/adapters/adapter-llm-client.test.ts packages/franken-orchestrator/tests/unit/adapters/provider-registry-adapter.test.ts --config packages/franken-orchestrator/vitest.config.ts` (48 passed)
- `npm run test --workspace @franken/orchestrator` (5,009 passed)
- `npm run lint` (passes with pre-existing warnings)
- `npm run typecheck`
- `npm run build`

## Notes
- The full root `npm run test` currently exits non-zero after all 5,009 orchestrator assertions pass because `runtime-contract.test.ts` leaves an unrelated Codex app-server unavailable rejection; that isolated test passes when rerun.

Closes #3851