### PR TITLE
fix(orchestrator): isolate planning telemetry failures

### DIFF
--- a/packages/franken-orchestrator/src/adapters/brain-memory-adapter.ts
+++ b/packages/franken-orchestrator/src/adapters/brain-memory-adapter.ts
@@ -36,10 +36,14 @@ export class SqliteBrainMemoryAdapter implements IMemoryModule {
         requiredSkills: [],
         dependsOn: [],
       };
-      if (trace.outcome === 'success') {
-        this.brain.planning.recordStepCompleted(task);
-      } else if (trace.objective !== undefined) {
-        this.brain.planning.recordStepFailed(task, new Error(trace.summary));
+      try {
+        if (trace.outcome === 'success') {
+          this.brain.planning.recordStepCompleted(task);
+        } else if (trace.objective !== undefined) {
+          this.brain.planning.recordStepFailed(task, new Error(trace.summary));
+        }
+      } catch {
+        // Optional lifecycle telemetry must not prevent the generic recovery trace.
       }
     }
 

--- a/packages/franken-orchestrator/tests/unit/adapters/brain-memory-adapter.test.ts
+++ b/packages/franken-orchestrator/tests/unit/adapters/brain-memory-adapter.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SqliteBrain } from '@franken/brain';
+import { SqliteBrainMemoryAdapter } from '../../../src/adapters/brain-memory-adapter.js';
+
+describe('SqliteBrainMemoryAdapter', () => {
+  const brains: SqliteBrain[] = [];
+
+  afterEach(() => {
+    for (const brain of brains.splice(0)) brain.close();
+  });
+
+  function makeBrain(): SqliteBrain {
+    const brain = new SqliteBrain(':memory:');
+    brains.push(brain);
+    return brain;
+  }
+
+  function attachThrowingPlanningFaculty(
+    brain: SqliteBrain,
+    hook: 'recordStepCompleted' | 'recordStepFailed',
+  ): void {
+    brain.attachPlanningFaculty({
+      kind: 'planning',
+      configured: true,
+      createPlan: vi.fn(async () => ({ tasks: [] })),
+      recordPlanCreated: vi.fn(),
+      recordStepCompleted: vi.fn(() => {
+        if (hook === 'recordStepCompleted') throw new Error('completion telemetry unavailable');
+      }),
+      recordStepFailed: vi.fn(() => {
+        if (hook === 'recordStepFailed') throw new Error('failure telemetry unavailable');
+      }),
+    });
+  }
+
+  it('preserves the generic success trace when completion lifecycle telemetry throws', async () => {
+    const brain = makeBrain();
+    attachThrowingPlanningFaculty(brain, 'recordStepCompleted');
+    const adapter = new SqliteBrainMemoryAdapter(brain);
+
+    await expect(adapter.recordTrace({
+      taskId: 'task-success',
+      summary: 'Completed requested work',
+      outcome: 'success',
+      timestamp: '2026-07-30T12:00:00.000Z',
+    })).resolves.toBeUndefined();
+
+    expect(brain.episodic.recent()).toContainEqual(expect.objectContaining({
+      type: 'success',
+      summary: '[task-success] Completed requested work',
+      createdAt: '2026-07-30T12:00:00.000Z',
+    }));
+  });
+
+  it('preserves the generic failure trace when failure lifecycle telemetry throws', async () => {
+    const brain = makeBrain();
+    attachThrowingPlanningFaculty(brain, 'recordStepFailed');
+    const adapter = new SqliteBrainMemoryAdapter(brain);
+
+    await expect(adapter.recordTrace({
+      taskId: 'task-failure',
+      objective: 'Compile the workspace',
+      summary: 'Compiler exited with an error',
+      outcome: 'failure',
+      timestamp: '2026-07-30T12:01:00.000Z',
+    })).resolves.toBeUndefined();
+
+    expect(brain.episodic.recent()).toContainEqual(expect.objectContaining({
+      type: 'failure',
+      summary: '[task-failure] Compiler exited with an error',
+      createdAt: '2026-07-30T12:01:00.000Z',
+    }));
+  });
+});

--- a/tasks/issue-3784-planning-telemetry-progress.md
+++ b/tasks/issue-3784-planning-telemetry-progress.md
@@ -1,0 +1,29 @@
+# Issue #3784 — Planning Telemetry Best-Effort Progress
+
+- [x] Fetch `origin/main` and verify the isolated branch starts at the exact current head.
+- [x] Read issue #3784, the late Codex finding on merged PR #3744, affected adapter/execution paths, and shared issue lessons.
+- [x] Add focused adapter regressions proving throwing completion/failure lifecycle hooks do not reject `recordTrace` and generic traces remain recorded.
+- [x] Run the focused test before implementation and capture the expected RED failure.
+- [x] Add the minimal best-effort boundary at the planning lifecycle hook seam.
+- [x] Run focused tests and relevant orchestrator/repository lint, typecheck, build, and test gates.
+- [x] Self-review the diff and append a concise reusable lesson.
+- [ ] Commit with the required identity and a Conventional Commit, push, and open one PR with `Closes #3784`.
+- [ ] Verify local, remote, and PR head equality; drive exact-head CI and GitHub Codex review to clean with zero unresolved threads.
+- [ ] Squash-merge only after immutable-head gates pass and verify issue closure.
+
+## Revalidation evidence
+
+- Fresh `origin/main` and local `HEAD`: `ffc3b2c37c21468cb654a569bc18c4ac334bacad`.
+- Issue: https://github.com/djm204/frankenbeast/issues/3784 remains open.
+- Late report: https://github.com/djm204/frankenbeast/pull/3744#discussion_r3647204080 identifies `SqliteBrainMemoryAdapter.recordTrace()` lifecycle hooks escaping before the generic episodic trace.
+- Current affected path: `packages/franken-orchestrator/src/adapters/brain-memory-adapter.ts:31-52` still invokes `recordStepCompleted` / `recordStepFailed` without a caller-side boundary.
+- Execution impact: `packages/franken-orchestrator/src/phases/execution.ts:282-299` converts a successful task to failure when `memory.recordTrace()` rejects.
+- Expected behavior: optional lifecycle telemetry may fail, but `recordTrace()` resolves and the established generic success/failure trace is still persisted.
+
+## Verification evidence
+
+- RED: `npm run test --workspace @franken/orchestrator -- tests/unit/adapters/brain-memory-adapter.test.ts` failed both regressions because completion/failure hook exceptions rejected `recordTrace()`.
+- GREEN: the same focused command passes 2/2 tests after the caller-side boundary.
+- Execution coverage: adapter regression plus `tests/unit/phases/execution.test.ts` passes 84/84 tests; three relevant consolidated-dependency integration cases pass.
+- `npm run lint --workspace @franken/orchestrator`, `npm run typecheck --workspace @franken/orchestrator`, root `npm run lint`, root `npm run typecheck`, and root `npm run build` pass (lint retains existing warnings only).
+- Root `npm run test` reached 5001 passing orchestrator tests but reported two unrelated parallel-suite failures in CLI availability and Codex initialization deadline tests; each exact failing test passed immediately in isolation.

--- a/tasks/resolve-issues-shared-lessons.md
+++ b/tasks/resolve-issues-shared-lessons.md
@@ -587,3 +587,6 @@
 
 ## 2026-07-30 — Best-effort persistence diagnostics
 - Emit persistence-failure diagnostics only around the failing adapter call, keep diagnostic sinks best-effort, log bounded hashes instead of raw payloads/errors, and restore console spies so rejection tests remain isolated and warning-free.
+
+## 2026-07-30 — Caller-side boundaries for optional faculty hooks
+- An adapter-owned faculty may already contain persistence failures, but custom faculties attached through the public brain boundary can still throw. Keep a caller-side best-effort boundary around optional lifecycle hooks and leave the established generic recovery write outside it; regress both success and failure hooks with a custom throwing faculty.


### PR DESCRIPTION
## Summary
- keep optional planning lifecycle hooks best-effort at the brain-memory adapter boundary
- preserve established generic success/failure recovery traces when custom faculties throw
- add focused completion and failure regressions

## Test plan
- [x] focused brain-memory adapter regression (RED then GREEN)
- [x] execution-path unit tests (84 passed)
- [x] relevant consolidated-dependency integration tests
- [x] orchestrator lint and typecheck
- [x] repository lint, typecheck, and build
- [x] full repository test run reached 5001 passing orchestrator tests; two unrelated parallel-only failures each passed immediately in isolation

Closes #3784